### PR TITLE
Use MinHeap for waiting_requests.

### DIFF
--- a/core/src/sync/error.rs
+++ b/core/src/sync/error.rs
@@ -30,6 +30,12 @@ error_chain! {
             display("Unexpected response"),
         }
 
+        RequestNotFound {
+            description("The response is received after the request timeout or \
+            there is not request for the response"),
+            display("Request not found for the respond"),
+        }
+
         TooManyTrans {
             description("Send too many transactions to node in catch-up mode"),
             display("Sent too many transactions"),

--- a/core/src/sync/request_manager/mod.rs
+++ b/core/src/sync/request_manager/mod.rs
@@ -19,6 +19,7 @@ pub use request_handler::{
     RequestHandler, RequestMessage, SynchronizationPeerRequest,
 };
 use std::{
+    cmp::Ordering,
     collections::{binary_heap::BinaryHeap, hash_map::Entry, HashMap, HashSet},
     sync::Arc,
     time::{Duration, Instant},
@@ -60,8 +61,7 @@ pub struct RequestManager {
     epochs_in_flight: Mutex<HashSet<u64>>,
 
     /// Each element is (timeout_time, request, chosen_peer)
-    waiting_requests:
-        Mutex<BinaryHeap<(Instant, WaitingRequest, Option<PeerId>)>>,
+    waiting_requests: Mutex<BinaryHeap<TimedWaitingRequest>>,
 
     /// The following fields are used to control how to
     /// propagate transactions in normal case.
@@ -125,11 +125,14 @@ impl RequestManager {
                     Entry::Vacant(entry) => {
                         entry.insert(*REQUEST_START_WAITING_TIME);
                         if peer_id.is_none() {
-                            self.waiting_requests.lock().push((
-                                Instant::now() + *REQUEST_START_WAITING_TIME,
-                                WaitingRequest::Header(*hash),
-                                *peer_id,
-                            ));
+                            self.waiting_requests.lock().push(
+                                TimedWaitingRequest::new(
+                                    Instant::now()
+                                        + *REQUEST_START_WAITING_TIME,
+                                    WaitingRequest::Header(*hash),
+                                    *peer_id,
+                                ),
+                            );
                             debug!(
                                 "Header {:?} request is delayed for later",
                                 hash
@@ -148,11 +151,13 @@ impl RequestManager {
                             "Header {:?} is requested again, delay for {:?}",
                             hash, t
                         );
-                        self.waiting_requests.lock().push((
-                            Instant::now() + *t,
-                            WaitingRequest::Header(*hash),
-                            *peer_id,
-                        ));
+                        self.waiting_requests.lock().push(
+                            TimedWaitingRequest::new(
+                                Instant::now() + *t,
+                                WaitingRequest::Header(*hash),
+                                *peer_id,
+                            ),
+                        );
                         *t += *REQUEST_START_WAITING_TIME;
                         false
                     }
@@ -197,7 +202,7 @@ impl RequestManager {
                 peer_id, hashes, e
             );
             for hash in hashes {
-                self.waiting_requests.lock().push((
+                self.waiting_requests.lock().push(TimedWaitingRequest::new(
                     Instant::now() + *REQUEST_START_WAITING_TIME,
                     WaitingRequest::Header(hash),
                     None,
@@ -224,7 +229,7 @@ impl RequestManager {
             Entry::Occupied(mut e) => {
                 // Requested before, so wait for the stored time and increase it
                 let t = e.get_mut();
-                self.waiting_requests.lock().push((
+                self.waiting_requests.lock().push(TimedWaitingRequest::new(
                     Instant::now() + *t,
                     WaitingRequest::HeaderChain(*hash),
                     peer_id,
@@ -242,11 +247,13 @@ impl RequestManager {
                 if peer_id.is_none() {
                     // No available peer, so add to the waiting queue directly
                     // to be sent later
-                    self.waiting_requests.lock().push((
-                        Instant::now() + *REQUEST_START_WAITING_TIME,
-                        WaitingRequest::HeaderChain(*hash),
-                        peer_id,
-                    ));
+                    self.waiting_requests.lock().push(
+                        TimedWaitingRequest::new(
+                            Instant::now() + *REQUEST_START_WAITING_TIME,
+                            WaitingRequest::HeaderChain(*hash),
+                            peer_id,
+                        ),
+                    );
                     debug!(
                         "Block header request is delayed peer={:?} hash={:?}",
                         peer_id, hash
@@ -274,7 +281,7 @@ impl RequestManager {
             // it from `headers_in_flight`. We can reach here only
             // if the request is not waited before, so we just wait for
             // the initial value.
-            self.waiting_requests.lock().push((
+            self.waiting_requests.lock().push(TimedWaitingRequest::new(
                 Instant::now() + *REQUEST_START_WAITING_TIME,
                 WaitingRequest::HeaderChain(*hash),
                 None,
@@ -325,7 +332,7 @@ impl RequestManager {
                 peer_id, epochs, e
             );
             for epoch_number in epochs {
-                self.waiting_requests.lock().push((
+                self.waiting_requests.lock().push(TimedWaitingRequest::new(
                     Instant::now() + *REQUEST_START_WAITING_TIME,
                     WaitingRequest::Epoch(epoch_number),
                     None,
@@ -350,11 +357,14 @@ impl RequestManager {
                     Entry::Vacant(entry) => {
                         entry.insert(*REQUEST_START_WAITING_TIME);
                         if peer_id.is_none() {
-                            self.waiting_requests.lock().push((
-                                Instant::now() + *REQUEST_START_WAITING_TIME,
-                                WaitingRequest::Block(*hash),
-                                *peer_id,
-                            ));
+                            self.waiting_requests.lock().push(
+                                TimedWaitingRequest::new(
+                                    Instant::now()
+                                        + *REQUEST_START_WAITING_TIME,
+                                    WaitingRequest::Block(*hash),
+                                    *peer_id,
+                                ),
+                            );
                             debug!(
                                 "Block {:?} request is delayed for later",
                                 hash
@@ -373,11 +383,13 @@ impl RequestManager {
                             "Block {:?} is requested again, delay for {:?}",
                             hash, t
                         );
-                        self.waiting_requests.lock().push((
-                            Instant::now() + *t,
-                            WaitingRequest::Block(*hash),
-                            *peer_id,
-                        ));
+                        self.waiting_requests.lock().push(
+                            TimedWaitingRequest::new(
+                                Instant::now() + *t,
+                                WaitingRequest::Block(*hash),
+                                *peer_id,
+                            ),
+                        );
                         *t += *REQUEST_START_WAITING_TIME;
                         false
                     }
@@ -425,7 +437,7 @@ impl RequestManager {
                 peer_id, hashes, e
             );
             for hash in hashes {
-                self.waiting_requests.lock().push((
+                self.waiting_requests.lock().push(TimedWaitingRequest::new(
                     Instant::now() + *REQUEST_START_WAITING_TIME,
                     WaitingRequest::Block(hash),
                     None,
@@ -524,7 +536,7 @@ impl RequestManager {
                 peer_id, hashes, e
             );
             for hash in hashes {
-                self.waiting_requests.lock().push((
+                self.waiting_requests.lock().push(TimedWaitingRequest::new(
                     Instant::now() + *REQUEST_START_WAITING_TIME,
                     WaitingRequest::Block(hash),
                     None,
@@ -875,12 +887,13 @@ impl RequestManager {
                 break;
             }
             let req = waiting_requests.pop().expect("queue not empty");
-            if req.0 >= now {
+            if req.time_to_send >= now {
                 waiting_requests.push(req);
                 break;
             } else {
-                let maybe_peer =
-                    req.2.or_else(|| self.syn.get_random_peer(&HashSet::new()));
+                let maybe_peer = req
+                    .peer
+                    .or_else(|| self.syn.get_random_peer(&HashSet::new()));
                 let chosen_peer = match maybe_peer {
                     Some(p) => p,
                     None => {
@@ -891,7 +904,7 @@ impl RequestManager {
 
                 // Waiting requests are already in-flight, so send them without
                 // checking
-                match &req.1 {
+                match &req.request {
                     WaitingRequest::Header(h) => {
                         if let Err(e) = self.request_handler.send_request(
                             io,
@@ -912,7 +925,7 @@ impl RequestManager {
                             // should
                             // be in `headers_waittime`, and thus we can remove
                             // `or_insert`
-                            waiting_requests.push((
+                            waiting_requests.push(TimedWaitingRequest::new(
                                 Instant::now()
                                     + *headers_waittime
                                         .entry(*h)
@@ -943,7 +956,7 @@ impl RequestManager {
                             // should
                             // be in `headers_waittime`, and thus we can remove
                             // `or_insert`
-                            waiting_requests.push((
+                            waiting_requests.push(TimedWaitingRequest::new(
                                 Instant::now()
                                     + *headers_waittime
                                         .entry(*h)
@@ -972,7 +985,7 @@ impl RequestManager {
                             SendQueuePriority::High,
                         ) {
                             warn!("Error requesting waiting epoch peer={:?} epoch_number={} err={:?}", chosen_peer, n, e);
-                            waiting_requests.push((
+                            waiting_requests.push(TimedWaitingRequest::new(
                                 Instant::now() + *REQUEST_START_WAITING_TIME,
                                 WaitingRequest::Epoch(*n),
                                 None,
@@ -997,20 +1010,22 @@ impl RequestManager {
                             // be in `blocks_waittime`, and thus we can remove
                             // `or_insert`
                             for hash in blocks {
-                                waiting_requests.push((
-                                    Instant::now()
-                                        + *blocks_waittime
-                                            .entry(*h)
-                                            .and_modify(|t| {
-                                                *t +=
+                                waiting_requests.push(
+                                    TimedWaitingRequest::new(
+                                        Instant::now()
+                                            + *blocks_waittime
+                                                .entry(*h)
+                                                .and_modify(|t| {
+                                                    *t +=
                                                     *REQUEST_START_WAITING_TIME
-                                            })
-                                            .or_insert(
-                                                *REQUEST_START_WAITING_TIME,
-                                            ),
-                                    WaitingRequest::Block(hash),
-                                    None,
-                                ));
+                                                })
+                                                .or_insert(
+                                                    *REQUEST_START_WAITING_TIME,
+                                                ),
+                                        WaitingRequest::Block(hash),
+                                        None,
+                                    ),
+                                );
                             }
                         }
                     }
@@ -1082,5 +1097,41 @@ impl RequestManager {
         } else {
             debug!("Peer already removed form request manager when disconnected peer={}", peer);
         }
+    }
+}
+
+#[derive(Debug)]
+struct TimedWaitingRequest {
+    time_to_send: Instant,
+    request: WaitingRequest,
+    peer: Option<PeerId>,
+}
+
+impl TimedWaitingRequest {
+    fn new(
+        time_to_send: Instant, request: WaitingRequest, peer: Option<PeerId>,
+    ) -> Self {
+        Self {
+            time_to_send,
+            request,
+            peer,
+        }
+    }
+}
+
+impl Ord for TimedWaitingRequest {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other.time_to_send.cmp(&self.time_to_send)
+    }
+}
+impl PartialOrd for TimedWaitingRequest {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        other.time_to_send.partial_cmp(&self.time_to_send)
+    }
+}
+impl Eq for TimedWaitingRequest {}
+impl PartialEq for TimedWaitingRequest {
+    fn eq(&self, other: &Self) -> bool {
+        self.time_to_send == other.time_to_send
     }
 }

--- a/core/src/sync/request_manager/request_handler.rs
+++ b/core/src/sync/request_manager/request_handler.rs
@@ -245,14 +245,14 @@ impl RequestContainer {
             }
             save_req
         } else {
-            warn!("Remove out of bound request peer={} request_id={} low={} next={}", self.peer_id, request_id, self.lowest_request_id, self.next_request_id);
+            debug!("Remove out of bound request peer={} request_id={} low={} next={}", self.peer_id, request_id, self.lowest_request_id, self.next_request_id);
             None
         }
     }
 
     // Match request with given response.
     // Could return the following error:
-    // 1. UnexpectedResponse:
+    // 1. RequestNotFound:
     //      In this case, no request is matched, so NO need to
     //      handle the resending of the request for caller;
     // 2. Error from send_message():
@@ -307,7 +307,7 @@ impl RequestContainer {
             }
             Ok(*removed_req.message)
         } else {
-            bail!(ErrorKind::UnexpectedResponse)
+            bail!(ErrorKind::RequestNotFound)
         }
     }
 

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -403,6 +403,7 @@ impl SynchronizationProtocolHandler {
             // TODO handle the unexpected response case (timeout or real invalid
             // message type)
             ErrorKind::UnexpectedResponse => disconnect = false,
+            ErrorKind::RequestNotFound => disconnect = false,
             ErrorKind::TooManyTrans => {}
             ErrorKind::Decoder(_) => op = Some(UpdateNodeOperation::Remove),
             ErrorKind::Network(kind) => match kind {


### PR DESCRIPTION
Using max heap makes requests delayed if there are other requests
that should wait for a long time.
Also add new RequestNotFound error for response to timeout request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/317)
<!-- Reviewable:end -->
