### PR TITLE
util/monitor/src/lib.rs: add #[allow(deprecated)].

### DIFF
--- a/util/monitor/src/lib.rs
+++ b/util/monitor/src/lib.rs
@@ -76,6 +76,7 @@ impl Monitor {
         }
     }
 
+    #[allow(deprecated)]
     pub fn update_state(epoch_number: usize, hash: &H256) {
         if let Some(ctx) = Monitor::context() {
             let mut point = point!("state");


### PR DESCRIPTION
add #[allow(deprecated)] to mute warning when using H256::low_u64(). 