### PR TITLE
State trie proofs

### DIFF
--- a/core/src/storage/impls/mod.rs
+++ b/core/src/storage/impls/mod.rs
@@ -6,6 +6,7 @@ pub(super) mod errors;
 pub(super) mod multi_version_merkle_patricia_trie;
 pub(super) mod state;
 pub(super) mod state_manager;
+pub(super) mod state_proof;
 pub(self) mod storage_db;
 pub(self) mod storage_manager;
 

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/mod.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/mod.rs
@@ -11,6 +11,8 @@ pub mod mpt_value;
 pub mod node_ref;
 pub mod subtrie_visitor;
 pub mod trie_node;
+pub mod trie_proof;
+pub(self) mod walk;
 
 #[cfg(test)]
 mod tests;

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/trie_proof.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/trie_proof.rs
@@ -1,0 +1,222 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use crate::hash::KECCAK_EMPTY;
+use primitives::MerkleHash;
+use std::collections::HashMap;
+
+use super::{
+    children_table::CHILDREN_COUNT,
+    compressed_path::CompressedPathRef,
+    merkle::compute_merkle,
+    walk::{access_mode::Read, walk, KeyPart, WalkStop},
+};
+
+#[derive(Clone, Debug, Default)]
+pub struct TrieProofNode {
+    // fields necessary for traversal & hashing
+    pub path_end_mask: u8,
+    pub path: Box<[u8]>,
+    pub value: Option<Box<[u8]>>,
+    pub children_table: Option<[MerkleHash; CHILDREN_COUNT]>,
+    pub merkle_hash: MerkleHash,
+}
+
+impl TrieProofNode {
+    pub fn is_valid(&self) -> bool { self.merkle_hash == self.merkle() }
+
+    fn compressed_path_ref(&self) -> CompressedPathRef {
+        CompressedPathRef {
+            path_slice: &self.path,
+            end_mask: self.path_end_mask,
+        }
+    }
+
+    // \w  path: keccak([mask, [path...], keccak(rlp([[children...]?, value]))])
+    // \wo path: keccak(rlp([[children...]?, value]))
+    pub fn merkle(&self) -> MerkleHash {
+        compute_merkle(
+            self.compressed_path_ref(),
+            self.children_table.as_ref().map(|x| &*x),
+            self.value.as_ref().map(|x| &**x),
+        )
+    }
+}
+
+impl TrieProofNode {
+    pub fn walk<'key>(&self, key: KeyPart<'key>) -> WalkStop<'key, MerkleHash> {
+        walk::<Read, MerkleHash>(
+            key,
+            self.compressed_path_ref(),
+            self.path_end_mask,
+            &|index| {
+                self.children_table
+                    .map(|table| table[index as usize])
+                    .and_then(|child| {
+                        if child == KECCAK_EMPTY {
+                            return None;
+                        }
+                        return Some(child);
+                    })
+            },
+        )
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct TrieProof {
+    pub nodes: Vec<TrieProofNode>,
+}
+
+impl TrieProof {
+    pub fn new(nodes: Vec<TrieProofNode>) -> Self { TrieProof { nodes } }
+
+    pub fn is_valid(
+        &self, key: &[u8], value: Option<&[u8]>, root: MerkleHash,
+    ) -> bool {
+        // empty proof
+        if self.nodes.is_empty() {
+            return value == None && root == KECCAK_EMPTY;
+        }
+
+        // store (hash -> node) mapping
+        let mut nodes = HashMap::new();
+        for node in &self.nodes {
+            nodes.insert(node.merkle_hash, node);
+        }
+
+        let mut key = key;
+        let mut hash = root;
+
+        loop {
+            match nodes.get(&hash) {
+                // proof has missing node
+                None => {
+                    debug_assert!(hash != KECCAK_EMPTY); // this should lead to `ChildNotFound`
+                    return false;
+                }
+                Some(node) => {
+                    // node hash does not match its contents
+                    if !node.is_valid() {
+                        return false;
+                    }
+
+                    match node.walk(key) {
+                        WalkStop::Arrived => {
+                            return value == node.value.as_ref().map(|x| &**x);
+                        }
+                        WalkStop::PathDiverted { .. } => {
+                            return value == None;
+                        }
+                        WalkStop::ChildNotFound { .. } => {
+                            return value == None;
+                        }
+                        WalkStop::Descent {
+                            key_remaining,
+                            child_node,
+                            ..
+                        } => {
+                            hash = child_node;
+                            key = key_remaining;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TrieProof, TrieProofNode};
+    use crate::hash::KECCAK_EMPTY;
+
+    #[test]
+    fn test_proofs() {
+        //       ------|path: []|-----
+        //      |                     |
+        //      |              |path: [0x00, 0x00]|
+        //      |                     |
+        // |path: [0x02]|   |path: [0x03]            |
+        // |val : [0x02]|   |val : [0x00, 0x00, 0x03]|
+
+        let (key1, value1) = ([0x02], [0x02]);
+        let (key2, value2) = ([0x00, 0x00, 0x03], [0x00, 0x00, 0x03]);
+
+        let leaf1 = {
+            let mut node = TrieProofNode::default();
+            node.path = Box::new([0x02]);
+            node.value = Some(Box::new(value1.clone()));
+            node.merkle_hash = node.merkle();
+            node
+        };
+
+        let leaf2 = {
+            let mut node = TrieProofNode::default();
+            node.path = Box::new([0x03]);
+            node.value = Some(Box::new(value2.clone()));
+            node.merkle_hash = node.merkle();
+            node
+        };
+
+        let ext = {
+            let mut children = [KECCAK_EMPTY; 16];
+            children[0x03] = leaf2.merkle();
+
+            let mut node = TrieProofNode::default();
+            node.path = Box::new([0x00, 0x00]);
+            node.children_table = Some(children);
+            node.merkle_hash = node.merkle();
+            node
+        };
+
+        let branch = {
+            let mut children = [KECCAK_EMPTY; 16];
+            children[0x00] = ext.merkle();
+            children[0x02] = leaf1.merkle();
+
+            let mut node = TrieProofNode::default();
+            node.path = Box::new([]);
+            node.children_table = Some(children);
+            node.merkle_hash = node.merkle();
+            node
+        };
+
+        // empty proof
+        let proof = TrieProof::new(vec![]);
+        assert!(proof.is_valid(&[0x00], None, KECCAK_EMPTY));
+        assert!(!proof.is_valid(&[0x00], None, leaf1.merkle()));
+        assert!(!proof.is_valid(&key1, Some(&[0x00]), KECCAK_EMPTY));
+
+        // valid proof
+        let proof = TrieProof::new(vec![
+            leaf1.clone(),
+            leaf2.clone(),
+            ext.clone(),
+            branch.clone(),
+        ]);
+
+        let root = branch.merkle();
+        assert!(proof.is_valid(&key1, Some(&value1), root));
+        assert!(proof.is_valid(&key2, Some(&value2), root));
+        assert!(proof.is_valid(&[0x01], None, root));
+
+        // wrong root
+        assert!(!proof.is_valid(&key2, Some(&value2), leaf1.merkle()));
+
+        // missing node
+        let proof = TrieProof::new(vec![ext.clone(), branch.clone()]);
+        assert!(!proof.is_valid(&key2, Some(&value2), root));
+
+        // wrong hash
+        let mut leaf2_wrong = leaf2;
+        leaf2_wrong.merkle_hash[0] = 0x00;
+
+        let proof = TrieProof::new(vec![leaf1, leaf2_wrong, ext, branch]);
+        assert!(!proof.is_valid(&key2, Some(&value2), root));
+
+        // wrong value
+        assert!(!proof.is_valid(&key2, Some(&[0x00, 0x00, 0x04]), root));
+    }
+}

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/walk.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/walk.rs
@@ -1,0 +1,251 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use super::compressed_path::*;
+use std::cmp::min;
+
+/// Key length should be multiple of 8.
+// TODO(yz): align key @8B with mask.
+pub type KeyPart<'a> = &'a [u8];
+
+pub enum WalkStop<'key, T> {
+    // path matching fails at some point. Want the new path_steps,
+    // path_end_mask, ..., etc Basically, a new node should be created to
+    // replace the current node from parent children table;
+    // modify this node or create a new node to insert as children of new
+    // node, (update path) then
+    // the child that should be followed is nil at the new node.
+    // if put single version, this node changes, this node replaced, parent
+    // update child and merkle. Before merkle update, this node must be saved
+    // in mem or into disk db (not that expensive). if get / delete (not
+    // found)
+    PathDiverted {
+        /// Key may terminate on the path.
+        key_child_index: Option<u8>,
+        key_remaining: KeyPart<'key>,
+        matched_path: CompressedPathRaw,
+        unmatched_child_index: u8,
+        unmatched_path_remaining: CompressedPathRaw,
+    },
+
+    // If exactly at this node.
+    // if put, update this node
+    // if delete, may cause deletion / path compression (delete this node,
+    // parent update child, update path of original child node)
+    Arrived,
+
+    Descent {
+        key_remaining: KeyPart<'key>,
+        child_index: u8,
+        child_node: T,
+    },
+
+    // To descent, however child doesn't exists:
+    // to modify this node or create a new node to replace this node (update
+    // child) Then create a new node for remaining key_part (we don't care
+    // about begin_mask). if put single version, this node changes, parent
+    // update merkle. if get / delete (not found)
+    ChildNotFound {
+        key_remaining: KeyPart<'key>,
+        child_index: u8,
+    },
+}
+
+impl<'key, T> WalkStop<'key, T> {
+    fn child_not_found_uninitialized() -> Self {
+        WalkStop::ChildNotFound {
+            key_remaining: Default::default(),
+            child_index: 0,
+        }
+    }
+
+    fn path_diverted_uninitialized() -> Self {
+        WalkStop::PathDiverted {
+            key_child_index: None,
+            key_remaining: Default::default(),
+            matched_path: Default::default(),
+            unmatched_child_index: 0,
+            unmatched_path_remaining: Default::default(),
+        }
+    }
+}
+
+pub mod access_mode {
+    pub trait AccessMode {
+        fn is_read_only() -> bool;
+    }
+
+    pub struct Read {}
+    pub struct Write {}
+
+    impl AccessMode for Read {
+        fn is_read_only() -> bool { return true; }
+    }
+
+    impl AccessMode for Write {
+        fn is_read_only() -> bool { return false; }
+    }
+}
+
+/// Traverse.
+// TODO(yz): write test.
+/// The start of key is always aligned with compressed path of
+/// current node, e.g. if compressed path starts at the second-half, so
+/// should be key.
+pub(super) fn walk<'key, AM: access_mode::AccessMode, T>(
+    key: KeyPart<'key>, path: CompressedPathRef, path_end_mask: u8,
+    get_child: &Fn(u8) -> Option<T>,
+) -> WalkStop<'key, T>
+{
+    let path_slice = path.path_slice;
+
+    // Compare bytes till the last full byte. The first byte is always
+    // included because even if it's the second-half, it must be
+    // already matched before entering this TrieNode.
+    let memcmp_len = min(
+        path_slice.len() - ((path.end_mask != 0) as usize),
+        key.len(),
+    );
+
+    for i in 0..memcmp_len {
+        if path_slice[i] != key[i] {
+            if AM::is_read_only() {
+                return WalkStop::path_diverted_uninitialized();
+            } else {
+                let matched_path: CompressedPathRaw;
+                let key_child_index: u8;
+                let key_remaining: &[u8];
+                let unmatched_child_index: u8;
+                let unmatched_path_remaining: &[u8];
+
+                if CompressedPathRaw::first_nibble(path_slice[i] ^ key[i]) == 0
+                {
+                    // "First half" matched
+                    matched_path = CompressedPathRaw::new_and_apply_mask(
+                        &path_slice[0..i + 1],
+                        CompressedPathRaw::first_nibble(!0),
+                    );
+
+                    key_child_index = CompressedPathRaw::second_nibble(key[i]);
+                    key_remaining = &key[i + 1..];
+                    unmatched_child_index =
+                        CompressedPathRaw::second_nibble(path_slice[i]);
+                    unmatched_path_remaining = &path_slice[i + 1..];
+                } else {
+                    matched_path = CompressedPathRaw::new(&path_slice[0..i], 0);
+                    key_child_index = CompressedPathRaw::first_nibble(key[i]);
+                    key_remaining = &key[i..];
+                    unmatched_child_index =
+                        CompressedPathRaw::first_nibble(path_slice[i]);
+                    unmatched_path_remaining = &path_slice[i..];
+                }
+                return WalkStop::PathDiverted {
+                    key_child_index: Some(key_child_index),
+                    key_remaining: key_remaining.into(),
+                    matched_path,
+                    unmatched_child_index,
+                    unmatched_path_remaining: CompressedPathRaw::new(
+                        unmatched_path_remaining,
+                        path_end_mask,
+                    ),
+                };
+            }
+        }
+    }
+    // Key is fully consumed, get value attached.
+    if key.len() == memcmp_len {
+        // Compressed path isn't fully consumed.
+        if path_slice.len() > memcmp_len {
+            if AM::is_read_only() {
+                return WalkStop::path_diverted_uninitialized();
+            } else {
+                return WalkStop::PathDiverted {
+                    // key_remaining is empty, and key_child_index doesn't
+                    // make sense, but we need to
+                    // mark it.
+                    key_remaining: Default::default(),
+                    key_child_index: None,
+                    matched_path: CompressedPathRaw::new(
+                        &path_slice[0..memcmp_len],
+                        0,
+                    ),
+                    unmatched_child_index: CompressedPathRaw::first_nibble(
+                        path_slice[memcmp_len],
+                    ),
+                    unmatched_path_remaining: CompressedPathRaw::new(
+                        &path_slice[memcmp_len..],
+                        path_end_mask,
+                    ),
+                };
+            }
+        } else {
+            return WalkStop::Arrived;
+        }
+    } else {
+        // Key is not fully consumed.
+
+        // When path is fully consumed, check if child exists under
+        // child_index.
+        let child_index;
+        let key_remaining;
+
+        if path_slice.len() == memcmp_len {
+            // Compressed path is fully consumed. Descend into one child.
+            child_index = CompressedPathRaw::first_nibble(key[memcmp_len]);
+            key_remaining = &key[memcmp_len..];
+        } else {
+            // One half byte remaining to match with path. Consume it in the
+            // key.
+            if CompressedPathRaw::first_nibble(
+                path_slice[memcmp_len] ^ key[memcmp_len],
+            ) != 0
+            {
+                // Mismatch.
+                if AM::is_read_only() {
+                    return WalkStop::path_diverted_uninitialized();
+                } else {
+                    return WalkStop::PathDiverted {
+                        key_child_index: Some(CompressedPathRaw::first_nibble(
+                            key[memcmp_len],
+                        )),
+                        key_remaining: &key[memcmp_len..],
+                        matched_path: CompressedPathRaw::new(
+                            &path_slice[0..memcmp_len],
+                            0,
+                        ),
+                        unmatched_child_index: CompressedPathRaw::first_nibble(
+                            path_slice[memcmp_len],
+                        ),
+                        unmatched_path_remaining: CompressedPathRaw::new(
+                            &path_slice[memcmp_len..],
+                            path_end_mask,
+                        ),
+                    };
+                }
+            } else {
+                child_index = CompressedPathRaw::second_nibble(key[memcmp_len]);
+                key_remaining = &key[memcmp_len + 1..];
+            }
+        }
+
+        match get_child(child_index) {
+            Option::None => {
+                if AM::is_read_only() {
+                    return WalkStop::child_not_found_uninitialized();
+                }
+                return WalkStop::ChildNotFound {
+                    key_remaining,
+                    child_index,
+                };
+            }
+            Option::Some(child_node) => {
+                return WalkStop::Descent {
+                    key_remaining,
+                    child_node,
+                    child_index,
+                };
+            }
+        }
+    }
+}

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/mod.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/mod.rs
@@ -138,6 +138,8 @@ pub(self) mod node_ref_map;
 /// mutability.
 mod slab;
 
+pub use merkle_patricia_trie::trie_proof::TrieProof;
+
 use self::{
     cache::algorithm::lru::LRU, merkle_patricia_trie::*,
     node_memory_manager::*, node_ref_map::DeltaMptDbKey,

--- a/core/src/storage/impls/state.rs
+++ b/core/src/storage/impls/state.rs
@@ -29,38 +29,39 @@ impl<'a> State<'a> {
         }
     }
 
-    pub fn get_from_delta(
+    fn get_from_delta(
         &self, mpt: &'a DeltaMpt, maybe_root_node: Option<NodeRefDeltaMpt>,
-        access_key: &[u8],
-    ) -> Result<Option<Box<[u8]>>>
+        access_key: &[u8], with_proof: bool,
+    ) -> Result<(Option<Box<[u8]>>, Option<TrieProof>)>
     {
         // Get won't create any new nodes so it's fine to pass an empty
         // owned_node_set.
         let mut empty_owned_node_set: Option<OwnedNodeSet> =
             Some(Default::default());
-        match maybe_root_node {
-            None => Ok(None),
-            Some(root_node) => {
-                SubTrieVisitor::new(mpt, root_node, &mut empty_owned_node_set)
-                    .get(access_key)
-            }
-        }
-    }
 
-    pub fn get_from_delta_with_proof(
-        &self, mpt: &'a DeltaMpt, maybe_root_node: Option<NodeRefDeltaMpt>,
-        access_key: &[u8],
-    ) -> Result<(Option<Box<[u8]>>, TrieProof)>
-    {
-        // Get won't create any new nodes so it's fine to pass an empty
-        // owned_node_set.
-        let mut empty_owned_node_set: Option<OwnedNodeSet> =
-            Some(Default::default());
         match maybe_root_node {
-            None => Ok((None, TrieProof::default())),
+            None => Ok((None, None)),
             Some(root_node) => {
-                SubTrieVisitor::new(mpt, root_node, &mut empty_owned_node_set)
-                    .get_with_proof(access_key)
+                let maybe_value = SubTrieVisitor::new(
+                    mpt,
+                    root_node.clone(),
+                    &mut empty_owned_node_set,
+                )
+                .get(access_key)?;
+
+                let maybe_proof = match with_proof {
+                    false => None,
+                    true => Some(
+                        SubTrieVisitor::new(
+                            mpt,
+                            root_node,
+                            &mut empty_owned_node_set,
+                        )
+                        .get_proof(access_key)?,
+                    ),
+                };
+
+                Ok((maybe_value, maybe_proof))
             }
         }
     }
@@ -69,6 +70,52 @@ impl<'a> State<'a> {
         &self, access_key: &[u8],
     ) -> Result<Option<Box<[u8]>>> {
         SnapshotDbTrait::get(&*self.snapshot_db, access_key)
+    }
+
+    fn get_from_all_tries(
+        &self, access_key: &[u8], with_proof: bool,
+    ) -> Result<(Option<Box<[u8]>>, StateProof)> {
+        let (maybe_value, maybe_delta_proof) = self.get_from_delta(
+            &self.delta_trie,
+            self.delta_trie_root.clone(),
+            access_key,
+            with_proof,
+        )?;
+
+        if maybe_value.is_some() {
+            let proof = StateProof::default().with_delta(maybe_delta_proof);
+            return Ok((maybe_value, proof));
+        }
+
+        let maybe_intermediate_proof = match self.intermediate_trie {
+            None => None,
+            Some(_) => {
+                let (maybe_value, maybe_proof) = self.get_from_delta(
+                    self.intermediate_trie.as_ref().unwrap(),
+                    self.intermediate_trie_root.clone(),
+                    access_key,
+                    with_proof,
+                )?;
+
+                if maybe_value.is_some() {
+                    let proof = StateProof::default()
+                        .with_delta(maybe_delta_proof)
+                        .with_intermediate(maybe_proof);
+                    return Ok((maybe_value, proof));
+                }
+
+                maybe_proof
+            }
+        };
+
+        // TODO: get from snapshot
+        // self.get_from_snapshot(access_key)
+
+        let proof = StateProof::default()
+            .with_delta(maybe_delta_proof)
+            .with_intermediate(maybe_intermediate_proof);
+
+        Ok((None, proof))
     }
 }
 
@@ -102,82 +149,14 @@ impl<'a> StateTrait for State<'a> {
     }
 
     fn get(&self, access_key: &[u8]) -> Result<Option<Box<[u8]>>> {
-        let maybe_delta_value = self.get_from_delta(
-            &self.delta_trie,
-            self.delta_trie_root.clone(),
-            access_key,
-        );
-        if maybe_delta_value.is_err()
-            || maybe_delta_value.as_ref().unwrap().is_some()
-        {
-            return maybe_delta_value;
-        }
-        match self.intermediate_trie {
-            None => {}
-            Some(_) => {
-                let maybe_delta_value = self.get_from_delta(
-                    self.intermediate_trie.as_ref().unwrap(),
-                    self.intermediate_trie_root.clone(),
-                    access_key,
-                );
-                if maybe_delta_value.is_err()
-                    || maybe_delta_value.as_ref().unwrap().is_some()
-                {
-                    return maybe_delta_value;
-                }
-            }
-        }
-        //let maybe_intermediate_value = self.get_from_delta();
-        self.get_from_snapshot(access_key)
+        self.get_from_all_tries(access_key, false)
+            .map(|(value, _)| value)
     }
 
     fn get_with_proof(
         &self, access_key: &[u8],
     ) -> Result<(Option<Box<[u8]>>, StateProof)> {
-        let (delta_maybe_val, delta_proof) = self.get_from_delta_with_proof(
-            &self.delta_trie,
-            self.delta_trie_root.clone(),
-            access_key,
-        )?;
-
-        if let Some(value) = delta_maybe_val {
-            let proof = StateProof::for_delta(delta_proof);
-            return Ok((Some(value), proof));
-        }
-
-        let maybe_intermediate_proof = match self.intermediate_trie {
-            None => None,
-            Some(_) => {
-                let (intermediate_maybe_val, intermediate_proof) = self
-                    .get_from_delta_with_proof(
-                        self.intermediate_trie.as_ref().unwrap(),
-                        self.intermediate_trie_root.clone(),
-                        access_key,
-                    )?;
-
-                if let Some(value) = intermediate_maybe_val {
-                    let proof = StateProof::for_intermediate(
-                        delta_proof,
-                        intermediate_proof,
-                    );
-                    return Ok((Some(value), proof));
-                }
-
-                Some(intermediate_proof)
-            }
-        };
-
-        // TODO: get from snapshot
-        // self.get_from_snapshot(access_key)
-
-        Ok((
-            None,
-            StateProof {
-                delta_proof: Some(delta_proof),
-                intermediate_proof: maybe_intermediate_proof,
-                snapshot_proof: None,
-            },
-        ))
+        self.get_from_all_tries(access_key, true)
     }
 
     // FIXME: re-implement all other methods.

--- a/core/src/storage/impls/state_proof.rs
+++ b/core/src/storage/impls/state_proof.rs
@@ -6,7 +6,7 @@ pub use super::multi_version_merkle_patricia_trie::TrieProof;
 use crate::hash::KECCAK_EMPTY;
 use primitives::MerkleHash;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct StateProof {
     pub delta_proof: Option<TrieProof>,
     pub intermediate_proof: Option<TrieProof>,
@@ -14,22 +14,16 @@ pub struct StateProof {
 }
 
 impl StateProof {
-    pub fn for_delta(delta_proof: TrieProof) -> Self {
-        StateProof {
-            delta_proof: Some(delta_proof),
-            intermediate_proof: None,
-            snapshot_proof: None,
-        }
+    pub fn with_delta(mut self, maybe_delta_proof: Option<TrieProof>) -> Self {
+        self.delta_proof = maybe_delta_proof;
+        self
     }
 
-    pub fn for_intermediate(
-        delta_proof: TrieProof, intermediate_proof: TrieProof,
+    pub fn with_intermediate(
+        mut self, maybe_intermediate_proof: Option<TrieProof>,
     ) -> Self {
-        StateProof {
-            delta_proof: Some(delta_proof),
-            intermediate_proof: Some(intermediate_proof),
-            snapshot_proof: None,
-        }
+        self.intermediate_proof = maybe_intermediate_proof;
+        self
     }
 
     pub fn is_valid(

--- a/core/src/storage/impls/state_proof.rs
+++ b/core/src/storage/impls/state_proof.rs
@@ -1,0 +1,89 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+pub use super::multi_version_merkle_patricia_trie::TrieProof;
+use crate::hash::KECCAK_EMPTY;
+use primitives::MerkleHash;
+
+#[derive(Clone, Debug)]
+pub struct StateProof {
+    pub delta_proof: Option<TrieProof>,
+    pub intermediate_proof: Option<TrieProof>,
+    pub snapshot_proof: Option<TrieProof>,
+}
+
+impl StateProof {
+    pub fn for_delta(delta_proof: TrieProof) -> Self {
+        StateProof {
+            delta_proof: Some(delta_proof),
+            intermediate_proof: None,
+            snapshot_proof: None,
+        }
+    }
+
+    pub fn for_intermediate(
+        delta_proof: TrieProof, intermediate_proof: TrieProof,
+    ) -> Self {
+        StateProof {
+            delta_proof: Some(delta_proof),
+            intermediate_proof: Some(intermediate_proof),
+            snapshot_proof: None,
+        }
+    }
+
+    pub fn is_valid(
+        &self, key: &[u8], value: Option<&[u8]>, delta_root: MerkleHash,
+        intermediate_root: MerkleHash, snapshot_root: MerkleHash,
+    ) -> bool
+    {
+        match (
+            value,
+            &self.delta_proof,
+            &self.intermediate_proof,
+            &self.snapshot_proof,
+        ) {
+            // proof of existence for key in delta trie
+            (Some(_), Some(p1), None, None) => {
+                p1.is_valid(key, value, delta_root)
+            }
+            // proof of existence for key in intermediate trie
+            (Some(_), Some(p1), Some(p2), None) => {
+                p1.is_valid(key, None, delta_root)
+                    && p2.is_valid(key, value, intermediate_root)
+            }
+            // proof of existence for key in snapshot
+            (Some(_), Some(p1), Some(p2), Some(p3)) => {
+                p1.is_valid(key, None, delta_root)
+                    && p2.is_valid(key, None, intermediate_root)
+                    && p3.is_valid(key, value, snapshot_root)
+            }
+            // proof of non-existence with a single trie
+            (None, Some(p1), None, None) => {
+                p1.is_valid(key, None, delta_root)
+                    && intermediate_root == KECCAK_EMPTY
+                    && snapshot_root == KECCAK_EMPTY
+            }
+            // proof of non-existence with two tries
+            (None, Some(p1), Some(p2), None) => {
+                p1.is_valid(key, None, delta_root)
+                    && p2.is_valid(key, None, intermediate_root)
+                    && snapshot_root == KECCAK_EMPTY
+            }
+            // proof of non-existence with all tries
+            (None, Some(p1), Some(p2), Some(p3)) => {
+                p1.is_valid(key, None, delta_root)
+                    && p2.is_valid(key, None, intermediate_root)
+                    && p3.is_valid(key, None, snapshot_root)
+            }
+            // no proofs available
+            (_, None, None, None) => {
+                value.is_none()
+                    && delta_root == KECCAK_EMPTY
+                    && intermediate_root == KECCAK_EMPTY
+                    && snapshot_root == KECCAK_EMPTY
+            }
+            _ => false,
+        }
+    }
+}

--- a/core/src/storage/mod.rs
+++ b/core/src/storage/mod.rs
@@ -11,6 +11,8 @@ pub mod tests;
 
 mod impls;
 
+pub use self::impls::state_proof::{StateProof, TrieProof};
+
 pub use self::{
     impls::{
         defaults,

--- a/core/src/storage/state.rs
+++ b/core/src/storage/state.rs
@@ -29,6 +29,9 @@ pub trait StateTrait {
 
     // Actions.
     fn get(&self, access_key: &[u8]) -> Result<Option<Box<[u8]>>>;
+    fn get_with_proof(
+        &self, access_key: &[u8],
+    ) -> Result<(Option<Box<[u8]>>, StateProof)>;
     fn set(&mut self, access_key: &[u8], value: &[u8]) -> Result<()>;
     fn delete(&mut self, access_key: &[u8]) -> Result<Option<Box<[u8]>>>;
     // Delete everything prefixed by access_key and return deleted key value
@@ -48,6 +51,6 @@ pub trait StateTrait {
     // TODO(yz): verifiable proof related methods.
 }
 
-use super::impls::errors::*;
+use super::impls::{errors::*, state_proof::StateProof};
 use crate::statedb::KeyPadding;
 use primitives::{EpochId, MerkleHash, StateRootWithAuxInfo};


### PR DESCRIPTION
**Overview**

The goal of state trie proofs is to provide enough information for light nodes and RPC clients so that they can verify the validity of a `key -> value` mapping provided that they know the root of the corresponding state trie.

**Main changes**

- Added **`TrieProofNode`** that represents a node in a trie proof. This is necessary as the existing `TrieNode` contains local u32 node references instead of child hashes. Traversal (`walk`) and hashing (`merkle`) are implemented for both node types.
- Added **`TrieProof`** that stores and validates a collection of type `Vec<TrieProofNode>` against a `(key, value, root)` tuple.
- Added **`StateProof`** that stores and validates 0 to 3 `TrieProof` objects for our three tries (`delta_proof`, `intermediate_proof`, `snapshot_proof`).
- Added **`StateTrait::get_with_proof(key)`** that returns a Merkle proof (`StateProof`) along with the retrieved value. I decided to use a separate method (as opposed to Parity's approach of passing a `Recorder` object into `get`) as we need to do multiple additional lookups to retrieve the children hashes, which will certainly have a performance impact.

**Implementation issues**

I tried to make trie nodes share common functionalities (e.g. `walk`) using a trait (`TrieNodeTrait`), but was unable to make the type system accept it due to the complex type signatures in `SubTrieVisitor`. Instead, I decided to put `walk` into its own module and make both `TrieNode` and `TrieProofNode` call it with the appropriate parameters.

**Example proof:**
```
key   = [137, 133, 236, 172] ~ [0x89, 0x85, 0xec, 0xac]
value = Some([137, 133, 236, 172])
root  = 0xdbfb4c70ed04494b31e89f29394b5d132418513e72d8a42385c4aaa70f856268

proof = StateProof {
  delta_proof: Some(
    TrieProof {
      nodes: [
        TrieProofNode {
          path_end_mask: 0,
          path: [],
          value: None,
          children_table: Some([
              0xf506f53f2c7141f751bf085584904471a6248f3c183fb2fafb2595682d68d848,
              0xa78533c539e669dcb1a80a923260bf61b9f08a64a74c86e7254c041cf8fb9672,
              0xba2137ed23d542cdc414939b13bb7711e438a11c43e5aff1285f7f84a77be7d7,
              0x54370e9d2cf3b08256d7a18b18d6fc56561e61335c093583447be0cac5c2049f,
              0x47621276f84af438716bd8dc70be5ac4d4658cdebba332ff7278da34a0dcf67c,
              0x0e05ffeb06961d89aa41862675b47aa3895fe7c5777ee8d8317a1c67d9fc11c8,
              0xee18715a06f75acdf943b9910ccbcfa241a343fc98c5e9ca497226ef4c9dd303,
              0x7761f62cdc30f940cdc3c4a608f1063a740aa6f63242f5a2d14d6b484282b21a,
              0xa7bc9c5d9c534050a82375909c826ad49bb7fbfbe9d1cec7b017d19b65f94951,
              0x702d5708610fffcaa3d224add56a1b9c29562617bd0fd41c40df9b504fc30434,
              0xeb0b329515d0fbf2cad9d0625f42e2088b93332be9bdd1164b229e1b2a0965f3,
              0xb13ce0c8bf68feed467669adf6ed911c47cca1b1e4289e478bba387a0f2e3208,
              0xb55ea81b82770e878b2d5698c1a71603b7253658069c6a8c59b94fb0d949ce62,
              0x1714fa3df3903817c569f9d7c1f6778242e30f994f95c5935c26d345dc087f0c,
              0x487f7280639c0b467e03fd0f13c422f9226caafd9c1ecfee641d4d24286f3b5a,
              0x235ed7e855cec573763b8161e8920b40bf96810e8785130442d7e1ea68545e47
          ]),
          merkle_hash: 0xdbfb4c70ed04494b31e89f29394b5d132418513e72d8a42385c4aaa70f856268
        },
        TrieProofNode {
          path_end_mask: 15,
          path: [9],
          value: None,
          children_table: Some([
              0x65be8864b844e461d4918df89b7b369f4ac472f8b19b4b740243445e7057d785,
              0x314b168be51c3ba47240bf989208ea5bb24094b10837137984e0f302ac93e164,
              0xc532e1a073b2e99694caf96747d5853d0138dfc7002b61017acdf8fbd13b1098,
              0xa00ef3e9dd749e61ff12cbc9e264a0ab69934db071096cfb8e9edbe296fe01e0,
              0x2237fa05f369b3f7f1c28a2d0d7db5c23c0c11159246245bf4832f40e4919970,
              0xda2fe0f5bf489ad5feb3f1e55b328ffba9a4ff6b24c878bc6a00962caf24bccc,
              0xda01025e29990924218cfdd3cb4d9560bc3d401a88ed2aa95faec3d33c409aca,
              0xb3b85893d0399d1a926d385659e00fdaa87c29712c06df27c870563698b0ace8,
              0x74feaf1918d4cc60549c2bd00f41ac4039dea6695353ab62c4545e5b2bc63bb7,
              0x6de93a52d58502118a4a1b636224c47227b48b6dd7c30e1138260f6f9c7fb45a,
              0xcbe4e74d19528c890292960dd906bc0e4216a9f759fe2c085f4850b8e5cee4ad,
              0x4167426c61a0697bf6b90dd25b6366a3e88308efe76725e001c0e95826d24336,
              0x759491ac05f8f5b5409e93b3474aaa5c8676a2883679178c3ff95eb7b92da74c,
              0x1290bae68fe7844967ed1ab20c603a74e67cf0a130a0acec54502c883df6c93b,
              0x3a2e40a17f5ee992bdb8785ec6fcde0df6262cdd28ff4f907335b142abae7aa9,
              0xbfb202515902d8f61a73ae02719fc706851b36cdf165155552143354973528b8
          ]),
          merkle_hash: 0x702d5708610fffcaa3d224add56a1b9c29562617bd0fd41c40df9b504fc30434
        },
        TrieProofNode {
          path_end_mask: 0,
          path: [],
          value: None,
          children_table: Some([
              0x78030a28ba5bdae933790896b14c6b1642109a52ee15abb13794964e8b7e1bde,
              0xed49ed86175c8f7cfdf75810461a627c2c0ad5c2e3d8d3d648bae7b3ad92c08e,
              0x461a8638299c13d2a34bcc777e894096e3118bb1dad50a462cfad251f314cccd,
              0x882b6b24f948129344e3f6a2f66af21208eaa845400cfe326830d3ab8b02a250,
              0x4369555a539b411c537d9750e1c19493dfa2c50a2ef0af91e67393c9b3849dba,
              0x1774df175e2e434a2488af01f061f9e6383d8ff299e7e3933faff1aec70b6d99,
              0x5c42ac44aca3d214b0817f584606d988714172097232470aa77de8b6a418f0fc,
              0xd5bb2c92167f6d361ba5c0f846f0175bfad48ea103e66804d345bb5b7d6ae154,
              0x74786ded40ba57be57d1bd64760e39c808e8f383ec47edbedfc5dd820b578e1e,
              0x961907be82c4232aec220f33ba83bfc8ee5bff2bef57c81f7f0816020d0b483b,
              0x3aa4aa0f7eb7abbd375073696c8898ece0a906976f229aa94cfc4631f95f3ed9,
              0x0ce9d305b0ffa9a424d0f1a696f5b1037dda33d17f2adea2f168df97919f22ed,
              0xa9ab6a0a2b84dacc7a453ae40cfefb7747523a842ea93dba6bd4dfa1417a831a,
              0x060d25bc66caeb9a6efdeb090d8f260bc41c1de44440b9e6991309bfe2a256e9,
              0x6ee165d0e04c758c480aa4c2b698e2b04883ce69578126156d46910483da05af,
              0xcff282c47bc1a59b32f311e4d55e9fce68a775a7d26fbbeb9581bd2b81611e90
          ]),
          merkle_hash: 0x74feaf1918d4cc60549c2bd00f41ac4039dea6695353ab62c4545e5b2bc63bb7
        },
        TrieProofNode {
          path_end_mask: 15,
          path: [5],
          value: None,
          children_table: Some([
              0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
              0x70488f11031bed0e8df8015cd6c63558f77f6bbf4579f51389eb7de3cd766492,
              0xbb5126d45a585676e2104c9639c4d0a0b1a20911245ac2b43b3537f230d950e5,
              0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
              0x003db8a6dab20d24b0a072926e73c2cf12e5e8cea482cb02190df572bef095c6,
              0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
              0xb9f26277f52b3d25900501c6b6c4bd0104150e1aef90f4f129180095fb28f797,
              0xd2743cd2c9b9638def5f690694244b5b4a6918af83fccd2ea4352f84f81aee63,
              0x6205bf3eef005f6ff77a0a41df65c852faa64d1cdfa88ec899db59b4a7196617,
              0x73ae093485059024089a8a0b2342b6a5e8ce345a42fd9da5697d1ebdb3cb505a,
              0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
              0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
              0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
              0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
              0xab4c4a5f8e84df8b5dea82dc661ac2ff088d2318771a9438361b963524db305a,
              0xbddd91ea84448529bb7560246ac9cf64c5f337817bb2e65f336e764d9d672433
          ]),
          merkle_hash: 0x1774df175e2e434a2488af01f061f9e6383d8ff299e7e3933faff1aec70b6d99
        },
        TrieProofNode {
          path_end_mask: 0,
          path: [236, 172],
          value: Some([137, 133, 236, 172]),
          children_table: None,
          merkle_hash: 0x6205bf3eef005f6ff77a0a41df65c852faa64d1cdfa88ec899db59b4a7196617
        }
      ]
    }
  ),
  intermediate_proof: None,
  snapshot_proof: None
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/412)
<!-- Reviewable:end -->
