### PR TITLE
Improve the sync checkpoint process

### DIFF
--- a/core/src/sync/state/snapshot_chunk_sync.rs
+++ b/core/src/sync/state/snapshot_chunk_sync.rs
@@ -26,7 +26,7 @@ pub enum Status {
     Inactive,
     DownloadingManifest(Instant),
     DownloadingChunks(Instant),
-    Completed,
+    Completed(H256),
 }
 
 impl Default for Status {
@@ -43,7 +43,9 @@ impl Debug for Status {
             Status::DownloadingChunks(t) => {
                 format!("downloading chunks ({:?})", t.elapsed())
             }
-            Status::Completed => "completed".into(),
+            Status::Completed(checkpoint) => {
+                format!("completed ({:?})", checkpoint)
+            }
         };
 
         write!(f, "{}", status)

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -1086,7 +1086,7 @@ impl SynchronizationProtocolHandler {
     pub fn update_sync_phase(&self, io: &NetworkContext) -> Option<()> {
         self.phase_manager.try_initialize(io, self);
         let current_phase = self.phase_manager.get_current_phase();
-        let next_phase_type = current_phase.next();
+        let next_phase_type = current_phase.next(io, self);
         if current_phase.phase_type() != next_phase_type {
             // Phase changed
             self.phase_manager


### PR DESCRIPTION
1. Retrieved snapshot chunks in manifest should not be empty.
2. If new era started while syncing checkpoint, abort the current checkpoint sync and start to sync the new checkpoint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/473)
<!-- Reviewable:end -->
