### PR TITLE
Divide light protocol handler into two parts: query and sync

### DIFF
--- a/core/src/light_protocol/handler/handler.rs
+++ b/core/src/light_protocol/handler/handler.rs
@@ -1,0 +1,99 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use std::{
+    collections::HashSet,
+    sync::{atomic::AtomicU64, Arc},
+};
+
+use io::TimerToken;
+use parking_lot::RwLock;
+use rand::Rng;
+use rlp::Rlp;
+
+use crate::{
+    consensus::ConsensusGraph,
+    light_protocol::{handle_error, message::msgid, Error, ErrorKind},
+    message::MsgId,
+    network::{NetworkContext, NetworkProtocolHandler, PeerId},
+};
+
+use super::{query::QueryHandler, sync::SyncHandler};
+
+/// Handler is responsible for maintaining peer meta-information and
+/// dispatching messages to the query and sync sub-handlers.
+pub struct Handler {
+    peers: RwLock<HashSet<PeerId>>,
+    pub query: QueryHandler,
+    pub sync: SyncHandler,
+}
+
+impl Handler {
+    pub fn new(consensus: Arc<ConsensusGraph>) -> Self {
+        let next_request_id = Arc::new(AtomicU64::new(0));
+
+        Handler {
+            peers: RwLock::new(HashSet::new()),
+            query: QueryHandler::new(consensus, next_request_id.clone()),
+            sync: SyncHandler::new(next_request_id),
+        }
+    }
+
+    fn dispatch_message(
+        &self, io: &NetworkContext, peer: PeerId, msg_id: MsgId, rlp: Rlp,
+    ) -> Result<(), Error> {
+        trace!("Dispatching message: peer={:?}, msg_id={:?}", peer, msg_id);
+
+        match msg_id {
+            msgid::STATE_ROOT => self.query.on_state_root(io, peer, &rlp),
+            msgid::STATE_ENTRY => self.query.on_state_entry(io, peer, &rlp),
+            _ => Err(ErrorKind::UnknownMessage.into()),
+        }
+    }
+
+    /// Get all peers in random order.
+    pub fn get_peers_shuffled(&self) -> Vec<PeerId> {
+        let mut rand = rand::thread_rng();
+        let mut peers: Vec<_> = self.peers.read().iter().cloned().collect();
+        rand.shuffle(&mut peers[..]);
+        peers
+    }
+}
+
+impl NetworkProtocolHandler for Handler {
+    fn initialize(&self, _io: &NetworkContext) {}
+
+    fn on_message(&self, io: &NetworkContext, peer: PeerId, raw: &[u8]) {
+        if raw.len() < 2 {
+            return handle_error(
+                io,
+                peer,
+                msgid::INVALID,
+                ErrorKind::InvalidMessageFormat.into(),
+            );
+        }
+
+        let msg_id = raw[0];
+        let rlp = Rlp::new(&raw[1..]);
+        debug!("on_message: peer={:?}, msgid={:?}", peer, msg_id);
+
+        if let Err(e) = self.dispatch_message(io, peer, msg_id.into(), rlp) {
+            handle_error(io, peer, msg_id.into(), e);
+        }
+    }
+
+    fn on_peer_connected(&self, _io: &NetworkContext, peer: PeerId) {
+        info!("on_peer_connected: peer={:?}", peer);
+        self.peers.write().insert(peer);
+    }
+
+    fn on_peer_disconnected(&self, _io: &NetworkContext, peer: PeerId) {
+        info!("on_peer_disconnected: peer={:?}", peer);
+        self.peers.write().remove(&peer);
+    }
+
+    fn on_timeout(&self, _io: &NetworkContext, _timer: TimerToken) {
+        // EMPTY
+    }
+}

--- a/core/src/light_protocol/handler/mod.rs
+++ b/core/src/light_protocol/handler/mod.rs
@@ -1,0 +1,11 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+mod handler;
+mod query;
+mod sync;
+
+pub(super) use query::QueryResult;
+
+pub use handler::Handler;

--- a/core/src/light_protocol/handler/sync.rs
+++ b/core/src/light_protocol/handler/sync.rs
@@ -1,0 +1,37 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use rlp::Rlp;
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
+
+use crate::{
+    light_protocol::Error,
+    message::RequestId,
+    network::{NetworkContext, PeerId},
+};
+
+pub struct SyncHandler {
+    next_request_id: Arc<AtomicU64>,
+}
+
+impl SyncHandler {
+    pub fn new(next_request_id: Arc<AtomicU64>) -> Self {
+        SyncHandler { next_request_id }
+    }
+
+    #[allow(dead_code)]
+    pub(super) fn on_block_headers(
+        &self, _io: &NetworkContext, _peer: PeerId, _rlp: &Rlp,
+    ) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    #[allow(dead_code)]
+    fn next_request_id(&self) -> RequestId {
+        self.next_request_id.fetch_add(1, Ordering::Relaxed).into()
+    }
+}

--- a/core/src/light_protocol/mod.rs
+++ b/core/src/light_protocol/mod.rs
@@ -3,15 +3,18 @@
 // See http://www.gnu.org/licenses/
 
 mod error;
+mod handler;
 mod message;
 mod query_provider;
 mod query_service;
 
 use crate::network::ProtocolId;
-pub(self) const LIGHT_PROTOCOL_ID: ProtocolId = *b"clp"; // Conflux Light Protocol
-pub(self) const LIGHT_PROTOCOL_VERSION: u8 = 1;
+const LIGHT_PROTOCOL_ID: ProtocolId = *b"clp"; // Conflux Light Protocol
+const LIGHT_PROTOCOL_VERSION: u8 = 1;
 
-pub(self) mod query_handler;
-pub(self) use self::error::{handle as handle_error, Error, ErrorKind};
+use self::error::{handle as handle_error, Error, ErrorKind};
 
-pub use self::{query_provider::QueryProvider, query_service::QueryService};
+pub use self::{
+    handler::Handler, query_provider::QueryProvider,
+    query_service::QueryService,
+};

--- a/core/src/light_protocol/query_service.rs
+++ b/core/src/light_protocol/query_service.rs
@@ -14,13 +14,14 @@ use crate::{
 };
 
 use super::{
+    handler::QueryResult,
     message::{GetStateEntry, GetStateRoot},
-    query_handler::{QueryHandler, QueryResult},
-    Error, ErrorKind, LIGHT_PROTOCOL_ID, LIGHT_PROTOCOL_VERSION,
+    Error, ErrorKind, Handler as LightHandler, LIGHT_PROTOCOL_ID,
+    LIGHT_PROTOCOL_VERSION,
 };
 
 pub struct QueryService {
-    handler: Arc<QueryHandler>,
+    handler: Arc<LightHandler>,
     network: Arc<NetworkService>,
 }
 
@@ -29,7 +30,7 @@ impl QueryService {
         consensus: Arc<ConsensusGraph>, network: Arc<NetworkService>,
     ) -> Self {
         QueryService {
-            handler: Arc::new(QueryHandler::new(consensus)),
+            handler: Arc::new(LightHandler::new(consensus)),
             network,
         }
     }
@@ -58,7 +59,7 @@ impl QueryService {
         };
 
         self.network.with_context(LIGHT_PROTOCOL_ID, |io| {
-            match self.handler.execute_request(io, peer, req)? {
+            match self.handler.query.execute(io, peer, req)? {
                 QueryResult::StateRoot(sr) => Ok(sr),
                 _ => Err(ErrorKind::UnexpectedResponse.into()),
             }
@@ -77,7 +78,7 @@ impl QueryService {
         };
 
         self.network.with_context(LIGHT_PROTOCOL_ID, |io| {
-            match self.handler.execute_request(io, peer, req)? {
+            match self.handler.query.execute(io, peer, req)? {
                 QueryResult::StateEntry(entry) => Ok(entry),
                 _ => Err(ErrorKind::UnexpectedResponse.into()),
             }


### PR DESCRIPTION
**Overview**

`LightProtocolHandler` provides two disctinct functionalities:
1. Syncing (epoch-by-epoch, header-only).
2. Querying (transactions, balances, state entries) with verification.

To keep the code clear and maintainable, these are separated into two structs (`QueryHandler` and `SyncHandler`). Messages to `light_protocol::Handler` (which is an instance of `NetworkProtocolHandler`) are dispatched to the appropriate sub-handler.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/488)
<!-- Reviewable:end -->
