### PR TITLE
light-node: add status message and peer management

### DIFF
--- a/core/src/light_protocol/error.rs
+++ b/core/src/light_protocol/error.rs
@@ -19,6 +19,10 @@ error_chain! {
     }
 
     errors {
+        GenesisMismatch {
+            description("Genesis mismatch"),
+            display("Genesis mismatch"),
+        }
         NoResponse {
             description("NoResponse"),
             display("NoResponse"),
@@ -95,9 +99,9 @@ pub fn handle(io: &NetworkContext, peer: PeerId, msg_id: MsgId, e: Error) {
         | ErrorKind::PivotHashMismatch
         | ErrorKind::UnknownMessage => disconnect = false,
 
-        ErrorKind::UnknownPeer | ErrorKind::Msg(_) => {
-            op = Some(UpdateNodeOperation::Failure)
-        }
+        ErrorKind::GenesisMismatch
+        | ErrorKind::UnknownPeer
+        | ErrorKind::Msg(_) => op = Some(UpdateNodeOperation::Failure),
 
         ErrorKind::UnexpectedRequestId | ErrorKind::UnexpectedResponse => {
             op = Some(UpdateNodeOperation::Demotion)

--- a/core/src/light_protocol/handler/handler.rs
+++ b/core/src/light_protocol/handler/handler.rs
@@ -2,29 +2,30 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use std::{
-    collections::HashSet,
-    sync::{atomic::AtomicU64, Arc},
-};
-
 use io::TimerToken;
-use parking_lot::RwLock;
-use rand::Rng;
 use rlp::Rlp;
+use std::sync::{atomic::AtomicU64, Arc};
 
 use crate::{
     consensus::ConsensusGraph,
-    light_protocol::{handle_error, message::msgid, Error, ErrorKind},
+    light_protocol::{
+        handle_error,
+        message::{msgid, Status},
+        Error, ErrorKind,
+    },
     message::MsgId,
     network::{NetworkContext, NetworkProtocolHandler, PeerId},
 };
 
-use super::{query::QueryHandler, sync::SyncHandler};
+use cfx_types::H256;
+
+use super::{peers::Peers, query::QueryHandler, sync::SyncHandler};
 
 /// Handler is responsible for maintaining peer meta-information and
 /// dispatching messages to the query and sync sub-handlers.
 pub struct Handler {
-    peers: RwLock<HashSet<PeerId>>,
+    consensus: Arc<ConsensusGraph>,
+    pub peers: Arc<Peers>,
     pub query: QueryHandler,
     pub sync: SyncHandler,
 }
@@ -34,7 +35,8 @@ impl Handler {
         let next_request_id = Arc::new(AtomicU64::new(0));
 
         Handler {
-            peers: RwLock::new(HashSet::new()),
+            consensus: consensus.clone(),
+            peers: Arc::new(Peers::default()),
             query: QueryHandler::new(consensus, next_request_id.clone()),
             sync: SyncHandler::new(next_request_id),
         }
@@ -46,18 +48,45 @@ impl Handler {
         trace!("Dispatching message: peer={:?}, msg_id={:?}", peer, msg_id);
 
         match msg_id {
+            msgid::STATUS => self.on_status(io, peer, &rlp),
             msgid::STATE_ROOT => self.query.on_state_root(io, peer, &rlp),
             msgid::STATE_ENTRY => self.query.on_state_entry(io, peer, &rlp),
             _ => Err(ErrorKind::UnknownMessage.into()),
         }
     }
 
-    /// Get all peers in random order.
-    pub fn get_peers_shuffled(&self) -> Vec<PeerId> {
-        let mut rand = rand::thread_rng();
-        let mut peers: Vec<_> = self.peers.read().iter().cloned().collect();
-        rand.shuffle(&mut peers[..]);
-        peers
+    #[inline]
+    fn validate_genesis_hash(&self, genesis: H256) -> Result<(), Error> {
+        match self.consensus.data_man.true_genesis_block.hash() {
+            h if h == genesis => Ok(()),
+            h => {
+                debug!(
+                    "Genesis mismatch (ours: {:?}, theirs: {:?})",
+                    h, genesis
+                );
+                Err(ErrorKind::GenesisMismatch.into())
+            }
+        }
+    }
+
+    fn on_status(
+        &self, _io: &NetworkContext, peer: PeerId, rlp: &Rlp,
+    ) -> Result<(), Error> {
+        let status: Status = rlp.as_val()?;
+        info!("on_status peer={:?} status={:?}", peer, status);
+
+        self.validate_genesis_hash(status.genesis_hash)?;
+        // TODO(thegaram): check protocol version
+
+        let peer_state = self.peers.insert(peer);
+        let mut state = peer_state.write();
+
+        state.protocol_version = status.protocol_version;
+        state.genesis_hash = status.genesis_hash;
+        state.best_epoch = status.best_epoch;
+        state.terminals = status.terminals.into_iter().collect();
+
+        Ok(())
     }
 }
 
@@ -85,12 +114,12 @@ impl NetworkProtocolHandler for Handler {
 
     fn on_peer_connected(&self, _io: &NetworkContext, peer: PeerId) {
         info!("on_peer_connected: peer={:?}", peer);
-        self.peers.write().insert(peer);
+        self.peers.insert(peer);
     }
 
     fn on_peer_disconnected(&self, _io: &NetworkContext, peer: PeerId) {
         info!("on_peer_disconnected: peer={:?}", peer);
-        self.peers.write().remove(&peer);
+        self.peers.remove(&peer);
     }
 
     fn on_timeout(&self, _io: &NetworkContext, _timer: TimerToken) {

--- a/core/src/light_protocol/handler/mod.rs
+++ b/core/src/light_protocol/handler/mod.rs
@@ -3,6 +3,7 @@
 // See http://www.gnu.org/licenses/
 
 mod handler;
+mod peers;
 mod query;
 mod sync;
 

--- a/core/src/light_protocol/handler/peers.rs
+++ b/core/src/light_protocol/handler/peers.rs
@@ -1,0 +1,45 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use parking_lot::RwLock;
+use rand::Rng;
+
+use cfx_types::H256;
+
+use crate::network::PeerId;
+
+#[derive(Default)]
+pub(super) struct PeerState {
+    pub protocol_version: u8,
+    pub genesis_hash: H256,
+    pub best_epoch: u64,
+    pub terminals: HashSet<H256>,
+}
+
+#[derive(Default)]
+pub struct Peers(RwLock<HashMap<PeerId, Arc<RwLock<PeerState>>>>);
+
+impl Peers {
+    pub(super) fn insert(&self, peer: PeerId) -> Arc<RwLock<PeerState>> {
+        self.0
+            .write()
+            .entry(peer)
+            .or_insert(Arc::new(RwLock::new(PeerState::default())))
+            .clone()
+    }
+
+    pub(super) fn remove(&self, peer: &PeerId) { self.0.write().remove(&peer); }
+
+    pub fn all_peers_shuffled(&self) -> Vec<PeerId> {
+        let mut rand = rand::thread_rng();
+        let mut peers: Vec<_> = self.0.read().keys().cloned().collect();
+        rand.shuffle(&mut peers[..]);
+        peers
+    }
+}

--- a/core/src/light_protocol/message/message.rs
+++ b/core/src/light_protocol/message/message.rs
@@ -2,13 +2,13 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use super::{GetStateEntry, GetStateRoot, StateEntry, StateRoot};
+use super::protocol::*;
 use crate::message::{HasRequestId, Message, MsgId, RequestId};
 use std::any::Any;
 
 // generate `pub mod msgid`
 build_msgid! {
-    // STATUS = 0x00
+    STATUS = 0x00
     GET_STATE_ROOT = 0x01
     STATE_ROOT = 0x02
     GET_STATE_ENTRY = 0x03
@@ -18,6 +18,7 @@ build_msgid! {
 }
 
 // generate `impl Message for _` for each message type
+build_msg_impl! { Status, msgid::STATUS, "Status" }
 build_msg_impl! { GetStateRoot, msgid::GET_STATE_ROOT, "GetStateRoot" }
 build_msg_impl! { StateRoot, msgid::STATE_ROOT, "StateRoot" }
 build_msg_impl! { GetStateEntry, msgid::GET_STATE_ENTRY, "GetStateEntry" }

--- a/core/src/light_protocol/message/mod.rs
+++ b/core/src/light_protocol/message/mod.rs
@@ -6,4 +6,6 @@ mod message;
 mod protocol;
 
 pub use message::msgid;
-pub use protocol::{GetStateEntry, GetStateRoot, StateEntry, StateRoot};
+pub use protocol::{
+    GetStateEntry, GetStateRoot, StateEntry, StateRoot, Status,
+};

--- a/core/src/light_protocol/message/protocol.rs
+++ b/core/src/light_protocol/message/protocol.rs
@@ -8,6 +8,15 @@ use primitives::StateRoot as PrimitiveStateRoot;
 use rlp_derive::{RlpDecodable, RlpEncodable};
 
 #[derive(Clone, Debug, PartialEq, RlpEncodable, RlpDecodable)]
+pub struct Status {
+    pub protocol_version: u8,
+    pub network_id: u8,
+    pub genesis_hash: H256,
+    pub best_epoch: u64,
+    pub terminals: Vec<H256>,
+}
+
+#[derive(Clone, Debug, PartialEq, RlpEncodable, RlpDecodable)]
 pub struct GetStateRoot {
     pub request_id: RequestId,
     pub epoch: u64,

--- a/core/src/light_protocol/query_service.rs
+++ b/core/src/light_protocol/query_service.rs
@@ -123,7 +123,7 @@ impl QueryService {
         info!("get_account epoch={:?} address={:?}", epoch, address);
 
         // try each peer until we succeed
-        for peer in self.handler.get_peers_shuffled() {
+        for peer in self.handler.peers.all_peers_shuffled() {
             match self.query_account(peer, epoch, address) {
                 Ok(account) => return account,
                 Err(e) => {


### PR DESCRIPTION
**Overview**

- Add `light_protocol::QueryProvider::send_status` for sending a status message on connection establishment.
- `light_protocol::Handler::on_status` for handling status messages from full nodes.
- Add simple peer management. `Arc<Peers>` is used as this will be shared between `Handler` (who adds / removes peers) and `SyncHandler` (who queries peer state).

**Notes**

Right now, only full clients send status messages to light clients, not the other way around. (Also not light-to-light.) This will likely be changed in the future.

Right now, we only send status on connection establishment. Later, we can consider sending it periodically, similar to `SynchronizationProtocolHandler`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/491)
<!-- Reviewable:end -->
