### PR TITLE
Allow sending empty blocks.

### DIFF
--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -920,11 +920,6 @@ impl SynchronizationProtocolHandler {
             });
 
             loop {
-                if msg.blocks.is_empty() {
-                    info!("No block is sent for GetBlocks request!");
-                    break;
-                }
-
                 if let Err(e) = self.send_message(
                     io,
                     peer,
@@ -965,11 +960,6 @@ impl SynchronizationProtocolHandler {
             });
 
             loop {
-                if msg.blocks.is_empty() {
-                    info!("No block is sent for GetBlocks request!");
-                    break;
-                }
-
                 if let Err(e) = self.send_message(
                     io,
                     peer,

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -920,6 +920,9 @@ impl SynchronizationProtocolHandler {
             });
 
             loop {
+                // The number of blocks will keep decreasing for each iteration in the loop.
+                // when `msg.blocks.len() == 0`, we should not get `OversizedPacket` error, and
+                // we will break out of the loop then.
                 if let Err(e) = self.send_message(
                     io,
                     peer,
@@ -960,6 +963,9 @@ impl SynchronizationProtocolHandler {
             });
 
             loop {
+                // The number of blocks will keep decreasing for each iteration in the loop.
+                // when `msg.blocks.len() == 0`, we should not get `OversizedPacket` error, and
+                // we will break out of the loop then.
                 if let Err(e) = self.send_message(
                     io,
                     peer,


### PR DESCRIPTION
Fix possible failure in getting blocks in our test.
If node A does not respond when node B is requesting the blocks that node A does not have (`msg.blocks.len() == 0` at this time), node B will have to wait until timeout to request the block again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/122)
<!-- Reviewable:end -->
