### PR TITLE
Fix a free of null value bug in the storage.

### DIFF
--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/trie_node.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/trie_node.rs
@@ -83,11 +83,13 @@ const EMPTY_KEY_PART: KeyPart = &[];
 impl<CacheAlgoDataT: CacheAlgoDataTrait> Drop for TrieNode<CacheAlgoDataT> {
     fn drop(&mut self) {
         unsafe {
-            let size = self.value_size as usize;
-            if size > MaybeInPlaceByteArray::MAX_INPLACE_SIZE {
-                self.value.ptr_into_vec(size);
+            // Check whether the value of this node is already deleted
+            if self.value_size != Self::VALUE_TOMBSTONE {
+                let size = self.value_size as usize;
+                if size > MaybeInPlaceByteArray::MAX_INPLACE_SIZE {
+                    self.value.ptr_into_vec(size);
+                }
             }
-
             self.clear_path();
         }
     }


### PR DESCRIPTION
When dropping a TrieNode, the value could be null.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/153)
<!-- Reviewable:end -->
