### PR TITLE
Add benchmark for recover public and verify.

### DIFF
--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -18,3 +18,10 @@ lru = "0.1"
 byteorder = "1.2.7"
 rand = "0.5"
 siphasher = "0.3"
+
+[dev-dependencies]
+criterion = "0.2"
+
+[[bench]]
+name = "benchmark"
+harness = false

--- a/primitives/benches/benchmark.rs
+++ b/primitives/benches/benchmark.rs
@@ -1,0 +1,43 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use criterion::Criterion;
+use keylib::{KeyPair, sign, recover, verify_public};
+use criterion::{criterion_group, criterion_main};
+use keccak_hash::keccak;
+
+fn recover_benchmark(c: &mut Criterion) {
+    let secret =
+        "46b9e861b63d3509c88b7817275a30d22d62c8cd8fa6486ddee35ef0d8e0495f"
+            .parse()
+            .unwrap();
+    let msg = keccak("0".as_bytes());
+    let kp = KeyPair::from_secret(secret).unwrap();
+    let sig = sign(kp.secret(), &msg).unwrap();
+    c.bench_function("Recover public for 100 times", move |b| {
+        b.iter(|| {
+            recover(&sig, &msg).unwrap();
+        });
+    });
+}
+
+
+fn verify_benchmark(c: &mut Criterion) {
+    let secret =
+        "46b9e861b63d3509c88b7817275a30d22d62c8cd8fa6486ddee35ef0d8e0495f"
+            .parse()
+            .unwrap();
+    let msg = keccak("0".as_bytes());
+    let kp = KeyPair::from_secret(secret).unwrap();
+    let pub_key = kp.public().clone();
+    let sig = sign(kp.secret(), &msg).unwrap();
+    c.bench_function("Verify public for 100 times", move |b| {
+        b.iter(|| {
+            verify_public(&pub_key, &sig, &msg).unwrap();
+        });
+    });
+}
+
+criterion_group!(benches, recover_benchmark, verify_benchmark);
+criterion_main!(benches);

--- a/primitives/benches/benchmark.rs
+++ b/primitives/benches/benchmark.rs
@@ -15,7 +15,7 @@ fn recover_benchmark(c: &mut Criterion) {
     let msg = keccak("0".as_bytes());
     let kp = KeyPair::from_secret(secret).unwrap();
     let sig = sign(kp.secret(), &msg).unwrap();
-    c.bench_function("Recover public for 100 times", move |b| {
+    c.bench_function("Recover public", move |b| {
         b.iter(|| {
             recover(&sig, &msg).unwrap();
         });
@@ -32,7 +32,7 @@ fn verify_benchmark(c: &mut Criterion) {
     let kp = KeyPair::from_secret(secret).unwrap();
     let pub_key = kp.public().clone();
     let sig = sign(kp.secret(), &msg).unwrap();
-    c.bench_function("Verify public for 100 times", move |b| {
+    c.bench_function("Verify public", move |b| {
         b.iter(|| {
             verify_public(&pub_key, &sig, &msg).unwrap();
         });


### PR DESCRIPTION
Recovering public time is reduced from 144 us to 77us with new compilation parameters in secp256k1. 
And verify with given public key costs 66 us.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/103)
<!-- Reviewable:end -->
