### PR TITLE
Separate light protocol handler from provider

### DIFF
--- a/core/src/light_protocol/mod.rs
+++ b/core/src/light_protocol/mod.rs
@@ -4,11 +4,14 @@
 
 mod error;
 mod message;
+mod query_provider;
 mod query_service;
 
-pub(self) mod query_handler;
+use crate::network::ProtocolId;
+pub(self) const LIGHT_PROTOCOL_ID: ProtocolId = *b"clp"; // Conflux Light Protocol
+pub(self) const LIGHT_PROTOCOL_VERSION: u8 = 1;
 
-pub use self::{
-    error::{Error, ErrorKind},
-    query_service::QueryService,
-};
+pub(self) mod query_handler;
+pub(self) use self::error::{handle as handle_error, Error, ErrorKind};
+
+pub use self::{query_provider::QueryProvider, query_service::QueryService};

--- a/core/src/light_protocol/query_provider.rs
+++ b/core/src/light_protocol/query_provider.rs
@@ -1,0 +1,190 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use io::TimerToken;
+use rlp::Rlp;
+use std::sync::Arc;
+
+use cfx_types::H256;
+use primitives::{BlockHeader, EpochNumber, StateRoot};
+
+use crate::{
+    consensus::{ConsensusGraph, DEFERRED_STATE_EPOCH_COUNT},
+    message::{Message, MsgId},
+    network::{NetworkContext, NetworkProtocolHandler, NetworkService, PeerId},
+    statedb::StateDb,
+    storage::{
+        state_manager::StateManagerTrait, SnapshotAndEpochIdRef, StateProof,
+    },
+};
+
+use super::{
+    handle_error,
+    message::{
+        msgid, GetStateEntry, GetStateRoot,
+        StateEntry as GetStateEntryResponse, StateRoot as GetStateRootResponse,
+    },
+    Error, ErrorKind, LIGHT_PROTOCOL_ID, LIGHT_PROTOCOL_VERSION,
+};
+
+pub struct QueryProvider {
+    consensus: Arc<ConsensusGraph>,
+}
+
+impl QueryProvider {
+    pub fn new(consensus: Arc<ConsensusGraph>) -> Self {
+        QueryProvider { consensus }
+    }
+
+    pub fn register(
+        self: Arc<Self>, network: Arc<NetworkService>,
+    ) -> Result<(), String> {
+        network
+            .register_protocol(
+                self,
+                LIGHT_PROTOCOL_ID,
+                &[LIGHT_PROTOCOL_VERSION],
+            )
+            .map_err(|e| {
+                format!("failed to register protocol QueryProvider: {:?}", e)
+            })
+    }
+
+    fn dispatch_message(
+        &self, io: &NetworkContext, peer: PeerId, msg_id: MsgId, rlp: Rlp,
+    ) -> Result<(), Error> {
+        trace!("Dispatching message: peer={:?}, msg_id={:?}", peer, msg_id);
+
+        match msg_id {
+            msgid::GET_STATE_ROOT => self.on_get_state_root(io, peer, &rlp),
+            msgid::GET_STATE_ENTRY => self.on_get_state_entry(io, peer, &rlp),
+            _ => Err(ErrorKind::UnknownMessage.into()),
+        }
+    }
+
+    #[inline]
+    fn get_local_pivot_hash(&self, epoch: u64) -> Result<H256, Error> {
+        let epoch = EpochNumber::Number(epoch);
+        let pivot_hash = self.consensus.get_hash_from_epoch_number(epoch)?;
+        Ok(pivot_hash)
+    }
+
+    #[inline]
+    fn get_local_header(&self, epoch: u64) -> Result<Arc<BlockHeader>, Error> {
+        let epoch = EpochNumber::Number(epoch);
+        let hash = self.consensus.get_hash_from_epoch_number(epoch)?;
+        let header = self.consensus.data_man.block_header_by_hash(&hash);
+        header.ok_or(ErrorKind::InternalError.into())
+    }
+
+    #[inline]
+    fn get_local_state_root(&self, epoch: u64) -> Result<StateRoot, Error> {
+        let h = self.get_local_header(epoch + DEFERRED_STATE_EPOCH_COUNT)?;
+        Ok(h.state_root_with_aux_info.state_root.clone())
+    }
+
+    #[inline]
+    fn get_local_state_entry(
+        &self, hash: H256, key: &Vec<u8>,
+    ) -> Result<(Option<Vec<u8>>, StateProof), Error> {
+        let maybe_state = self
+            .consensus
+            .data_man
+            .storage_manager
+            .get_state_no_commit(SnapshotAndEpochIdRef::new(&hash, None))
+            .map_err(|e| format!("Failed to get state, err={:?}", e))?;
+
+        match maybe_state {
+            None => Err(ErrorKind::InternalError.into()),
+            Some(state) => {
+                let (value, proof) = StateDb::new(state)
+                    .get_raw_with_proof(key)
+                    .or(Err(ErrorKind::InternalError))?;
+
+                let value = value.map(|x| x.to_vec());
+                Ok((value, proof))
+            }
+        }
+    }
+
+    fn on_get_state_root(
+        &self, io: &NetworkContext, peer: PeerId, rlp: &Rlp,
+    ) -> Result<(), Error> {
+        let req: GetStateRoot = rlp.as_val()?;
+        info!("on_get_state_root req={:?}", req);
+        let request_id = req.request_id;
+
+        let pivot_hash = self.get_local_pivot_hash(req.epoch)?;
+        let state_root = self.get_local_state_root(req.epoch)?;
+
+        let msg: Box<dyn Message> = Box::new(GetStateRootResponse {
+            request_id,
+            pivot_hash,
+            state_root,
+        });
+
+        msg.send(io, peer)?;
+        Ok(())
+    }
+
+    fn on_get_state_entry(
+        &self, io: &NetworkContext, peer: PeerId, rlp: &Rlp,
+    ) -> Result<(), Error> {
+        let req: GetStateEntry = rlp.as_val()?;
+        info!("on_get_state_entry req={:?}", req);
+        let request_id = req.request_id;
+
+        let pivot_hash = self.get_local_pivot_hash(req.epoch)?;
+        let state_root = self.get_local_state_root(req.epoch)?;
+        let (entry, proof) =
+            self.get_local_state_entry(pivot_hash, &req.key)?;
+        let entry = entry.map(|x| x.to_vec());
+
+        let msg: Box<dyn Message> = Box::new(GetStateEntryResponse {
+            request_id,
+            pivot_hash,
+            state_root,
+            entry,
+            proof,
+        });
+
+        msg.send(io, peer)?;
+        Ok(())
+    }
+}
+
+impl NetworkProtocolHandler for QueryProvider {
+    fn initialize(&self, _io: &NetworkContext) {}
+
+    fn on_message(&self, io: &NetworkContext, peer: PeerId, raw: &[u8]) {
+        if raw.len() < 2 {
+            return handle_error(
+                io,
+                peer,
+                msgid::INVALID,
+                ErrorKind::InvalidMessageFormat.into(),
+            );
+        }
+
+        let msg_id = raw[0];
+        let rlp = Rlp::new(&raw[1..]);
+        debug!("on_message: peer={:?}, msgid={:?}", peer, msg_id);
+
+        if let Err(e) = self.dispatch_message(io, peer, msg_id.into(), rlp) {
+            handle_error(io, peer, msg_id.into(), e);
+        }
+    }
+
+    fn on_peer_connected(&self, _io: &NetworkContext, peer: PeerId) {
+        info!("on_peer_connected: peer={:?}", peer);
+    }
+
+    fn on_peer_disconnected(&self, _io: &NetworkContext, peer: PeerId) {
+        info!("on_peer_disconnected: peer={:?}", peer);
+    }
+
+    fn on_timeout(&self, _io: &NetworkContext, _timer: TimerToken) {
+        // EMPTY
+    }
+}

--- a/core/src/light_protocol/query_service.rs
+++ b/core/src/light_protocol/query_service.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use crate::{
     consensus::ConsensusGraph,
-    network::{NetworkService, PeerId, ProtocolId},
+    network::{NetworkService, PeerId},
     statedb::StorageKey,
     storage,
 };
@@ -16,11 +16,8 @@ use crate::{
 use super::{
     message::{GetStateEntry, GetStateRoot},
     query_handler::{QueryHandler, QueryResult},
-    Error, ErrorKind,
+    Error, ErrorKind, LIGHT_PROTOCOL_ID, LIGHT_PROTOCOL_VERSION,
 };
-
-const LIGHT_PROTOCOL_ID: ProtocolId = *b"clp"; // Conflux Light Protocol
-const LIGHT_PROTOCOL_VERSION: u8 = 1;
 
 pub struct QueryService {
     handler: Arc<QueryHandler>,


### PR DESCRIPTION
**Overview**

The light protocol is inherently asymmetric:
- *Light nodes* can only query other nodes and serve simple requests (e.g. serve headers available locally).
- *Full nodes* only serve, do not query.

This PR divides `light_protocol::QueryHandler` into two parts accordingly.
- `QueryHandler` is the *light node* side, querying other nodes and handling query responses.
- `QueryProvider` is the *full node* side, serving queries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/476)
<!-- Reviewable:end -->
