### PR TITLE
Only persist DAG terminals.

### DIFF
--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -114,7 +114,6 @@ pub struct ConsensusGraphInner {
     genesis_block_index: usize,
     genesis_block_state_root: H256,
     genesis_block_receipts_root: H256,
-    parental_terminals: HashSet<usize>,
     indices_in_epochs: HashMap<usize, Vec<usize>>,
     vm: VmFactory,
     weight_tree: LinkCutTree,
@@ -150,7 +149,6 @@ impl ConsensusGraphInner {
                 .block_header
                 .deferred_receipts_root()
                 .clone(),
-            parental_terminals: HashSet::new(),
             indices_in_epochs: HashMap::new(),
             vm,
             weight_tree: LinkCutTree::new(),
@@ -180,7 +178,6 @@ impl ConsensusGraphInner {
             .epoch_number
             .borrow_mut() = 0;
         inner.pivot_chain.push(inner.genesis_block_index);
-        inner.parental_terminals.insert(inner.genesis_block_index);
         assert!(inner.genesis_block_receipts_root == KECCAK_EMPTY_LIST_RLP);
         inner.block_receipts_root.insert(
             inner.genesis_block_index,
@@ -319,11 +316,9 @@ impl ConsensusGraphInner {
         self.indices.insert(hash, index);
 
         if parent != NULL {
-            self.parental_terminals.remove(&parent);
             self.terminal_hashes.remove(&self.arena[parent].hash);
             self.arena[parent].children.push(index);
         }
-        self.parental_terminals.insert(index);
         self.terminal_hashes.insert(hash);
         let referees = self.arena[index].referees.clone();
         for referee in referees {

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -1518,14 +1518,14 @@ impl ConsensusGraphInner {
     }
 
     pub fn persist_terminals(&self) {
-        let mut terminals = Vec::with_capacity(self.parental_terminals.len());
-        for index in &self.parental_terminals {
-            terminals.push(self.arena[*index].hash);
+        let mut terminals = Vec::with_capacity(self.terminal_hashes.len());
+        for h in &self.terminal_hashes {
+            terminals.push(h);
         }
         let mut rlp_stream = RlpStream::new();
         rlp_stream.begin_list(terminals.len());
         for hash in terminals {
-            rlp_stream.append(&hash);
+            rlp_stream.append(hash);
         }
         let mut dbops = self.db.key_value().transaction();
         dbops.put(COL_MISC, b"terminals", &rlp_stream.drain());

--- a/src/main.rs
+++ b/src/main.rs
@@ -231,7 +231,6 @@ fn main() {
                 .value_name("VALUE")
                 .help("Sets node's name in monitor.")
                 .takes_value(true)
-                .validator(from_str_validator::<usize>),
         )
         .arg(
             Arg::with_name("monitor-host")
@@ -239,7 +238,6 @@ fn main() {
                 .value_name("VALUE")
                 .help("Sets monitor's influxdb host.")
                 .takes_value(true)
-                .validator(from_str_validator::<usize>),
         )
         .arg(
             Arg::with_name("monitor-db")
@@ -247,7 +245,6 @@ fn main() {
                 .value_name("VALUE")
                 .help("Sets monitor's influxdb database.")
                 .takes_value(true)
-                .validator(from_str_validator::<usize>),
         )
         .arg(
             Arg::with_name("monitor-username")
@@ -255,7 +252,6 @@ fn main() {
                 .value_name("VALUE")
                 .help("Sets monitor's influxdb username.")
                 .takes_value(true)
-                .validator(from_str_validator::<usize>),
         )
         .arg(
             Arg::with_name("monitor-password")
@@ -263,7 +259,6 @@ fn main() {
                 .value_name("VALUE")
                 .help("Sets monitor's influxdb password.")
                 .takes_value(true)
-                .validator(from_str_validator::<usize>),
         )
         .get_matches_from(std::env::args().collect::<Vec<_>>());
 


### PR DESCRIPTION
When we are recovering the graph from db, we will traverse the graph following both parent edges and referee edges, so we only need to persist the DAG terminals instead of the parental terminals.

Remove wrong cli parameter validation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/66)
<!-- Reviewable:end -->
