### PR TITLE
Increase initial difficulty.

### DIFF
--- a/core/src/pow/mod.rs
+++ b/core/src/pow/mod.rs
@@ -9,7 +9,7 @@ use rlp::RlpStream;
 pub const DIFFICULTY_ADJUSTMENT_EPOCH_PERIOD: u64 = 200;
 // Time unit is micro-second (usec)
 pub const TARGET_AVERAGE_BLOCK_GENERATION_PERIOD: u64 = 5000000;
-pub const INITIAL_DIFFICULTY: u64 = 100_000_000;
+pub const INITIAL_DIFFICULTY: u64 = 5_000_000_000;
 
 //FIXME: May be better to place in other place.
 pub const WORKER_COMPUTATION_PARALLELISM: usize = 8;


### PR DESCRIPTION
Before we fix the issue of mining during sync, this should reduce forking.
The original is about 5 second a block for a single thread.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/30)
<!-- Reviewable:end -->
