### PR TITLE
refine cfx_getLogs filter syntax

### DIFF
--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -26,8 +26,7 @@ use network::{
 };
 use parking_lot::{Condvar, Mutex};
 use primitives::{
-    block::MAX_BLOCK_SIZE_IN_BYTES, Action,
-    EpochNumber as PrimitiveEpochNumber, SignedTransaction, Transaction,
+    block::MAX_BLOCK_SIZE_IN_BYTES, Action, SignedTransaction, Transaction,
     TransactionWithSignature,
 };
 use rlp::Rlp;
@@ -57,17 +56,6 @@ impl RpcImpl {
         }
     }
 
-    fn get_primitive_epoch_number(
-        &self, number: EpochNumber,
-    ) -> PrimitiveEpochNumber {
-        match number {
-            EpochNumber::Earliest => PrimitiveEpochNumber::Earliest,
-            EpochNumber::LatestMined => PrimitiveEpochNumber::LatestMined,
-            EpochNumber::LatestState => PrimitiveEpochNumber::LatestState,
-            EpochNumber::Num(num) => PrimitiveEpochNumber::Number(num.into()),
-        }
-    }
-
     fn best_block_hash(&self) -> RpcResult<RpcH256> {
         info!("RPC Request: cfx_getBestBlockHash()");
         Ok(self.consensus.best_block_hash().into())
@@ -83,9 +71,10 @@ impl RpcImpl {
     ) -> RpcResult<RpcU256> {
         let epoch_num = epoch_num.unwrap_or(EpochNumber::LatestMined);
         info!("RPC Request: cfx_epochNumber({:?})", epoch_num);
-        match self.consensus.get_height_from_epoch_number(
-            self.get_primitive_epoch_number(epoch_num),
-        ) {
+        match self
+            .consensus
+            .get_height_from_epoch_number(epoch_num.into())
+        {
             Ok(height) => Ok(height.into()),
             Err(e) => Err(RpcError::invalid_params(e)),
         }
@@ -97,9 +86,7 @@ impl RpcImpl {
         let inner = &*self.consensus.inner.read();
         info!("RPC Request: cfx_getBlockByEpochNumber epoch_number={:?} include_txs={:?}", epoch_num, include_txs);
         inner
-            .get_hash_from_epoch_number(
-                self.get_primitive_epoch_number(epoch_num),
-            )
+            .get_hash_from_epoch_number(epoch_num.into())
             .map_err(|err| RpcError::invalid_params(err))
             .and_then(|hash| {
                 let block = self
@@ -210,7 +197,7 @@ impl RpcImpl {
         info!("RPC Request: cfx_getBlocks epoch_number={:?}", num);
 
         self.consensus
-            .block_hashes_by_epoch(self.get_primitive_epoch_number(num))
+            .block_hashes_by_epoch(num.into())
             .map_err(|err| RpcError::invalid_params(err))
             .and_then(|vec| Ok(vec.into_iter().map(|x| x.into()).collect()))
     }
@@ -226,7 +213,7 @@ impl RpcImpl {
         );
 
         self.consensus
-            .get_balance(address, self.get_primitive_epoch_number(num))
+            .get_balance(address, num.into())
             .map(|x| x.into())
             .map_err(|err| RpcError::invalid_params(err))
     }
@@ -249,7 +236,7 @@ impl RpcImpl {
     //            .get_account(
     //                address,
     //                num_txs,
-    //                self.get_primitive_epoch_number(epoch_num),
+    //                epoch_num.into(),
     //            )
     //            .and_then(|(balance, transactions)| {
     //                Ok(Account {
@@ -274,10 +261,7 @@ impl RpcImpl {
         );
 
         self.consensus
-            .transaction_count(
-                address.into(),
-                self.get_primitive_epoch_number(num),
-            )
+            .transaction_count(address.into(), num.into())
             .map_err(|err| RpcError::invalid_params(err))
             .map(|x| x.into())
     }
@@ -549,7 +533,6 @@ impl RpcImpl {
         &self, rpc_tx: RpcTransaction, epoch: Option<EpochNumber>,
     ) -> RpcResult<Bytes> {
         let epoch = epoch.unwrap_or(EpochNumber::LatestState);
-        let epoch = self.get_primitive_epoch_number(epoch);
 
         let tx = Transaction {
             nonce: rpc_tx.nonce.into(),
@@ -569,7 +552,7 @@ impl RpcImpl {
         signed_tx.sender = rpc_tx.from.into();
         trace!("call tx {:?}", signed_tx);
         self.consensus
-            .call_virtual(&signed_tx, epoch)
+            .call_virtual(&signed_tx, epoch.into())
             .map(|output| Bytes::new(output.0))
             .map_err(|e| RpcError::invalid_params(e))
     }

--- a/client/src/rpc/types/epoch_number.rs
+++ b/client/src/rpc/types/epoch_number.rs
@@ -2,6 +2,7 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
+use primitives::EpochNumber as PrimitiveEpochNumber;
 use serde::{
     de::{Error, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
@@ -50,6 +51,25 @@ impl Serialize for EpochNumber {
              * serializer.serialize_str("pending"), */
         }
     }
+}
+
+impl EpochNumber {
+    pub fn into_primitive(self) -> PrimitiveEpochNumber {
+        match self {
+            EpochNumber::Earliest => PrimitiveEpochNumber::Earliest,
+            EpochNumber::LatestMined => PrimitiveEpochNumber::LatestMined,
+            EpochNumber::LatestState => PrimitiveEpochNumber::LatestState,
+            EpochNumber::Num(num) => PrimitiveEpochNumber::Number(num.into()),
+        }
+    }
+}
+
+impl Into<PrimitiveEpochNumber> for EpochNumber {
+    fn into(self) -> PrimitiveEpochNumber { self.into_primitive() }
+}
+
+impl Into<EpochNumber> for u64 {
+    fn into(self) -> EpochNumber { EpochNumber::Num(self) }
 }
 
 struct EpochNumberVisitor;

--- a/client/src/rpc/types/filter.rs
+++ b/client/src/rpc/types/filter.rs
@@ -145,7 +145,7 @@ impl Filter {
 
         PrimitiveFilter {
             from_epoch: self.from_epoch.unwrap_or(EpochNumber::Earliest).into(),
-            to_epoch: self.to_epoch.unwrap_or(EpochNumber::LatestState).into(),
+            to_epoch: self.to_epoch.unwrap_or(EpochNumber::LatestMined).into(),
             block_hashes: maybe_vec_into(&self.block_hashes),
             address: maybe_vec_into(&address),
             topics: topics.iter().map(maybe_vec_into).collect(),
@@ -356,7 +356,7 @@ mod tests {
 
         let primitive_filter = PrimitiveFilter {
             from_epoch: PrimitiveEpochNumber::Earliest,
-            to_epoch: PrimitiveEpochNumber::LatestState,
+            to_epoch: PrimitiveEpochNumber::LatestMined,
             block_hashes: Some(vec![
                 "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470".into(),
                 "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347".into()

--- a/primitives/src/epoch.rs
+++ b/primitives/src/epoch.rs
@@ -7,7 +7,7 @@ use cfx_types::H256;
 pub type EpochId = H256;
 
 /// Uniquely identifies epoch.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum EpochNumber {
     /// Epoch number within canon blockchain.
     Number(u64),
@@ -17,4 +17,8 @@ pub enum EpochNumber {
     LatestMined,
     /// Latest block with state.
     LatestState,
+}
+
+impl Into<EpochNumber> for u64 {
+    fn into(self) -> EpochNumber { EpochNumber::Number(self) }
 }

--- a/primitives/src/filter.rs
+++ b/primitives/src/filter.rs
@@ -20,7 +20,7 @@
 
 //! Blockchain filter
 
-use crate::log_entry::LogEntry;
+use crate::{epoch::EpochNumber, log_entry::LogEntry};
 use cfx_types::{Address, Bloom, BloomInput, H256};
 use std::{error, fmt};
 
@@ -56,10 +56,10 @@ impl error::Error for FilterError {
 #[derive(Debug, PartialEq)]
 pub struct Filter {
     /// Search will be applied from this epoch number.
-    pub from_epoch: u64,
+    pub from_epoch: EpochNumber,
 
     /// Till this epoch number.
-    pub to_epoch: u64,
+    pub to_epoch: EpochNumber,
 
     /// Search will be applied in these blocks if given.
     /// This will override from/to_epoch fields.
@@ -92,8 +92,8 @@ impl Clone for Filter {
         }
 
         Filter {
-            from_epoch: self.from_epoch,
-            to_epoch: self.to_epoch,
+            from_epoch: self.from_epoch.clone(),
+            to_epoch: self.to_epoch.clone(),
             block_hashes: self.block_hashes.clone(),
             address: self.address.clone(),
             topics: topics[..].to_vec(),

--- a/tests/conflux/filter.py
+++ b/tests/conflux/filter.py
@@ -1,5 +1,5 @@
 class Filter():
-    def __init__(self, from_epoch="earliest", to_epoch="latest_state", block_hashes = None, address = None, topics = [], limit = None):
+    def __init__(self, from_epoch="earliest", to_epoch="latest_mined", block_hashes = None, address = None, topics = [], limit = None):
         self.fromEpoch = from_epoch
         self.toEpoch = to_epoch
         self.blockHashes = block_hashes

--- a/tests/conflux/filter.py
+++ b/tests/conflux/filter.py
@@ -1,5 +1,5 @@
 class Filter():
-    def __init__(self, from_epoch, to_epoch, block_hashes = None, address = None, topics = [], limit = None):
+    def __init__(self, from_epoch="earliest", to_epoch="latest_state", block_hashes = None, address = None, topics = [], limit = None):
         self.fromEpoch = from_epoch
         self.toEpoch = to_epoch
         self.blockHashes = block_hashes

--- a/tests/log_filtering_test.py
+++ b/tests/log_filtering_test.py
@@ -103,6 +103,16 @@ class LogFilteringTest(ConfluxTestFramework):
         self.assert_response_format_correct(logs)
         assert_equal(len(logs), NUM_CALLS - 1)
 
+        filter = Filter(topics=[[CONSTRUCTED_TOPIC], [CALLED_TOPIC]]) # AND-relation
+        logs = self.rpc.get_logs(filter)
+        self.assert_response_format_correct(logs)
+        assert_equal(len(logs), 0)
+
+        filter = Filter(topics=[[CONSTRUCTED_TOPIC, CALLED_TOPIC]]) # OR-relation
+        logs = self.rpc.get_logs(filter)
+        self.assert_response_format_correct(logs)
+        assert_equal(len(logs), NUM_CALLS)
+
         # apply filter with limit
         filter = Filter(limit=("0x%x" % (NUM_CALLS // 2)))
         logs = self.rpc.get_logs(filter)

--- a/tests/log_filtering_test.py
+++ b/tests/log_filtering_test.py
@@ -30,7 +30,7 @@ class LogFilteringTest(ConfluxTestFramework):
         self.rpc = RpcClient(self.nodes[0])
 
         # apply filter, we expect no logs
-        filter = Filter(from_epoch="earliest", to_epoch="latest_state")
+        filter = Filter(from_epoch="earliest", to_epoch="latest_mined")
         result = self.rpc.get_logs(filter)
         assert_equal(result, [])
 
@@ -41,7 +41,7 @@ class LogFilteringTest(ConfluxTestFramework):
         _, contractAddr = self.deploy_contract(sender, priv_key, bytecode)
 
         # apply filter, we expect a single log with 2 topics
-        filter = Filter(from_epoch="earliest", to_epoch="latest_state")
+        filter = Filter(from_epoch="earliest", to_epoch="latest_mined")
         logs0 = self.rpc.get_logs(filter)
 
         self.assert_response_format_correct(logs0)
@@ -55,7 +55,7 @@ class LogFilteringTest(ConfluxTestFramework):
         receipt = self.call_contract(sender, priv_key, contractAddr, encode_hex_0x(keccak(b"foo()")))
 
         # apply filter, we expect two logs with 2 and 3 topics respectively
-        filter = Filter(from_epoch="earliest", to_epoch="latest_state")
+        filter = Filter(from_epoch="earliest", to_epoch="latest_mined")
         logs1 = self.rpc.get_logs(filter)
 
         self.assert_response_format_correct(logs1)
@@ -80,7 +80,7 @@ class LogFilteringTest(ConfluxTestFramework):
             self.call_contract(sender, priv_key, contractAddr, encode_hex_0x(keccak(b"foo()")))
 
         # apply filter, we expect NUM_CALLS log entries with inreasing uint32 fields
-        filter = Filter(from_epoch="earliest", to_epoch="latest_state")
+        filter = Filter(from_epoch="earliest", to_epoch="latest_mined")
         logs = self.rpc.get_logs(filter)
 
         self.assert_response_format_correct(logs)
@@ -140,9 +140,6 @@ class LogFilteringTest(ConfluxTestFramework):
         assert_equal(result, [])
 
         self.log.info("Pass")
-
-    def latest_epoch_plus_one(self):
-        return "0x%x" % (self.rpc.epoch_number("latest_mined") + 1)
 
     def address_to_topic(self, address):
         return "0x" + address[2:].zfill(64)

--- a/tests/log_filtering_test.py
+++ b/tests/log_filtering_test.py
@@ -93,25 +93,26 @@ class LogFilteringTest(ConfluxTestFramework):
             assert_equal(logs[ii]["topics"][2], self.number_to_topic(ii))
 
         # apply filter for specific topics
-        filter = Filter(topics=[[CONSTRUCTED_TOPIC]])
+        filter = Filter(topics=[CONSTRUCTED_TOPIC])
         logs = self.rpc.get_logs(filter)
         self.assert_response_format_correct(logs)
         assert_equal(len(logs), 1)
 
-        filter = Filter(topics=[[CALLED_TOPIC]])
+        filter = Filter(topics=[CALLED_TOPIC])
         logs = self.rpc.get_logs(filter)
         self.assert_response_format_correct(logs)
         assert_equal(len(logs), NUM_CALLS - 1)
 
-        filter = Filter(topics=[[CONSTRUCTED_TOPIC], [CALLED_TOPIC]]) # AND-relation
-        logs = self.rpc.get_logs(filter)
-        self.assert_response_format_correct(logs)
-        assert_equal(len(logs), 0)
-
-        filter = Filter(topics=[[CONSTRUCTED_TOPIC, CALLED_TOPIC]]) # OR-relation
+        filter = Filter(topics=[None, self.address_to_topic(sender)])
         logs = self.rpc.get_logs(filter)
         self.assert_response_format_correct(logs)
         assert_equal(len(logs), NUM_CALLS)
+
+        # find logs with `CALLED_TOPIC` as 1st topic and `3` or `4` as 3rd topic
+        filter = Filter(topics=[CALLED_TOPIC, None, [self.number_to_topic(3), self.number_to_topic(4)]])
+        logs = self.rpc.get_logs(filter)
+        self.assert_response_format_correct(logs)
+        assert_equal(len(logs), 2)
 
         # apply filter with limit
         filter = Filter(limit=("0x%x" % (NUM_CALLS // 2)))

--- a/tests/rpc/test_get_logs.py
+++ b/tests/rpc/test_get_logs.py
@@ -14,6 +14,13 @@ class TestGetLogs(RpcClient):
         filter = Filter(from_epoch="latest") # should be `latest_state` or `latest_mined`
         assert_raises_rpc_error(None, None, self.get_logs, filter)
 
+        # inconsistent epoch numbers
+        filter = Filter(from_epoch="0x10", to_epoch="0x01")
+        assert_raises_rpc_error(None, None, self.get_logs, filter)
+
+        filter = Filter(from_epoch="latest_state", to_epoch="earliest")
+        assert_raises_rpc_error(None, None, self.get_logs, filter)
+
         # invalid epoch hex
         filter = Filter(from_epoch="0xQQQQ")
         assert_raises_rpc_error(None, None, self.get_logs, filter)

--- a/tests/rpc/test_get_logs.py
+++ b/tests/rpc/test_get_logs.py
@@ -7,16 +7,11 @@ from test_framework.util import assert_equal, assert_raises_rpc_error
 
 class TestGetLogs(RpcClient):
     def test_invalid_filter(self):
-        # missing `fromEpoch`
-        filter = Filter("0x0", "0x0"); del filter.fromEpoch
-        assert_raises_rpc_error(None, None, self.get_logs, filter)
-
-        # missing `toEpoch`
-        filter = Filter("0x0", "0x0"); del filter.toEpoch
-        assert_raises_rpc_error(None, None, self.get_logs, filter)
-
         # invalid epoch type
         filter = Filter(0, "0x0")
+        assert_raises_rpc_error(None, None, self.get_logs, filter)
+
+        filter = Filter(0, "latest") # should be `latest_state` or `latest_mined`
         assert_raises_rpc_error(None, None, self.get_logs, filter)
 
         # invalid epoch hex
@@ -54,7 +49,7 @@ class TestGetLogs(RpcClient):
     def test_valid_filter(self):
         filter = Filter(
             from_epoch="0x0",
-            to_epoch="0x0",
+            to_epoch="latest_state",
             block_hashes=["0x0000000000000000000000000000000000000000000000000000000000000000"],
             address=["0x0000000000000000000000000000000000000000"],
             topics=[["0x0000000000000000000000000000000000000000000000000000000000000000"]],

--- a/tests/rpc/test_get_logs.py
+++ b/tests/rpc/test_get_logs.py
@@ -33,9 +33,6 @@ class TestGetLogs(RpcClient):
         assert_raises_rpc_error(None, None, self.get_logs, filter)
 
         # invalid `topics` type
-        filter = Filter(topics=None)
-        assert_raises_rpc_error(None, None, self.get_logs, filter)
-
         filter = Filter(topics="")
         assert_raises_rpc_error(None, None, self.get_logs, filter)
 
@@ -47,7 +44,7 @@ class TestGetLogs(RpcClient):
         assert_raises_rpc_error(None, None, self.get_logs, filter)
 
     def test_valid_filter(self):
-        # variadic address field
+        # variadic `address` field
         filter = Filter(address=None)
         logs = self.get_logs(filter)
         assert_equal(logs, [])
@@ -60,13 +57,28 @@ class TestGetLogs(RpcClient):
         logs = self.get_logs(filter)
         assert_equal(logs, [])
 
+        # variadic `topics` field
+        filter = Filter(topics=None)
+        logs = self.get_logs(filter)
+        assert_equal(logs, [])
+
+        filter = Filter(topics=["0x0000000000000000000000000000000000000000000000000000000000000000"])
+        logs = self.get_logs(filter)
+        assert_equal(logs, [])
+
+        filter = Filter(topics=["0x0000000000000000000000000000000000000000000000000000000000000000", ["0x0000000000000000000000000000000000000000000000000000000000000000"]])
+        logs = self.get_logs(filter)
+        assert_equal(logs, [])
+
         ## all fields
         filter = Filter(
             from_epoch="0x0",
             to_epoch="latest_state",
             block_hashes=["0x0000000000000000000000000000000000000000000000000000000000000000"],
             address=["0x0000000000000000000000000000000000000000"],
-            topics=[["0x0000000000000000000000000000000000000000000000000000000000000000"]],
+            topics=[
+                "0x0000000000000000000000000000000000000000000000000000000000000000",
+                ["0x0000000000000000000000000000000000000000000000000000000000000000", "0x0000000000000000000000000000000000000000000000000000000000000000"]],
             limit="0x1"
         )
         logs = self.get_logs(filter)

--- a/tests/rpc/test_get_logs.py
+++ b/tests/rpc/test_get_logs.py
@@ -15,7 +15,7 @@ class TestGetLogs(RpcClient):
         assert_raises_rpc_error(None, None, self.get_logs, filter)
 
         # inconsistent epoch numbers
-        filter = Filter(from_epoch="0x10", to_epoch="0x01")
+        filter = Filter(from_epoch="0x02", to_epoch="0x01")
         assert_raises_rpc_error(None, None, self.get_logs, filter)
 
         filter = Filter(from_epoch="latest_state", to_epoch="earliest")
@@ -51,6 +51,11 @@ class TestGetLogs(RpcClient):
         assert_raises_rpc_error(None, None, self.get_logs, filter)
 
     def test_valid_filter(self):
+        # epoch fields inclusive
+        filter = Filter(from_epoch="0x1", to_epoch="0x1")
+        logs = self.get_logs(filter)
+        assert_equal(logs, [])
+
         # variadic `address` field
         filter = Filter(address=None)
         logs = self.get_logs(filter)

--- a/tests/rpc/test_get_logs.py
+++ b/tests/rpc/test_get_logs.py
@@ -8,45 +8,59 @@ from test_framework.util import assert_equal, assert_raises_rpc_error
 class TestGetLogs(RpcClient):
     def test_invalid_filter(self):
         # invalid epoch type
-        filter = Filter(0, "0x0")
+        filter = Filter(from_epoch=0)
         assert_raises_rpc_error(None, None, self.get_logs, filter)
 
-        filter = Filter(0, "latest") # should be `latest_state` or `latest_mined`
+        filter = Filter(from_epoch="latest") # should be `latest_state` or `latest_mined`
         assert_raises_rpc_error(None, None, self.get_logs, filter)
 
         # invalid epoch hex
-        filter = Filter("0xQQQQ", "0x0")
+        filter = Filter(from_epoch="0xQQQQ")
         assert_raises_rpc_error(None, None, self.get_logs, filter)
 
         # invalid `blockHashes` type
-        filter = Filter("0x0", "0x0", block_hashes="")
+        filter = Filter(block_hashes="")
         assert_raises_rpc_error(None, None, self.get_logs, filter)
 
-        filter = Filter("0x0", "0x0", block_hashes=["0x0"])
+        filter = Filter(block_hashes=["0x0"])
         assert_raises_rpc_error(None, None, self.get_logs, filter)
 
         # invalid `address` type
-        filter = Filter("0x0", "0x0", address="")
+        filter = Filter(address="")
         assert_raises_rpc_error(None, None, self.get_logs, filter)
 
-        filter = Filter("0x0", "0x0", address=["0x0"])
+        filter = Filter(address=["0x0"])
         assert_raises_rpc_error(None, None, self.get_logs, filter)
 
         # invalid `topics` type
-        filter = Filter("0x0", "0x0", topics=None)
+        filter = Filter(topics=None)
         assert_raises_rpc_error(None, None, self.get_logs, filter)
 
-        filter = Filter("0x0", "0x0", topics="")
+        filter = Filter(topics="")
         assert_raises_rpc_error(None, None, self.get_logs, filter)
 
-        filter = Filter("0x0", "0x0", topics=["0x0"])
+        filter = Filter(topics=["0x0"])
         assert_raises_rpc_error(None, None, self.get_logs, filter)
 
         # invalid `limit` type
-        filter = Filter("0x0", "0x0", limit=1)
+        filter = Filter(limit=1)
         assert_raises_rpc_error(None, None, self.get_logs, filter)
 
     def test_valid_filter(self):
+        # variadic address field
+        filter = Filter(address=None)
+        logs = self.get_logs(filter)
+        assert_equal(logs, [])
+
+        filter = Filter(address="0x0000000000000000000000000000000000000000")
+        logs = self.get_logs(filter)
+        assert_equal(logs, [])
+
+        filter = Filter(address=["0x0000000000000000000000000000000000000000", "0x0000000000000000000000000000000000000000"])
+        logs = self.get_logs(filter)
+        assert_equal(logs, [])
+
+        ## all fields
         filter = Filter(
             from_epoch="0x0",
             to_epoch="latest_state",
@@ -55,6 +69,5 @@ class TestGetLogs(RpcClient):
             topics=[["0x0000000000000000000000000000000000000000000000000000000000000000"]],
             limit="0x1"
         )
-
         logs = self.get_logs(filter)
         assert_equal(logs, [])


### PR DESCRIPTION
**cfx_getLogs**

Returns an array of all logs matching a given filter object.

**Parameters**

1. `Object` - The filter options:

    - `fromEpoch`: `QUANTITY|TAG` - (optional, default: `"earliest"`) Integer epoch number, or one of `"earliest"`, `"latest_state"`, `"latest_mined"`. Search will be applied from this epoch number.
    - `toEpoch`: `QUANTITY|TAG` - (optional, default: `"latest_state"`) Integer epoch number, or one of `"earliest"`, `"latest_state"`, `"latest_mined"`. Search will be applied until this epoch number (inclusive).
    - `blockHashes`: `Array of DATA`, - (optional) Array of 32 Bytes block hashes. Search will be applied to these blocks if given. This will override the `fromEpoch`/`toEpoch` fields.
    - `address`: `DATA|Array`, 20 Bytes - (optional) Contract address or a list of addresses from which logs should originate.
    - `topics`: `Array of DATA`, - (optional) Array of 32 Bytes `DATA` topics. Topics are order-dependent. Each topic can also be an array of DATA with "or" options.
    - `limit`: `QUANTITY` - (optional) Integer number. If specified, the query will only return the *last* `n` logs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/373)
<!-- Reviewable:end -->
