### PR TITLE
support to propagate fake data periodically for test

### DIFF
--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -80,6 +80,9 @@ build_config! {
         (monitor_username, (Option<String>), None)
         (monitor_password, (Option<String>), None)
         (monitor_node, (Option<String>), None)
+        (data_propagate_enabled, (bool), false)
+        (data_propagate_interval_ms, (u64), 1000)
+        (data_propagate_size, (usize), 1000)
     }
     {
         (

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -36,6 +36,7 @@ use cfx_types::Address;
 use ctrlc::CtrlC;
 use db::SystemDB;
 use monitor::Monitor;
+use network::NetworkService;
 use parking_lot::{Condvar, Mutex};
 use primitives::Block;
 use secret_store::SecretStore;
@@ -50,7 +51,7 @@ use std::{
     time::{Duration, Instant},
 };
 use threadpool::ThreadPool;
-use txgen::TransactionGenerator;
+use txgen::{propagate::DataPropagation, TransactionGenerator};
 
 /// Used in Genesis author to indicate testnet version
 /// Increase by one for every test net reset
@@ -191,14 +192,24 @@ impl Client {
             pow_config.clone(),
         ));
 
-        let sync_config = cfxcore::SynchronizationConfiguration {
-            network: network_config,
-            consensus: consensus.clone(),
-        };
+        let mut network = NetworkService::new(network_config);
+        network
+            .start()
+            .map_err(|e| format!("failed to start network service: {:?}", e))?;
+
+        if conf.raw_conf.test_mode && conf.raw_conf.data_propagate_enabled {
+            DataPropagation::register(
+                conf.raw_conf.data_propagate_interval_ms,
+                conf.raw_conf.data_propagate_size,
+                &network,
+            )?;
+        }
+
         let verification_config = conf.verification_config();
         let protocol_config = conf.protocol_config();
-        let mut sync = cfxcore::SynchronizationService::new(
-            sync_config,
+        let sync = cfxcore::SynchronizationService::new(
+            network,
+            consensus.clone(),
             protocol_config,
             verification_config,
             pow_config.clone(),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -64,8 +64,7 @@ pub use crate::{
     consensus::{ConsensusGraph, SharedConsensusGraph},
     sync::{
         BestInformation, SharedSynchronizationGraph,
-        SharedSynchronizationService, SynchronizationConfiguration,
-        SynchronizationService,
+        SharedSynchronizationService, SynchronizationService,
     },
     transaction_pool::{SharedTransactionPool, TransactionPool},
 };

--- a/core/src/sync/mod.rs
+++ b/core/src/sync/mod.rs
@@ -20,8 +20,7 @@ pub use self::{
         SYNCHRONIZATION_PROTOCOL_VERSION,
     },
     synchronization_service::{
-        SharedSynchronizationService, SynchronizationConfiguration,
-        SynchronizationService,
+        SharedSynchronizationService, SynchronizationService,
     },
     synchronization_state::{SynchronizationPeerState, SynchronizationState},
 };

--- a/core/src/sync/synchronization_service.rs
+++ b/core/src/sync/synchronization_service.rs
@@ -15,16 +15,10 @@ use cfx_types::H256;
 use keylib::KeyPair;
 use network::{
     node_table::{NodeEntry, NodeId},
-    Error as NetworkError, NetworkConfiguration, NetworkService, PeerInfo,
-    ProtocolId,
+    Error as NetworkError, NetworkService, PeerInfo, ProtocolId,
 };
 use primitives::Block;
 use std::sync::Arc;
-
-pub struct SynchronizationConfiguration {
-    pub network: NetworkConfiguration,
-    pub consensus: SharedConsensusGraph,
-}
 
 pub struct SynchronizationService {
     network: NetworkService,
@@ -34,7 +28,7 @@ pub struct SynchronizationService {
 
 impl SynchronizationService {
     pub fn new(
-        config: SynchronizationConfiguration,
+        network: NetworkService, consensus_graph: SharedConsensusGraph,
         protocol_config: ProtocolConfiguration,
         verification_config: VerificationConfig, pow_config: ProofOfWorkConfig,
         fast_recover: bool,
@@ -42,14 +36,14 @@ impl SynchronizationService {
     {
         let sync_handler = Arc::new(SynchronizationProtocolHandler::new(
             protocol_config,
-            config.consensus,
+            consensus_graph,
             verification_config,
             pow_config,
             fast_recover,
         ));
 
         SynchronizationService {
-            network: NetworkService::new(config.network),
+            network,
             protocol_handler: sync_handler,
             protocol: *b"cfx",
         }
@@ -63,8 +57,7 @@ impl SynchronizationService {
         self.protocol_handler.get_synchronization_graph()
     }
 
-    pub fn start(&mut self) -> Result<(), Error> {
-        self.network.start()?;
+    pub fn start(&self) -> Result<(), Error> {
         self.network.register_protocol(
             self.protocol_handler.clone(),
             self.protocol,

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -207,7 +207,10 @@ pub trait NetworkProtocolHandler: Sync + Send {
 
     fn on_timeout(&self, io: &NetworkContext, timer: TimerToken);
 
-    fn on_work_dispatch(&self, io: &NetworkContext, work_type: HandlerWorkType);
+    fn on_work_dispatch(
+        &self, _io: &NetworkContext, _work_type: HandlerWorkType,
+    ) {
+    }
 }
 
 pub trait NetworkContext {

--- a/transactiongen/Cargo.toml
+++ b/transactiongen/Cargo.toml
@@ -23,3 +23,5 @@ log = "0.4"
 db = { path = "../db" }
 kvdb-rocksdb = "0.1.3"
 toml = "0.4"
+io = { path = "../util/io" }
+priority-send-queue = { path = "../util/priority-send-queue" }

--- a/transactiongen/src/lib.rs
+++ b/transactiongen/src/lib.rs
@@ -29,6 +29,8 @@ use rand::prelude::*;
 use secret_store::{SecretStore, SharedSecretStore};
 use std::{collections::HashMap, sync::Arc, thread, time};
 
+pub mod propagate;
+
 #[allow(unused)]
 enum TransGenState {
     Start,

--- a/transactiongen/src/propagate.rs
+++ b/transactiongen/src/propagate.rs
@@ -1,0 +1,109 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use io::TimerToken;
+use network::{
+    NetworkContext, NetworkProtocolHandler, NetworkService, PeerId, ProtocolId,
+};
+use parking_lot::RwLock;
+use priority_send_queue::SendQueuePriority;
+use std::{collections::HashSet, sync::Arc, time::Duration};
+
+const PROTOCOL_ID_DATA_PROPAGATION: ProtocolId = *b"dpp";
+const PROTOCOL_VERSION_DATA_PROPAGATION: u8 = 1;
+
+pub struct DataPropagation {
+    interval: Duration,
+    size: usize,
+    peers: RwLock<HashSet<PeerId>>,
+}
+
+impl DataPropagation {
+    pub fn register(
+        interval_ms: u64, size: usize, network: &NetworkService,
+    ) -> Result<(), String> {
+        if interval_ms == 0 || size == 0 {
+            return Ok(());
+        }
+
+        let dp = DataPropagation {
+            interval: Duration::from_millis(interval_ms),
+            size,
+            peers: RwLock::new(HashSet::new()),
+        };
+
+        network
+            .register_protocol(
+                Arc::new(dp),
+                PROTOCOL_ID_DATA_PROPAGATION,
+                &[PROTOCOL_VERSION_DATA_PROPAGATION],
+            )
+            .map_err(|e| {
+                format!("failed to register protocol DataPropagation: {:?}", e)
+            })
+    }
+}
+
+impl NetworkProtocolHandler for DataPropagation {
+    fn initialize(&self, io: &NetworkContext) {
+        info!("DataPropagation.initialize: register timers");
+
+        if let Err(e) = io.register_timer(0, self.interval) {
+            error!(
+                "DataPropagation.initialize: failed to register timer, {:?}",
+                e
+            );
+        }
+    }
+
+    fn on_message(&self, _io: &NetworkContext, peer: PeerId, data: &[u8]) {
+        if data.len() != self.size {
+            error!("DataPropagation.on_message: received invalid data, len = {}, expected = {}", data.len(), self.size);
+        }
+
+        trace!(
+            "DataPropagation.on_message: received data from peer {}",
+            peer
+        );
+    }
+
+    fn on_peer_connected(&self, _io: &NetworkContext, peer: PeerId) {
+        debug!(
+            "DataPropagation.on_peer_connected: new peer {} connected",
+            peer
+        );
+        self.peers.write().insert(peer);
+    }
+
+    fn on_peer_disconnected(&self, _io: &NetworkContext, peer: PeerId) {
+        debug!(
+            "DataPropagation.on_peer_disconnected: peer {} disconnected",
+            peer
+        );
+        self.peers.write().remove(&peer);
+    }
+
+    fn on_timeout(&self, io: &NetworkContext, timer: TimerToken) {
+        assert_eq!(timer, 0);
+
+        for p in self.peers.read().iter() {
+            if let Err(e) = io.send(
+                p.clone(),
+                vec![0; self.size],
+                SendQueuePriority::Normal,
+            ) {
+                warn!(
+                    "failed to propagate data to peer {}: {:?}",
+                    p.clone(),
+                    e
+                );
+            }
+
+            trace!(
+                "DataPropagation.on_timeout: sent data to peer {}",
+                p.clone()
+            );
+        }
+    }
+}


### PR DESCRIPTION
1. Create network service out of Synchronization service.
2. Propagate fake data periodically if configured in test mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/91)
<!-- Reviewable:end -->
