### PR TITLE
When a node disconnected, mark it as failure instead of demoting it to untrusted

### DIFF
--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -2401,7 +2401,7 @@ impl NetworkProtocolHandler for SynchronizationProtocolHandler {
                 for peer in timeout_peers {
                     io.disconnect_peer(
                         peer,
-                        Some(UpdateNodeOperation::Demotion),
+                        Some(UpdateNodeOperation::Failure),
                     );
                 }
             }

--- a/network/src/node_table.rs
+++ b/network/src/node_table.rs
@@ -861,8 +861,7 @@ mod json {
         pub fn into_node(self) -> Option<super::Node> {
             match super::Node::from_str(&self.url) {
                 Ok(mut node) => {
-                    node.last_contact =
-                        self.last_contact.map(|c| c.into_node_contact());
+                    node.last_contact = Some(self.last_contact?.into_node_contact());
                     Some(node)
                 }
                 _ => None,

--- a/network/src/node_table.rs
+++ b/network/src/node_table.rs
@@ -861,7 +861,8 @@ mod json {
         pub fn into_node(self) -> Option<super::Node> {
             match super::Node::from_str(&self.url) {
                 Ok(mut node) => {
-                    node.last_contact = Some(self.last_contact?.into_node_contact());
+                    node.last_contact =
+                        self.last_contact.map(NodeContact::into_node_contact);
                     Some(node)
                 }
                 _ => None,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/401)
<!-- Reviewable:end -->
