### PR TITLE
decouple network from sync

### DIFF
--- a/client/src/archive/mod.rs
+++ b/client/src/archive/mod.rs
@@ -11,8 +11,8 @@ use blockgen::BlockGenerator;
 use cfxcore::{
     genesis, pow::WORKER_COMPUTATION_PARALLELISM, statistics::Statistics,
     storage::StorageManager, transaction_pool::DEFAULT_MAX_BLOCK_GAS_LIMIT,
-    vm_factory::VmFactory, ConsensusGraph, SynchronizationService,
-    TransactionPool,
+    vm_factory::VmFactory, ConsensusGraph, SynchronizationGraph,
+    SynchronizationService, TransactionPool,
 };
 
 use crate::rpc::{
@@ -39,7 +39,7 @@ use std::{
 };
 use threadpool::ThreadPool;
 use txgen::{
-    propagate::DataPropagation, SpecialTransactionGenerator,
+    propagate::DataPropagationService, SpecialTransactionGenerator,
     TransactionGenerator,
 };
 
@@ -189,37 +189,45 @@ impl ArchiveClient {
         let protocol_config = conf.protocol_config();
         let verification_config = conf.verification_config();
 
-        let mut sync = cfxcore::SynchronizationService::new(
-            false,
-            NetworkService::new(network_config),
+        let network = {
+            let mut network = NetworkService::new(network_config);
+            network.start().unwrap();
+            Arc::new(network)
+        };
+
+        let sync_graph = Arc::new(SynchronizationGraph::new(
             consensus.clone(),
-            protocol_config,
             verification_config,
-            pow_config.clone(),
-        );
-        sync.start().unwrap();
+            pow_config,
+        ));
+
+        let sync = Arc::new(SynchronizationService::new(
+            false,
+            network.clone(),
+            consensus.clone(),
+            sync_graph.clone(),
+            protocol_config,
+        ));
+        sync.register().unwrap();
 
         if conf.raw_conf.test_mode && conf.raw_conf.data_propagate_enabled {
-            DataPropagation::register(
+            let dp = DataPropagationService::new(
                 conf.raw_conf.data_propagate_interval_ms,
                 conf.raw_conf.data_propagate_size,
-                sync.get_network_service(),
-            )?;
+            );
+            dp.register(network.clone())?;
         }
-
-        let sync = Arc::new(sync);
-        let sync_graph = sync.get_synchronization_graph();
 
         let txgen = Arc::new(TransactionGenerator::new(
             consensus.clone(),
             txpool.clone(),
             secret_store.clone(),
-            sync.net_key_pair().ok(),
+            network.net_key_pair().ok(),
         ));
 
         let special_txgen =
             Arc::new(Mutex::new(SpecialTransactionGenerator::new(
-                sync.net_key_pair().unwrap(),
+                network.net_key_pair().unwrap(),
                 &public_to_address(secret_store.get_keypair(0).public()),
                 U256::from_dec_str("10000000000000000").unwrap(),
                 U256::from_dec_str("10000000000000000").unwrap(),
@@ -298,6 +306,7 @@ impl ArchiveClient {
             blockgen.clone(),
             txpool.clone(),
             exit,
+            network.clone(),
         ));
 
         let debug_rpc_http_server = super::rpc::new_http(

--- a/client/src/archive/mod.rs
+++ b/client/src/archive/mod.rs
@@ -39,7 +39,7 @@ use std::{
 };
 use threadpool::ThreadPool;
 use txgen::{
-    propagate::DataPropagationService, SpecialTransactionGenerator,
+    propagate::DataPropagation, SpecialTransactionGenerator,
     TransactionGenerator,
 };
 
@@ -211,11 +211,11 @@ impl ArchiveClient {
         sync.register().unwrap();
 
         if conf.raw_conf.test_mode && conf.raw_conf.data_propagate_enabled {
-            let dp = DataPropagationService::new(
+            let dp = Arc::new(DataPropagation::new(
                 conf.raw_conf.data_propagate_interval_ms,
                 conf.raw_conf.data_propagate_size,
-            );
-            dp.register(network.clone())?;
+            ));
+            DataPropagation::register(dp, network.clone())?;
         }
 
         let txgen = Arc::new(TransactionGenerator::new(

--- a/client/src/full/mod.rs
+++ b/client/src/full/mod.rs
@@ -11,8 +11,8 @@ use blockgen::BlockGenerator;
 use cfxcore::{
     genesis, pow::WORKER_COMPUTATION_PARALLELISM, statistics::Statistics,
     storage::StorageManager, transaction_pool::DEFAULT_MAX_BLOCK_GAS_LIMIT,
-    vm_factory::VmFactory, ConsensusGraph, SynchronizationService,
-    TransactionPool,
+    vm_factory::VmFactory, ConsensusGraph, SynchronizationGraph,
+    SynchronizationService, TransactionPool,
 };
 
 use crate::rpc::{
@@ -39,7 +39,7 @@ use std::{
 };
 use threadpool::ThreadPool;
 use txgen::{
-    propagate::DataPropagation, SpecialTransactionGenerator,
+    propagate::DataPropagationService, SpecialTransactionGenerator,
     TransactionGenerator,
 };
 
@@ -189,37 +189,45 @@ impl FullClient {
         let protocol_config = conf.protocol_config();
         let verification_config = conf.verification_config();
 
-        let mut sync = cfxcore::SynchronizationService::new(
-            true,
-            NetworkService::new(network_config),
+        let network = {
+            let mut network = NetworkService::new(network_config);
+            network.start().unwrap();
+            Arc::new(network)
+        };
+
+        let sync_graph = Arc::new(SynchronizationGraph::new(
             consensus.clone(),
-            protocol_config,
             verification_config,
-            pow_config.clone(),
-        );
-        sync.start().unwrap();
+            pow_config,
+        ));
+
+        let sync = Arc::new(SynchronizationService::new(
+            true,
+            network.clone(),
+            consensus.clone(),
+            sync_graph.clone(),
+            protocol_config,
+        ));
+        sync.register().unwrap();
 
         if conf.raw_conf.test_mode && conf.raw_conf.data_propagate_enabled {
-            DataPropagation::register(
+            let dp = DataPropagationService::new(
                 conf.raw_conf.data_propagate_interval_ms,
                 conf.raw_conf.data_propagate_size,
-                sync.get_network_service(),
-            )?;
+            );
+            dp.register(network.clone())?;
         }
-
-        let sync = Arc::new(sync);
-        let sync_graph = sync.get_synchronization_graph();
 
         let txgen = Arc::new(TransactionGenerator::new(
             consensus.clone(),
             txpool.clone(),
             secret_store.clone(),
-            sync.net_key_pair().ok(),
+            network.net_key_pair().ok(),
         ));
 
         let special_txgen =
             Arc::new(Mutex::new(SpecialTransactionGenerator::new(
-                sync.net_key_pair().unwrap(),
+                network.net_key_pair().unwrap(),
                 &public_to_address(secret_store.get_keypair(0).public()),
                 U256::from_dec_str("10000000000000000").unwrap(),
                 U256::from_dec_str("10000000000000000").unwrap(),
@@ -298,6 +306,7 @@ impl FullClient {
             blockgen.clone(),
             txpool.clone(),
             exit,
+            network.clone(),
         ));
 
         let debug_rpc_http_server = super::rpc::new_http(

--- a/client/src/full/mod.rs
+++ b/client/src/full/mod.rs
@@ -39,7 +39,7 @@ use std::{
 };
 use threadpool::ThreadPool;
 use txgen::{
-    propagate::DataPropagationService, SpecialTransactionGenerator,
+    propagate::DataPropagation, SpecialTransactionGenerator,
     TransactionGenerator,
 };
 
@@ -211,11 +211,11 @@ impl FullClient {
         sync.register().unwrap();
 
         if conf.raw_conf.test_mode && conf.raw_conf.data_propagate_enabled {
-            let dp = DataPropagationService::new(
+            let dp = Arc::new(DataPropagation::new(
                 conf.raw_conf.data_propagate_interval_ms,
                 conf.raw_conf.data_propagate_size,
-            );
-            dp.register(network.clone())?;
+            ));
+            DataPropagation::register(dp, network.clone())?;
         }
 
         let txgen = Arc::new(TransactionGenerator::new(

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -22,7 +22,7 @@ use network::{
     get_high_priority_packets,
     node_table::{Node, NodeEndpoint, NodeEntry, NodeId},
     throttling::{self, THROTTLING_SERVICE},
-    SessionDetails,
+    NetworkService, SessionDetails,
 };
 use parking_lot::{Condvar, Mutex};
 use primitives::{
@@ -42,13 +42,14 @@ pub struct RpcImpl {
     block_gen: Arc<BlockGenerator>,
     tx_pool: SharedTransactionPool,
     exit: Arc<(Mutex<bool>, Condvar)>,
+    network: Arc<NetworkService>,
 }
 
 impl RpcImpl {
     pub fn new(
         consensus: SharedConsensusGraph, sync: SharedSynchronizationService,
         block_gen: Arc<BlockGenerator>, tx_pool: SharedTransactionPool,
-        exit: Arc<(Mutex<bool>, Condvar)>,
+        exit: Arc<(Mutex<bool>, Condvar)>, network: Arc<NetworkService>,
     ) -> Self
     {
         RpcImpl {
@@ -57,6 +58,7 @@ impl RpcImpl {
             block_gen,
             tx_pool,
             exit,
+            network,
         }
     }
 
@@ -359,7 +361,7 @@ impl RpcImpl {
             },
         };
         info!("RPC Request: add_peer({:?})", node.clone());
-        match self.sync.add_peer(node) {
+        match self.network.add_peer(node) {
             Ok(x) => Ok(x),
             Err(_) => Err(RpcError::internal_error()),
         }
@@ -374,7 +376,7 @@ impl RpcImpl {
             },
         };
         info!("RPC Request: drop_peer({:?})", node.clone());
-        match self.sync.drop_peer(node) {
+        match self.network.drop_peer(node) {
             Ok(_) => Ok(()),
             Err(_) => Err(RpcError::internal_error()),
         }
@@ -510,7 +512,10 @@ impl RpcImpl {
 
     fn get_peer_info(&self) -> RpcResult<Vec<PeerInfo>> {
         info!("RPC Request: get_peer_info");
-        Ok(self.sync.get_peer_info())
+        match self.network.get_peer_info() {
+            None => Ok(Vec::new()),
+            Some(peers) => Ok(peers),
+        }
     }
 
     fn stop(&self) -> RpcResult<()> {
@@ -521,7 +526,7 @@ impl RpcImpl {
     }
 
     fn get_nodeid(&self, challenge: Vec<u8>) -> RpcResult<Vec<u8>> {
-        match self.sync.sign_challenge(challenge) {
+        match self.network.sign_challenge(challenge) {
             Ok(r) => Ok(r),
             Err(_) => Err(RpcError::internal_error()),
         }
@@ -546,7 +551,7 @@ impl RpcImpl {
     }
 
     fn add_latency(&self, id: NodeId, latency_ms: f64) -> RpcResult<()> {
-        match self.sync.add_latency(id, latency_ms) {
+        match self.network.add_latency(id, latency_ms) {
             Ok(_) => Ok(()),
             Err(_) => Err(RpcError::internal_error()),
         }
@@ -741,7 +746,7 @@ impl RpcImpl {
     }
 
     fn net_node(&self, id: NodeId) -> RpcResult<Option<(String, Node)>> {
-        match self.sync.get_network_service().get_node(&id) {
+        match self.network.get_node(&id) {
             None => Ok(None),
             Some((trusted, node)) => {
                 if trusted {
@@ -756,11 +761,7 @@ impl RpcImpl {
     fn net_sessions(
         &self, node_id: Option<NodeId>,
     ) -> RpcResult<Vec<SessionDetails>> {
-        match self
-            .sync
-            .get_network_service()
-            .get_detailed_sessions(node_id.into())
-        {
+        match self.network.get_detailed_sessions(node_id.into()) {
             None => Ok(Vec::new()),
             Some(sessions) => Ok(sessions),
         }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -65,7 +65,7 @@ pub use crate::{
     consensus::{BestInformation, ConsensusGraph, SharedConsensusGraph},
     sync::{
         SharedSynchronizationGraph, SharedSynchronizationService,
-        SynchronizationService,
+        SynchronizationGraph, SynchronizationService,
     },
     transaction_pool::{SharedTransactionPool, TransactionPool},
     verification::REFEREE_BOUND,

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -4,12 +4,10 @@
 
 use super::{
     super::transaction_pool::SharedTransactionPool, random, Error, ErrorKind,
-    SharedSynchronizationGraph, SynchronizationGraph, SynchronizationPeerState,
-    SynchronizationState,
+    SharedSynchronizationGraph, SynchronizationPeerState, SynchronizationState,
 };
 use crate::{
     consensus::SharedConsensusGraph,
-    pow::ProofOfWorkConfig,
     sync::message::{
         GetBlockHashesByEpoch, GetBlockHashesResponse, GetBlockHeaderChain,
         GetBlockHeaders, GetBlockHeadersResponse, GetBlockTxn,
@@ -47,7 +45,7 @@ use crate::{
         synchronization_state::SyncPhase,
         SynchronizationGraphInner,
     },
-    verification::{VerificationConfig, ACCEPTABLE_TIME_DRIFT},
+    verification::ACCEPTABLE_TIME_DRIFT,
 };
 use metrics::{register_meter_with_group, Meter, MeterTimer};
 use primitives::{Block, BlockHeader, SignedTransaction, TxPropagateId};
@@ -251,7 +249,7 @@ impl SynchronizationProtocolHandler {
     pub fn new(
         is_full_node: bool, protocol_config: ProtocolConfiguration,
         consensus_graph: SharedConsensusGraph,
-        verification_config: VerificationConfig, pow_config: ProofOfWorkConfig,
+        sync_graph: SharedSynchronizationGraph,
     ) -> Self
     {
         let syn = Arc::new(SynchronizationState::new(
@@ -269,11 +267,7 @@ impl SynchronizationProtocolHandler {
 
         Self {
             protocol_config,
-            graph: Arc::new(SynchronizationGraph::new(
-                consensus_graph.clone(),
-                verification_config,
-                pow_config,
-            )),
+            graph: sync_graph,
             syn: syn.clone(),
             request_manager,
             latest_epoch_requested: Mutex::new(0),

--- a/core/src/sync/synchronization_service.rs
+++ b/core/src/sync/synchronization_service.rs
@@ -7,39 +7,33 @@ use super::{
     SYNCHRONIZATION_PROTOCOL_VERSION,
 };
 use crate::{
-    consensus::SharedConsensusGraph, pow::ProofOfWorkConfig,
+    consensus::SharedConsensusGraph,
     sync::synchronization_protocol_handler::ProtocolConfiguration,
-    verification::VerificationConfig,
 };
 use cfx_types::H256;
-use keylib::KeyPair;
-use network::{
-    node_table::{NodeEntry, NodeId},
-    Error as NetworkError, NetworkService, PeerInfo, ProtocolId,
-};
+use network::{NetworkService, ProtocolId};
 use primitives::{transaction::SignedTransaction, Block};
 use std::sync::Arc;
 
 pub struct SynchronizationService {
-    network: NetworkService,
+    network: Arc<NetworkService>,
     protocol_handler: Arc<SynchronizationProtocolHandler>,
     protocol: ProtocolId,
 }
 
 impl SynchronizationService {
     pub fn new(
-        is_full_node: bool, network: NetworkService,
+        is_full_node: bool, network: Arc<NetworkService>,
         consensus_graph: SharedConsensusGraph,
+        sync_graph: SharedSynchronizationGraph,
         protocol_config: ProtocolConfiguration,
-        verification_config: VerificationConfig, pow_config: ProofOfWorkConfig,
     ) -> Self
     {
         let sync_handler = Arc::new(SynchronizationProtocolHandler::new(
             is_full_node,
             protocol_config,
             consensus_graph,
-            verification_config,
-            pow_config,
+            sync_graph,
         ));
 
         SynchronizationService {
@@ -48,8 +42,6 @@ impl SynchronizationService {
             protocol: *b"cfx",
         }
     }
-
-    pub fn get_network_service(&self) -> &NetworkService { &self.network }
 
     pub fn catch_up_mode(&self) -> bool {
         self.protocol_handler.catch_up_mode()
@@ -66,8 +58,7 @@ impl SynchronizationService {
             .append_received_transactions(transactions);
     }
 
-    pub fn start(&mut self) -> Result<(), Error> {
-        self.network.start()?;
+    pub fn register(&self) -> Result<(), Error> {
         self.network.register_protocol(
             self.protocol_handler.clone(),
             self.protocol,
@@ -76,7 +67,7 @@ impl SynchronizationService {
         Ok(())
     }
 
-    pub fn relay_blocks(&self, need_to_relay: Vec<H256>) {
+    fn relay_blocks(&self, need_to_relay: Vec<H256>) {
         self.network.with_context(self.protocol, |io| {
             // FIXME: We may need to propagate the error up
             self.protocol_handler
@@ -91,36 +82,8 @@ impl SynchronizationService {
         self.relay_blocks(vec![hash]);
     }
 
-    pub fn add_peer(&self, node: NodeEntry) -> Result<(), NetworkError> {
-        self.network.add_peer(node)
-    }
-
-    pub fn drop_peer(&self, node: NodeEntry) -> Result<(), NetworkError> {
-        self.network.drop_peer(node)
-    }
-
-    pub fn get_peer_info(&self) -> Vec<PeerInfo> {
-        self.network.get_peer_info().unwrap()
-    }
-
-    pub fn sign_challenge(
-        &self, challenge: Vec<u8>,
-    ) -> Result<Vec<u8>, NetworkError> {
-        self.network.sign_challenge(challenge)
-    }
-
-    pub fn add_latency(
-        &self, id: NodeId, latency_ms: f64,
-    ) -> Result<(), NetworkError> {
-        self.network.add_latency(id, latency_ms)
-    }
-
     pub fn block_by_hash(&self, hash: &H256) -> Option<Arc<Block>> {
         self.protocol_handler.block_by_hash(hash)
-    }
-
-    pub fn net_key_pair(&self) -> Result<KeyPair, NetworkError> {
-        self.network.net_key_pair()
     }
 }
 


### PR DESCRIPTION
**Overview**

The goal of this PR is to decouple both `NetworkService` and `SynchronizationGraph` from `SynchronizationService`. This way, these layers can be shared by multiple different services (e.g. `OnDemandService` and `LightSync` for light clients, etc.).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/431)
<!-- Reviewable:end -->
