### PR TITLE
add session manager to limits sessions by IP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
       - env:
             - CACHE_NAME=unit_tests
         cache:
-            timeout: 300
+            timeout: 600
             cargo: true
         install:
             - export RUSTFLAGS="-D warnings"
@@ -16,7 +16,7 @@ matrix:
       - env:
             - CACHE_NAME=bench
         cache:
-            timeout: 300
+            timeout: 600
             cargo: true
         install:
             - export RUSTFLAGS="-g -D warnings"
@@ -26,7 +26,7 @@ matrix:
       - env:
             - CACHE_NAME=integration_tests
         cache:
-            timeout: 300
+            timeout: 600
             cargo: true
         before_install:
             # python3.6 is requried for integration tests.

--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -1027,7 +1027,8 @@ impl SynchronizationGraph {
             return (insert_success, need_to_relay);
         }
 
-        self.statistics.set_sync_graph_inserted_block_count(inner.indices.len());
+        self.statistics
+            .set_sync_graph_inserted_block_count(inner.indices.len());
 
         let me = *inner.indices.get(&hash).unwrap();
         debug_assert!(hash == inner.arena[me].block_header.hash());

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -44,6 +44,7 @@ mod node_database;
 pub mod node_table;
 mod service;
 mod session;
+mod session_manager;
 pub mod throttling;
 
 pub use crate::{

--- a/network/src/node_database.rs
+++ b/network/src/node_database.rs
@@ -253,13 +253,13 @@ pub enum InsertResult {
 }
 
 /// IP address limitation for P2P nodes.
-struct NodeIpLimit {
+pub struct NodeIpLimit {
     nodes_per_ip: usize, // 0 presents unlimited
     ip_to_nodes: HashMap<IpAddr, usize>,
 }
 
 impl NodeIpLimit {
-    fn new(nodes_per_ip: usize) -> Self {
+    pub fn new(nodes_per_ip: usize) -> Self {
         debug!(target: "network", "NodeIpLimit::new: nodes_per_ip = {}", nodes_per_ip);
         NodeIpLimit {
             nodes_per_ip,
@@ -293,8 +293,20 @@ impl NodeIpLimit {
 
     fn is_enabled(&self) -> bool { self.nodes_per_ip > 0 }
 
+    /// Check if the specified IP address is allowed.
+    pub fn is_ip_allowed(&self, ip: &IpAddr) -> bool {
+        if !self.is_enabled() {
+            return true;
+        }
+
+        match self.ip_to_nodes.get(ip) {
+            Some(num) => *num < self.nodes_per_ip,
+            None => true,
+        }
+    }
+
     /// Validate IP address when adding a new node.
-    fn on_add(&mut self, ip: IpAddr) -> bool {
+    pub fn on_add(&mut self, ip: IpAddr) -> bool {
         if !self.is_enabled() {
             return true;
         }
@@ -329,7 +341,7 @@ impl NodeIpLimit {
 
     /// Update the number of nodes for the specified IP address when deleting a
     /// node.
-    fn on_delete(&mut self, ip: IpAddr) {
+    pub fn on_delete(&mut self, ip: IpAddr) {
         if !self.is_enabled() {
             return;
         }

--- a/network/src/session_manager.rs
+++ b/network/src/session_manager.rs
@@ -1,0 +1,190 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use crate::{
+    node_database::NodeIpLimit, node_table::NodeId,
+    service::NetworkServiceInner, session::Session, NetworkIoMessage,
+};
+use io::IoContext;
+use mio::net::TcpStream;
+use parking_lot::RwLock;
+use slab::{Slab, SlabIter};
+use std::{collections::HashMap, net::SocketAddr, sync::Arc};
+
+struct SessionStatus {
+    node_id_index: HashMap<NodeId, usize>,
+    ip_limit: NodeIpLimit,
+}
+
+impl SessionStatus {
+    fn new(nodes_per_ip: usize) -> Self {
+        SessionStatus {
+            node_id_index: HashMap::new(),
+            ip_limit: NodeIpLimit::new(nodes_per_ip),
+        }
+    }
+}
+
+/// Session manager maintains all ingress and egress TCP connections.
+/// It supports to limit the connections according to node IP policy.
+pub struct SessionManager {
+    sessions: Slab<Arc<RwLock<Session>>, usize>,
+    ingress_status: SessionStatus,
+    egress_status: SessionStatus,
+}
+
+impl SessionManager {
+    pub fn new(offset: usize, capacity: usize, nodes_per_ip: usize) -> Self {
+        SessionManager {
+            sessions: Slab::new_starting_at(offset, capacity),
+            ingress_status: SessionStatus::new(nodes_per_ip),
+            egress_status: SessionStatus::new(nodes_per_ip),
+        }
+    }
+
+    pub fn count(&self) -> usize { self.sessions.count() }
+
+    pub fn get(&self, idx: usize) -> Option<&Arc<RwLock<Session>>> {
+        self.sessions.get(idx)
+    }
+
+    pub fn iter(&self) -> SlabIter<Arc<RwLock<Session>>, usize> {
+        self.sessions.iter()
+    }
+
+    /// Retrieves the session count of handshakes, egress and ingress.
+    pub fn stat(&self) -> (usize, usize, usize) {
+        let mut handshakes = 0;
+        let mut egress = 0;
+        let mut ingress = 0;
+
+        for s in self.sessions.iter() {
+            match s.try_read() {
+                Some(ref s) if s.is_ready() && s.metadata.originated => {
+                    egress += 1
+                }
+                Some(ref s) if s.is_ready() && !s.metadata.originated => {
+                    ingress += 1
+                }
+                _ => handshakes += 1,
+            }
+        }
+
+        (handshakes, egress, ingress)
+    }
+
+    pub fn contains_node(&self, id: &NodeId) -> bool {
+        self.ingress_status.node_id_index.contains_key(id)
+            || self.egress_status.node_id_index.contains_key(id)
+    }
+
+    /// Creates a new session with specified TCP socket. It is egress connection
+    /// if the `id` is not `None`, otherwise it is ingress connection.
+    pub fn create(
+        &mut self, socket: TcpStream, address: SocketAddr, id: Option<&NodeId>,
+        io: &IoContext<NetworkIoMessage>, host: &NetworkServiceInner,
+    ) -> Result<usize, String>
+    {
+        let ip = address.ip();
+
+        // ensure unique node id and validate against node IP policy
+        match id {
+            Some(node_id) => {
+                if self.egress_status.node_id_index.contains_key(node_id) {
+                    return Err(format!(
+                        "egress session already exists, nodeId = {:?}",
+                        node_id
+                    ));
+                }
+
+                if !self.egress_status.ip_limit.is_ip_allowed(&ip) {
+                    return Err(format!(
+                        "egress IP policy limited, nodeId = {:?}, addr = {:?}",
+                        node_id, address
+                    ));
+                }
+            }
+            None => {
+                if !self.ingress_status.ip_limit.is_ip_allowed(&ip) {
+                    return Err(format!(
+                        "ingress IP policy limited, addr = {:?}",
+                        address
+                    ));
+                }
+            }
+        }
+
+        let index = match self.sessions.vacant_entry() {
+            None => Err(String::from("Max sessions reached")),
+            Some(entry) => {
+                match Session::new(io, socket, address, id, entry.index(), host)
+                {
+                    Err(e) => Err(format!("{:?}", e)),
+                    Ok(session) => {
+                        let session = Arc::new(RwLock::new(session));
+                        Ok(entry.insert(session).index())
+                    }
+                }
+            }
+        }?;
+
+        // update status on creation succeeded
+        match id {
+            Some(node_id) => {
+                self.egress_status
+                    .node_id_index
+                    .insert(node_id.clone(), index);
+                self.egress_status.ip_limit.on_add(ip);
+            }
+            None => {
+                self.ingress_status.ip_limit.on_add(ip);
+            }
+        }
+
+        Ok(index)
+    }
+
+    pub fn remove(&mut self, session: &Session) {
+        if self.sessions.remove(session.token()).is_some() {
+            if session.metadata.originated {
+                self.egress_status
+                    .ip_limit
+                    .on_delete(session.address().ip());
+                self.egress_status.node_id_index.remove(
+                    session.id().expect("egress session should have node id"),
+                );
+            } else {
+                self.ingress_status
+                    .ip_limit
+                    .on_delete(session.address().ip());
+                if let Some(id) = session.id() {
+                    self.ingress_status.node_id_index.remove(id);
+                }
+            }
+        }
+    }
+
+    pub fn update_ingress_node_id(
+        &mut self, idx: usize, node_id: &NodeId,
+    ) -> Result<(), String> {
+        // ensure the ingress node id is unique
+        if let Some(cur_idx) = self.ingress_status.node_id_index.get(node_id) {
+            return Err(format!("ingress session already exists, node_id = {:?}, cur_idx = {}, new_idx = {}", node_id.clone(), *cur_idx, idx));
+        }
+
+        if !self.sessions.contains(idx) {
+            return Err(format!(
+                "session not found, index = {}, node_id = {:?}",
+                idx,
+                node_id.clone()
+            ));
+        }
+
+        self.ingress_status
+            .node_id_index
+            .insert(node_id.clone(), idx);
+
+        Ok(())
+    }
+}

--- a/network/src/session_manager.rs
+++ b/network/src/session_manager.rs
@@ -12,34 +12,20 @@ use parking_lot::RwLock;
 use slab::{Slab, SlabIter};
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 
-struct SessionStatus {
-    node_id_index: HashMap<NodeId, usize>,
-    ip_limit: NodeIpLimit,
-}
-
-impl SessionStatus {
-    fn new(nodes_per_ip: usize) -> Self {
-        SessionStatus {
-            node_id_index: HashMap::new(),
-            ip_limit: NodeIpLimit::new(nodes_per_ip),
-        }
-    }
-}
-
 /// Session manager maintains all ingress and egress TCP connections.
 /// It supports to limit the connections according to node IP policy.
 pub struct SessionManager {
     sessions: Slab<Arc<RwLock<Session>>, usize>,
-    ingress_status: SessionStatus,
-    egress_status: SessionStatus,
+    node_id_index: HashMap<NodeId, usize>,
+    ip_limit: NodeIpLimit,
 }
 
 impl SessionManager {
     pub fn new(offset: usize, capacity: usize, nodes_per_ip: usize) -> Self {
         SessionManager {
             sessions: Slab::new_starting_at(offset, capacity),
-            ingress_status: SessionStatus::new(nodes_per_ip),
-            egress_status: SessionStatus::new(nodes_per_ip),
+            node_id_index: HashMap::new(),
+            ip_limit: NodeIpLimit::new(nodes_per_ip),
         }
     }
 
@@ -75,8 +61,7 @@ impl SessionManager {
     }
 
     pub fn contains_node(&self, id: &NodeId) -> bool {
-        self.ingress_status.node_id_index.contains_key(id)
-            || self.egress_status.node_id_index.contains_key(id)
+        self.node_id_index.contains_key(id)
     }
 
     /// Creates a new session with specified TCP socket. It is egress connection
@@ -86,33 +71,23 @@ impl SessionManager {
         io: &IoContext<NetworkIoMessage>, host: &NetworkServiceInner,
     ) -> Result<usize, String>
     {
+        // ensure the node id is unique if specified.
+        if let Some(node_id) = id {
+            if self.node_id_index.contains_key(node_id) {
+                return Err(format!(
+                    "session already exists, nodeId = {:?}",
+                    node_id
+                ));
+            }
+        }
+
+        // validate against node IP policy.
         let ip = address.ip();
-
-        // ensure unique node id and validate against node IP policy
-        match id {
-            Some(node_id) => {
-                if self.egress_status.node_id_index.contains_key(node_id) {
-                    return Err(format!(
-                        "egress session already exists, nodeId = {:?}",
-                        node_id
-                    ));
-                }
-
-                if !self.egress_status.ip_limit.is_ip_allowed(&ip) {
-                    return Err(format!(
-                        "egress IP policy limited, nodeId = {:?}, addr = {:?}",
-                        node_id, address
-                    ));
-                }
-            }
-            None => {
-                if !self.ingress_status.ip_limit.is_ip_allowed(&ip) {
-                    return Err(format!(
-                        "ingress IP policy limited, addr = {:?}",
-                        address
-                    ));
-                }
-            }
+        if !self.ip_limit.is_ip_allowed(&ip) {
+            return Err(format!(
+                "IP policy limited, nodeId = {:?}, addr = {:?}",
+                id, address
+            ));
         }
 
         let index = match self.sessions.vacant_entry() {
@@ -122,55 +97,38 @@ impl SessionManager {
                 {
                     Err(e) => Err(format!("{:?}", e)),
                     Ok(session) => {
-                        let session = Arc::new(RwLock::new(session));
-                        Ok(entry.insert(session).index())
+                        Ok(entry.insert(Arc::new(RwLock::new(session))).index())
                     }
                 }
             }
         }?;
 
-        // update status on creation succeeded
-        match id {
-            Some(node_id) => {
-                self.egress_status
-                    .node_id_index
-                    .insert(node_id.clone(), index);
-                self.egress_status.ip_limit.on_add(ip);
-            }
-            None => {
-                self.ingress_status.ip_limit.on_add(ip);
-            }
+        // update on creation succeeded
+        if let Some(node_id) = id {
+            self.node_id_index.insert(node_id.clone(), index);
         }
+
+        self.ip_limit.on_add(ip);
 
         Ok(index)
     }
 
     pub fn remove(&mut self, session: &Session) {
         if self.sessions.remove(session.token()).is_some() {
-            if session.metadata.originated {
-                self.egress_status
-                    .ip_limit
-                    .on_delete(session.address().ip());
-                self.egress_status.node_id_index.remove(
-                    session.id().expect("egress session should have node id"),
-                );
-            } else {
-                self.ingress_status
-                    .ip_limit
-                    .on_delete(session.address().ip());
-                if let Some(id) = session.id() {
-                    self.ingress_status.node_id_index.remove(id);
-                }
+            if let Some(node_id) = session.id() {
+                self.node_id_index.remove(node_id);
             }
+
+            self.ip_limit.on_delete(session.address().ip());
         }
     }
 
     pub fn update_ingress_node_id(
         &mut self, idx: usize, node_id: &NodeId,
     ) -> Result<(), String> {
-        // ensure the ingress node id is unique
-        if let Some(cur_idx) = self.ingress_status.node_id_index.get(node_id) {
-            return Err(format!("ingress session already exists, node_id = {:?}, cur_idx = {}, new_idx = {}", node_id.clone(), *cur_idx, idx));
+        // ensure the node id is unique
+        if let Some(cur_idx) = self.node_id_index.get(node_id) {
+            return Err(format!("session already exists, node_id = {:?}, cur_idx = {}, new_idx = {}", node_id.clone(), *cur_idx, idx));
         }
 
         if !self.sessions.contains(idx) {
@@ -181,9 +139,7 @@ impl SessionManager {
             ));
         }
 
-        self.ingress_status
-            .node_id_index
-            .insert(node_id.clone(), idx);
+        self.node_id_index.insert(node_id.clone(), idx);
 
         Ok(())
     }


### PR DESCRIPTION
1) Move session related operations into SessionManager.
2) When create ingress/egress session, validate node IP address.
3) Different sessions must use different node IDs.
4) Improve the query operation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/85)
<!-- Reviewable:end -->
