### PR TITLE
Wait for best state when needed.

### DIFF
--- a/blockgen/src/lib.rs
+++ b/blockgen/src/lib.rs
@@ -231,7 +231,7 @@ impl BlockGenerator {
             num_txs,
             block_gas_limit,
             block_size_limit,
-            self.txgen.get_best_state(),
+            self.graph.consensus.get_best_state(),
         );
 
         self.assemble_new_block_impl(
@@ -263,8 +263,9 @@ impl BlockGenerator {
                 num_txs,
                 block_gas_limit,
                 block_size_limit,
-                self.txgen
-                    .get_best_state_at(&guarded.best_state_block_hash()),
+                guarded
+                    .try_get_best_state(&self.graph.consensus.data_man)
+                    .expect("State execution ensured by get_best_info"),
             );
             let transactions = [
                 additional_transactions.as_slice(),

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -3351,8 +3351,10 @@ impl ConsensusGraph {
 
     /// Wait until the best state has been executed, and return the state
     pub fn get_best_state(&self) -> State {
-        self.wait_for_block_state(&self.best_state_block_hash());
-        self.try_get_best_state()
+        let inner = self.inner.read();
+        self.wait_for_block_state(&inner.best_state_block_hash());
+        inner
+            .try_get_best_state(&self.data_man)
             .expect("Best state has been executed")
     }
 

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -3346,8 +3346,7 @@ impl ConsensusGraph {
     }
 
     pub fn try_get_best_state(&self) -> Option<State> {
-        let inner = self.inner.read();
-        inner.try_get_best_state(&self.data_man)
+        self.inner.read().try_get_best_state(&self.data_man)
     }
 
     /// Wait until the best state has been executed, and return the state


### PR DESCRIPTION
After this change, best_state_block_hash() will only be used for insert_new_transactions().
After the new transaction pool implementation is merged, we should not allow best_state_block_hash() to be used out of ConsensusGraph to avoid problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/253)
<!-- Reviewable:end -->
