### PR TITLE
refactor BlockDataManager

### DIFF
--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -319,14 +319,11 @@ impl ConsensusExecutor {
             {
                 match maybe_cached_state {
                     Some(cached_state) => {
-                        if let (Some(receipts_root), Some(logs_bloom_hash)) = (
-                            self.handler
-                                .data_man
-                                .get_receipts_root(&block_hash),
-                            self.handler
-                                .data_man
-                                .get_logs_bloom_hash(&block_hash),
-                        ) {
+                        if let Some((receipts_root, logs_bloom_hash)) = self
+                            .handler
+                            .data_man
+                            .get_epoch_execution_commitments(&block_hash)
+                        {
                             return Ok((
                                 cached_state.get_state_root().unwrap().unwrap(),
                                 receipts_root,
@@ -498,11 +495,10 @@ impl ConsensusExecutionHandler {
             .unwrap()
             .unwrap();
 
-        let receipts_root =
-            self.data_man.get_receipts_root(&task.epoch_hash).unwrap();
-
-        let logs_bloom_hash =
-            self.data_man.get_logs_bloom_hash(&task.epoch_hash).unwrap();
+        let (receipts_root, logs_bloom_hash) = self
+            .data_man
+            .get_epoch_execution_commitments(&task.epoch_hash)
+            .unwrap();
 
         task.sender
             .send((state_root, receipts_root, logs_bloom_hash))
@@ -594,19 +590,13 @@ impl ConsensusExecutionHandler {
         } else {
             state.commit(*epoch_hash).unwrap();
         };
+        let (receipts_root, logs_bloom_hash) = self
+            .data_man
+            .get_epoch_execution_commitments(&epoch_hash)
+            .unwrap();
         debug!(
             "compute_epoch: on_local_pivot={}, epoch={:?} state_root={:?} receipt_root={:?}, logs_bloom_hash={:?}",
-            on_local_pivot,
-            epoch_hash,
-            state_root,
-            self
-                .data_man
-                .get_receipts_root(&epoch_hash)
-                .unwrap(),
-            self
-                .data_man
-                .get_logs_bloom_hash(&epoch_hash)
-                .unwrap()
+            on_local_pivot, epoch_hash, state_root, receipts_root, logs_bloom_hash,
         );
     }
 
@@ -728,13 +718,9 @@ impl ConsensusExecutionHandler {
             );
         }
 
-        self.data_man.insert_receipts_root(
+        self.data_man.insert_epoch_execution_commitments(
             pivot_block.hash(),
             BlockHeaderBuilder::compute_block_receipts_root(&epoch_receipts),
-        );
-
-        self.data_man.insert_logs_bloom_hash(
-            pivot_block.hash(),
             BlockHeaderBuilder::compute_block_logs_bloom_hash(&epoch_receipts),
         );
 

--- a/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
+++ b/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
@@ -852,11 +852,9 @@ impl ConsensusNewBlockHandler {
             );
             debug!("Deferred block is {:?}", inner.arena[deferred].hash);
 
-            let correct_receipts_root =
-                self.data_man.get_receipts_root(&inner.arena[deferred].hash);
-            let correct_logs_bloom_hash = self
+            let epoch_exec_commitments = self
                 .data_man
-                .get_logs_bloom_hash(&inner.arena[deferred].hash);
+                .get_epoch_execution_commitments(&inner.arena[deferred].hash);
 
             if self
                 .data_man
@@ -866,8 +864,7 @@ impl ConsensusNewBlockHandler {
                     None,
                 ))
                 .unwrap()
-                && correct_receipts_root.is_some()
-                && correct_logs_bloom_hash.is_some()
+                && epoch_exec_commitments.is_some()
             {
                 let mut valid = true;
                 let correct_state_root = self
@@ -896,8 +893,11 @@ impl ConsensusNewBlockHandler {
                     valid = false;
                 }
 
+                let (correct_receipts_root, correct_logs_bloom_hash) =
+                    epoch_exec_commitments.unwrap();
+
                 if *block.block_header.deferred_receipts_root()
-                    != correct_receipts_root.unwrap()
+                    != correct_receipts_root
                 {
                     warn!(
                         "Invalid receipt root: {:?}, should be {:?}",
@@ -908,7 +908,7 @@ impl ConsensusNewBlockHandler {
                 }
 
                 if *block.block_header.deferred_logs_bloom_hash()
-                    != correct_logs_bloom_hash.unwrap()
+                    != correct_logs_bloom_hash
                 {
                     warn!(
                         "Invalid logs bloom hash: {:?}, should be {:?}",
@@ -1263,13 +1263,9 @@ impl ConsensusNewBlockHandler {
                     .block_header_by_hash(&future_block_hash)
                     .unwrap();
 
-                self.data_man.insert_receipts_root(
+                self.data_man.insert_epoch_execution_commitments(
                     inner.arena[new_pivot_chain[pivot_index]].hash,
                     future_block_header.deferred_receipts_root().clone(),
-                );
-
-                self.data_man.insert_logs_bloom_hash(
-                    inner.arena[new_pivot_chain[pivot_index]].hash,
                     future_block_header.deferred_logs_bloom_hash().clone(),
                 );
             }
@@ -1325,17 +1321,18 @@ impl ConsensusNewBlockHandler {
                 }
             }
             if receipts_correct {
-                self.data_man.insert_receipts_root(
-                    pivot_hash,
+                let pivot_receipts_root =
                     BlockHeaderBuilder::compute_block_receipts_root(
                         &epoch_receipts,
-                    ),
-                );
-                self.data_man.insert_logs_bloom_hash(
-                    pivot_hash,
+                    );
+                let pivot_logs_bloom_hash =
                     BlockHeaderBuilder::compute_block_logs_bloom_hash(
                         &epoch_receipts,
-                    ),
+                    );
+                self.data_man.insert_epoch_execution_commitments(
+                    pivot_hash,
+                    pivot_receipts_root,
+                    pivot_logs_bloom_hash,
                 );
             } else {
                 let reward_execution_info = inner.get_reward_execution_info(


### PR DESCRIPTION
**Overview**

`BlockDataManager::{block_receipts_root, block_logs_bloom_hash}` have to be updated 
simultaneously. To ensure this, they are combined into `BlockDataManager::epoch_execution_commitments`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/349)
<!-- Reviewable:end -->
