### PR TITLE
Refactor sync request manager

### DIFF
--- a/core/src/sync/message/getblockhashesbyepoch.rs
+++ b/core/src/sync/message/getblockhashesbyepoch.rs
@@ -4,18 +4,55 @@
 
 use crate::sync::{
     message::{
-        Context, GetBlockHashesResponse, Handleable, Message, MsgId, RequestId,
+        Context, GetBlockHashesResponse, Handleable, Key, KeyContainer,
+        Message, MsgId, RequestId,
     },
+    request_manager::Request,
     synchronization_protocol_handler::MAX_EPOCHS_TO_SEND,
-    Error,
+    Error, ProtocolConfiguration,
 };
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
-use std::ops::{Deref, DerefMut};
+use std::{
+    any::Any,
+    ops::{Deref, DerefMut},
+    time::Duration,
+};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct GetBlockHashesByEpoch {
     pub request_id: RequestId,
     pub epochs: Vec<u64>,
+}
+
+impl Request for GetBlockHashesByEpoch {
+    fn set_request_id(&mut self, request_id: u64) {
+        self.request_id.set_request_id(request_id);
+    }
+
+    fn as_message(&self) -> &Message { self }
+
+    fn as_any(&self) -> &Any { self }
+
+    fn timeout(&self, conf: &ProtocolConfiguration) -> Duration {
+        conf.headers_request_timeout
+    }
+
+    fn on_removed(&self, inflight_keys: &mut KeyContainer) {
+        let msg_type = self.msg_id().into();
+        for epoch in self.epochs.iter() {
+            inflight_keys.remove(msg_type, Key::Num(*epoch));
+        }
+    }
+
+    fn with_inflight(&mut self, inflight_keys: &mut KeyContainer) {
+        let msg_type = self.msg_id().into();
+        self.epochs
+            .retain(|epoch| inflight_keys.add(msg_type, Key::Num(*epoch)));
+    }
+
+    fn is_empty(&self) -> bool { self.epochs.is_empty() }
+
+    fn resend(&self) -> Box<Request> { Box::new(self.clone()) }
 }
 
 impl Handleable for GetBlockHashesByEpoch {

--- a/core/src/sync/message/getblockhashesbyepoch.rs
+++ b/core/src/sync/message/getblockhashesbyepoch.rs
@@ -52,7 +52,7 @@ impl Request for GetBlockHashesByEpoch {
 
     fn is_empty(&self) -> bool { self.epochs.is_empty() }
 
-    fn resend(&self) -> Box<Request> { Box::new(self.clone()) }
+    fn resend(&self) -> Option<Box<Request>> { Some(Box::new(self.clone())) }
 }
 
 impl Handleable for GetBlockHashesByEpoch {

--- a/core/src/sync/message/getblockheaderchain.rs
+++ b/core/src/sync/message/getblockheaderchain.rs
@@ -58,7 +58,7 @@ impl Request for GetBlockHeaderChain {
 
     fn is_empty(&self) -> bool { self.hash.is_zero() }
 
-    fn resend(&self) -> Box<Request> { Box::new(self.clone()) }
+    fn resend(&self) -> Option<Box<Request>> { Some(Box::new(self.clone())) }
 }
 
 impl Handleable for GetBlockHeaderChain {

--- a/core/src/sync/message/getblockheaderchain.rs
+++ b/core/src/sync/message/getblockheaderchain.rs
@@ -4,16 +4,20 @@
 
 use crate::sync::{
     message::{
-        Context, GetBlockHeadersResponse, Handleable, Message, MsgId, RequestId,
+        Context, GetBlockHeadersResponse, Handleable, Key, KeyContainer,
+        Message, MsgId, RequestId,
     },
+    request_manager::Request,
     synchronization_protocol_handler::MAX_HEADERS_TO_SEND,
-    Error,
+    Error, ProtocolConfiguration,
 };
 use cfx_types::H256;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 use std::{
+    any::Any,
     cmp::min,
     ops::{Deref, DerefMut},
+    time::Duration,
 };
 
 #[derive(Debug, PartialEq, Clone)]
@@ -21,6 +25,40 @@ pub struct GetBlockHeaderChain {
     pub request_id: RequestId,
     pub hash: H256,
     pub max_blocks: u64,
+}
+
+impl Request for GetBlockHeaderChain {
+    fn set_request_id(&mut self, request_id: u64) {
+        self.request_id.set_request_id(request_id);
+    }
+
+    fn as_message(&self) -> &Message { self }
+
+    fn as_any(&self) -> &Any { self }
+
+    fn timeout(&self, conf: &ProtocolConfiguration) -> Duration {
+        conf.headers_request_timeout
+    }
+
+    fn on_removed(&self, inflight_keys: &mut KeyContainer) {
+        inflight_keys.remove(
+            MsgId::GET_BLOCK_HEADERS.into(),
+            Key::Hash(self.hash.clone()),
+        );
+    }
+
+    fn with_inflight(&mut self, inflight_keys: &mut KeyContainer) {
+        if !inflight_keys.add(
+            MsgId::GET_BLOCK_HEADERS.into(),
+            Key::Hash(self.hash.clone()),
+        ) {
+            self.hash = H256::zero();
+        }
+    }
+
+    fn is_empty(&self) -> bool { self.hash.is_zero() }
+
+    fn resend(&self) -> Box<Request> { Box::new(self.clone()) }
 }
 
 impl Handleable for GetBlockHeaderChain {

--- a/core/src/sync/message/getblockheaders.rs
+++ b/core/src/sync/message/getblockheaders.rs
@@ -53,7 +53,7 @@ impl Request for GetBlockHeaders {
 
     fn is_empty(&self) -> bool { self.hashes.is_empty() }
 
-    fn resend(&self) -> Box<Request> { Box::new(self.clone()) }
+    fn resend(&self) -> Option<Box<Request>> { Some(Box::new(self.clone())) }
 }
 
 impl Handleable for GetBlockHeaders {

--- a/core/src/sync/message/getblockheaders.rs
+++ b/core/src/sync/message/getblockheaders.rs
@@ -4,19 +4,56 @@
 
 use crate::sync::{
     message::{
-        Context, GetBlockHeadersResponse, Handleable, Message, MsgId, RequestId,
+        Context, GetBlockHeadersResponse, Handleable, Key, KeyContainer,
+        Message, MsgId, RequestId,
     },
+    request_manager::Request,
     synchronization_protocol_handler::MAX_HEADERS_TO_SEND,
-    Error,
+    Error, ProtocolConfiguration,
 };
 use cfx_types::H256;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
-use std::ops::{Deref, DerefMut};
+use std::{
+    any::Any,
+    ops::{Deref, DerefMut},
+    time::Duration,
+};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct GetBlockHeaders {
     pub request_id: RequestId,
     pub hashes: Vec<H256>,
+}
+
+impl Request for GetBlockHeaders {
+    fn set_request_id(&mut self, request_id: u64) {
+        self.request_id.set_request_id(request_id);
+    }
+
+    fn as_message(&self) -> &Message { self }
+
+    fn as_any(&self) -> &Any { self }
+
+    fn timeout(&self, conf: &ProtocolConfiguration) -> Duration {
+        conf.headers_request_timeout
+    }
+
+    fn on_removed(&self, inflight_keys: &mut KeyContainer) {
+        let msg_type = self.msg_id().into();
+        for hash in self.hashes.iter() {
+            inflight_keys.remove(msg_type, Key::Hash(*hash));
+        }
+    }
+
+    fn with_inflight(&mut self, inflight_keys: &mut KeyContainer) {
+        let msg_type = self.msg_id().into();
+        self.hashes
+            .retain(|h| inflight_keys.add(msg_type, Key::Hash(*h)));
+    }
+
+    fn is_empty(&self) -> bool { self.hashes.is_empty() }
+
+    fn resend(&self) -> Box<Request> { Box::new(self.clone()) }
 }
 
 impl Handleable for GetBlockHeaders {

--- a/core/src/sync/message/getblocks.rs
+++ b/core/src/sync/message/getblocks.rs
@@ -5,21 +5,57 @@
 use crate::sync::{
     message::{
         Context, GetBlocksResponse, GetBlocksWithPublicResponse, Handleable,
-        Message, MsgId, RequestId,
+        Key, KeyContainer, Message, MsgId, RequestId,
     },
+    request_manager::Request,
     synchronization_protocol_handler::MAX_PACKET_SIZE,
-    Error, ErrorKind,
+    Error, ErrorKind, ProtocolConfiguration,
 };
 use cfx_types::H256;
 use primitives::Block;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
-use std::ops::{Deref, DerefMut};
+use std::{
+    any::Any,
+    ops::{Deref, DerefMut},
+    time::Duration,
+};
 
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, PartialEq, Default, Clone)]
 pub struct GetBlocks {
     pub request_id: RequestId,
     pub with_public: bool,
     pub hashes: Vec<H256>,
+}
+
+impl Request for GetBlocks {
+    fn set_request_id(&mut self, request_id: u64) {
+        self.request_id.set_request_id(request_id);
+    }
+
+    fn as_message(&self) -> &Message { self }
+
+    fn as_any(&self) -> &Any { self }
+
+    fn timeout(&self, conf: &ProtocolConfiguration) -> Duration {
+        conf.blocks_request_timeout
+    }
+
+    fn on_removed(&self, inflight_keys: &mut KeyContainer) {
+        let msg_type = self.msg_id().into();
+        for hash in self.hashes.iter() {
+            inflight_keys.remove(msg_type, Key::Hash(*hash));
+        }
+    }
+
+    fn with_inflight(&mut self, inflight_keys: &mut KeyContainer) {
+        let msg_type = self.msg_id().into();
+        self.hashes
+            .retain(|h| inflight_keys.add(msg_type, Key::Hash(*h)));
+    }
+
+    fn is_empty(&self) -> bool { self.hashes.is_empty() }
+
+    fn resend(&self) -> Box<Request> { Box::new(self.clone()) }
 }
 
 impl GetBlocks {

--- a/core/src/sync/message/getblocks.rs
+++ b/core/src/sync/message/getblocks.rs
@@ -55,7 +55,7 @@ impl Request for GetBlocks {
 
     fn is_empty(&self) -> bool { self.hashes.is_empty() }
 
-    fn resend(&self) -> Box<Request> { Box::new(self.clone()) }
+    fn resend(&self) -> Option<Box<Request>> { Some(Box::new(self.clone())) }
 }
 
 impl GetBlocks {

--- a/core/src/sync/message/getblocktxn.rs
+++ b/core/src/sync/message/getblocktxn.rs
@@ -4,19 +4,53 @@
 
 use crate::sync::{
     message::{
-        Context, GetBlockTxnResponse, Handleable, Message, MsgId, RequestId,
+        Context, GetBlockTxnResponse, GetBlocks, Handleable, KeyContainer,
+        Message, MsgId, RequestId,
     },
-    Error, ErrorKind,
+    request_manager::Request,
+    Error, ErrorKind, ProtocolConfiguration,
 };
 use cfx_types::H256;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
-use std::ops::{Deref, DerefMut};
+use std::{
+    any::Any,
+    ops::{Deref, DerefMut},
+    time::Duration,
+};
 
 #[derive(Debug, PartialEq, Default)]
 pub struct GetBlockTxn {
     pub request_id: RequestId,
     pub block_hash: H256,
     pub indexes: Vec<usize>,
+}
+
+impl Request for GetBlockTxn {
+    fn set_request_id(&mut self, request_id: u64) {
+        self.request_id.set_request_id(request_id)
+    }
+
+    fn as_message(&self) -> &Message { self }
+
+    fn as_any(&self) -> &Any { self }
+
+    fn timeout(&self, conf: &ProtocolConfiguration) -> Duration {
+        conf.blocks_request_timeout
+    }
+
+    fn on_removed(&self, _inflight_keys: &mut KeyContainer) {}
+
+    fn with_inflight(&mut self, _inflight_keys: &mut KeyContainer) {}
+
+    fn is_empty(&self) -> bool { false }
+
+    fn resend(&self) -> Box<Request> {
+        Box::new(GetBlocks {
+            request_id: 0.into(),
+            with_public: true,
+            hashes: vec![self.block_hash.clone()],
+        })
+    }
 }
 
 impl Handleable for GetBlockTxn {

--- a/core/src/sync/message/getblocktxn.rs
+++ b/core/src/sync/message/getblocktxn.rs
@@ -44,12 +44,12 @@ impl Request for GetBlockTxn {
 
     fn is_empty(&self) -> bool { false }
 
-    fn resend(&self) -> Box<Request> {
-        Box::new(GetBlocks {
+    fn resend(&self) -> Option<Box<Request>> {
+        Some(Box::new(GetBlocks {
             request_id: 0.into(),
             with_public: true,
             hashes: vec![self.block_hash.clone()],
-        })
+        }))
     }
 }
 

--- a/core/src/sync/message/getcmpctblocks.rs
+++ b/core/src/sync/message/getcmpctblocks.rs
@@ -4,22 +4,64 @@
 
 use crate::sync::{
     message::{
-        Context, GetCompactBlocksResponse, Handleable, Message, MsgId,
-        RequestId,
+        Context, GetBlocks, GetCompactBlocksResponse, Handleable, Key,
+        KeyContainer, Message, MsgId, RequestId,
     },
+    request_manager::Request,
     synchronization_protocol_handler::{
         MAX_BLOCKS_TO_SEND, MAX_HEADERS_TO_SEND,
     },
-    Error,
+    Error, ProtocolConfiguration,
 };
 use cfx_types::H256;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
-use std::ops::{Deref, DerefMut};
+use std::{
+    any::Any,
+    ops::{Deref, DerefMut},
+    time::Duration,
+};
 
 #[derive(Debug, PartialEq, Default)]
 pub struct GetCompactBlocks {
     pub request_id: RequestId,
     pub hashes: Vec<H256>,
+}
+
+impl Request for GetCompactBlocks {
+    fn set_request_id(&mut self, request_id: u64) {
+        self.request_id.set_request_id(request_id);
+    }
+
+    fn as_message(&self) -> &Message { self }
+
+    fn as_any(&self) -> &Any { self }
+
+    fn timeout(&self, conf: &ProtocolConfiguration) -> Duration {
+        conf.blocks_request_timeout
+    }
+
+    fn on_removed(&self, inflight_keys: &mut KeyContainer) {
+        let msg_type = MsgId::GET_BLOCKS.into();
+        for hash in self.hashes.iter() {
+            inflight_keys.remove(msg_type, Key::Hash(*hash));
+        }
+    }
+
+    fn with_inflight(&mut self, inflight_keys: &mut KeyContainer) {
+        let msg_type = MsgId::GET_BLOCKS.into();
+        self.hashes
+            .retain(|h| inflight_keys.add(msg_type, Key::Hash(*h)));
+    }
+
+    fn is_empty(&self) -> bool { self.hashes.is_empty() }
+
+    fn resend(&self) -> Box<Request> {
+        Box::new(GetBlocks {
+            request_id: 0.into(),
+            with_public: true,
+            hashes: self.hashes.iter().cloned().collect(),
+        })
+    }
 }
 
 impl Handleable for GetCompactBlocks {

--- a/core/src/sync/message/getcmpctblocks.rs
+++ b/core/src/sync/message/getcmpctblocks.rs
@@ -55,12 +55,12 @@ impl Request for GetCompactBlocks {
 
     fn is_empty(&self) -> bool { self.hashes.is_empty() }
 
-    fn resend(&self) -> Box<Request> {
-        Box::new(GetBlocks {
+    fn resend(&self) -> Option<Box<Request>> {
+        Some(Box::new(GetBlocks {
             request_id: 0.into(),
             with_public: true,
             hashes: self.hashes.iter().cloned().collect(),
-        })
+        }))
     }
 }
 

--- a/core/src/sync/message/keys.rs
+++ b/core/src/sync/message/keys.rs
@@ -1,0 +1,41 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use cfx_types::{H256, H64};
+use std::collections::{HashMap, HashSet};
+
+#[derive(Hash, Eq, PartialEq, Debug)]
+pub enum Key {
+    Hash(H256),
+    Num(u64),
+    Id(H64),
+}
+
+#[derive(Default)]
+pub struct KeyContainer {
+    keys: HashMap<u8, HashSet<Key>>,
+}
+
+impl KeyContainer {
+    pub fn add(&mut self, msg_type: u8, key: Key) -> bool {
+        self.keys
+            .entry(msg_type)
+            .or_insert_with(|| HashSet::new())
+            .insert(key)
+    }
+
+    pub fn remove(&mut self, msg_type: u8, key: Key) -> bool {
+        match self.keys.get_mut(&msg_type) {
+            Some(keys) => keys.remove(&key),
+            None => return false,
+        }
+    }
+
+    pub fn len(&self, msg_type: u8) -> usize {
+        match self.keys.get(&msg_type) {
+            Some(keys) => keys.len(),
+            None => 0,
+        }
+    }
+}

--- a/core/src/sync/message/mod.rs
+++ b/core/src/sync/message/mod.rs
@@ -15,6 +15,7 @@ mod getblocktxn;
 mod getcmpctblocks;
 mod getterminalblockhashes;
 mod handleable;
+mod keys;
 mod message;
 mod metrics;
 mod newblock;
@@ -37,6 +38,7 @@ pub use self::{
     getcmpctblocks::GetCompactBlocks,
     getterminalblockhashes::GetTerminalBlockHashes,
     handleable::{Context, Handleable},
+    keys::{Key, KeyContainer},
     message::{Message, MsgId, RequestId},
     newblock::NewBlock,
     newblockhashes::NewBlockHashes,

--- a/core/src/sync/message/transactions.rs
+++ b/core/src/sync/message/transactions.rs
@@ -265,9 +265,7 @@ impl Request for GetTransactions {
 
     fn is_empty(&self) -> bool { self.tx_ids.is_empty() }
 
-    fn is_resend_enabled(&self) -> bool { false }
-
-    fn resend(&self) -> Box<Request> { panic!("should not re-propagate txs") }
+    fn resend(&self) -> Option<Box<Request>> { None }
 }
 
 impl Handleable for GetTransactions {

--- a/core/src/sync/message/transactions.rs
+++ b/core/src/sync/message/transactions.rs
@@ -4,19 +4,21 @@
 
 use crate::sync::{
     message::{
-        metrics::TX_HANDLE_TIMER, Context, Handleable, Message, MsgId,
-        RequestId,
+        metrics::TX_HANDLE_TIMER, Context, Handleable, Key, KeyContainer,
+        Message, MsgId, RequestId,
     },
-    request_manager::RequestMessage,
-    Error, ErrorKind,
+    request_manager::Request,
+    Error, ErrorKind, ProtocolConfiguration,
 };
 use metrics::MeterTimer;
 use primitives::{transaction::TxPropagateId, TransactionWithSignature};
 use priority_send_queue::SendQueuePriority;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 use std::{
+    any::Any,
     collections::HashSet,
     ops::{Deref, DerefMut},
+    time::Duration,
 };
 
 #[derive(Debug, PartialEq)]
@@ -228,6 +230,46 @@ pub struct GetTransactions {
     pub tx_ids: HashSet<TxPropagateId>,
 }
 
+impl Request for GetTransactions {
+    fn set_request_id(&mut self, request_id: u64) {
+        self.request_id.set_request_id(request_id);
+    }
+
+    fn as_message(&self) -> &Message { self }
+
+    fn as_any(&self) -> &Any { self }
+
+    fn timeout(&self, conf: &ProtocolConfiguration) -> Duration {
+        conf.transaction_request_timeout
+    }
+
+    fn on_removed(&self, inflight_keys: &mut KeyContainer) {
+        let msg_type = self.msg_id().into();
+        for tx_id in self.tx_ids.iter() {
+            inflight_keys.remove(msg_type, Key::Id(*tx_id));
+        }
+    }
+
+    fn with_inflight(&mut self, inflight_keys: &mut KeyContainer) {
+        let msg_type = self.msg_id().into();
+
+        let mut tx_ids: HashSet<TxPropagateId> = HashSet::new();
+        for id in self.tx_ids.iter() {
+            if inflight_keys.add(msg_type, Key::Id(*id)) {
+                tx_ids.insert(*id);
+            }
+        }
+
+        self.tx_ids = tx_ids;
+    }
+
+    fn is_empty(&self) -> bool { self.tx_ids.is_empty() }
+
+    fn is_resend_enabled(&self) -> bool { false }
+
+    fn resend(&self) -> Box<Request> { panic!("should not re-propagate txs") }
+}
+
 impl Handleable for GetTransactions {
     fn handle(self, ctx: &Context) -> Result<(), Error> {
         let transactions = ctx
@@ -302,14 +344,12 @@ impl Handleable for GetTransactionsResponse {
         debug!("on_get_transactions_response {:?}", self.request_id());
 
         let req = ctx.match_request(self.request_id())?;
+        let req = req.downcast_general::<GetTransactions>(
+            ctx.io,
+            &ctx.manager.request_manager,
+            false,
+        )?;
 
-        let req_tx_ids: HashSet<TxPropagateId> = match req {
-            RequestMessage::Transactions(request) => request.tx_ids,
-            _ => {
-                warn!("Get response not matching the request! req={:?}, resp={:?}", req, self);
-                return Err(ErrorKind::UnexpectedResponse.into());
-            }
-        };
         // FIXME: Do some check based on transaction request.
 
         debug!(
@@ -320,7 +360,7 @@ impl Handleable for GetTransactionsResponse {
 
         ctx.manager
             .request_manager
-            .transactions_received(&req_tx_ids);
+            .transactions_received(&req.tx_ids);
 
         let (signed_trans, _) = ctx
             .manager

--- a/core/src/sync/request_manager/mod.rs
+++ b/core/src/sync/request_manager/mod.rs
@@ -549,9 +549,7 @@ impl RequestManager {
     }
 
     /// Send waiting requests that their backoff delay have passes
-    pub fn resend_waiting_requests(
-        &self, io: &NetworkContext, _with_public: bool,
-    ) {
+    pub fn resend_waiting_requests(&self, io: &NetworkContext) {
         debug!("resend_waiting_requests: start");
         let mut waiting_requests = self.waiting_requests.lock();
         let now = Instant::now();
@@ -582,7 +580,7 @@ impl RequestManager {
             };
             let next_delay = delay + *REQUEST_START_WAITING_TIME;
 
-            if let Err(e) = self.request_handler.send_general_request(
+            if let Err(req) = self.request_handler.send_general_request(
                 io,
                 Some(chosen_peer),
                 request,
@@ -590,7 +588,7 @@ impl RequestManager {
             ) {
                 self.waiting_requests.lock().push(TimedWaitingRequest::new(
                     Instant::now() + delay,
-                    WaitingRequest(e, next_delay),
+                    WaitingRequest(req, next_delay),
                     None,
                 ));
             }

--- a/core/src/sync/request_manager/mod.rs
+++ b/core/src/sync/request_manager/mod.rs
@@ -7,7 +7,8 @@ use super::{
 use crate::sync::{
     message::{
         GetBlockHashesByEpoch, GetBlockHeaderChain, GetBlockHeaders,
-        GetBlockTxn, GetBlocks, GetCompactBlocks, GetTransactions, TransIndex,
+        GetBlockTxn, GetBlocks, GetCompactBlocks, GetTransactions, Key,
+        KeyContainer, MsgId, TransIndex,
     },
     Error,
 };
@@ -22,7 +23,7 @@ pub use request_handler::{
 };
 use std::{
     cmp::Ordering,
-    collections::{binary_heap::BinaryHeap, hash_map::Entry, HashMap, HashSet},
+    collections::{binary_heap::BinaryHeap, HashSet},
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -45,15 +46,7 @@ lazy_static! {
 }
 
 #[derive(Debug)]
-enum WaitingRequest {
-    Header(H256),
-    HeaderChain(H256),
-    Block(H256),
-    Epoch(u64),
-    // todo change other kind of waiting requests to such general one to
-    // support batch request
-    General(Box<Request>),
-}
+struct WaitingRequest(Box<Request>, Duration); // (request, delay)
 
 /// When a header or block is requested by the `RequestManager`, it is ensured
 /// that if it's not fully received, its hash exists
@@ -67,12 +60,8 @@ enum WaitingRequest {
 // TODO A non-existing block request will remain in the struct forever, and we
 // need garbage collect
 pub struct RequestManager {
-    inflight_requested_transactions: Mutex<HashSet<TxPropagateId>>,
-    headers_in_flight: Mutex<HashSet<H256>>,
-    header_request_waittime: Mutex<HashMap<H256, Duration>>,
-    blocks_in_flight: Mutex<HashSet<H256>>,
-    block_request_waittime: Mutex<HashMap<H256, Duration>>,
-    epochs_in_flight: Mutex<HashSet<u64>>,
+    // used to avoid send duplicated requests.
+    inflight_keys: Mutex<KeyContainer>,
 
     /// Each element is (timeout_time, request, chosen_peer)
     waiting_requests: Mutex<BinaryHeap<TimedWaitingRequest>>,
@@ -106,15 +95,10 @@ impl RequestManager {
                     received_tx_index_maintain_timeout.as_secs(),
                 ),
             )),
-            inflight_requested_transactions: Default::default(),
             sent_transactions: RwLock::new(SentTransactionContainer::new(
                 sent_transaction_window_size as usize,
             )),
-            headers_in_flight: Default::default(),
-            header_request_waittime: Default::default(),
-            blocks_in_flight: Default::default(),
-            block_request_waittime: Default::default(),
-            epochs_in_flight: Default::default(),
+            inflight_keys: Default::default(),
             waiting_requests: Default::default(),
             request_handler: Arc::new(RequestHandler::new(protocol_config)),
             syn,
@@ -122,110 +106,71 @@ impl RequestManager {
     }
 
     pub fn num_epochs_in_flight(&self) -> u64 {
-        self.epochs_in_flight.lock().len() as u64
+        self.inflight_keys
+            .lock()
+            .len(MsgId::GET_BLOCK_HASHES_BY_EPOCH.into()) as u64
     }
 
-    /// Remove in-flight headers, and headers requested before will be delayed.
-    /// If `peer_id` is `None`, all headers will be delayed and `hashes` will
-    /// always become empty.
-    fn preprocess_header_request(
-        &self, hashes: &mut Vec<H256>, peer_id: &Option<PeerId>,
-    ) {
-        let mut headers_in_flight = self.headers_in_flight.lock();
-        let mut header_request_waittime = self.header_request_waittime.lock();
-        hashes.retain(|hash| {
-            if headers_in_flight.insert(*hash) {
-                match header_request_waittime.entry(*hash) {
-                    Entry::Vacant(entry) => {
-                        entry.insert(*REQUEST_START_WAITING_TIME);
-                        if peer_id.is_none() {
-                            self.waiting_requests.lock().push(
-                                TimedWaitingRequest::new(
-                                    Instant::now()
-                                        + *REQUEST_START_WAITING_TIME,
-                                    WaitingRequest::Header(*hash),
-                                    *peer_id,
-                                ),
-                            );
-                            debug!(
-                                "Header {:?} request is delayed for later",
-                                hash
-                            );
-                            false
-                        } else {
-                            true
-                        }
-                    }
-                    Entry::Occupied(mut entry) => {
-                        // It is requested before. To prevent possible attacks,
-                        // we wait for more time to start
-                        // the next request.
-                        let t = entry.get_mut();
-                        debug!(
-                            "Header {:?} is requested again, delay for {:?}",
-                            hash, t
-                        );
-                        self.waiting_requests.lock().push(
-                            TimedWaitingRequest::new(
-                                Instant::now() + *t,
-                                WaitingRequest::Header(*hash),
-                                *peer_id,
-                            ),
-                        );
-                        *t += *REQUEST_START_WAITING_TIME;
-                        false
-                    }
-                }
-            } else {
-                debug!(
-                    "preprocess_header_request: {:?} already in flight",
-                    hash
-                );
-                false
-            }
-        });
+    /// Send request to remote peer with delay mechanism. If failed,
+    /// add the request to waiting queue to resend later.
+    pub fn request_with_delay(
+        &self, io: &NetworkContext, mut request: Box<Request>,
+        peer: Option<PeerId>, delay: Option<Duration>,
+    )
+    {
+        {
+            // retain the request items that not in flight.
+            let mut inflight_keys = self.inflight_keys.lock();
+            request.with_inflight(&mut inflight_keys);
+        }
+
+        // increase delay for resent request.
+        let (cur_delay, next_delay) = match delay {
+            Some(d) => (d, d + *REQUEST_START_WAITING_TIME),
+            None => (*REQUEST_START_WAITING_TIME, *REQUEST_START_WAITING_TIME),
+        };
+
+        // delay if no peer available or delay required
+        if peer.is_none() || delay.is_some() {
+            // todo remove the request if waiting time is too long?
+            // E.g. attacker may broadcast many many invalid block hashes,
+            // and no peer could return the corresponding block header.
+            self.waiting_requests.lock().push(TimedWaitingRequest::new(
+                Instant::now() + cur_delay,
+                WaitingRequest(request, next_delay),
+                peer,
+            ));
+
+            return;
+        }
+
+        if request.is_empty() {
+            return;
+        }
+
+        if let Err(e) = self
+            .request_handler
+            .send_general_request(io, peer, request, delay)
+        {
+            self.waiting_requests.lock().push(TimedWaitingRequest::new(
+                Instant::now() + cur_delay,
+                WaitingRequest(e, next_delay),
+                None,
+            ));
+        }
     }
 
     pub fn request_block_headers(
-        &self, io: &NetworkContext, peer_id: Option<PeerId>,
-        mut hashes: Vec<H256>,
-    )
-    {
-        let _timer = MeterTimer::time_func(REQUEST_MANAGER_TIMER.as_ref());
-        self.preprocess_header_request(&mut hashes, &peer_id);
-        if hashes.is_empty() {
-            debug!("All headers in_flight, skip requesting");
-            return;
-        }
-        self.request_headers_unchecked(io, peer_id.unwrap(), hashes)
-    }
-
-    fn request_headers_unchecked(
-        &self, io: &NetworkContext, peer_id: PeerId, hashes: Vec<H256>,
+        &self, io: &NetworkContext, peer_id: Option<PeerId>, hashes: Vec<H256>,
     ) {
-        if let Err(e) = self.request_handler.send_request(
-            io,
-            peer_id,
-            Box::new(RequestMessage::Headers(GetBlockHeaders {
-                request_id: 0.into(),
-                hashes: hashes.clone(),
-            })),
-            SendQueuePriority::High,
-        ) {
-            warn!(
-                "Error requesting headers peer={:?} hashes={:?} err={:?}",
-                peer_id, hashes, e
-            );
-            for hash in hashes {
-                self.waiting_requests.lock().push(TimedWaitingRequest::new(
-                    Instant::now() + *REQUEST_START_WAITING_TIME,
-                    WaitingRequest::Header(hash),
-                    None,
-                ));
-            }
-        } else {
-            debug!("Requesting headers peer={:?} hashes={:?}", peer_id, hashes);
-        }
+        let _timer = MeterTimer::time_func(REQUEST_MANAGER_TIMER.as_ref());
+
+        let request = GetBlockHeaders {
+            request_id: 0.into(),
+            hashes,
+        };
+
+        self.request_with_delay(io, Box::new(request), peer_id, None);
     }
 
     /// Request a header if it's not already in_flight. The request is delayed
@@ -236,233 +181,41 @@ impl RequestManager {
     )
     {
         let _timer = MeterTimer::time_func(REQUEST_MANAGER_TIMER.as_ref());
-        if !self.headers_in_flight.lock().insert(*hash) {
-            // Already inflight, return directly
-            return;
-        }
-        let mut header_request_waittime = self.header_request_waittime.lock();
-        match header_request_waittime.entry(*hash) {
-            Entry::Occupied(mut e) => {
-                // Requested before, so wait for the stored time and increase it
-                let t = e.get_mut();
-                self.waiting_requests.lock().push(TimedWaitingRequest::new(
-                    Instant::now() + *t,
-                    WaitingRequest::HeaderChain(*hash),
-                    peer_id,
-                ));
-                *t += *REQUEST_START_WAITING_TIME;
-                debug!(
-                    "Block header request is delayed peer={:?} hash={:?}",
-                    peer_id, hash
-                );
-                return;
-            }
-            Entry::Vacant(e) => {
-                // Not requested before, so store the initial wait time
-                e.insert(*REQUEST_START_WAITING_TIME);
-                if peer_id.is_none() {
-                    // No available peer, so add to the waiting queue directly
-                    // to be sent later
-                    self.waiting_requests.lock().push(
-                        TimedWaitingRequest::new(
-                            Instant::now() + *REQUEST_START_WAITING_TIME,
-                            WaitingRequest::HeaderChain(*hash),
-                            peer_id,
-                        ),
-                    );
-                    debug!(
-                        "Block header request is delayed peer={:?} hash={:?}",
-                        peer_id, hash
-                    );
-                    return;
-                }
-            }
-        }
 
-        if let Err(e) = self.request_handler.send_request(
-            io,
-            peer_id.unwrap(),
-            Box::new(RequestMessage::HeaderChain(GetBlockHeaderChain {
-                request_id: 0.into(),
-                hash: *hash,
-                max_blocks,
-            })),
-            SendQueuePriority::High,
-        ) {
-            warn!("Error requesting block header peer={:?} hash={} max_blocks={} err={:?}", peer_id, hash, max_blocks, e);
+        let request = GetBlockHeaderChain {
+            request_id: 0.into(),
+            hash: *hash,
+            max_blocks,
+        };
 
-            // TODO handle different errors
-            // Currently we just queue the request and send it later with the
-            // same logic as delayed requests, so we do not remove
-            // it from `headers_in_flight`. We can reach here only
-            // if the request is not waited before, so we just wait for
-            // the initial value.
-            self.waiting_requests.lock().push(TimedWaitingRequest::new(
-                Instant::now() + *REQUEST_START_WAITING_TIME,
-                WaitingRequest::HeaderChain(*hash),
-                None,
-            ));
-        } else {
-            debug!(
-                "Requesting block header peer={:?} hash={} max_blocks={}",
-                peer_id, hash, max_blocks
-            );
-        }
-    }
-
-    /// Remove in-flight epochs.
-    fn preprocess_epoch_request(
-        &self, epochs: &mut Vec<u64>, _peer_id: &Option<PeerId>,
-    ) {
-        let mut epochs_in_flight = self.epochs_in_flight.lock();
-        epochs.retain(|epoch_number| epochs_in_flight.insert(*epoch_number));
+        self.request_with_delay(io, Box::new(request), peer_id, None);
     }
 
     pub fn request_epoch_hashes(
-        &self, io: &NetworkContext, peer_id: Option<PeerId>,
-        mut epochs: Vec<u64>,
-    )
-    {
-        self.preprocess_epoch_request(&mut epochs, &peer_id);
-        if epochs.is_empty() {
-            debug!("All epochs in_flight, skip requesting");
-            return;
-        }
-        self.request_epochs_unchecked(io, peer_id.unwrap(), epochs)
-    }
-
-    fn request_epochs_unchecked(
-        &self, io: &NetworkContext, peer_id: PeerId, epochs: Vec<u64>,
+        &self, io: &NetworkContext, peer_id: Option<PeerId>, epochs: Vec<u64>,
     ) {
-        if let Err(e) = self.request_handler.send_request(
-            io,
-            peer_id,
-            Box::new(RequestMessage::Epochs(GetBlockHashesByEpoch {
-                request_id: 0.into(),
-                epochs: epochs.clone(),
-            })),
-            SendQueuePriority::High,
-        ) {
-            warn!(
-                "Error requesting epochs peer={:?} epochs={:?} err={:?}",
-                peer_id, epochs, e
-            );
-            for epoch_number in epochs {
-                self.waiting_requests.lock().push(TimedWaitingRequest::new(
-                    Instant::now() + *REQUEST_START_WAITING_TIME,
-                    WaitingRequest::Epoch(epoch_number),
-                    None,
-                ));
-            }
-        } else {
-            debug!("Requesting epochs peer={:?} epochs={:?}", peer_id, epochs);
-        }
-    }
+        let request = GetBlockHashesByEpoch {
+            request_id: 0.into(),
+            epochs,
+        };
 
-    /// Remove in-flight blocks, and blocks requested before will be delayed.
-    /// If `peer_id` is `None`, all blocks will be delayed and `hashes` will
-    /// always become empty.
-    fn preprocess_block_request(
-        &self, hashes: &mut Vec<H256>, peer_id: &Option<PeerId>,
-    ) {
-        let mut blocks_in_flight = self.blocks_in_flight.lock();
-        let mut block_request_waittime = self.block_request_waittime.lock();
-        hashes.retain(|hash| {
-            if blocks_in_flight.insert(*hash) {
-                match block_request_waittime.entry(*hash) {
-                    Entry::Vacant(entry) => {
-                        entry.insert(*REQUEST_START_WAITING_TIME);
-                        if peer_id.is_none() {
-                            self.waiting_requests.lock().push(
-                                TimedWaitingRequest::new(
-                                    Instant::now()
-                                        + *REQUEST_START_WAITING_TIME,
-                                    WaitingRequest::Block(*hash),
-                                    *peer_id,
-                                ),
-                            );
-                            debug!(
-                                "Block {:?} request is delayed for later",
-                                hash
-                            );
-                            false
-                        } else {
-                            true
-                        }
-                    }
-                    Entry::Occupied(mut entry) => {
-                        // It is requested before. To prevent possible attacks,
-                        // we wait for more time to start
-                        // the next request.
-                        let t = entry.get_mut();
-                        debug!(
-                            "Block {:?} is requested again, delay for {:?}",
-                            hash, t
-                        );
-                        self.waiting_requests.lock().push(
-                            TimedWaitingRequest::new(
-                                Instant::now() + *t,
-                                WaitingRequest::Block(*hash),
-                                *peer_id,
-                            ),
-                        );
-                        *t += *REQUEST_START_WAITING_TIME;
-                        false
-                    }
-                }
-            } else {
-                debug!(
-                    "preprocess_block_request: {:?} already in flight",
-                    hash
-                );
-                false
-            }
-        });
+        self.request_with_delay(io, Box::new(request), peer_id, None);
     }
 
     pub fn request_blocks(
-        &self, io: &NetworkContext, peer_id: Option<PeerId>,
-        mut hashes: Vec<H256>, with_public: bool,
-    )
-    {
-        let _timer = MeterTimer::time_func(REQUEST_MANAGER_TIMER.as_ref());
-        self.preprocess_block_request(&mut hashes, &peer_id);
-        if hashes.is_empty() {
-            debug!("All blocks in_flight, skip requesting");
-            return;
-        }
-        self.request_blocks_unchecked(io, peer_id.unwrap(), hashes, with_public)
-    }
-
-    fn request_blocks_unchecked(
-        &self, io: &NetworkContext, peer_id: PeerId, hashes: Vec<H256>,
+        &self, io: &NetworkContext, peer_id: Option<PeerId>, hashes: Vec<H256>,
         with_public: bool,
     )
     {
-        if let Err(e) = self.request_handler.send_request(
-            io,
-            peer_id,
-            Box::new(RequestMessage::Blocks(GetBlocks {
-                request_id: 0.into(),
-                with_public,
-                hashes: hashes.clone(),
-            })),
-            SendQueuePriority::High,
-        ) {
-            warn!(
-                "Error requesting blocks peer={:?} hashes={:?} err={:?}",
-                peer_id, hashes, e
-            );
-            for hash in hashes {
-                self.waiting_requests.lock().push(TimedWaitingRequest::new(
-                    Instant::now() + *REQUEST_START_WAITING_TIME,
-                    WaitingRequest::Block(hash),
-                    None,
-                ));
-            }
-        } else {
-            debug!("Requesting blocks peer={:?} hashes={:?}", peer_id, hashes);
-        }
+        let _timer = MeterTimer::time_func(REQUEST_MANAGER_TIMER.as_ref());
+
+        let request = GetBlocks {
+            request_id: 0.into(),
+            with_public,
+            hashes,
+        };
+
+        self.request_with_delay(io, Box::new(request), peer_id, None);
     }
 
     pub fn request_transactions(
@@ -474,11 +227,11 @@ impl RequestManager {
         if received_tx_ids.is_empty() {
             return;
         }
-        let mut inflight_transactions =
-            self.inflight_requested_transactions.lock();
+        let mut inflight_keys = self.inflight_keys.lock();
         let received_transactions = self.received_transactions.read();
 
-        INFLIGHT_TX_POOL_METER.mark(inflight_transactions.len());
+        let msg_type = MsgId::GET_TRANSACTIONS.into();
+        INFLIGHT_TX_POOL_METER.mark(inflight_keys.len(msg_type));
         TX_RECEIVED_POOL_METER.mark(received_transactions.get_length());
 
         let (indices, tx_ids) = {
@@ -491,7 +244,7 @@ impl RequestManager {
                     continue;
                 }
 
-                if !inflight_transactions.insert(*tx_id) {
+                if !inflight_keys.add(msg_type, Key::Id(*tx_id)) {
                     // Already being requested
                     continue;
                 }
@@ -505,14 +258,17 @@ impl RequestManager {
         };
         TX_REQUEST_METER.mark(tx_ids.len());
         debug!("Request {} tx from peer={}", tx_ids.len(), peer_id);
+
+        let request = GetTransactions {
+            request_id: 0.into(),
+            indices,
+            tx_ids: tx_ids.clone(),
+        };
+
         if let Err(e) = self.request_handler.send_request(
             io,
             peer_id,
-            Box::new(RequestMessage::Transactions(GetTransactions {
-                request_id: 0.into(),
-                indices,
-                tx_ids: tx_ids.clone(),
-            })),
+            RequestMessage::new(Box::new(request), None),
             SendQueuePriority::Normal,
         ) {
             warn!(
@@ -522,54 +278,22 @@ impl RequestManager {
                 e
             );
             for tx_id in tx_ids {
-                inflight_transactions.remove(&tx_id);
+                inflight_keys.remove(msg_type, Key::Id(tx_id));
             }
         }
     }
 
     pub fn request_compact_blocks(
-        &self, io: &NetworkContext, peer_id: Option<PeerId>,
-        mut hashes: Vec<H256>,
-    )
-    {
-        let _timer = MeterTimer::time_func(REQUEST_MANAGER_TIMER.as_ref());
-        self.preprocess_block_request(&mut hashes, &peer_id);
-        if hashes.is_empty() {
-            debug!("All blocks in_flight, skip requesting");
-            return;
-        }
-        self.request_compact_block_unchecked(io, peer_id, hashes)
-    }
-
-    pub fn request_compact_block_unchecked(
         &self, io: &NetworkContext, peer_id: Option<PeerId>, hashes: Vec<H256>,
     ) {
-        if let Err(e) = self.request_handler.send_request(
-            io,
-            peer_id.unwrap(),
-            Box::new(RequestMessage::Compact(GetCompactBlocks {
-                request_id: 0.into(),
-                hashes: hashes.clone(),
-            })),
-            SendQueuePriority::High,
-        ) {
-            warn!(
-                "Error requesting compact blocks peer={:?} hashes={:?} err={:?}",
-                peer_id, hashes, e
-            );
-            for hash in hashes {
-                self.waiting_requests.lock().push(TimedWaitingRequest::new(
-                    Instant::now() + *REQUEST_START_WAITING_TIME,
-                    WaitingRequest::Block(hash),
-                    None,
-                ));
-            }
-        } else {
-            debug!(
-                "Requesting compact blocks peer={:?} hashes={:?}",
-                peer_id, hashes
-            );
-        }
+        let _timer = MeterTimer::time_func(REQUEST_MANAGER_TIMER.as_ref());
+
+        let request = GetCompactBlocks {
+            request_id: 0.into(),
+            hashes,
+        };
+
+        self.request_with_delay(io, Box::new(request), peer_id, None);
     }
 
     pub fn request_blocktxn(
@@ -578,14 +302,17 @@ impl RequestManager {
     )
     {
         let _timer = MeterTimer::time_func(REQUEST_MANAGER_TIMER.as_ref());
+
+        let request = GetBlockTxn {
+            request_id: 0.into(),
+            block_hash: block_hash.clone(),
+            indexes,
+        };
+
         if let Err(e) = self.request_handler.send_request(
             io,
             peer_id,
-            Box::new(RequestMessage::BlockTxn(GetBlockTxn {
-                request_id: 0.into(),
-                block_hash: block_hash.clone(),
-                indexes: indexes.clone(),
-            })),
+            RequestMessage::new(Box::new(request), None),
             SendQueuePriority::High,
         ) {
             warn!(
@@ -601,124 +328,27 @@ impl RequestManager {
     }
 
     pub fn send_request_again(
-        &self, io: &NetworkContext, request: &RequestMessage,
+        &self, io: &NetworkContext, msg: &RequestMessage,
     ) {
         let chosen_peer = self.syn.get_random_peer(&HashSet::new());
-        match request {
-            RequestMessage::Headers(get_headers) => {
-                self.request_block_headers(
-                    io,
-                    chosen_peer,
-                    get_headers.hashes.clone(),
-                );
-            }
-            RequestMessage::HeaderChain(get_headers) => {
-                self.request_block_header_chain(
-                    io,
-                    chosen_peer,
-                    &get_headers.hash,
-                    get_headers.max_blocks,
-                );
-            }
-            RequestMessage::Blocks(get_blocks) => {
-                self.request_blocks(
-                    io,
-                    chosen_peer,
-                    get_blocks.hashes.clone(),
-                    true,
-                );
-            }
-            RequestMessage::Compact(get_compact) => {
-                self.request_blocks(
-                    io,
-                    chosen_peer,
-                    get_compact.hashes.clone(),
-                    true,
-                );
-            }
-            RequestMessage::BlockTxn(blocktxn) => {
-                let mut hashes = Vec::new();
-                hashes.push(blocktxn.block_hash);
-                self.request_blocks(io, chosen_peer, hashes, true);
-            }
-            RequestMessage::Transactions(_) => {}
-            RequestMessage::Epochs(get_epoch_hashes) => {
-                self.request_epoch_hashes(
-                    io,
-                    chosen_peer,
-                    get_epoch_hashes.epochs.clone(),
-                );
-            }
-            RequestMessage::General(request) => {
-                self.send_general_request(
-                    io,
-                    chosen_peer,
-                    request.preprocess(),
-                );
-            }
-        }
-    }
-
-    /// Send the request to specified peer. If no peer available or send request
-    /// failed, add the request into waiting queue to resend in a short
-    /// time.
-    pub fn send_general_request(
-        &self, io: &NetworkContext, peer: Option<PeerId>, request: Box<Request>,
-    ) {
-        if let Err(e) =
-            self.request_handler.send_general_request(io, peer, request)
-        {
-            self.waiting_requests.lock().push(TimedWaitingRequest::new(
-                Instant::now() + *REQUEST_START_WAITING_TIME,
-                WaitingRequest::General(e),
-                None,
-            ));
+        if msg.request.is_resend_enabled() {
+            self.request_with_delay(
+                io,
+                msg.request.resend(),
+                chosen_peer,
+                msg.delay,
+            );
         }
     }
 
     pub fn remove_mismatch_request(
         &self, io: &NetworkContext, req: &RequestMessage,
     ) {
-        match req {
-            RequestMessage::Headers(ref get_headers) => {
-                let mut headers_in_flight = self.headers_in_flight.lock();
-                for hash in &get_headers.hashes {
-                    headers_in_flight.remove(hash);
-                }
-            }
-            RequestMessage::HeaderChain(ref get_headers) => {
-                self.headers_in_flight.lock().remove(&get_headers.hash);
-            }
-            RequestMessage::Blocks(ref get_blocks) => {
-                let mut blocks_in_flight = self.blocks_in_flight.lock();
-                for hash in &get_blocks.hashes {
-                    blocks_in_flight.remove(hash);
-                }
-            }
-            RequestMessage::Compact(get_compact) => {
-                let mut blocks_in_flight = self.blocks_in_flight.lock();
-                for hash in &get_compact.hashes {
-                    blocks_in_flight.remove(hash);
-                }
-            }
-            RequestMessage::BlockTxn(ref blocktxn) => {
-                self.blocks_in_flight.lock().remove(&blocktxn.block_hash);
-            }
-            RequestMessage::Transactions(ref get_transactions) => {
-                let mut inflight_requested_transactions =
-                    self.inflight_requested_transactions.lock();
-                for tx_id in &get_transactions.tx_ids {
-                    inflight_requested_transactions.remove(tx_id);
-                }
-            }
-            RequestMessage::Epochs(ref get_epoch_hashes) => {
-                let mut epochs_in_flight = self.epochs_in_flight.lock();
-                for epoch_number in &get_epoch_hashes.epochs {
-                    epochs_in_flight.remove(epoch_number);
-                }
-            }
-            RequestMessage::General(request) => request.on_removed(),
+        {
+            let mut inflight_keys = self.inflight_keys.lock();
+            req.request.on_removed(&mut inflight_keys);
         }
+
         self.send_request_again(io, req);
     }
 
@@ -730,7 +360,7 @@ impl RequestManager {
         self.request_handler.match_request(io, peer_id, request_id)
     }
 
-    /// Remove from `headers_in_flight` when a header is received.
+    /// Remove inflight keys when a header is received.
     ///
     /// If a request is removed from `req_hashes`, it's the caller's
     /// responsibility to ensure that the removed request either has already
@@ -746,8 +376,8 @@ impl RequestManager {
             req_hashes, received_headers
         );
         let missing_headers = {
-            let mut headers_in_flight = self.headers_in_flight.lock();
-            let mut header_waittime = self.header_request_waittime.lock();
+            let mut inflight_keys = self.inflight_keys.lock();
+            let msg_type = MsgId::GET_BLOCK_HEADERS.into();
             let mut missing_headers = Vec::new();
             for req_hash in &req_hashes {
                 if !received_headers.remove(req_hash) {
@@ -755,17 +385,15 @@ impl RequestManager {
                     // been received or requested
                     // again by another thread, so we do not need to request it
                     // in that case
-                    if headers_in_flight.remove(&req_hash) {
+                    if inflight_keys.remove(msg_type, Key::Hash(*req_hash)) {
                         missing_headers.push(*req_hash);
                     }
                 } else {
-                    headers_in_flight.remove(req_hash);
-                    header_waittime.remove(req_hash);
+                    inflight_keys.remove(msg_type, Key::Hash(*req_hash));
                 }
             }
             for h in &received_headers {
-                headers_in_flight.remove(h);
-                header_waittime.remove(h);
+                inflight_keys.remove(msg_type, Key::Hash(*h));
             }
             missing_headers
         };
@@ -775,7 +403,7 @@ impl RequestManager {
         }
     }
 
-    /// Remove from `epochs_in_flight` when a epoch is received.
+    /// Remove from inflight keys when a epoch is received.
     pub fn epochs_received(
         &self, io: &NetworkContext, req_epochs: HashSet<u64>,
         mut received_epochs: HashSet<u64>,
@@ -786,7 +414,8 @@ impl RequestManager {
             req_epochs, received_epochs
         );
         let missing_epochs = {
-            let mut epochs_in_flight = self.epochs_in_flight.lock();
+            let mut inflight_keys = self.inflight_keys.lock();
+            let msg_type = MsgId::GET_BLOCK_HASHES_BY_EPOCH.into();
             let mut missing_epochs = Vec::new();
             for epoch_number in &req_epochs {
                 if !received_epochs.remove(epoch_number) {
@@ -794,15 +423,15 @@ impl RequestManager {
                     // has been received or requested
                     // again by another thread, so we do not need to request it
                     // in that case
-                    if epochs_in_flight.remove(&epoch_number) {
+                    if inflight_keys.remove(msg_type, Key::Num(*epoch_number)) {
                         missing_epochs.push(*epoch_number);
                     }
                 } else {
-                    epochs_in_flight.remove(epoch_number);
+                    inflight_keys.remove(msg_type, Key::Num(*epoch_number));
                 }
             }
             for epoch_number in &received_epochs {
-                epochs_in_flight.remove(epoch_number);
+                inflight_keys.remove(msg_type, Key::Num(*epoch_number));
             }
             missing_epochs
         };
@@ -812,7 +441,7 @@ impl RequestManager {
         }
     }
 
-    /// Remove from `blocks_in_flight` when a block is received.
+    /// Remove from inflight keys when a block is received.
     ///
     /// If a request is removed from `req_hashes`, it's the caller's
     /// responsibility to ensure that the removed request either has already
@@ -830,8 +459,8 @@ impl RequestManager {
             req_hashes, received_blocks, peer
         );
         let missing_blocks = {
-            let mut blocks_in_flight = self.blocks_in_flight.lock();
-            let mut block_waittime = self.block_request_waittime.lock();
+            let mut inflight_keys = self.inflight_keys.lock();
+            let msg_type = MsgId::GET_BLOCKS.into();
             let mut missing_blocks = Vec::new();
             for req_hash in &req_hashes {
                 if !received_blocks.remove(req_hash) {
@@ -839,17 +468,15 @@ impl RequestManager {
                     // been received or requested
                     // again by another thread, so we do not need to request it
                     // in that case
-                    if blocks_in_flight.remove(&req_hash) {
+                    if inflight_keys.remove(msg_type, Key::Hash(*req_hash)) {
                         missing_blocks.push(*req_hash);
                     }
                 } else {
-                    blocks_in_flight.remove(req_hash);
-                    block_waittime.remove(req_hash);
+                    inflight_keys.remove(msg_type, Key::Hash(*req_hash));
                 }
             }
             for h in &received_blocks {
-                blocks_in_flight.remove(h);
-                block_waittime.remove(h);
+                inflight_keys.remove(msg_type, Key::Hash(*h));
             }
             missing_blocks
         };
@@ -879,10 +506,10 @@ impl RequestManager {
         &self, received_transactions: &HashSet<TxPropagateId>,
     ) {
         let _timer = MeterTimer::time_func(REQUEST_MANAGER_TX_TIMER.as_ref());
-        let mut inflight_transactions =
-            self.inflight_requested_transactions.lock();
+        let mut inflight_keys = self.inflight_keys.lock();
+        let msg_type = MsgId::GET_TRANSACTIONS.into();
         for tx in received_transactions {
-            inflight_transactions.remove(tx);
+            inflight_keys.remove(msg_type, Key::Id(*tx));
         }
     }
 
@@ -926,168 +553,45 @@ impl RequestManager {
 
     /// Send waiting requests that their backoff delay have passes
     pub fn resend_waiting_requests(
-        &self, io: &NetworkContext, with_public: bool,
+        &self, io: &NetworkContext, _with_public: bool,
     ) {
         debug!("resend_waiting_requests: start");
-        let mut headers_waittime = self.header_request_waittime.lock();
-        let mut blocks_waittime = self.block_request_waittime.lock();
         let mut waiting_requests = self.waiting_requests.lock();
         let now = Instant::now();
-        loop {
-            if waiting_requests.is_empty() {
-                break;
-            }
-            let req = waiting_requests.pop().expect("queue not empty");
+
+        while let Some(req) = waiting_requests.pop() {
             if req.time_to_send >= now {
                 waiting_requests.push(req);
                 break;
-            } else {
-                let maybe_peer = req
-                    .peer
-                    .or_else(|| self.syn.get_random_peer(&HashSet::new()));
-                let chosen_peer = match maybe_peer {
-                    Some(p) => p,
-                    None => {
-                        break;
-                    }
-                };
-                debug!("Send waiting req {:?} to peer={}", req, chosen_peer);
+            }
 
-                // Waiting requests are already in-flight, so send them without
-                // checking
-                match &req.request {
-                    WaitingRequest::Header(h) => {
-                        if let Err(e) = self.request_handler.send_request(
-                            io,
-                            chosen_peer,
-                            Box::new(RequestMessage::Headers(
-                                GetBlockHeaders {
-                                    request_id: 0.into(),
-                                    hashes: vec![h.clone()], /* TODO: group
-                                                              * multiple hashes
-                                                              * into a single
-                                                              * request */
-                                },
-                            )),
-                            SendQueuePriority::High,
-                        ) {
-                            warn!("Error requesting waiting block header peer={:?} hash={} max_blocks={} err={:?}", chosen_peer, h, 1, e);
-                            // TODO `h` is got from `waiting_requests`, so it
-                            // should
-                            // be in `headers_waittime`, and thus we can remove
-                            // `or_insert`
-                            waiting_requests.push(TimedWaitingRequest::new(
-                                Instant::now()
-                                    + *headers_waittime
-                                        .entry(*h)
-                                        .and_modify(|t| {
-                                            *t += *REQUEST_START_WAITING_TIME
-                                        })
-                                        .or_insert(*REQUEST_START_WAITING_TIME),
-                                WaitingRequest::Header(*h),
-                                None,
-                            ));
-                        }
-                    }
-                    WaitingRequest::HeaderChain(h) => {
-                        if let Err(e) = self.request_handler.send_request(
-                            io,
-                            chosen_peer,
-                            Box::new(RequestMessage::HeaderChain(
-                                GetBlockHeaderChain {
-                                    request_id: 0.into(),
-                                    hash: *h,
-                                    max_blocks: 1,
-                                },
-                            )),
-                            SendQueuePriority::High,
-                        ) {
-                            warn!("Error requesting waiting block header peer={:?} hash={} max_blocks={} err={:?}", chosen_peer, h, 1, e);
-                            // TODO `h` is got from `waiting_requests`, so it
-                            // should
-                            // be in `headers_waittime`, and thus we can remove
-                            // `or_insert`
-                            waiting_requests.push(TimedWaitingRequest::new(
-                                Instant::now()
-                                    + *headers_waittime
-                                        .entry(*h)
-                                        .and_modify(|t| {
-                                            *t += *REQUEST_START_WAITING_TIME
-                                        })
-                                        .or_insert(*REQUEST_START_WAITING_TIME),
-                                WaitingRequest::HeaderChain(*h),
-                                None,
-                            ));
-                        }
-                    }
-                    WaitingRequest::Epoch(n) => {
-                        if let Err(e) = self.request_handler.send_request(
-                            io,
-                            chosen_peer,
-                            Box::new(RequestMessage::Epochs(
-                                GetBlockHashesByEpoch {
-                                    request_id: 0.into(),
-                                    epochs: vec![n.clone()], /* TODO: group
-                                                              * multiple epochs
-                                                              * into a single
-                                                              * request */
-                                },
-                            )),
-                            SendQueuePriority::High,
-                        ) {
-                            warn!("Error requesting waiting epoch peer={:?} epoch_number={} err={:?}", chosen_peer, n, e);
-                            waiting_requests.push(TimedWaitingRequest::new(
-                                Instant::now() + *REQUEST_START_WAITING_TIME,
-                                WaitingRequest::Epoch(*n),
-                                None,
-                            ));
-                        }
-                    }
-                    WaitingRequest::Block(h) => {
-                        let blocks = vec![h.clone()];
-                        if let Err(e) = self.request_handler.send_request(
-                            io,
-                            chosen_peer,
-                            Box::new(RequestMessage::Blocks(GetBlocks {
-                                request_id: 0.into(),
-                                with_public,
-                                hashes: blocks.clone(),
-                            })),
-                            SendQueuePriority::High,
-                        ) {
-                            warn!("Error requesting waiting blocks peer={:?} hashes={:?} err={:?}", chosen_peer, blocks, e);
-                            // TODO `blocks` is got from `waiting_requests`, so
-                            // it should
-                            // be in `blocks_waittime`, and thus we can remove
-                            // `or_insert`
-                            for hash in blocks {
-                                waiting_requests.push(
-                                    TimedWaitingRequest::new(
-                                        Instant::now()
-                                            + *blocks_waittime
-                                                .entry(*h)
-                                                .and_modify(|t| {
-                                                    *t +=
-                                                    *REQUEST_START_WAITING_TIME
-                                                })
-                                                .or_insert(
-                                                    *REQUEST_START_WAITING_TIME,
-                                                ),
-                                        WaitingRequest::Block(hash),
-                                        None,
-                                    ),
-                                );
-                            }
-                        }
-                    }
-                    WaitingRequest::General(request) => {
-                        self.send_general_request(
-                            io,
-                            Some(chosen_peer),
-                            request.preprocess(),
-                        );
-                    }
+            let maybe_peer = req
+                .peer
+                .or_else(|| self.syn.get_random_peer(&HashSet::new()));
+            let chosen_peer = match maybe_peer {
+                Some(p) => p,
+                None => {
+                    break;
                 }
+            };
+            debug!("Send waiting req {:?} to peer={}", req, chosen_peer);
+
+            // Waiting requests are already in-flight, so send them without
+            // checking
+            let WaitingRequest(request, delay) = req.request;
+            let new_delay = delay + *REQUEST_START_WAITING_TIME;
+
+            if let Err(e) = self.request_handler.send_general_request(
+                io,
+                Some(chosen_peer),
+                request.resend(),
+                Some(new_delay),
+            ) {
+                self.waiting_requests.lock().push(TimedWaitingRequest::new(
+                    Instant::now() + new_delay,
+                    WaitingRequest(e, new_delay),
+                    None,
+                ));
             }
         }
     }
@@ -1097,63 +601,18 @@ impl RequestManager {
     }
 
     pub fn on_peer_disconnected(&self, io: &NetworkContext, peer: PeerId) {
-        if let Some(unfinished_requests) =
+        if let Some(mut unfinished_requests) =
             self.request_handler.remove_peer(peer)
         {
             {
-                let mut headers_in_flight = self.headers_in_flight.lock();
-                let mut header_waittime = self.header_request_waittime.lock();
-                let mut blocks_in_flight = self.blocks_in_flight.lock();
-                let mut block_waittime = self.block_request_waittime.lock();
-                let mut epochs_in_flight = self.epochs_in_flight.lock();
-                let mut inflight_transactions =
-                    self.inflight_requested_transactions.lock();
-                for request in &unfinished_requests {
-                    match &**request {
-                        RequestMessage::Headers(get_headers) => {
-                            for hash in &get_headers.hashes {
-                                headers_in_flight.remove(hash);
-                                header_waittime.remove(hash);
-                            }
-                        }
-                        RequestMessage::HeaderChain(get_headers) => {
-                            headers_in_flight.remove(&get_headers.hash);
-                            header_waittime.remove(&get_headers.hash);
-                        }
-                        RequestMessage::Blocks(get_blocks) => {
-                            for hash in &get_blocks.hashes {
-                                blocks_in_flight.remove(hash);
-                                block_waittime.remove(hash);
-                            }
-                        }
-                        RequestMessage::Compact(get_compact) => {
-                            for hash in &get_compact.hashes {
-                                blocks_in_flight.remove(hash);
-                                block_waittime.remove(hash);
-                            }
-                        }
-                        RequestMessage::BlockTxn(blocktxn) => {
-                            blocks_in_flight.remove(&blocktxn.block_hash);
-                            block_waittime.remove(&blocktxn.block_hash);
-                        }
-                        RequestMessage::Transactions(get_transactions) => {
-                            for tx_id in &get_transactions.tx_ids {
-                                inflight_transactions.remove(tx_id);
-                            }
-                        }
-                        RequestMessage::Epochs(get_epoch_hashes) => {
-                            for epoch_number in &get_epoch_hashes.epochs {
-                                epochs_in_flight.remove(epoch_number);
-                            }
-                        }
-                        RequestMessage::General(request) => {
-                            request.on_removed()
-                        }
-                    }
+                let mut inflight_keys = self.inflight_keys.lock();
+                for msg in &unfinished_requests {
+                    msg.request.on_removed(&mut inflight_keys);
                 }
             }
-            for request in unfinished_requests {
-                self.send_request_again(io, &*request);
+            for msg in unfinished_requests.iter_mut() {
+                msg.delay = None;
+                self.send_request_again(io, &msg);
             }
         } else {
             debug!("Peer already removed form request manager when disconnected peer={}", peer);

--- a/core/src/sync/request_manager/request_handler.rs
+++ b/core/src/sync/request_manager/request_handler.rs
@@ -1,8 +1,5 @@
 use crate::sync::{
-    message::{
-        GetBlockHashesByEpoch, GetBlockHeaderChain, GetBlockHeaders,
-        GetBlockTxn, GetBlocks, GetCompactBlocks, GetTransactions, Message,
-    },
+    message::{KeyContainer, Message},
     msg_sender::send_message,
     request_manager::RequestManager,
     synchronization_protocol_handler::ProtocolConfiguration,
@@ -83,7 +80,7 @@ impl RequestHandler {
     }
 
     pub fn send_request(
-        &self, io: &NetworkContext, peer: PeerId, mut msg: Box<RequestMessage>,
+        &self, io: &NetworkContext, peer: PeerId, mut msg: RequestMessage,
         priority: SendQueuePriority,
     ) -> Result<(), Error>
     {
@@ -119,7 +116,7 @@ impl RequestHandler {
     /// failed, return the request back to caller to handle in advance.
     pub fn send_general_request(
         &self, io: &NetworkContext, peer: Option<PeerId>,
-        mut request: Box<Request>,
+        mut request: Box<Request>, delay: Option<Duration>,
     ) -> Result<(), Box<Request>>
     {
         let peer = match peer {
@@ -138,20 +135,20 @@ impl RequestHandler {
         let request_id = match peer_info.get_next_request_id() {
             Some(id) => id,
             None => {
-                return Ok(peer_info.append_pending_request(Box::new(
-                    RequestMessage::General(request),
-                )))
+                peer_info.append_pending_request(RequestMessage::new(
+                    request, delay,
+                ));
+                return Ok(());
             }
         };
 
         request.set_request_id(request_id);
-        if let Err(_) =
-            send_message(io, peer, request.as_message(), request.priority())
-        {
+        let message = request.as_message();
+        if send_message(io, peer, message, message.priority()).is_err() {
             return Err(request);
         }
 
-        let msg = Box::new(RequestMessage::General(request));
+        let msg = RequestMessage::new(request, delay);
 
         let timed_req = Arc::new(TimedSyncRequests::from_request(
             peer,
@@ -207,9 +204,7 @@ impl RequestHandler {
     }
 
     /// Return unfinished_requests
-    pub fn remove_peer(
-        &self, peer_id: PeerId,
-    ) -> Option<Vec<Box<RequestMessage>>> {
+    pub fn remove_peer(&self, peer_id: PeerId) -> Option<Vec<RequestMessage>> {
         self.peers
             .lock()
             .remove(&peer_id)
@@ -225,7 +220,7 @@ struct RequestContainer {
     pub lowest_request_id: u64,
     pub next_request_id: u64,
     pub max_inflight_request_count: u64,
-    pub pending_requests: VecDeque<Box<RequestMessage>>,
+    pub pending_requests: VecDeque<RequestMessage>,
 }
 
 impl RequestContainer {
@@ -245,7 +240,7 @@ impl RequestContainer {
     }
 
     pub fn append_inflight_request(
-        &mut self, request_id: u64, message: Box<RequestMessage>,
+        &mut self, request_id: u64, message: RequestMessage,
         timed_req: Arc<TimedSyncRequests>,
     )
     {
@@ -254,7 +249,7 @@ impl RequestContainer {
             Some(SynchronizationPeerRequest { message, timed_req });
     }
 
-    pub fn append_pending_request(&mut self, msg: Box<RequestMessage>) {
+    pub fn append_pending_request(&mut self, msg: RequestMessage) {
         self.pending_requests.push_back(msg);
     }
 
@@ -271,7 +266,7 @@ impl RequestContainer {
         !self.pending_requests.is_empty()
     }
 
-    pub fn pop_pending_request(&mut self) -> Option<Box<RequestMessage>> {
+    pub fn pop_pending_request(&mut self) -> Option<RequestMessage> {
         self.pending_requests.pop_front()
     }
 
@@ -359,13 +354,13 @@ impl RequestContainer {
                     break;
                 }
             }
-            Ok(*removed_req.message)
+            Ok(removed_req.message)
         } else {
             bail!(ErrorKind::RequestNotFound)
         }
     }
 
-    pub fn get_unfinished_requests(&mut self) -> Vec<Box<RequestMessage>> {
+    pub fn get_unfinished_requests(&mut self) -> Vec<RequestMessage> {
         let mut unfinished_requests = Vec::new();
         while let Some(maybe_req) = self.inflight_requests.pop() {
             if let Some(req) = maybe_req {
@@ -383,7 +378,7 @@ impl RequestContainer {
 
 #[derive(Debug)]
 pub struct SynchronizationPeerRequest {
-    pub message: Box<RequestMessage>,
+    pub message: RequestMessage,
     pub timed_req: Arc<TimedSyncRequests>,
 }
 
@@ -392,91 +387,48 @@ pub trait Request: Send + Debug {
     fn set_request_id(&mut self, request_id: u64);
     fn as_message(&self) -> &Message;
     fn as_any(&self) -> &Any; // to support downcast trait to struct
-    fn timeout(&self) -> Duration; // request timeout for resend purpose
-    fn priority(&self) -> SendQueuePriority { SendQueuePriority::High }
+    fn timeout(&self, conf: &ProtocolConfiguration) -> Duration; // request timeout for resend purpose
 
     // occurs when peer disconnected or invalid message received
-    fn on_removed(&self);
-
-    // preprocess request before sending out, e.g. update inflight queue
-    fn preprocess(&self) -> Box<Request>;
+    fn on_removed(&self, inflight_keys: &mut KeyContainer);
+    fn with_inflight(&mut self, inflight_keys: &mut KeyContainer);
+    fn is_empty(&self) -> bool;
+    fn is_resend_enabled(&self) -> bool { true }
+    fn resend(&self) -> Box<Request>;
 }
 
 #[derive(Debug)]
-pub enum RequestMessage {
-    Headers(GetBlockHeaders),
-    HeaderChain(GetBlockHeaderChain),
-    Blocks(GetBlocks),
-    Compact(GetCompactBlocks),
-    BlockTxn(GetBlockTxn),
-    Transactions(GetTransactions),
-    Epochs(GetBlockHashesByEpoch),
-    General(Box<Request>),
+pub struct RequestMessage {
+    pub request: Box<Request>,
+    pub delay: Option<Duration>,
 }
 
 impl RequestMessage {
-    pub fn set_request_id(&mut self, request_id: u64) {
-        match self {
-            RequestMessage::Headers(ref mut msg) => {
-                msg.set_request_id(request_id)
-            }
-            RequestMessage::HeaderChain(ref mut msg) => {
-                msg.set_request_id(request_id)
-            }
-            RequestMessage::Blocks(ref mut msg) => {
-                msg.set_request_id(request_id)
-            }
-            RequestMessage::Compact(ref mut msg) => {
-                msg.set_request_id(request_id)
-            }
-            RequestMessage::BlockTxn(ref mut msg) => {
-                msg.set_request_id(request_id)
-            }
-            RequestMessage::Transactions(ref mut msg) => {
-                msg.set_request_id(request_id)
-            }
-            RequestMessage::Epochs(ref mut msg) => {
-                msg.set_request_id(request_id)
-            }
-            RequestMessage::General(ref mut request) => {
-                request.set_request_id(request_id);
-            }
-        }
+    pub fn new(request: Box<Request>, delay: Option<Duration>) -> Self {
+        RequestMessage { request, delay }
     }
 
-    pub fn get_msg(&self) -> &Message {
-        match self {
-            RequestMessage::Headers(ref msg) => msg,
-            RequestMessage::HeaderChain(ref msg) => msg,
-            RequestMessage::Blocks(ref msg) => msg,
-            RequestMessage::Compact(ref msg) => msg,
-            RequestMessage::BlockTxn(ref msg) => msg,
-            RequestMessage::Transactions(ref msg) => msg,
-            RequestMessage::Epochs(ref msg) => msg,
-            RequestMessage::General(ref request) => request.as_message(),
-        }
+    pub fn set_request_id(&mut self, request_id: u64) {
+        self.request.set_request_id(request_id);
     }
+
+    pub fn get_msg(&self) -> &Message { self.request.as_message() }
 
     /// Download cast general request to specified request type.
     /// If downcast failed, resend the request again and return
     /// `UnexpectedResponse` error.
     pub fn downcast_general<T: Request + Any>(
         &self, io: &NetworkContext, request_manager: &RequestManager,
-    ) -> Result<&T, Error> {
-        let request = match *self {
-            RequestMessage::General(ref request) => request,
-            _ => {
-                warn!("failed to downcast message to RequestMessage::General(Request), message = {:?}", self);
-                request_manager.remove_mismatch_request(io, self);
-                return Err(ErrorKind::UnexpectedResponse.into());
-            }
-        };
-
-        match request.as_any().downcast_ref::<T>() {
+        remove_on_mismatch: bool,
+    ) -> Result<&T, Error>
+    {
+        match self.request.as_any().downcast_ref::<T>() {
             Some(req) => Ok(req),
             None => {
                 warn!("failed to downcast general request to concrete request type, message = {:?}", self);
-                request_manager.remove_mismatch_request(io, self);
+                if remove_on_mismatch {
+                    request_manager.remove_mismatch_request(io, self);
+                }
                 Err(ErrorKind::UnexpectedResponse.into())
             }
         }
@@ -508,16 +460,7 @@ impl TimedSyncRequests {
         conf: &ProtocolConfiguration,
     ) -> TimedSyncRequests
     {
-        let timeout = match *msg {
-            RequestMessage::Headers(_) => conf.headers_request_timeout,
-            RequestMessage::HeaderChain(_) => conf.headers_request_timeout,
-            RequestMessage::Epochs(_) => conf.headers_request_timeout,
-            RequestMessage::Blocks(_)
-            | RequestMessage::Compact(_)
-            | RequestMessage::BlockTxn(_) => conf.blocks_request_timeout,
-            RequestMessage::Transactions(_) => conf.transaction_request_timeout,
-            RequestMessage::General(ref request) => request.timeout(),
-        };
+        let timeout = msg.request.timeout(conf);
         TimedSyncRequests::new(peer_id, timeout, request_id)
     }
 }

--- a/core/src/sync/state/snapshot_chunk_request.rs
+++ b/core/src/sync/state/snapshot_chunk_request.rs
@@ -3,10 +3,10 @@
 // See http://www.gnu.org/licenses/
 
 use crate::sync::{
-    message::{Context, Handleable, Message, MsgId},
-    request_manager::Request as RequestMessage,
+    message::{Context, Handleable, KeyContainer, Message, MsgId},
+    request_manager::Request,
     state::snapshot_chunk_response::SnapshotChunkResponse,
-    Error,
+    Error, ProtocolConfiguration,
 };
 use cfx_types::H256;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
@@ -41,7 +41,7 @@ impl Handleable for SnapshotChunkRequest {
     }
 }
 
-impl RequestMessage for SnapshotChunkRequest {
+impl Request for SnapshotChunkRequest {
     fn set_request_id(&mut self, request_id: u64) {
         self.request_id = request_id;
     }
@@ -50,16 +50,17 @@ impl RequestMessage for SnapshotChunkRequest {
 
     fn as_any(&self) -> &Any { self }
 
-    fn timeout(&self) -> Duration { Duration::from_secs(120) }
-
-    fn on_removed(&self) {}
-
-    fn preprocess(&self) -> Box<RequestMessage> {
-        Box::new(SnapshotChunkRequest::new(
-            self.checkpoint.clone(),
-            self.chunk_hash.clone(),
-        ))
+    fn timeout(&self, conf: &ProtocolConfiguration) -> Duration {
+        conf.blocks_request_timeout
     }
+
+    fn on_removed(&self, _inflight_keys: &mut KeyContainer) {}
+
+    fn with_inflight(&mut self, _inflight_keys: &mut KeyContainer) {}
+
+    fn is_empty(&self) -> bool { false }
+
+    fn resend(&self) -> Box<Request> { Box::new(self.clone()) }
 }
 
 impl Message for SnapshotChunkRequest {

--- a/core/src/sync/state/snapshot_chunk_request.rs
+++ b/core/src/sync/state/snapshot_chunk_request.rs
@@ -60,7 +60,7 @@ impl Request for SnapshotChunkRequest {
 
     fn is_empty(&self) -> bool { false }
 
-    fn resend(&self) -> Box<Request> { Box::new(self.clone()) }
+    fn resend(&self) -> Option<Box<Request>> { Some(Box::new(self.clone())) }
 }
 
 impl Message for SnapshotChunkRequest {

--- a/core/src/sync/state/snapshot_manifest_request.rs
+++ b/core/src/sync/state/snapshot_manifest_request.rs
@@ -60,7 +60,7 @@ impl Request for SnapshotManifestRequest {
 
     fn is_empty(&self) -> bool { false }
 
-    fn resend(&self) -> Box<Request> { Box::new(self.clone()) }
+    fn resend(&self) -> Option<Box<Request>> { Some(Box::new(self.clone())) }
 }
 
 impl Message for SnapshotManifestRequest {

--- a/core/src/sync/state/snapshot_manifest_request.rs
+++ b/core/src/sync/state/snapshot_manifest_request.rs
@@ -3,10 +3,10 @@
 // See http://www.gnu.org/licenses/
 
 use crate::sync::{
-    message::{Context, Handleable, Message, MsgId},
-    request_manager::Request as RequestMessage,
+    message::{Context, Handleable, KeyContainer, Message, MsgId},
+    request_manager::Request,
     state::snapshot_manifest_response::SnapshotManifestResponse,
-    Error,
+    Error, ProtocolConfiguration,
 };
 use cfx_types::H256;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
@@ -41,7 +41,7 @@ impl Handleable for SnapshotManifestRequest {
     }
 }
 
-impl RequestMessage for SnapshotManifestRequest {
+impl Request for SnapshotManifestRequest {
     fn set_request_id(&mut self, request_id: u64) {
         self.request_id = request_id;
     }
@@ -50,14 +50,17 @@ impl RequestMessage for SnapshotManifestRequest {
 
     fn as_any(&self) -> &Any { self }
 
-    // todo configurable
-    fn timeout(&self) -> Duration { Duration::from_secs(30) }
-
-    fn on_removed(&self) {}
-
-    fn preprocess(&self) -> Box<RequestMessage> {
-        Box::new(SnapshotManifestRequest::new(self.checkpoint.clone()))
+    fn timeout(&self, conf: &ProtocolConfiguration) -> Duration {
+        conf.headers_request_timeout
     }
+
+    fn on_removed(&self, _inflight_keys: &mut KeyContainer) {}
+
+    fn with_inflight(&mut self, _inflight_keys: &mut KeyContainer) {}
+
+    fn is_empty(&self) -> bool { false }
+
+    fn resend(&self) -> Box<Request> { Box::new(self.clone()) }
 }
 
 impl Message for SnapshotManifestRequest {

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -1059,8 +1059,7 @@ impl SynchronizationProtocolHandler {
 
     pub fn remove_expired_flying_request(&self, io: &NetworkContext) {
         self.request_manager.resend_timeout_requests(io);
-        self.request_manager
-            .resend_waiting_requests(io, self.request_block_need_public());
+        self.request_manager.resend_waiting_requests(io);
     }
 
     fn block_cache_gc(&self) { self.graph.data_man.gc_cache() }


### PR DESCRIPTION
This pull request is to refactor the request manager to reduce many duplicated codes, e.g. 
- inflight msg keys
- preprocess msg before send to remote peer
- add into waiting queue if send request failed
- resend request logic

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/443)
<!-- Reviewable:end -->
