### PR TITLE
Make light node provider serve epoch hashes and block headers

### DIFF
--- a/core/src/light_protocol/message/message.rs
+++ b/core/src/light_protocol/message/message.rs
@@ -13,6 +13,10 @@ build_msgid! {
     STATE_ROOT = 0x02
     GET_STATE_ENTRY = 0x03
     STATE_ENTRY = 0x04
+    GET_BLOCK_HASHES_BY_EPOCH = 0x05
+    BLOCK_HASHES = 0x06
+    GET_BLOCK_HEADERS = 0x07
+    BLOCK_HEADERS = 0x08
 
     INVALID = 0xff
 }
@@ -23,6 +27,10 @@ build_msg_impl! { GetStateRoot, msgid::GET_STATE_ROOT, "GetStateRoot" }
 build_msg_impl! { StateRoot, msgid::STATE_ROOT, "StateRoot" }
 build_msg_impl! { GetStateEntry, msgid::GET_STATE_ENTRY, "GetStateEntry" }
 build_msg_impl! { StateEntry, msgid::STATE_ENTRY, "StateEntry" }
+build_msg_impl! { GetBlockHashesByEpoch, msgid::GET_BLOCK_HASHES_BY_EPOCH, "GetBlockHashesByEpoch" }
+build_msg_impl! { BlockHashes, msgid::BLOCK_HASHES, "BlockHashes" }
+build_msg_impl! { GetBlockHeaders, msgid::GET_BLOCK_HEADERS, "GetBlockHeaders" }
+build_msg_impl! { BlockHeaders, msgid::BLOCK_HEADERS, "BlockHeaders" }
 
 // generate `impl HasRequestId for _` for each request type
 build_has_request_id_impl! { GetStateRoot }

--- a/core/src/light_protocol/message/mod.rs
+++ b/core/src/light_protocol/message/mod.rs
@@ -7,5 +7,6 @@ mod protocol;
 
 pub use message::msgid;
 pub use protocol::{
+    BlockHashes, BlockHeaders, GetBlockHashesByEpoch, GetBlockHeaders,
     GetStateEntry, GetStateRoot, StateEntry, StateRoot, Status,
 };

--- a/core/src/light_protocol/message/protocol.rs
+++ b/core/src/light_protocol/message/protocol.rs
@@ -4,7 +4,9 @@
 
 use crate::{message::RequestId, storage::StateProof};
 use cfx_types::H256;
-use primitives::StateRoot as PrimitiveStateRoot;
+use primitives::{
+    BlockHeader as PrimitiveBlockHeader, StateRoot as PrimitiveStateRoot,
+};
 use rlp_derive::{RlpDecodable, RlpEncodable};
 
 #[derive(Clone, Debug, PartialEq, RlpEncodable, RlpDecodable)]
@@ -43,4 +45,28 @@ pub struct StateEntry {
     pub state_root: PrimitiveStateRoot,
     pub entry: Option<Vec<u8>>,
     pub proof: StateProof,
+}
+
+#[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
+pub struct GetBlockHashesByEpoch {
+    pub request_id: RequestId,
+    pub epochs: Vec<u64>,
+}
+
+#[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
+pub struct BlockHashes {
+    pub request_id: RequestId,
+    pub hashes: Vec<H256>,
+}
+
+#[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
+pub struct GetBlockHeaders {
+    pub request_id: RequestId,
+    pub hashes: Vec<H256>,
+}
+
+#[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
+pub struct BlockHeaders {
+    pub request_id: RequestId,
+    pub headers: Vec<PrimitiveBlockHeader>,
 }


### PR DESCRIPTION
**Overview**

Implement `light_protocol::QueryProvider::{on_get_block_hashes_by_epoch, on_get_block_headers}`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/496)
<!-- Reviewable:end -->
