### PR TITLE
Fix panic to handle rpc.

### DIFF
--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -724,7 +724,9 @@ impl ConsensusGraphInner {
     }
 
     pub fn epoch_hash(&self, epoch_number: usize) -> Option<H256> {
-        self.arena.get(self.pivot_chain[epoch_number]).map(|node| node.hash )
+        self.pivot_chain
+            .get(epoch_number)
+            .map(|idx| self.arena[*idx].hash)
     }
 
     pub fn get_epoch_hash_for_block(&self, hash: &H256) -> Option<H256> {

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -723,15 +723,15 @@ impl ConsensusGraphInner {
             })
     }
 
-    pub fn epoch_hash(&self, epoch_number: usize) -> H256 {
-        self.arena[self.pivot_chain[epoch_number]].hash
+    pub fn epoch_hash(&self, epoch_number: usize) -> Option<H256> {
+        self.arena.get(self.pivot_chain[epoch_number]).map(|node| node.hash )
     }
 
     pub fn get_epoch_hash_for_block(&self, hash: &H256) -> Option<H256> {
         self.indices.get(hash).and_then(|block_index| {
             let epoch_number =
                 self.arena[*block_index].data.epoch_number.borrow().clone();
-            Some(self.epoch_hash(epoch_number))
+            self.epoch_hash(epoch_number)
         })
     }
 
@@ -1895,10 +1895,6 @@ impl ConsensusGraph {
 
     pub fn best_state_epoch_number(&self) -> usize {
         self.inner.read().best_state_epoch_number()
-    }
-
-    pub fn epoch_hash(&self, epoch_number: usize) -> H256 {
-        self.inner.read().epoch_hash(epoch_number)
     }
 
     pub fn get_hash_from_epoch_number(

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -920,8 +920,9 @@ impl SynchronizationProtocolHandler {
             });
 
             loop {
-                // The number of blocks will keep decreasing for each iteration in the loop.
-                // when `msg.blocks.len() == 0`, we should not get `OversizedPacket` error, and
+                // The number of blocks will keep decreasing for each iteration
+                // in the loop. when `msg.blocks.len() == 0`, we
+                // should not get `OversizedPacket` error, and
                 // we will break out of the loop then.
                 if let Err(e) = self.send_message(
                     io,
@@ -963,8 +964,9 @@ impl SynchronizationProtocolHandler {
             });
 
             loop {
-                // The number of blocks will keep decreasing for each iteration in the loop.
-                // when `msg.blocks.len() == 0`, we should not get `OversizedPacket` error, and
+                // The number of blocks will keep decreasing for each iteration
+                // in the loop. when `msg.blocks.len() == 0`, we
+                // should not get `OversizedPacket` error, and
                 // we will break out of the loop then.
                 if let Err(e) = self.send_message(
                     io,


### PR DESCRIPTION
It may panic to handle rpcs like `get_transaction_receipt()` when `block_hash` passed to `get_epoch_hash_for_block(block_hash)` has `epoch_numer == NULL`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/129)
<!-- Reviewable:end -->
