### PR TITLE
Epoch-by-epoch syncing

### DIFF
--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -1345,6 +1345,12 @@ impl ConsensusGraph {
         self.inner.read().get_block_epoch_number(hash)
     }
 
+    pub fn get_block_hashes_by_epoch(
+        &self, epoch_number: EpochNumber,
+    ) -> Result<Vec<H256>, String> {
+        self.inner.read().block_hashes_by_epoch(epoch_number)
+    }
+
     pub fn gas_price(&self) -> Option<U256> {
         let inner = self.inner.read();
         let mut last_epoch_number = inner.best_epoch_number();

--- a/core/src/sync/request_manager/request_handler.rs
+++ b/core/src/sync/request_manager/request_handler.rs
@@ -3,8 +3,8 @@ use crate::sync::{
     synchronization_protocol_handler::ProtocolConfiguration, Error, ErrorKind,
 };
 use message::{
-    GetBlockHeaders, GetBlockTxn, GetBlocks, GetCompactBlocks, GetTransactions,
-    Message,
+    GetBlockHashesByEpoch, GetBlockHeaders, GetBlockTxn, GetBlocks,
+    GetCompactBlocks, GetTransactions, Message,
 };
 use network::{NetworkContext, PeerId};
 use parking_lot::Mutex;
@@ -321,6 +321,7 @@ pub enum RequestMessage {
     Compact(GetCompactBlocks),
     BlockTxn(GetBlockTxn),
     Transactions(GetTransactions),
+    Epochs(GetBlockHashesByEpoch),
 }
 
 impl RequestMessage {
@@ -341,6 +342,9 @@ impl RequestMessage {
             RequestMessage::Transactions(ref mut msg) => {
                 msg.set_request_id(request_id)
             }
+            RequestMessage::Epochs(ref mut msg) => {
+                msg.set_request_id(request_id)
+            }
         }
     }
 
@@ -351,6 +355,7 @@ impl RequestMessage {
             RequestMessage::Compact(ref msg) => msg,
             RequestMessage::BlockTxn(ref msg) => msg,
             RequestMessage::Transactions(ref msg) => msg,
+            RequestMessage::Epochs(ref msg) => msg,
         }
     }
 }
@@ -382,6 +387,7 @@ impl TimedSyncRequests {
     {
         let timeout = match *msg {
             RequestMessage::Headers(_) => conf.headers_request_timeout,
+            RequestMessage::Epochs(_) => conf.headers_request_timeout,
             RequestMessage::Blocks(_)
             | RequestMessage::Compact(_)
             | RequestMessage::BlockTxn(_) => conf.blocks_request_timeout,

--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -19,7 +19,7 @@ use crate::{
 use cfx_types::{H256, U256, U512};
 use heapsize::HeapSizeOf;
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
-use primitives::{block::CompactBlock, Block, BlockHeader};
+use primitives::{block::CompactBlock, Block, BlockHeader, EpochNumber};
 use rlp::Rlp;
 use slab::Slab;
 use std::{
@@ -1143,6 +1143,13 @@ impl SynchronizationGraph {
             deferred_receipts_root,
         };
         GuardedValue::new(consensus_inner, value)
+    }
+
+    pub fn get_block_hashes_by_epoch(
+        &self, epoch_number: u64,
+    ) -> Result<Vec<H256>, String> {
+        self.consensus
+            .get_block_hashes_by_epoch(EpochNumber::Number(epoch_number.into()))
     }
 
     pub fn verified_invalid(&self, hash: &H256) -> bool {

--- a/core/src/sync/synchronization_state.rs
+++ b/core/src/sync/synchronization_state.rs
@@ -19,6 +19,7 @@ pub struct SynchronizationPeerState {
     pub protocol_version: u8,
     pub genesis_hash: H256,
     pub best_epoch: u64,
+    pub terminal_block_hashes: Vec<H256>,
 
     /// The following fields are used to control how to handle
     /// transaction propagation for nodes in catch-up mode.
@@ -82,6 +83,20 @@ impl SynchronizationState {
         let peer_set: HashSet<PeerId> =
             self.peers.read().keys().cloned().collect();
         let choose_from: Vec<&PeerId> = peer_set.difference(exclude).collect();
+        let mut rand = random::new();
+        rand.choose(&choose_from).cloned().cloned()
+    }
+
+    /// Choose one random peer that satisfies `predicate`.
+    /// Return None if there is no peer to choose from
+    pub fn get_random_peer_satisfying<F>(
+        &self, predicate: F,
+    ) -> Option<PeerId>
+    where F: Fn(&&PeerId) -> bool {
+        let peer_set: HashSet<PeerId> =
+            self.peers.read().keys().cloned().collect();
+        let choose_from: Vec<&PeerId> =
+            peer_set.iter().filter(predicate).collect();
         let mut rand = random::new();
         rand.choose(&choose_from).cloned().cloned()
     }

--- a/message/src/getblockhashesbyepoch.rs
+++ b/message/src/getblockhashesbyepoch.rs
@@ -3,44 +3,47 @@
 // See http://www.gnu.org/licenses/
 
 use crate::{Message, MsgId, RequestId};
-use cfx_types::H256;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Debug, PartialEq)]
-pub struct GetBlockHashesResponse {
+pub struct GetBlockHashesByEpoch {
     pub request_id: RequestId,
-    pub hashes: Vec<H256>,
+    pub epoch_number: u64,
 }
 
-impl Message for GetBlockHashesResponse {
-    fn msg_id(&self) -> MsgId { MsgId::GET_BLOCK_HASHES_RESPONSE }
+impl Message for GetBlockHashesByEpoch {
+    fn msg_id(&self) -> MsgId { MsgId::GET_BLOCK_HASHES_BY_EPOCH }
 }
 
-impl Deref for GetBlockHashesResponse {
+impl Deref for GetBlockHashesByEpoch {
     type Target = RequestId;
 
     fn deref(&self) -> &Self::Target { &self.request_id }
 }
 
-impl DerefMut for GetBlockHashesResponse {
+impl DerefMut for GetBlockHashesByEpoch {
     fn deref_mut(&mut self) -> &mut RequestId { &mut self.request_id }
 }
 
-impl Encodable for GetBlockHashesResponse {
+impl Encodable for GetBlockHashesByEpoch {
     fn rlp_append(&self, stream: &mut RlpStream) {
         stream
             .begin_list(2)
             .append(&self.request_id)
-            .append_list(&self.hashes);
+            .append(&self.epoch_number);
     }
 }
 
-impl Decodable for GetBlockHashesResponse {
-    fn decode(rlp: &Rlp) -> Result<GetBlockHashesResponse, DecoderError> {
-        Ok(GetBlockHashesResponse {
+impl Decodable for GetBlockHashesByEpoch {
+    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+        if rlp.item_count()? != 2 {
+            return Err(DecoderError::RlpIncorrectListLen);
+        }
+
+        Ok(GetBlockHashesByEpoch {
             request_id: rlp.val_at(0)?,
-            hashes: rlp.list_at(1)?,
+            epoch_number: rlp.val_at(1)?,
         })
     }
 }

--- a/message/src/lib.rs
+++ b/message/src/lib.rs
@@ -8,12 +8,14 @@ extern crate primitives;
 extern crate rlp;
 
 mod blockbodies;
+mod blockhashes;
 mod blockheaders;
 mod blocks;
 mod blocktxn;
 mod cmpctblocks;
 mod getblockbodies;
 mod getblockhashes;
+mod getblockhashesbyepoch;
 mod getblockheaders;
 mod getblocks;
 mod getblocktxn;
@@ -28,12 +30,14 @@ mod transactions;
 
 pub use crate::{
     blockbodies::GetBlockBodiesResponse,
+    blockhashes::GetBlockHashesResponse,
     blockheaders::GetBlockHeadersResponse,
     blocks::{GetBlocksResponse, GetBlocksWithPublicResponse},
     blocktxn::GetBlockTxnResponse,
     cmpctblocks::GetCompactBlocksResponse,
     getblockbodies::GetBlockBodies,
     getblockhashes::GetBlockHashes,
+    getblockhashesbyepoch::GetBlockHashesByEpoch,
     getblockheaders::GetBlockHeaders,
     getblocks::GetBlocks,
     getblocktxn::GetBlockTxn,

--- a/message/src/message.rs
+++ b/message/src/message.rs
@@ -42,6 +42,7 @@ build_msgid! {
     TRANSACTION_DIGESTS = 0x14
     GET_TRANSACTIONS = 0x15
     GET_TRANSACTIONS_RESPONSE = 0x16
+    GET_BLOCK_HASHES_BY_EPOCH = 0x17
 }
 
 impl From<u8> for MsgId {

--- a/test/conflux/messages.py
+++ b/test/conflux/messages.py
@@ -55,6 +55,8 @@ GET_CMPCT_BLOCKS_RESPONSE = 0x10
 GET_BLOCK_TXN = 0x11
 GET_BLOCK_TXN_RESPONSE = 0x12
 
+GET_BLOCK_HASHES_BY_EPOCH = 0x17
+
 class Capability(rlp.Serializable):
     fields = [
         ("protocol", binary),
@@ -147,6 +149,19 @@ class GetBlockHashes(rlp.Serializable):
             reqid=reqid,
             hash=hash,
             max_blocks=max_blocks,
+        )
+
+
+class GetBlockHashesByEpoch(rlp.Serializable):
+    fields = [
+        ("reqid", big_endian_int),
+        ("epoch_number", big_endian_int),
+    ]
+
+    def __init__(self, epoch_number, reqid=0):
+        super().__init__(
+            reqid=reqid,
+            epoch_number=epoch_number
         )
 
 
@@ -403,6 +418,7 @@ msg_id_dict = {
     GetCompactBlocksResponse: GET_CMPCT_BLOCKS_RESPONSE,
     GetBlockTxn: GET_BLOCK_TXN,
     GetBlockTxnResponse: GET_BLOCK_TXN_RESPONSE,
+    GetBlockHashesByEpoch: GET_BLOCK_HASHES_BY_EPOCH,
 }
 
 msg_class_dict = {}

--- a/test/test_framework/mininode.py
+++ b/test/test_framework/mininode.py
@@ -350,6 +350,9 @@ class P2PInterface(P2PConnection):
                 elif packet_type == GET_BLOCK_TXN:
                     self._log_message("receive", "GET_BLOCK_TXN, hash={}".format(len(msg.block_hash)))
                     self.on_get_blocktxn(msg)
+                elif packet_type == GET_BLOCK_HASHES_BY_EPOCH:
+                    self._log_message("receive", "GET_BLOCK_HASHES_BY_EPOCH, epoch number: {}".format(msg.epoch_number))
+                    self.on_get_block_hashes_by_epoch(msg)
                 else:
                     self._log_message("receive", "Unknown packet {}".format(packet_type))
                     return
@@ -416,6 +419,11 @@ class P2PInterface(P2PConnection):
     def on_get_blocktxn(self, msg):
         resp = GetBlockTxnResponse(reqid=msg.reqid, block_hash=b'\x00'*32, block_txn=[])
         self.send_protocol_msg(resp)
+
+    def on_get_block_hashes_by_epoch(self, msg):
+        resp = BlockHashes(reqid=msg.reqid, hashes=[])
+        self.send_protocol_msg(resp)
+
 # Keep our own socket map for asyncore, so that we can track disconnects
 # ourselves (to work around an issue with closing an asyncore socket when
 # using select)


### PR DESCRIPTION
**Updated sync logic overview:**
- During *catch-up mode*, sync epoch-by-epoch (from genesis towards terminals/tips).
- Otherwise, sync recursively starting from terminals/tips of peers.

**The process of syncing an epoch:**
1. `A` sends a `GetBlockHashesByEpoch(epoch_number)` message to `B`.
2. `B` replies with a `GetBlockHashesResponse(hashes[])` message, sending a list of block hashes that belong to the requested epoch.
3. `A` requests the corresponding blocks from `B`. `A` also requests all unsynced dependent blocks recursively.
4. `A` requests subsequent epochs. (In reality, we request `MAX_EPOCHS_TO_REQUEST` epochs in parallel from randomly chosen peers.)

**Note:** This is a breaking change in the sync protocol. Old nodes can still sync from updated nodes. However, updated nodes cannot sync from old nodes, as they cannot serve the new epoch-sync messages.

**Benchmarks:** Tested using the `test/sync_test.py` script with ~10k blocks and 2 nodes. Performance is about the same as before. Performance is likely to be superior if

1. there are more nodes (as we request multiple epochs in parallel from random nodes) and
2. epochs are large (i.e. we have a *"broad"* DAG instead of just a chain).

**Known issues (to be investigated):**
- `GetBlockHashesByEpoch` requests with no reply might make the system hang in some cases. (This was observed while running `test/sync_test.py` when the test framework did not know how to handle the new message types.) This needs to be investigated to prevent attack scenarios.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/171)
<!-- Reviewable:end -->
