### PR TITLE
Re-introduce GetBlockHeaderChain message type for syncing

### DIFF
--- a/core/src/sync/request_manager/request_handler.rs
+++ b/core/src/sync/request_manager/request_handler.rs
@@ -3,8 +3,8 @@ use crate::sync::{
     synchronization_protocol_handler::ProtocolConfiguration, Error, ErrorKind,
 };
 use message::{
-    GetBlockHashesByEpoch, GetBlockHeaders, GetBlockTxn, GetBlocks,
-    GetCompactBlocks, GetTransactions, Message,
+    GetBlockHashesByEpoch, GetBlockHeaderChain, GetBlockHeaders, GetBlockTxn,
+    GetBlocks, GetCompactBlocks, GetTransactions, Message,
 };
 use network::{NetworkContext, PeerId};
 use parking_lot::Mutex;
@@ -336,6 +336,7 @@ pub struct SynchronizationPeerRequest {
 #[derive(Debug)]
 pub enum RequestMessage {
     Headers(GetBlockHeaders),
+    HeaderChain(GetBlockHeaderChain),
     Blocks(GetBlocks),
     Compact(GetCompactBlocks),
     BlockTxn(GetBlockTxn),
@@ -347,6 +348,9 @@ impl RequestMessage {
     pub fn set_request_id(&mut self, request_id: u64) {
         match self {
             RequestMessage::Headers(ref mut msg) => {
+                msg.set_request_id(request_id)
+            }
+            RequestMessage::HeaderChain(ref mut msg) => {
                 msg.set_request_id(request_id)
             }
             RequestMessage::Blocks(ref mut msg) => {
@@ -370,6 +374,7 @@ impl RequestMessage {
     pub fn get_msg(&self) -> &Message {
         match self {
             RequestMessage::Headers(ref msg) => msg,
+            RequestMessage::HeaderChain(ref msg) => msg,
             RequestMessage::Blocks(ref msg) => msg,
             RequestMessage::Compact(ref msg) => msg,
             RequestMessage::BlockTxn(ref msg) => msg,
@@ -406,6 +411,7 @@ impl TimedSyncRequests {
     {
         let timeout = match *msg {
             RequestMessage::Headers(_) => conf.headers_request_timeout,
+            RequestMessage::HeaderChain(_) => conf.headers_request_timeout,
             RequestMessage::Epochs(_) => conf.headers_request_timeout,
             RequestMessage::Blocks(_)
             | RequestMessage::Compact(_)

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -11,10 +11,10 @@ use crate::{consensus::SharedConsensusGraph, pow::ProofOfWorkConfig};
 use cfx_types::H256;
 use io::TimerToken;
 use message::{
-    GetBlockHashesByEpoch, GetBlockHashesResponse, GetBlockHeaders,
-    GetBlockHeadersResponse, GetBlockTxn, GetBlockTxnResponse, GetBlocks,
-    GetBlocksResponse, GetBlocksWithPublicResponse, GetCompactBlocks,
-    GetCompactBlocksResponse, GetTerminalBlockHashes,
+    GetBlockHashesByEpoch, GetBlockHashesResponse, GetBlockHeaderChain,
+    GetBlockHeaders, GetBlockHeadersResponse, GetBlockTxn, GetBlockTxnResponse,
+    GetBlocks, GetBlocksResponse, GetBlocksWithPublicResponse,
+    GetCompactBlocks, GetCompactBlocksResponse, GetTerminalBlockHashes,
     GetTerminalBlockHashesResponse, GetTransactions, GetTransactionsResponse,
     Message, MsgId, NewBlock, NewBlockHashes, Status, TransactionDigests,
     TransactionPropagationControl, Transactions,
@@ -64,6 +64,8 @@ pub const MAX_HEADERS_TO_SEND: u64 = 512;
 pub const MAX_BLOCKS_TO_SEND: u64 = 256;
 pub const MAX_EPOCHS_TO_SEND: u64 = 128;
 const MAX_PACKET_SIZE: usize = 15 * 1024 * 1024 + 512 * 1024; // 15.5 MB
+const DEFAULT_GET_HEADERS_NUM: u64 = 1;
+const DEFAULT_GET_PARENT_HEADERS_NUM: u64 = 30;
 lazy_static! {
     pub static ref REQUEST_START_WAITING_TIME: Duration =
         Duration::from_secs(1);
@@ -327,6 +329,9 @@ impl SynchronizationProtocolHandler {
             }
             MsgId::GET_BLOCK_HEADERS => {
                 self.on_get_block_headers(io, peer, &rlp)
+            }
+            MsgId::GET_BLOCK_HEADER_CHAIN => {
+                self.on_get_block_header_chain(io, peer, &rlp)
             }
             MsgId::NEW_BLOCK => self.on_new_block(io, peer, &rlp),
             MsgId::NEW_BLOCK_HASHES => self.on_new_block_hashes(io, peer, &rlp),
@@ -963,6 +968,39 @@ impl SynchronizationProtocolHandler {
         Ok(())
     }
 
+    fn on_get_block_header_chain(
+        &self, io: &NetworkContext, peer: PeerId, rlp: &Rlp,
+    ) -> Result<(), Error> {
+        let req = rlp.as_val::<GetBlockHeaderChain>()?;
+        debug!("on_get_block_header_chain, msg=:{:?}", req);
+
+        let mut hash = req.hash;
+        let mut block_headers_resp = GetBlockHeadersResponse::default();
+        block_headers_resp.set_request_id(req.request_id());
+
+        for _n in 0..cmp::min(MAX_HEADERS_TO_SEND, req.max_blocks) {
+            let header = self.graph.block_header_by_hash(&hash);
+            if header.is_none() {
+                break;
+            }
+            let header = header.unwrap();
+            block_headers_resp.headers.push(header.clone());
+            if hash == self.graph.genesis_hash() {
+                break;
+            }
+            hash = header.parent_hash().clone();
+        }
+        debug!(
+            "Returned {:?} block headers to peer {:?}",
+            block_headers_resp.headers.len(),
+            peer
+        );
+
+        let msg: Box<dyn Message> = Box::new(block_headers_resp);
+        send_message(io, peer, msg.as_ref(), SendQueuePriority::High)?;
+        Ok(())
+    }
+
     fn on_trans_prop_ctrl(&self, peer: PeerId, rlp: &Rlp) -> Result<(), Error> {
         let trans_prop_ctrl = rlp.as_val::<TransactionPropagationControl>()?;
         debug!(
@@ -1179,19 +1217,29 @@ impl SynchronizationProtocolHandler {
         let missing_headers = resp
             .hashes
             .iter()
-            .filter(|h| !self.graph.contains_block_header(&h))
-            .cloned()
-            .collect();
+            .filter(|h| !self.graph.contains_block_header(&h));
+        // .cloned()
+        // .collect();
 
         // NOTE: this is to make sure no section of the DAG is skipped
         // e.g. if the request for epoch 4 is lost or the reply is in-
         // correct, the request for epoch 5 should recursively request
         // all dependent blocks (see on_block_headers_response)
-        self.request_manager.request_block_headers(
-            io,
-            Some(peer),
-            missing_headers,
-        );
+
+        // self.request_manager.request_block_headers(
+        //     io,
+        //     Some(peer),
+        //     missing_headers,
+        // );
+
+        for h in missing_headers {
+            self.request_manager.request_block_header_chain(
+                io,
+                Some(peer),
+                h,
+                1,
+            );
+        }
 
         // TODO: handle empty response
 
@@ -1276,13 +1324,24 @@ impl SynchronizationProtocolHandler {
                     .cloned()
                     .collect::<Vec<H256>>();
 
-                debug!("Requesting terminals {:?}", to_request);
+                if terminals.len() > 0 {
+                    debug!("Requesting terminals {:?}", to_request);
+                }
 
-                self.request_manager.request_block_headers(
-                    io,
-                    Some(peer),
-                    to_request.clone(),
-                );
+                // self.request_manager.request_block_headers(
+                //     io,
+                //     Some(peer),
+                //     to_request.clone(),
+                // );
+
+                for hash in to_request.clone() {
+                    self.request_manager.request_block_header_chain(
+                        io,
+                        Some(peer),
+                        &hash,
+                        1,
+                    )
+                }
 
                 requested.extend(to_request);
             }
@@ -1367,22 +1426,13 @@ impl SynchronizationProtocolHandler {
     fn on_block_headers_response(
         &self, io: &NetworkContext, peer: PeerId, rlp: &Rlp,
     ) -> Result<(), Error> {
-        let mut block_headers = rlp.as_val::<GetBlockHeadersResponse>()?;
+        let block_headers = rlp.as_val::<GetBlockHeadersResponse>()?;
         debug!("on_block_headers_response, msg=:{:?}", block_headers);
 
         let id = block_headers.request_id();
         let req = self.request_manager.match_request(io, peer, id)?;
 
-        let req_hashes = match &req {
-            RequestMessage::Headers(header_req) => &header_req.hashes,
-            _ => {
-                warn!("Get response not matching the request! req={:?}, resp={:?}", req, block_headers);
-                // Although the response matches the request id,
-                // it does not match the content, so resend the request again.
-                self.request_manager.remove_mismatch_request(io, &req);
-                return Err(ErrorKind::UnexpectedResponse.into());
-            }
-        };
+        self.validate_block_headers_response(io, &req, &block_headers)?;
 
         // process request
         let mut hashes = HashSet::new();
@@ -1413,10 +1463,11 @@ impl SynchronizationProtocolHandler {
             .unwrap()
             .as_secs();
 
-        for header in &mut block_headers.headers {
+        for header in &block_headers.headers {
             let hash = header.hash();
             returned_headers.insert(hash);
 
+            // check timestamp drift
             if self.graph.verification_config.verify_timestamp {
                 if header.timestamp() > now_timestamp {
                     self.future_blocks.insert(header.clone());
@@ -1424,8 +1475,12 @@ impl SynchronizationProtocolHandler {
                 }
             }
 
-            let (valid, to_relay, is_old) =
-                self.graph.insert_block_header(header, true, false);
+            // insert into sync graph
+            let (valid, to_relay, is_old) = self.graph.insert_block_header(
+                &mut header.clone(),
+                true,
+                false,
+            );
             if !valid {
                 continue;
             }
@@ -1476,9 +1531,15 @@ impl SynchronizationProtocolHandler {
         );
 
         // re-request headers requested but not received
+        let requested = match &req {
+            RequestMessage::Headers(h) => h.hashes.clone(),
+            RequestMessage::HeaderChain(h) => vec![h.hash],
+            _ => return Err(ErrorKind::UnexpectedResponse.into()),
+        };
+
         self.request_manager.headers_received(
             io,
-            req_hashes.into_iter().cloned().collect(),
+            requested.into_iter().collect(),
             returned_headers,
         );
 
@@ -1491,10 +1552,12 @@ impl SynchronizationProtocolHandler {
         };
 
         // request missing headers
-        self.request_manager.request_block_headers(
+        self.request_dependent_headers(
             io,
             chosen_peer,
-            dependent_hashes.into_iter().cloned().collect(),
+            &req,
+            &block_headers,
+            dependent_hashes,
         );
 
         // request missing blocks
@@ -1529,6 +1592,95 @@ impl SynchronizationProtocolHandler {
         }
 
         timestamp_validation_result
+    }
+
+    fn validate_block_headers_response(
+        &self, io: &NetworkContext, req: &RequestMessage,
+        resp: &GetBlockHeadersResponse,
+    ) -> Result<(), Error>
+    {
+        match &req {
+            // For normal header requests, we have no
+            // assumption about the response structure.
+            RequestMessage::Headers(_) => return Ok(()),
+
+            // For chained header requests, we assume the
+            // response contains a sequence of block headers
+            // which are listed in order with parent-child
+            // relationship. For example, bh[i-1] should be
+            // the parent of bh[i] which is in turn the parent
+            // of bh[i+1].
+            RequestMessage::HeaderChain(_) => {
+                let mut parent_hash = None;
+                for header in &resp.headers {
+                    let hash = header.hash();
+                    if parent_hash != None && parent_hash.unwrap() != hash {
+                        // chain assumption not met, resend request
+                        self.request_manager.remove_mismatch_request(io, req);
+                        return Err(ErrorKind::Invalid.into());
+                    }
+                    parent_hash = Some(header.parent_hash().clone());
+                }
+
+                return Ok(());
+            }
+
+            // Although the response matches the request id, it does
+            // not match the content, so resend the request again.
+            _ => {
+                warn!("Get response not matching the request! req={:?}, resp={:?}", req, resp);
+                self.request_manager.remove_mismatch_request(io, &req);
+                return Err(ErrorKind::UnexpectedResponse.into());
+            }
+        };
+    }
+
+    fn request_dependent_headers(
+        &self, io: &NetworkContext, peer: Option<PeerId>, req: &RequestMessage,
+        resp: &GetBlockHeadersResponse, hashes: HashSet<&H256>,
+    )
+    {
+        match &req {
+            // For normal header requests, we simply
+            // request all dependent headers in a single
+            // request.
+            RequestMessage::Headers(_) => {
+                let hashes = hashes.into_iter().cloned().collect();
+                self.request_manager.request_block_headers(io, peer, hashes);
+            }
+
+            // For chained header requests, we request
+            // more chains recursively.
+            RequestMessage::HeaderChain(_) => {
+                let last = resp.headers.last().unwrap();
+                let parent_hash = last.parent_hash();
+                let parent_height = last.height();
+
+                let current_height =
+                    self.graph.consensus.best_epoch_number() as u64;
+
+                for h in hashes {
+                    let num = if *h == *parent_hash {
+                        // Without fork, we only need to request missing blocks
+                        // since current_height
+                        if parent_height > current_height {
+                            cmp::min(
+                                DEFAULT_GET_PARENT_HEADERS_NUM,
+                                parent_height - current_height,
+                            )
+                        } else {
+                            DEFAULT_GET_HEADERS_NUM
+                        }
+                    } else {
+                        DEFAULT_GET_HEADERS_NUM
+                    };
+                    self.request_manager
+                        .request_block_header_chain(io, peer, h, num);
+                }
+            }
+
+            _ => (),
+        };
     }
 
     fn on_blocks_response(
@@ -1815,13 +1967,22 @@ impl SynchronizationProtocolHandler {
             .iter()
             .filter(|hash| !self.graph.contains_block_header(&hash))
             .cloned()
-            .collect();
+            .collect::<Vec<_>>();
 
-        self.request_manager.request_block_headers(
-            io,
-            Some(peer),
-            headers_to_request,
-        );
+        // self.request_manager.request_block_headers(
+        //     io,
+        //     Some(peer),
+        //     headers_to_request,
+        // );
+
+        for hash in headers_to_request {
+            self.request_manager.request_block_header_chain(
+                io,
+                Some(peer),
+                &hash,
+                1,
+            )
+        }
 
         Ok(())
     }

--- a/message/src/getblockheaderchain.rs
+++ b/message/src/getblockheaderchain.rs
@@ -8,43 +8,46 @@ use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Debug, PartialEq, Clone)]
-pub struct GetBlockHeaders {
+pub struct GetBlockHeaderChain {
     pub request_id: RequestId,
-    pub hashes: Vec<H256>,
+    pub hash: H256,
+    pub max_blocks: u64,
 }
 
-impl Message for GetBlockHeaders {
-    fn msg_id(&self) -> MsgId { MsgId::GET_BLOCK_HEADERS }
+impl Message for GetBlockHeaderChain {
+    fn msg_id(&self) -> MsgId { MsgId::GET_BLOCK_HEADER_CHAIN }
 }
 
-impl Deref for GetBlockHeaders {
+impl Deref for GetBlockHeaderChain {
     type Target = RequestId;
 
     fn deref(&self) -> &Self::Target { &self.request_id }
 }
 
-impl DerefMut for GetBlockHeaders {
+impl DerefMut for GetBlockHeaderChain {
     fn deref_mut(&mut self) -> &mut RequestId { &mut self.request_id }
 }
 
-impl Encodable for GetBlockHeaders {
+impl Encodable for GetBlockHeaderChain {
     fn rlp_append(&self, stream: &mut RlpStream) {
         stream
-            .begin_list(2)
+            .begin_list(3)
             .append(&self.request_id)
-            .append_list(&self.hashes);
+            .append(&self.hash)
+            .append(&self.max_blocks);
     }
 }
 
-impl Decodable for GetBlockHeaders {
+impl Decodable for GetBlockHeaderChain {
     fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-        if rlp.item_count()? != 2 {
+        if rlp.item_count()? != 3 {
             return Err(DecoderError::RlpIncorrectListLen);
         }
 
-        Ok(GetBlockHeaders {
+        Ok(GetBlockHeaderChain {
             request_id: rlp.val_at(0)?,
-            hashes: rlp.list_at(1)?,
+            hash: rlp.val_at(1)?,
+            max_blocks: rlp.val_at(2)?,
         })
     }
 }

--- a/message/src/lib.rs
+++ b/message/src/lib.rs
@@ -16,6 +16,7 @@ mod cmpctblocks;
 mod getblockbodies;
 mod getblockhashes;
 mod getblockhashesbyepoch;
+mod getblockheaderchain;
 mod getblockheaders;
 mod getblocks;
 mod getblocktxn;
@@ -38,6 +39,7 @@ pub use crate::{
     getblockbodies::GetBlockBodies,
     getblockhashes::GetBlockHashes,
     getblockhashesbyepoch::GetBlockHashesByEpoch,
+    getblockheaderchain::GetBlockHeaderChain,
     getblockheaders::GetBlockHeaders,
     getblocks::GetBlocks,
     getblocktxn::GetBlockTxn,

--- a/message/src/message.rs
+++ b/message/src/message.rs
@@ -43,6 +43,7 @@ build_msgid! {
     GET_TRANSACTIONS = 0x15
     GET_TRANSACTIONS_RESPONSE = 0x16
     GET_BLOCK_HASHES_BY_EPOCH = 0x17
+    GET_BLOCK_HEADER_CHAIN = 0x18
 }
 
 impl From<u8> for MsgId {
@@ -66,7 +67,7 @@ pub trait Message: Send + Sync + Encodable + 'static {
     fn is_size_sensitive(&self) -> bool { false }
 }
 
-#[derive(Debug, PartialEq, Eq, Default)]
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct RequestId {
     request_id: u64,
 }

--- a/tests/conflux/messages.py
+++ b/tests/conflux/messages.py
@@ -56,6 +56,7 @@ GET_BLOCK_TXN = 0x11
 GET_BLOCK_TXN_RESPONSE = 0x12
 
 GET_BLOCK_HASHES_BY_EPOCH = 0x17
+GET_BLOCK_HEADER_CHAIN = 0x18
 
 class Capability(rlp.Serializable):
     fields = [
@@ -182,6 +183,21 @@ class GetBlockHeaders(rlp.Serializable):
         super().__init__(
             reqid=reqid,
             hashes=hashes,
+        )
+
+
+class GetBlockHeaderChain(rlp.Serializable):
+    fields = [
+        ("reqid", big_endian_int),
+        ("hash", hash32),
+        ("max_blocks", big_endian_int),
+    ]
+
+    def __init__(self, hash, max_blocks, reqid=0):
+        super().__init__(
+            reqid=reqid,
+            hash=hash,
+            max_blocks=max_blocks,
         )
 
 
@@ -432,6 +448,7 @@ msg_id_dict = {
     GetBlockTxn: GET_BLOCK_TXN,
     GetBlockTxnResponse: GET_BLOCK_TXN_RESPONSE,
     GetBlockHashesByEpoch: GET_BLOCK_HASHES_BY_EPOCH,
+    GetBlockHeaderChain: GET_BLOCK_HEADER_CHAIN,
 }
 
 msg_class_dict = {}

--- a/tests/test_framework/mininode.py
+++ b/tests/test_framework/mininode.py
@@ -313,6 +313,8 @@ class P2PInterface(P2PConnection):
                     self.had_status = True
                 elif packet_type == GET_BLOCK_HEADERS:
                     self._log_message("receive", "GET_BLOCK_HEADERS of {} {}".format(msg.hash, msg.max_blocks))
+                elif packet_type == GET_BLOCK_HEADER_CHAIN:
+                    self._log_message("receive", "GET_BLOCK_HEADER_CHAIN of {} {}".format(msg.hash, msg.max_blocks))
                 elif packet_type == GET_BLOCK_BODIES:
                     hashes = msg.hashes
                     self._log_message("receive", "GET_BLOCK_BODIES of {} blocks".format(len(hashes)))


### PR DESCRIPTION
**Ways to request headers from peers:**
- `GetBlockHeaders(hashes) ---> BlockHeadersResponse(headers)`: request an arbitrary set of headers using their hashes (see `synchronization_protocol_handler::on_get_block_headers`)
- `GetBlockHeaderChain(hash, max_depth) ---> BlockHeadersResponse(headers)`: request a parental-sub-chain of the DAG of depth `max_depth` starting from `hash`  (see `synchronization_protocol_handler::on_get_block_header_chain`)

**Current syncing logic:**
1. Request some epochs in batches, e.g. `[11..20]`, `[21..31]`, ... in parallel (controlled by `EPOCH_SYNC_BATCH_SIZE` and `EPOCH_SYNC_MAX_INFLIGHT`).
2. Upon receiving hashes for epochs `[11..20]`, request a sub-chain of length 1 from each recursively.

Ideally, we simply go epoch-batch-by-epoch-batch, from genesis towards terminals. If a section of the DAG is skipped (e.g. due to a fork or a malicious/lagging peer), the recursive chain logic in `on_block_headers_response` should quickly fill the gaps.

**Known weaknesses:** (to be addressed later on if needed)
- Peers' best epochs are only sent in the initial status messages. Thus, once the node *catches up*, the network might have already created numerous new epochs. Our normal syncing logic (based on `GetBlockHeaderChain`) should be able to deal with this, but this might result in many off-pivot-chain blocks being mined. Possible solution: piggyback `best_epoch` updates on `NewBlockHashes` messages.
- After timeout, we request headers one-by-one. It might be better to group them together into one request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/284)
<!-- Reviewable:end -->
