### PR TITLE
add heavy block logic for mining

### DIFF
--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -622,6 +622,13 @@ impl SynchronizationGraph {
         self.consensus.construct_pivot(&*inner);
     }
 
+    pub fn check_mining_heavy_block(
+        &self, parent_hash: &H256, light_difficulty: &U256,
+    ) -> bool {
+        self.consensus
+            .check_mining_heavy_block(parent_hash, light_difficulty)
+    }
+
     pub fn block_header_by_hash(&self, hash: &H256) -> Option<BlockHeader> {
         self.block_headers
             .read()


### PR DESCRIPTION
def shouldBeHeavyBlock(G,b):
    assert b in G
    assert Parent(b) == PivotTip(Past(G,b))
    G1 = Past(G,b)

    a = P(b)
    while a != Genesis(G1):
        m = Weight(Past(G,b) \ Past(G,P(a)).union(P(a)))
        n = SubTree(G1,a)
        if 2(m-n) > n  and m > 2000: 
            # These two parameters are under discussion. 
            return True
        a = Parent(G1,a)
    return False

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/24)
<!-- Reviewable:end -->
