### PR TITLE
Light node error handling

### DIFF
--- a/core/src/light_protocol/error.rs
+++ b/core/src/light_protocol/error.rs
@@ -35,11 +35,6 @@ error_chain! {
             display("Invalid proof"),
         }
 
-        InvalidRequestId {
-            description("Invalid request id"),
-            display("Invalid request id"),
-        }
-
         InvalidStateRoot {
             description("Invalid state root"),
             display("Invalid state root"),
@@ -48,6 +43,11 @@ error_chain! {
         PivotHashMismatch {
             description("Pivot hash mismatch"),
             display("Pivot hash mismatch"),
+        }
+
+        UnexpectedRequestId {
+            description("Unexpected request id"),
+            display("Unexpected request id"),
         }
 
         UnexpectedResponse {

--- a/core/src/light_protocol/error.rs
+++ b/core/src/light_protocol/error.rs
@@ -25,6 +25,11 @@ error_chain! {
             display("Internal error"),
         }
 
+        InvalidMessageFormat {
+            description("Invalid message format"),
+            display("Invalid message format"),
+        }
+
         InvalidProof {
             description("Invalid proof"),
             display("Invalid proof"),
@@ -48,6 +53,11 @@ error_chain! {
         UnexpectedResponse {
             description("Unexpected response"),
             display("Unexpected response"),
+        }
+
+        UnknownMessage {
+            description("Unknown message"),
+            display("Unknown message"),
         }
 
         UnknownPeer {

--- a/core/src/light_protocol/message/message.rs
+++ b/core/src/light_protocol/message/message.rs
@@ -13,6 +13,8 @@ build_msgid! {
     STATE_ROOT = 0x02
     GET_STATE_ENTRY = 0x03
     STATE_ENTRY = 0x04
+
+    INVALID = 0xff
 }
 
 // generate `impl Message for _` for each message type

--- a/core/src/sync/error.rs
+++ b/core/src/sync/error.rs
@@ -20,6 +20,11 @@ error_chain! {
             display("Invalid block"),
         }
 
+        InvalidMessageFormat {
+            description("Invalid message format"),
+            display("Invalid message format"),
+        }
+
         UnknownPeer {
             description("Unknown peer"),
             display("Unknown peer"),

--- a/core/src/sync/message/message.rs
+++ b/core/src/sync/message/message.rs
@@ -48,6 +48,8 @@ build_msgid! {
     GET_SNAPSHOT_MANIFEST_RESPONSE = 0x1a
     GET_SNAPSHOT_CHUNK = 0x1b
     GET_SNAPSHOT_CHUNK_RESPONSE = 0x1c
+
+    INVALID = 0xff
 }
 
 // generate `impl Message for _` for each message type


### PR DESCRIPTION
**Overview**

Add proper error handling to `light_protocol::QueryHandler`. Disconnect/demote peer when appropriate.

---


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/463)
<!-- Reviewable:end -->
