### PR TITLE
Simplify the sync msg code

### DIFF
--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -7,7 +7,7 @@ pub type MsgId = u8;
 
 pub use cfx_bytes::Bytes;
 pub use priority_send_queue::SendQueuePriority;
-pub use rlp::Encodable;
+use rlp::Encodable;
 use std::any::Any;
 
 pub use crate::network::{

--- a/core/src/sync/message/blockhashes.rs
+++ b/core/src/sync/message/blockhashes.rs
@@ -10,9 +10,9 @@ use crate::{
     },
 };
 use cfx_types::H256;
-use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+use rlp_derive::{RlpDecodable, RlpEncodable};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, RlpEncodable, RlpDecodable)]
 pub struct GetBlockHashesResponse {
     pub request_id: RequestId,
     pub hashes: Vec<H256>,
@@ -68,23 +68,5 @@ impl Handleable for GetBlockHashesResponse {
         ctx.manager.start_sync(ctx.io);
 
         Ok(())
-    }
-}
-
-impl Encodable for GetBlockHashesResponse {
-    fn rlp_append(&self, stream: &mut RlpStream) {
-        stream
-            .begin_list(2)
-            .append(&self.request_id)
-            .append_list(&self.hashes);
-    }
-}
-
-impl Decodable for GetBlockHashesResponse {
-    fn decode(rlp: &Rlp) -> Result<GetBlockHashesResponse, DecoderError> {
-        Ok(GetBlockHashesResponse {
-            request_id: rlp.val_at(0)?,
-            hashes: rlp.list_at(1)?,
-        })
     }
 }

--- a/core/src/sync/message/blockhashes.rs
+++ b/core/src/sync/message/blockhashes.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 use cfx_types::H256;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
-use std::ops::{Deref, DerefMut};
 
 #[derive(Debug, PartialEq)]
 pub struct GetBlockHashesResponse {
@@ -70,16 +69,6 @@ impl Handleable for GetBlockHashesResponse {
 
         Ok(())
     }
-}
-
-impl Deref for GetBlockHashesResponse {
-    type Target = RequestId;
-
-    fn deref(&self) -> &Self::Target { &self.request_id }
-}
-
-impl DerefMut for GetBlockHashesResponse {
-    fn deref_mut(&mut self) -> &mut RequestId { &mut self.request_id }
 }
 
 impl Encodable for GetBlockHashesResponse {

--- a/core/src/sync/message/blockheaders.rs
+++ b/core/src/sync/message/blockheaders.rs
@@ -17,13 +17,13 @@ use crate::{
 use cfx_types::H256;
 use metrics::MeterTimer;
 use primitives::BlockHeader;
-use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+use rlp_derive::{RlpDecodable, RlpEncodable};
 use std::{
     collections::HashSet,
     time::{SystemTime, UNIX_EPOCH},
 };
 
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, PartialEq, Default, RlpDecodable, RlpEncodable)]
 pub struct GetBlockHeadersResponse {
     pub request_id: RequestId,
     pub headers: Vec<BlockHeader>,
@@ -196,23 +196,5 @@ impl GetBlockHeadersResponse {
                 .relay_blocks(ctx.io, need_to_relay.into_iter().collect())
                 .ok();
         }
-    }
-}
-
-impl Encodable for GetBlockHeadersResponse {
-    fn rlp_append(&self, stream: &mut RlpStream) {
-        stream
-            .begin_list(2)
-            .append(&self.request_id)
-            .append_list(&self.headers);
-    }
-}
-
-impl Decodable for GetBlockHeadersResponse {
-    fn decode(rlp: &Rlp) -> Result<GetBlockHeadersResponse, DecoderError> {
-        Ok(GetBlockHeadersResponse {
-            request_id: rlp.val_at(0)?,
-            headers: rlp.list_at(1)?,
-        })
     }
 }

--- a/core/src/sync/message/blockheaders.rs
+++ b/core/src/sync/message/blockheaders.rs
@@ -20,7 +20,6 @@ use primitives::BlockHeader;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 use std::{
     collections::HashSet,
-    ops::{Deref, DerefMut},
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -198,15 +197,6 @@ impl GetBlockHeadersResponse {
                 .ok();
         }
     }
-}
-impl Deref for GetBlockHeadersResponse {
-    type Target = RequestId;
-
-    fn deref(&self) -> &Self::Target { &self.request_id }
-}
-
-impl DerefMut for GetBlockHeadersResponse {
-    fn deref_mut(&mut self) -> &mut RequestId { &mut self.request_id }
 }
 
 impl Encodable for GetBlockHeadersResponse {

--- a/core/src/sync/message/blocks.rs
+++ b/core/src/sync/message/blocks.rs
@@ -17,9 +17,10 @@ use cfx_types::H256;
 use metrics::MeterTimer;
 use primitives::Block;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+use rlp_derive::{RlpDecodable, RlpEncodable};
 use std::collections::HashSet;
 
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, PartialEq, Default, RlpDecodable, RlpEncodable)]
 pub struct GetBlocksResponse {
     pub request_id: RequestId,
     pub blocks: Vec<Block>,
@@ -59,24 +60,6 @@ impl Handleable for GetBlocksResponse {
         );
 
         Ok(())
-    }
-}
-
-impl Encodable for GetBlocksResponse {
-    fn rlp_append(&self, stream: &mut RlpStream) {
-        stream
-            .begin_list(2)
-            .append(&self.request_id)
-            .append_list(&self.blocks);
-    }
-}
-
-impl Decodable for GetBlocksResponse {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-        Ok(GetBlocksResponse {
-            request_id: rlp.val_at(0)?,
-            blocks: rlp.list_at(1)?,
-        })
     }
 }
 

--- a/core/src/sync/message/blocks.rs
+++ b/core/src/sync/message/blocks.rs
@@ -17,10 +17,7 @@ use cfx_types::H256;
 use metrics::MeterTimer;
 use primitives::Block;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
-use std::{
-    collections::HashSet,
-    ops::{Deref, DerefMut},
-};
+use std::collections::HashSet;
 
 #[derive(Debug, PartialEq, Default)]
 pub struct GetBlocksResponse {
@@ -63,16 +60,6 @@ impl Handleable for GetBlocksResponse {
 
         Ok(())
     }
-}
-
-impl Deref for GetBlocksResponse {
-    type Target = RequestId;
-
-    fn deref(&self) -> &Self::Target { &self.request_id }
-}
-
-impl DerefMut for GetBlocksResponse {
-    fn deref_mut(&mut self) -> &mut RequestId { &mut self.request_id }
 }
 
 impl Encodable for GetBlocksResponse {
@@ -134,16 +121,6 @@ impl Handleable for GetBlocksWithPublicResponse {
 
         Ok(())
     }
-}
-
-impl Deref for GetBlocksWithPublicResponse {
-    type Target = RequestId;
-
-    fn deref(&self) -> &Self::Target { &self.request_id }
-}
-
-impl DerefMut for GetBlocksWithPublicResponse {
-    fn deref_mut(&mut self) -> &mut RequestId { &mut self.request_id }
 }
 
 impl Encodable for GetBlocksWithPublicResponse {

--- a/core/src/sync/message/blocktxn.rs
+++ b/core/src/sync/message/blocktxn.rs
@@ -14,10 +14,10 @@ use crate::{
 use cfx_types::H256;
 use metrics::MeterTimer;
 use primitives::{Block, TransactionWithSignature};
-use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+use rlp_derive::{RlpDecodable, RlpEncodable};
 use std::collections::HashSet;
 
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, PartialEq, Default, RlpDecodable, RlpEncodable)]
 pub struct GetBlockTxnResponse {
     pub request_id: RequestId,
     pub block_hash: H256,
@@ -129,25 +129,5 @@ impl Handleable for GetBlockTxnResponse {
             );
         }
         Ok(())
-    }
-}
-
-impl Encodable for GetBlockTxnResponse {
-    fn rlp_append(&self, stream: &mut RlpStream) {
-        stream
-            .begin_list(3)
-            .append(&self.request_id)
-            .append(&self.block_hash)
-            .append_list(&self.block_txn);
-    }
-}
-
-impl Decodable for GetBlockTxnResponse {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-        Ok(GetBlockTxnResponse {
-            request_id: rlp.val_at(0)?,
-            block_hash: rlp.val_at(1)?,
-            block_txn: rlp.list_at(2)?,
-        })
     }
 }

--- a/core/src/sync/message/blocktxn.rs
+++ b/core/src/sync/message/blocktxn.rs
@@ -15,10 +15,7 @@ use cfx_types::H256;
 use metrics::MeterTimer;
 use primitives::{Block, TransactionWithSignature};
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
-use std::{
-    collections::HashSet,
-    ops::{Deref, DerefMut},
-};
+use std::collections::HashSet;
 
 #[derive(Debug, PartialEq, Default)]
 pub struct GetBlockTxnResponse {
@@ -133,16 +130,6 @@ impl Handleable for GetBlockTxnResponse {
         }
         Ok(())
     }
-}
-
-impl Deref for GetBlockTxnResponse {
-    type Target = RequestId;
-
-    fn deref(&self) -> &Self::Target { &self.request_id }
-}
-
-impl DerefMut for GetBlockTxnResponse {
-    fn deref_mut(&mut self) -> &mut RequestId { &mut self.request_id }
 }
 
 impl Encodable for GetBlockTxnResponse {

--- a/core/src/sync/message/cmpctblocks.rs
+++ b/core/src/sync/message/cmpctblocks.rs
@@ -17,10 +17,7 @@ use cfx_types::H256;
 use metrics::MeterTimer;
 use primitives::{block::CompactBlock, Block};
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
-use std::{
-    collections::HashSet,
-    ops::{Deref, DerefMut},
-};
+use std::collections::HashSet;
 
 #[derive(Debug, PartialEq, Default)]
 pub struct GetCompactBlocksResponse {
@@ -150,16 +147,6 @@ impl Handleable for GetCompactBlocksResponse {
         // Broadcast completed block_header_ready blocks
         ctx.manager.relay_blocks(ctx.io, completed_blocks)
     }
-}
-
-impl Deref for GetCompactBlocksResponse {
-    type Target = RequestId;
-
-    fn deref(&self) -> &Self::Target { &self.request_id }
-}
-
-impl DerefMut for GetCompactBlocksResponse {
-    fn deref_mut(&mut self) -> &mut RequestId { &mut self.request_id }
 }
 
 impl Encodable for GetCompactBlocksResponse {

--- a/core/src/sync/message/cmpctblocks.rs
+++ b/core/src/sync/message/cmpctblocks.rs
@@ -16,10 +16,10 @@ use crate::{
 use cfx_types::H256;
 use metrics::MeterTimer;
 use primitives::{block::CompactBlock, Block};
-use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+use rlp_derive::{RlpDecodable, RlpEncodable};
 use std::collections::HashSet;
 
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, PartialEq, Default, RlpDecodable, RlpEncodable)]
 pub struct GetCompactBlocksResponse {
     pub request_id: RequestId,
     pub compact_blocks: Vec<CompactBlock>,
@@ -146,25 +146,5 @@ impl Handleable for GetCompactBlocksResponse {
 
         // Broadcast completed block_header_ready blocks
         ctx.manager.relay_blocks(ctx.io, completed_blocks)
-    }
-}
-
-impl Encodable for GetCompactBlocksResponse {
-    fn rlp_append(&self, stream: &mut RlpStream) {
-        stream
-            .begin_list(3)
-            .append(&self.request_id)
-            .append_list(&self.compact_blocks)
-            .append_list(&self.blocks);
-    }
-}
-
-impl Decodable for GetCompactBlocksResponse {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-        Ok(GetCompactBlocksResponse {
-            request_id: rlp.val_at(0)?,
-            compact_blocks: rlp.list_at(1)?,
-            blocks: rlp.list_at(2)?,
-        })
     }
 }

--- a/core/src/sync/message/getblockhashesbyepoch.rs
+++ b/core/src/sync/message/getblockhashesbyepoch.rs
@@ -13,10 +13,10 @@ use crate::{
         Error, ProtocolConfiguration,
     },
 };
-use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+use rlp_derive::{RlpDecodable, RlpEncodable};
 use std::{any::Any, time::Duration};
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, RlpDecodable, RlpEncodable)]
 pub struct GetBlockHashesByEpoch {
     pub request_id: RequestId,
     pub epochs: Vec<u64>,
@@ -68,27 +68,5 @@ impl Handleable for GetBlockHashesByEpoch {
         };
 
         ctx.send_response(&response)
-    }
-}
-
-impl Encodable for GetBlockHashesByEpoch {
-    fn rlp_append(&self, stream: &mut RlpStream) {
-        stream
-            .begin_list(2)
-            .append(&self.request_id)
-            .append_list(&self.epochs);
-    }
-}
-
-impl Decodable for GetBlockHashesByEpoch {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-        if rlp.item_count()? != 2 {
-            return Err(DecoderError::RlpIncorrectListLen);
-        }
-
-        Ok(GetBlockHashesByEpoch {
-            request_id: rlp.val_at(0)?,
-            epochs: rlp.list_at(1)?,
-        })
     }
 }

--- a/core/src/sync/message/getblockhashesbyepoch.rs
+++ b/core/src/sync/message/getblockhashesbyepoch.rs
@@ -14,11 +14,7 @@ use crate::{
     },
 };
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
-use std::{
-    any::Any,
-    ops::{Deref, DerefMut},
-    time::Duration,
-};
+use std::{any::Any, time::Duration};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct GetBlockHashesByEpoch {
@@ -73,16 +69,6 @@ impl Handleable for GetBlockHashesByEpoch {
 
         ctx.send_response(&response)
     }
-}
-
-impl Deref for GetBlockHashesByEpoch {
-    type Target = RequestId;
-
-    fn deref(&self) -> &Self::Target { &self.request_id }
-}
-
-impl DerefMut for GetBlockHashesByEpoch {
-    fn deref_mut(&mut self) -> &mut RequestId { &mut self.request_id }
 }
 
 impl Encodable for GetBlockHashesByEpoch {

--- a/core/src/sync/message/getblockheaders.rs
+++ b/core/src/sync/message/getblockheaders.rs
@@ -14,10 +14,10 @@ use crate::{
     },
 };
 use cfx_types::H256;
-use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+use rlp_derive::{RlpDecodable, RlpEncodable};
 use std::{any::Any, time::Duration};
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, RlpDecodable, RlpEncodable)]
 pub struct GetBlockHeaders {
     pub request_id: RequestId,
     pub hashes: Vec<H256>,
@@ -70,27 +70,5 @@ impl Handleable for GetBlockHeaders {
         );
 
         ctx.send_response(&block_headers_resp)
-    }
-}
-
-impl Encodable for GetBlockHeaders {
-    fn rlp_append(&self, stream: &mut RlpStream) {
-        stream
-            .begin_list(2)
-            .append(&self.request_id)
-            .append_list(&self.hashes);
-    }
-}
-
-impl Decodable for GetBlockHeaders {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-        if rlp.item_count()? != 2 {
-            return Err(DecoderError::RlpIncorrectListLen);
-        }
-
-        Ok(GetBlockHeaders {
-            request_id: rlp.val_at(0)?,
-            hashes: rlp.list_at(1)?,
-        })
     }
 }

--- a/core/src/sync/message/getblockheaders.rs
+++ b/core/src/sync/message/getblockheaders.rs
@@ -15,11 +15,7 @@ use crate::{
 };
 use cfx_types::H256;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
-use std::{
-    any::Any,
-    ops::{Deref, DerefMut},
-    time::Duration,
-};
+use std::{any::Any, time::Duration};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct GetBlockHeaders {
@@ -75,16 +71,6 @@ impl Handleable for GetBlockHeaders {
 
         ctx.send_response(&block_headers_resp)
     }
-}
-
-impl Deref for GetBlockHeaders {
-    type Target = RequestId;
-
-    fn deref(&self) -> &Self::Target { &self.request_id }
-}
-
-impl DerefMut for GetBlockHeaders {
-    fn deref_mut(&mut self) -> &mut RequestId { &mut self.request_id }
 }
 
 impl Encodable for GetBlockHeaders {

--- a/core/src/sync/message/getblocks.rs
+++ b/core/src/sync/message/getblocks.rs
@@ -17,11 +17,7 @@ use crate::{
 use cfx_types::H256;
 use primitives::Block;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
-use std::{
-    any::Any,
-    ops::{Deref, DerefMut},
-    time::Duration,
-};
+use std::{any::Any, time::Duration};
 
 #[derive(Debug, PartialEq, Default, Clone)]
 pub struct GetBlocks {
@@ -142,16 +138,6 @@ impl Handleable for GetBlocks {
             self.send_response(ctx, blocks)
         }
     }
-}
-
-impl Deref for GetBlocks {
-    type Target = RequestId;
-
-    fn deref(&self) -> &Self::Target { &self.request_id }
-}
-
-impl DerefMut for GetBlocks {
-    fn deref_mut(&mut self) -> &mut RequestId { &mut self.request_id }
 }
 
 impl Encodable for GetBlocks {

--- a/core/src/sync/message/getblocks.rs
+++ b/core/src/sync/message/getblocks.rs
@@ -16,10 +16,10 @@ use crate::{
 };
 use cfx_types::H256;
 use primitives::Block;
-use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+use rlp_derive::{RlpDecodable, RlpEncodable};
 use std::{any::Any, time::Duration};
 
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Default, Clone, RlpDecodable, RlpEncodable)]
 pub struct GetBlocks {
     pub request_id: RequestId,
     pub with_public: bool,
@@ -137,30 +137,5 @@ impl Handleable for GetBlocks {
         } else {
             self.send_response(ctx, blocks)
         }
-    }
-}
-
-impl Encodable for GetBlocks {
-    fn rlp_append(&self, stream: &mut RlpStream) {
-        let with_public_n = if self.with_public { 1 as u8 } else { 0 as u8 };
-        stream
-            .begin_list(3)
-            .append(&self.request_id)
-            .append(&with_public_n)
-            .append_list(&self.hashes);
-    }
-}
-
-impl Decodable for GetBlocks {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-        if rlp.item_count()? != 3 {
-            return Err(DecoderError::RlpIncorrectListLen);
-        }
-
-        Ok(GetBlocks {
-            request_id: rlp.val_at(0)?,
-            with_public: rlp.val_at::<u8>(1)? == 1,
-            hashes: rlp.list_at(2)?,
-        })
     }
 }

--- a/core/src/sync/message/getblocktxn.rs
+++ b/core/src/sync/message/getblocktxn.rs
@@ -14,11 +14,7 @@ use crate::{
 };
 use cfx_types::H256;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
-use std::{
-    any::Any,
-    ops::{Deref, DerefMut},
-    time::Duration,
-};
+use std::{any::Any, time::Duration};
 
 #[derive(Debug, PartialEq, Default)]
 pub struct GetBlockTxn {
@@ -95,16 +91,6 @@ impl Handleable for GetBlockTxn {
             }
         }
     }
-}
-
-impl Deref for GetBlockTxn {
-    type Target = RequestId;
-
-    fn deref(&self) -> &Self::Target { &self.request_id }
-}
-
-impl DerefMut for GetBlockTxn {
-    fn deref_mut(&mut self) -> &mut RequestId { &mut self.request_id }
 }
 
 impl Encodable for GetBlockTxn {

--- a/core/src/sync/message/getblocktxn.rs
+++ b/core/src/sync/message/getblocktxn.rs
@@ -13,10 +13,10 @@ use crate::{
     },
 };
 use cfx_types::H256;
-use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+use rlp_derive::{RlpDecodable, RlpEncodable};
 use std::{any::Any, time::Duration};
 
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, PartialEq, Default, RlpDecodable, RlpEncodable)]
 pub struct GetBlockTxn {
     pub request_id: RequestId,
     pub block_hash: H256,
@@ -90,29 +90,5 @@ impl Handleable for GetBlockTxn {
                 ctx.send_response(&response)
             }
         }
-    }
-}
-
-impl Encodable for GetBlockTxn {
-    fn rlp_append(&self, stream: &mut RlpStream) {
-        stream
-            .begin_list(3)
-            .append(&self.request_id)
-            .append(&self.block_hash)
-            .append_list(&self.indexes);
-    }
-}
-
-impl Decodable for GetBlockTxn {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-        if rlp.item_count()? != 3 {
-            return Err(DecoderError::RlpIncorrectListLen);
-        }
-
-        Ok(GetBlockTxn {
-            request_id: rlp.val_at(0)?,
-            block_hash: rlp.val_at(1)?,
-            indexes: rlp.list_at(2)?,
-        })
     }
 }

--- a/core/src/sync/message/getcmpctblocks.rs
+++ b/core/src/sync/message/getcmpctblocks.rs
@@ -18,11 +18,7 @@ use crate::{
 };
 use cfx_types::H256;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
-use std::{
-    any::Any,
-    ops::{Deref, DerefMut},
-    time::Duration,
-};
+use std::{any::Any, time::Duration};
 
 #[derive(Debug, PartialEq, Default)]
 pub struct GetCompactBlocks {
@@ -96,16 +92,6 @@ impl Handleable for GetCompactBlocks {
 
         ctx.send_response(&response)
     }
-}
-
-impl Deref for GetCompactBlocks {
-    type Target = RequestId;
-
-    fn deref(&self) -> &Self::Target { &self.request_id }
-}
-
-impl DerefMut for GetCompactBlocks {
-    fn deref_mut(&mut self) -> &mut RequestId { &mut self.request_id }
 }
 
 impl Encodable for GetCompactBlocks {

--- a/core/src/sync/message/getcmpctblocks.rs
+++ b/core/src/sync/message/getcmpctblocks.rs
@@ -17,10 +17,10 @@ use crate::{
     },
 };
 use cfx_types::H256;
-use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+use rlp_derive::{RlpDecodable, RlpEncodable};
 use std::{any::Any, time::Duration};
 
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, PartialEq, Default, RlpDecodable, RlpEncodable)]
 pub struct GetCompactBlocks {
     pub request_id: RequestId,
     pub hashes: Vec<H256>,
@@ -91,27 +91,5 @@ impl Handleable for GetCompactBlocks {
         };
 
         ctx.send_response(&response)
-    }
-}
-
-impl Encodable for GetCompactBlocks {
-    fn rlp_append(&self, stream: &mut RlpStream) {
-        stream
-            .begin_list(2)
-            .append(&self.request_id)
-            .append_list(&self.hashes);
-    }
-}
-
-impl Decodable for GetCompactBlocks {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-        if rlp.item_count()? != 2 {
-            return Err(DecoderError::RlpIncorrectListLen);
-        }
-
-        Ok(GetCompactBlocks {
-            request_id: rlp.val_at(0)?,
-            hashes: rlp.list_at(1)?,
-        })
     }
 }

--- a/core/src/sync/message/getterminalblockhashes.rs
+++ b/core/src/sync/message/getterminalblockhashes.rs
@@ -9,9 +9,9 @@ use crate::{
         Error,
     },
 };
-use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+use rlp_derive::{RlpDecodable, RlpEncodable};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, RlpDecodable, RlpEncodable)]
 pub struct GetTerminalBlockHashes {
     pub request_id: RequestId,
 }
@@ -28,19 +28,5 @@ impl Handleable for GetTerminalBlockHashes {
             hashes: terminal_hashes,
         };
         ctx.send_response(&response)
-    }
-}
-
-impl Encodable for GetTerminalBlockHashes {
-    fn rlp_append(&self, stream: &mut RlpStream) {
-        stream.begin_list(1).append(&self.request_id);
-    }
-}
-
-impl Decodable for GetTerminalBlockHashes {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-        Ok(GetTerminalBlockHashes {
-            request_id: rlp.val_at(0)?,
-        })
     }
 }

--- a/core/src/sync/message/getterminalblockhashes.rs
+++ b/core/src/sync/message/getterminalblockhashes.rs
@@ -10,7 +10,6 @@ use crate::{
     },
 };
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
-use std::ops::{Deref, DerefMut};
 
 #[derive(Debug, PartialEq)]
 pub struct GetTerminalBlockHashes {
@@ -30,16 +29,6 @@ impl Handleable for GetTerminalBlockHashes {
         };
         ctx.send_response(&response)
     }
-}
-
-impl Deref for GetTerminalBlockHashes {
-    type Target = RequestId;
-
-    fn deref(&self) -> &Self::Target { &self.request_id }
-}
-
-impl DerefMut for GetTerminalBlockHashes {
-    fn deref_mut(&mut self) -> &mut RequestId { &mut self.request_id }
 }
 
 impl Encodable for GetTerminalBlockHashes {

--- a/core/src/sync/message/message.rs
+++ b/core/src/sync/message/message.rs
@@ -54,6 +54,7 @@ build_msgid! {
 
 // generate `impl Message for _` for each message type
 // high priority message types
+build_msg_impl! { Status, msgid::STATUS, "Status" }
 build_msg_impl! { NewBlockHashes, msgid::NEW_BLOCK_HASHES, "NewBlockHashes" }
 build_msg_impl! { GetBlockHashesResponse, msgid::GET_BLOCK_HASHES_RESPONSE, "GetBlockHashesResponse" }
 build_msg_impl! { GetBlockHeaders, msgid::GET_BLOCK_HEADERS, "GetBlockHeaders" }
@@ -69,16 +70,6 @@ build_msg_impl! { TransactionPropagationControl, msgid::TRANSACTION_PROPAGATION_
 build_msg_impl! { GetBlockHashesByEpoch, msgid::GET_BLOCK_HASHES_BY_EPOCH, "GetBlockHashesByEpoch" }
 
 // normal priority and size-sensitive message types
-impl Message for Status {
-    fn as_any(&self) -> &Any { self }
-
-    fn msg_id(&self) -> MsgId { msgid::STATUS }
-
-    fn msg_name(&self) -> &'static str { "Status" }
-
-    fn priority(&self) -> SendQueuePriority { SendQueuePriority::Normal }
-}
-
 impl Message for Transactions {
     fn as_any(&self) -> &Any { self }
 

--- a/core/src/sync/message/newblock.rs
+++ b/core/src/sync/message/newblock.rs
@@ -8,9 +8,9 @@ use crate::sync::{
 };
 use cfx_types::H256;
 use primitives::Block;
-use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+use rlp_derive::{RlpDecodable, RlpEncodable};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, RlpDecodable, RlpEncodable)]
 pub struct NewBlock {
     pub block: Block,
 }
@@ -82,16 +82,4 @@ fn on_new_decoded_block(
         need_to_relay.push(hash);
     }
     Ok(need_to_relay)
-}
-
-impl Encodable for NewBlock {
-    fn rlp_append(&self, stream: &mut RlpStream) { stream.append(&self.block); }
-}
-
-impl Decodable for NewBlock {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-        Ok(NewBlock {
-            block: rlp.as_val::<Block>()?,
-        })
-    }
 }

--- a/core/src/sync/message/newblock.rs
+++ b/core/src/sync/message/newblock.rs
@@ -8,9 +8,9 @@ use crate::sync::{
 };
 use cfx_types::H256;
 use primitives::Block;
-use rlp_derive::{RlpDecodable, RlpEncodable};
+use rlp_derive::{RlpDecodableWrapper, RlpEncodableWrapper};
 
-#[derive(Debug, PartialEq, RlpDecodable, RlpEncodable)]
+#[derive(Debug, PartialEq, RlpDecodableWrapper, RlpEncodableWrapper)]
 pub struct NewBlock {
     pub block: Block,
 }

--- a/core/src/sync/message/newblockhashes.rs
+++ b/core/src/sync/message/newblockhashes.rs
@@ -7,9 +7,9 @@ use crate::sync::{
     Error,
 };
 use cfx_types::H256;
-use rlp_derive::{RlpDecodable, RlpEncodable};
+use rlp_derive::{RlpDecodableWrapper, RlpEncodableWrapper};
 
-#[derive(Debug, PartialEq, RlpDecodable, RlpEncodable)]
+#[derive(Debug, PartialEq, RlpDecodableWrapper, RlpEncodableWrapper)]
 pub struct NewBlockHashes {
     pub block_hashes: Vec<H256>,
 }

--- a/core/src/sync/message/newblockhashes.rs
+++ b/core/src/sync/message/newblockhashes.rs
@@ -7,9 +7,9 @@ use crate::sync::{
     Error,
 };
 use cfx_types::H256;
-use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+use rlp_derive::{RlpDecodable, RlpEncodable};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, RlpDecodable, RlpEncodable)]
 pub struct NewBlockHashes {
     pub block_hashes: Vec<H256>,
 }
@@ -48,19 +48,5 @@ impl Handleable for NewBlockHashes {
         );
 
         Ok(())
-    }
-}
-
-impl Encodable for NewBlockHashes {
-    fn rlp_append(&self, stream: &mut RlpStream) {
-        stream.append_list(&self.block_hashes);
-    }
-}
-
-impl Decodable for NewBlockHashes {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-        Ok(NewBlockHashes {
-            block_hashes: rlp.as_list()?,
-        })
     }
 }

--- a/core/src/sync/message/status.rs
+++ b/core/src/sync/message/status.rs
@@ -7,10 +7,10 @@ use crate::sync::{
     Error, ErrorKind, SynchronizationPeerState,
 };
 use cfx_types::H256;
-use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+use rlp_derive::{RlpDecodable, RlpEncodable};
 use std::{collections::HashSet, time::Instant};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, RlpDecodable, RlpEncodable)]
 pub struct Status {
     pub protocol_version: u8,
     pub network_id: u8,
@@ -90,29 +90,5 @@ impl Handleable for Status {
         }
 
         Ok(())
-    }
-}
-
-impl Encodable for Status {
-    fn rlp_append(&self, stream: &mut RlpStream) {
-        stream
-            .begin_list(5)
-            .append(&self.protocol_version)
-            .append(&self.network_id)
-            .append(&self.genesis_hash)
-            .append(&self.best_epoch)
-            .append_list(&self.terminal_block_hashes);
-    }
-}
-
-impl Decodable for Status {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-        Ok(Status {
-            protocol_version: rlp.val_at::<u8>(0)?,
-            network_id: rlp.val_at::<u8>(1)?,
-            genesis_hash: rlp.val_at::<H256>(2)?,
-            best_epoch: rlp.val_at::<u64>(3)?,
-            terminal_block_hashes: rlp.list_at(4)?,
-        })
     }
 }

--- a/core/src/sync/message/terminalblockhashes.rs
+++ b/core/src/sync/message/terminalblockhashes.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 use cfx_types::H256;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
-use std::ops::{Deref, DerefMut};
 
 #[derive(Debug, PartialEq)]
 pub struct GetTerminalBlockHashesResponse {
@@ -37,16 +36,6 @@ impl Handleable for GetTerminalBlockHashesResponse {
 
         Ok(())
     }
-}
-
-impl Deref for GetTerminalBlockHashesResponse {
-    type Target = RequestId;
-
-    fn deref(&self) -> &Self::Target { &self.request_id }
-}
-
-impl DerefMut for GetTerminalBlockHashesResponse {
-    fn deref_mut(&mut self) -> &mut RequestId { &mut self.request_id }
 }
 
 impl Encodable for GetTerminalBlockHashesResponse {

--- a/core/src/sync/message/terminalblockhashes.rs
+++ b/core/src/sync/message/terminalblockhashes.rs
@@ -10,9 +10,9 @@ use crate::{
     },
 };
 use cfx_types::H256;
-use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+use rlp_derive::{RlpDecodable, RlpEncodable};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, RlpDecodable, RlpEncodable)]
 pub struct GetTerminalBlockHashesResponse {
     pub request_id: RequestId,
     pub hashes: Vec<H256>,
@@ -35,23 +35,5 @@ impl Handleable for GetTerminalBlockHashesResponse {
         }
 
         Ok(())
-    }
-}
-
-impl Encodable for GetTerminalBlockHashesResponse {
-    fn rlp_append(&self, stream: &mut RlpStream) {
-        stream
-            .begin_list(2)
-            .append(&self.request_id)
-            .append_list(&self.hashes);
-    }
-}
-
-impl Decodable for GetTerminalBlockHashesResponse {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-        Ok(GetTerminalBlockHashesResponse {
-            request_id: rlp.val_at(0)?,
-            hashes: rlp.list_at(1)?,
-        })
     }
 }

--- a/core/src/sync/message/transactions.rs
+++ b/core/src/sync/message/transactions.rs
@@ -16,12 +16,7 @@ use cfx_types::H256;
 use metrics::MeterTimer;
 use primitives::{transaction::TxPropagateId, TransactionWithSignature};
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
-use std::{
-    any::Any,
-    collections::HashSet,
-    ops::{Deref, DerefMut},
-    time::Duration,
-};
+use std::{any::Any, collections::HashSet, time::Duration};
 
 #[derive(Debug, PartialEq)]
 pub struct Transactions {
@@ -325,16 +320,6 @@ impl Handleable for GetTransactions {
     }
 }
 
-impl Deref for GetTransactions {
-    type Target = RequestId;
-
-    fn deref(&self) -> &Self::Target { &self.request_id }
-}
-
-impl DerefMut for GetTransactions {
-    fn deref_mut(&mut self) -> &mut RequestId { &mut self.request_id }
-}
-
 impl Encodable for GetTransactions {
     fn rlp_append(&self, stream: &mut RlpStream) {
         stream
@@ -406,16 +391,6 @@ impl Handleable for GetTransactionsResponse {
 
         Ok(())
     }
-}
-
-impl Deref for GetTransactionsResponse {
-    type Target = RequestId;
-
-    fn deref(&self) -> &Self::Target { &self.request_id }
-}
-
-impl DerefMut for GetTransactionsResponse {
-    fn deref_mut(&mut self) -> &mut RequestId { &mut self.request_id }
 }
 
 impl Encodable for GetTransactionsResponse {

--- a/core/src/sync/message/transactions.rs
+++ b/core/src/sync/message/transactions.rs
@@ -81,7 +81,7 @@ impl Handleable for Transactions {
 
 ////////////////////////////////////////////////////////////////////
 
-#[derive(Debug, PartialEq, RlpDecodable, RlpEncodable)]
+#[derive(Debug, PartialEq, RlpDecodableWrapper, RlpEncodableWrapper)]
 pub struct TransactionPropagationControl {
     pub catch_up_mode: bool,
 }

--- a/core/src/sync/message/transactions.rs
+++ b/core/src/sync/message/transactions.rs
@@ -16,10 +16,12 @@ use cfx_types::H256;
 use metrics::MeterTimer;
 use primitives::{transaction::TxPropagateId, TransactionWithSignature};
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
-use rlp_derive::{RlpDecodable, RlpEncodable};
+use rlp_derive::{
+    RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper,
+};
 use std::{any::Any, collections::HashSet, time::Duration};
 
-#[derive(Debug, PartialEq, RlpDecodable, RlpEncodable)]
+#[derive(Debug, PartialEq, RlpDecodableWrapper, RlpEncodableWrapper)]
 pub struct Transactions {
     pub transactions: Vec<TransactionWithSignature>,
 }

--- a/core/src/sync/state/snapshot_chunk_request.rs
+++ b/core/src/sync/state/snapshot_chunk_request.rs
@@ -12,10 +12,10 @@ use crate::{
     },
 };
 use cfx_types::H256;
-use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+use rlp_derive::{RlpDecodable, RlpEncodable};
 use std::{any::Any, collections::HashMap, time::Duration};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, RlpDecodable, RlpEncodable)]
 pub struct SnapshotChunkRequest {
     pub request_id: u64,
     pub checkpoint: H256,
@@ -60,27 +60,4 @@ impl Request for SnapshotChunkRequest {
     fn is_empty(&self) -> bool { false }
 
     fn resend(&self) -> Option<Box<Request>> { Some(Box::new(self.clone())) }
-}
-
-impl Encodable for SnapshotChunkRequest {
-    fn rlp_append(&self, s: &mut RlpStream) {
-        s.begin_list(3)
-            .append(&self.request_id)
-            .append(&self.checkpoint)
-            .append(&self.chunk_hash);
-    }
-}
-
-impl Decodable for SnapshotChunkRequest {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-        if rlp.item_count()? != 3 {
-            return Err(DecoderError::RlpIncorrectListLen);
-        }
-
-        Ok(SnapshotChunkRequest {
-            request_id: rlp.val_at(0)?,
-            checkpoint: rlp.val_at(1)?,
-            chunk_hash: rlp.val_at(2)?,
-        })
-    }
 }

--- a/core/src/sync/state/snapshot_chunk_response.rs
+++ b/core/src/sync/state/snapshot_chunk_response.rs
@@ -13,10 +13,11 @@ use crate::{
 use cfx_bytes::Bytes;
 use cfx_types::H256;
 use keccak_hash::keccak;
-use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+use rlp::{DecoderError, Rlp, RlpStream};
+use rlp_derive::{RlpDecodable, RlpEncodable};
 use std::{any::Any, collections::HashMap};
 
-#[derive(Debug)]
+#[derive(Debug, RlpDecodable, RlpEncodable)]
 pub struct SnapshotChunkResponse {
     pub request_id: u64,
     pub chunk: Bytes,
@@ -95,26 +96,5 @@ impl SnapshotChunkResponse {
         }
 
         Ok(kvs)
-    }
-}
-
-impl Encodable for SnapshotChunkResponse {
-    fn rlp_append(&self, s: &mut RlpStream) {
-        s.begin_list(2)
-            .append(&self.request_id)
-            .append_list(&self.chunk);
-    }
-}
-
-impl Decodable for SnapshotChunkResponse {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-        if rlp.item_count()? != 2 {
-            return Err(DecoderError::RlpIncorrectListLen);
-        }
-
-        Ok(SnapshotChunkResponse {
-            request_id: rlp.val_at(0)?,
-            chunk: rlp.list_at(1)?,
-        })
     }
 }

--- a/core/src/sync/state/snapshot_manifest_request.rs
+++ b/core/src/sync/state/snapshot_manifest_request.rs
@@ -12,10 +12,10 @@ use crate::{
     },
 };
 use cfx_types::H256;
-use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+use rlp_derive::{RlpDecodable, RlpEncodable};
 use std::{any::Any, time::Duration};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, RlpDecodable, RlpEncodable)]
 pub struct SnapshotManifestRequest {
     pub request_id: u64,
     pub checkpoint: H256,
@@ -62,25 +62,4 @@ impl Request for SnapshotManifestRequest {
     fn is_empty(&self) -> bool { false }
 
     fn resend(&self) -> Option<Box<Request>> { Some(Box::new(self.clone())) }
-}
-
-impl Encodable for SnapshotManifestRequest {
-    fn rlp_append(&self, s: &mut RlpStream) {
-        s.begin_list(2)
-            .append(&self.request_id)
-            .append(&self.checkpoint);
-    }
-}
-
-impl Decodable for SnapshotManifestRequest {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-        if rlp.item_count()? != 2 {
-            return Err(DecoderError::RlpIncorrectListLen);
-        }
-
-        Ok(SnapshotManifestRequest {
-            request_id: rlp.val_at(0)?,
-            checkpoint: rlp.val_at(1)?,
-        })
-    }
 }

--- a/core/src/sync/state/snapshot_manifest_response.rs
+++ b/core/src/sync/state/snapshot_manifest_response.rs
@@ -11,10 +11,10 @@ use crate::{
     },
 };
 use cfx_types::H256;
-use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+use rlp_derive::{RlpDecodable, RlpEncodable};
 use std::{any::Any, collections::HashSet};
 
-#[derive(Debug)]
+#[derive(Debug, RlpDecodable, RlpEncodable)]
 pub struct SnapshotManifestResponse {
     pub request_id: u64,
     pub checkpoint: H256,
@@ -60,28 +60,5 @@ impl Handleable for SnapshotManifestResponse {
             .handle_snapshot_manifest_response(ctx, self);
 
         Ok(())
-    }
-}
-
-impl Encodable for SnapshotManifestResponse {
-    fn rlp_append(&self, s: &mut RlpStream) {
-        s.begin_list(3)
-            .append(&self.request_id)
-            .append(&self.checkpoint)
-            .append_list(&self.chunk_hashes);
-    }
-}
-
-impl Decodable for SnapshotManifestResponse {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-        if rlp.item_count()? != 3 {
-            return Err(DecoderError::RlpIncorrectListLen);
-        }
-
-        Ok(SnapshotManifestResponse {
-            request_id: rlp.val_at(0)?,
-            checkpoint: rlp.val_at(1)?,
-            chunk_hashes: rlp.list_at(2)?,
-        })
     }
 }


### PR DESCRIPTION
1. Remove the useless Deref and Deref_Mut trait
2. Use Rlp derive instead of implementing the Encodable and Decodable trait in manual.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/466)
<!-- Reviewable:end -->
