### PR TITLE
refactor network so that it can be started after sync graph init

### DIFF
--- a/client/src/archive/mod.rs
+++ b/client/src/archive/mod.rs
@@ -189,11 +189,7 @@ impl ArchiveClient {
         let protocol_config = conf.protocol_config();
         let verification_config = conf.verification_config();
 
-        let network = {
-            let mut network = NetworkService::new(network_config);
-            network.start().unwrap();
-            Arc::new(network)
-        };
+        let network = Arc::new(NetworkService::new(network_config));
 
         let sync_graph = Arc::new(SynchronizationGraph::new(
             consensus.clone(),
@@ -208,6 +204,8 @@ impl ArchiveClient {
             sync_graph.clone(),
             protocol_config,
         ));
+
+        network.start().unwrap();
         sync.register().unwrap();
 
         if conf.raw_conf.test_mode && conf.raw_conf.data_propagate_enabled {

--- a/client/src/full/mod.rs
+++ b/client/src/full/mod.rs
@@ -189,11 +189,7 @@ impl FullClient {
         let protocol_config = conf.protocol_config();
         let verification_config = conf.verification_config();
 
-        let network = {
-            let mut network = NetworkService::new(network_config);
-            network.start().unwrap();
-            Arc::new(network)
-        };
+        let network = Arc::new(NetworkService::new(network_config));
 
         let sync_graph = Arc::new(SynchronizationGraph::new(
             consensus.clone(),
@@ -208,6 +204,8 @@ impl FullClient {
             sync_graph.clone(),
             protocol_config,
         ));
+
+        network.start().unwrap();
         sync.register().unwrap();
 
         if conf.raw_conf.test_mode && conf.raw_conf.data_propagate_enabled {


### PR DESCRIPTION
**Overview**

Make `NetworkService::start` take `&self` instead of `&mut self`. This way, we can call this method on an `Arc<NetworkService>`, which in turn lets us start the network service after sync graph has been initialized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/437)
<!-- Reviewable:end -->
