### PR TITLE
initialize sync graph before network

### DIFF
--- a/client/src/archive/mod.rs
+++ b/client/src/archive/mod.rs
@@ -189,17 +189,17 @@ impl ArchiveClient {
         let protocol_config = conf.protocol_config();
         let verification_config = conf.verification_config();
 
-        let network = {
-            let mut network = NetworkService::new(network_config);
-            network.start().unwrap();
-            Arc::new(network)
-        };
-
         let sync_graph = Arc::new(SynchronizationGraph::new(
             consensus.clone(),
             verification_config,
             pow_config,
         ));
+
+        let network = {
+            let mut network = NetworkService::new(network_config);
+            network.start().unwrap();
+            Arc::new(network)
+        };
 
         let sync = Arc::new(SynchronizationService::new(
             false,

--- a/client/src/full/mod.rs
+++ b/client/src/full/mod.rs
@@ -189,17 +189,17 @@ impl FullClient {
         let protocol_config = conf.protocol_config();
         let verification_config = conf.verification_config();
 
-        let network = {
-            let mut network = NetworkService::new(network_config);
-            network.start().unwrap();
-            Arc::new(network)
-        };
-
         let sync_graph = Arc::new(SynchronizationGraph::new(
             consensus.clone(),
             verification_config,
             pow_config,
         ));
+
+        let network = {
+            let mut network = NetworkService::new(network_config);
+            network.start().unwrap();
+            Arc::new(network)
+        };
 
         let sync = Arc::new(SynchronizationService::new(
             true,


### PR DESCRIPTION
**Overview**

Initializing the synchronization graph might take a long time as we might read a lot of data from disk. For this reason, it is better to initialize and start the network service after the sync graph has been initialized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/439)
<!-- Reviewable:end -->
