### PR TITLE
add optional operation when disconnect a peer

### DIFF
--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -21,7 +21,7 @@ use message::{
 };
 use network::{
     throttling::THROTTLING_SERVICE, Error as NetworkError, HandlerWorkType,
-    NetworkContext, NetworkProtocolHandler, PeerId,
+    NetworkContext, NetworkProtocolHandler, PeerId, UpdateNodeOperation,
 };
 use parking_lot::Mutex;
 use rand::Rng;
@@ -514,7 +514,7 @@ impl SynchronizationProtocolHandler {
             }
         };
         if should_disconnect {
-            io.disconnect_peer(peer);
+            io.disconnect_peer(peer, None);
             return Err(ErrorKind::TooManyTrans.into());
         }
         self.request_manager.request_transactions(
@@ -726,7 +726,7 @@ impl SynchronizationProtocolHandler {
         };
 
         if should_disconnect {
-            io.disconnect_peer(peer);
+            io.disconnect_peer(peer, None);
             return Err(ErrorKind::TooManyTrans.into());
         }
 
@@ -2151,7 +2151,7 @@ impl NetworkProtocolHandler for SynchronizationProtocolHandler {
         info!("Peer connected: peer={:?}", peer);
         if let Err(e) = self.send_status(io, peer) {
             debug!("Error sending status message: {:?}", e);
-            io.disconnect_peer(peer);
+            io.disconnect_peer(peer, Some(UpdateNodeOperation::Failure));
         } else {
             self.syn
                 .handshaking_peers

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -213,6 +213,11 @@ pub trait NetworkProtocolHandler: Sync + Send {
     }
 }
 
+pub enum UpdateNodeOperation {
+    Failure,
+    Demotion,
+}
+
 pub trait NetworkContext {
     fn get_peer_node_id(&self, peer: PeerId) -> NodeId;
 
@@ -220,7 +225,7 @@ pub trait NetworkContext {
         &self, peer: PeerId, msg: Vec<u8>, priority: SendQueuePriority,
     ) -> Result<(), Error>;
 
-    fn disconnect_peer(&self, peer: PeerId);
+    fn disconnect_peer(&self, peer: PeerId, op: Option<UpdateNodeOperation>);
 
     /// Register a new IO timer. 'IoHandler::timeout' will be called with the
     /// token.


### PR DESCRIPTION
enable to demote a trusted node to unstrusted one for critical error, e.g. bad protocol, rlp decode error, invalid data

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/218)
<!-- Reviewable:end -->
