### PR TITLE
Add memory manager for all MaybeInPlaceByteArray usage to remove memory leak from uncareful handling of CompressedPathRaw.

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -44,6 +44,7 @@ toml = "0.4"
 metrics = { path = "../util/metrics" }
 hibitset = { path = "../util/hibitset" }
 futures = "0.1"
+memoffset = "0.5.1"
 
 [dev-dependencies]
 rustc-hex = "1.0"

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/compressed_path.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/compressed_path.rs
@@ -48,7 +48,7 @@ mod tests {
     use super::{super::maybe_in_place_byte_array::*, *};
 
     #[test]
-    fn test_compressed_path_raw_size() {
+    fn test_compressed_path_raw_memory_manager_size() {
         assert_eq!(
             std::mem::size_of::<
                 FieldsOffsetMaybeInPlaceByteArrayMemoryManager<
@@ -141,7 +141,6 @@ impl CompressedPathRaw {
         }
     }
 
-    // FIXME: check what's the nibble order in Ethereum's proof.
     pub fn first_nibble(x: u8) -> u8 { x & Self::BITS_0_3_MASK }
 
     pub fn second_nibble(x: u8) -> u8 { (x & Self::BITS_4_7_MASK) >> 4 }

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/compressed_path.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/compressed_path.rs
@@ -3,15 +3,17 @@
 // See http://www.gnu.org/licenses/
 
 pub trait CompressedPathTrait {
-    type SelfType;
-
     fn path_slice(&self) -> &[u8];
     fn end_mask(&self) -> u8;
+
+    fn path_size(&self) -> u16 { self.path_slice().len() as u16 }
+
+    fn path_steps(&self) -> u16 {
+        self.path_size() * 2 - (self.end_mask() != 0) as u16
+    }
 }
 
 impl<'a> CompressedPathTrait for &'a [u8] {
-    type SelfType = Self;
-
     fn path_slice(&self) -> &[u8] { self }
 
     fn end_mask(&self) -> u8 { 0 }
@@ -25,10 +27,50 @@ pub struct CompressedPathRef<'a> {
 
 #[derive(Default)]
 pub struct CompressedPathRaw {
-    pub(super) path_size: u16,
-    pub(super) path: MaybeInPlaceByteArray,
+    path_size: u16,
+    path: MaybeInPlaceByteArray,
     end_mask: u8,
+    pub byte_array_memory_manager:
+        FieldsOffsetMaybeInPlaceByteArrayMemoryManager<
+            u16,
+            TrivialSizeFieldConverterU16,
+            CompressedPathRawByteArrayMemoryManager,
+            CompressedPathRawByteArrayMemoryManager,
+        >,
 }
+
+/// CompressedPathRaw is Send + Sync.
+unsafe impl Send for CompressedPathRaw {}
+unsafe impl Sync for CompressedPathRaw {}
+
+#[cfg(test)]
+mod tests {
+    use super::{super::maybe_in_place_byte_array::*, *};
+
+    #[test]
+    fn test_compressed_path_raw_size() {
+        assert_eq!(
+            std::mem::size_of::<
+                FieldsOffsetMaybeInPlaceByteArrayMemoryManager<
+                    u16,
+                    TrivialSizeFieldConverterU16,
+                    CompressedPathRawByteArrayMemoryManager,
+                    CompressedPathRawByteArrayMemoryManager,
+                >,
+            >(),
+            0
+        );
+    }
+}
+
+make_parallel_field_maybe_in_place_byte_array_memory_manager!(
+    CompressedPathRawByteArrayMemoryManager,
+    CompressedPathRaw,
+    byte_array_memory_manager,
+    path,
+    path_size: u16,
+    TrivialSizeFieldConverterU16,
+);
 
 impl CompressedPathRaw {
     const BITS_0_3_MASK: u8 = 0x0f;
@@ -36,16 +78,18 @@ impl CompressedPathRaw {
 }
 
 impl<'a> CompressedPathTrait for CompressedPathRef<'a> {
-    type SelfType = Self;
-
     fn path_slice(&self) -> &[u8] { self.path_slice }
 
     fn end_mask(&self) -> u8 { self.end_mask }
+
+    fn path_size(&self) -> u16 { self.path_slice.len() as u16 }
+
+    fn path_steps(&self) -> u16 {
+        (self.path_slice.len() as u16 * 2) - (self.end_mask != 0) as u16
+    }
 }
 
 impl CompressedPathTrait for CompressedPathRaw {
-    type SelfType = Self;
-
     fn path_slice(&self) -> &[u8] {
         self.path.get_slice(self.path_size as usize)
     }
@@ -66,10 +110,12 @@ impl<'a> From<CompressedPathRef<'a>> for CompressedPathRaw {
 impl CompressedPathRaw {
     pub fn new(path_slice: &[u8], end_mask: u8) -> Self {
         let path_size = path_slice.len();
+
         Self {
             path_size: path_size as u16,
             path: MaybeInPlaceByteArray::copy_from(path_slice, path_size),
             end_mask,
+            byte_array_memory_manager: Default::default(),
         }
     }
 
@@ -79,6 +125,7 @@ impl CompressedPathRaw {
             path_size: path_size as u16,
             path: MaybeInPlaceByteArray::copy_from(path_slice, path_size),
             end_mask,
+            byte_array_memory_manager: Default::default(),
         };
         ret.path.get_slice_mut(path_size)[path_size - 1] &= end_mask;
 
@@ -90,15 +137,85 @@ impl CompressedPathRaw {
             path_size,
             path: MaybeInPlaceByteArray::new_zeroed(path_size as usize),
             end_mask,
+            byte_array_memory_manager: Default::default(),
         }
     }
 
+    // FIXME: check what's the nibble order in Ethereum's proof.
     pub fn first_nibble(x: u8) -> u8 { x & Self::BITS_0_3_MASK }
 
     pub fn second_nibble(x: u8) -> u8 { (x & Self::BITS_4_7_MASK) >> 4 }
 
     pub fn set_second_nibble(x: u8, second_nibble: u8) -> u8 {
         Self::first_nibble(x) | (second_nibble << 4)
+    }
+
+    pub fn concat<X: CompressedPathTrait, Y: CompressedPathTrait>(
+        x: &X, child_index: u8, y: &Y,
+    ) -> Self {
+        let x_slice = x.path_slice();
+        let x_slice_len = x_slice.len();
+        let y_slice = y.path_slice();
+
+        // TODO(yz): it happens to be the same no matter what end_mask of x is,
+        // because u8 = 2 nibbles. When we switch to u32 as path unit
+        // the concated size may vary.
+        let size = x_slice_len + y_slice.len();
+
+        let mut path;
+        {
+            let slice;
+            unsafe {
+                if size > MaybeInPlaceByteArray::MAX_INPLACE_SIZE {
+                    // Create uninitialized vector.
+                    let mut value = Vec::with_capacity(size);
+                    value.set_len(size);
+
+                    let ptr = value.as_mut_ptr();
+                    path = MaybeInPlaceByteArray { ptr };
+                    slice = std::slice::from_raw_parts_mut(ptr, size);
+                } else {
+                    let in_place: [u8;
+                        MaybeInPlaceByteArray::MAX_INPLACE_SIZE] =
+                        std::mem::uninitialized();
+                    path = MaybeInPlaceByteArray { in_place };
+                    slice = &mut path.in_place[0..size];
+                }
+            }
+
+            if x.end_mask() == 0 {
+                slice[0..x_slice_len].copy_from_slice(x_slice);
+            } else {
+                slice[0..x_slice_len - 1]
+                    .copy_from_slice(&x_slice[0..x_slice_len - 1]);
+                slice[x_slice_len - 1] = CompressedPathRaw::set_second_nibble(
+                    x_slice[x_slice_len - 1],
+                    child_index,
+                );
+            }
+            slice[x_slice_len..].copy_from_slice(y_slice);
+        }
+
+        Self {
+            path_size: size as u16,
+            path,
+            end_mask: y.end_mask(),
+            byte_array_memory_manager: Default::default(),
+        }
+    }
+}
+
+impl Clone for CompressedPathRaw {
+    fn clone(&self) -> Self {
+        Self {
+            end_mask: self.end_mask,
+            path_size: self.path_size,
+            path: MaybeInPlaceByteArray::clone(
+                &self.path,
+                self.path_size as usize,
+            ),
+            byte_array_memory_manager: Default::default(),
+        }
     }
 }
 
@@ -127,42 +244,17 @@ impl Decodable for CompressedPathRaw {
 }
 
 impl CompressedPathRaw {
-    pub fn concat<X: CompressedPathTrait, Y: CompressedPathTrait>(
-        x: &X, child_index: u8, y: &Y,
-    ) -> Self {
-        let x_slice = x.path_slice();
-        let y_slice = y.path_slice();
-        let size = x_slice.len() + y_slice.len();
-
-        let mut path;
-        if size <= MaybeInPlaceByteArray::MAX_INPLACE_SIZE {
-            path = MaybeInPlaceByteArray::copy_from(x_slice, x_slice.len());
-            path.get_slice_mut(size)
-                [x_slice.len()..x_slice.len() + y_slice.len()]
-                .clone_from_slice(y_slice);
-        } else {
-            path = MaybeInPlaceByteArray::copy_from(
-                &([x_slice, y_slice].concat()),
-                size,
-            );
+    pub fn as_ref(&self) -> CompressedPathRef {
+        CompressedPathRef {
+            path_slice: self.path_slice(),
+            end_mask: self.end_mask,
         }
+    }
 
-        if x.end_mask() != 0 {
-            let path_slice_mut = path.get_slice_mut(size);
-            path_slice_mut[x_slice.len() - 1] =
-                CompressedPathRaw::set_second_nibble(
-                    path_slice_mut[x_slice.len() - 1],
-                    child_index,
-                );
-        }
-
-        Self {
-            path_size: size as u16,
-            path,
-            end_mask: y.end_mask(),
-        }
+    pub fn path_slice_mut(&mut self) -> &mut [u8] {
+        self.path.get_slice_mut(self.path_size as usize)
     }
 }
 
-use super::maybe_in_place_byte_array::MaybeInPlaceByteArray;
+use super::maybe_in_place_byte_array::*;
 use rlp::*;

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/cow_node_ref.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/cow_node_ref.rs
@@ -541,7 +541,11 @@ impl CowNodeRef {
         // FIXME: becomes difficult.
         let child_trie_node =
             child_node_cow.get_trie_node(node_memory_manager, &allocator)?;
-        let new_path = child_trie_node.path_prepended(path_prefix, child_index);
+        let new_path = CompressedPathRaw::concat(
+            &path_prefix,
+            child_index,
+            &child_trie_node.compressed_path_ref(),
+        );
 
         // FIXME: if child_trie_node isn't owned, but node_cow is owned, modify
         // FIXME: node_cow.

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/maybe_in_place_byte_array.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/maybe_in_place_byte_array.rs
@@ -16,6 +16,10 @@ pub union MaybeInPlaceByteArray {
     pub ptr: *mut u8,
 }
 
+impl MaybeInPlaceByteArray {
+    pub const MAX_INPLACE_SIZE: usize = 8;
+}
+
 #[test]
 fn test_maybe_inplace_byte_array_size_is_8_bytes() {
     assert_eq!(
@@ -266,9 +270,4 @@ impl<
     fn get_in_place_byte_array_mut(&mut self) -> &mut MaybeInPlaceByteArray {
         ByteArrayOffsetAccessor::get_mut(self)
     }
-}
-
-#[allow(unused)]
-impl MaybeInPlaceByteArray {
-    pub const MAX_INPLACE_SIZE: usize = 8;
 }

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/maybe_in_place_byte_array.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/maybe_in_place_byte_array.rs
@@ -2,24 +2,115 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use std::{ptr::null_mut, slice};
+use std::{marker::PhantomData, ptr::null_mut, slice};
 
+/// Use FieldsOffsetMaybeInPlaceByteArrayMemoryManager and macro
+/// make_parallel_field_maybe_in_place_byte_array_memory_manager to manage
+/// construction / destruction of MaybeInPlaceByteArray.
+///
+/// The memory manager should be placed as a parallel field in the same struct
+/// as the MaybeInPlaceByteArray. See CompressedPathRaw for example.
 pub union MaybeInPlaceByteArray {
-    in_place: [u8; 8],
-    // TODO(yz): statically assert that the ptr has size of at most 8.
-    // TODO(yz): to initialize and destruct, convert from/into Vec.
-    // TODO(yz): introduce a type to pass into template which manages the
-    // conversion from/to  Vec<A>. The type should also take the offset of
-    // u16 size from the TrieNode struct to manage memory buffer, and
-    // should offer a type for ptr here.
+    pub in_place: [u8; Self::MAX_INPLACE_SIZE],
     /// Only raw pointer is 8B.
-    ptr: *mut u8,
+    pub ptr: *mut u8,
 }
 
+#[test]
+fn test_maybe_inplace_byte_array_size_is_8_bytes() {
+    assert_eq!(
+        std::mem::size_of::<MaybeInPlaceByteArray>(),
+        MaybeInPlaceByteArray::MAX_INPLACE_SIZE
+    );
+}
 impl Default for MaybeInPlaceByteArray {
     fn default() -> Self {
         Self {
             in_place: Default::default(),
+        }
+    }
+}
+
+/// Trait for managing construction / destruction of MaybeInPlaceByteArray.
+/// FieldsOffsetMaybeInPlaceByteArrayMemoryManager implements this trait.
+pub trait MaybeInPlaceByteArrayMemoryManagerTrait: Drop {
+    /// Unsafe because the size isn't set to 0.
+    unsafe fn drop_value(&mut self) {
+        let size = self.get_size();
+        if size > MaybeInPlaceByteArray::MAX_INPLACE_SIZE {
+            self.get_in_place_byte_array_mut().ptr_into_vec(size);
+        }
+    }
+
+    fn get_size(&self) -> usize;
+    fn set_size(&mut self, size: usize);
+    fn get_in_place_byte_array(&self) -> &MaybeInPlaceByteArray;
+    fn get_in_place_byte_array_mut(&mut self) -> &mut MaybeInPlaceByteArray;
+
+    /// Unsafe because the destination may not be empty.
+    unsafe fn move_byte_array_dest_unchecked(
+        &mut self, free_dest: &mut MaybeInPlaceByteArray,
+    ) {
+        self.set_size(0);
+
+        std::ptr::copy_nonoverlapping(
+            self.get_in_place_byte_array(),
+            free_dest,
+            1,
+        );
+    }
+
+    fn move_to<T: MaybeInPlaceByteArrayMemoryManagerTrait>(
+        &mut self, dest: &mut T,
+    ) {
+        let size = self.get_size();
+
+        // Safe because the dest size is set right later.
+        unsafe {
+            dest.drop_value();
+            dest.set_size(size);
+        }
+        if size != 0 {
+            // Safe because the old content in destination is already freed.
+            unsafe {
+                self.move_byte_array_dest_unchecked(
+                    dest.get_in_place_byte_array_mut(),
+                );
+            }
+        }
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct FieldsOffsetMaybeInPlaceByteArrayMemoryManager<
+    SizeFieldType,
+    SizeFieldGetterSetter: SizeFieldConverterTrait<SizeFieldType>,
+    ByteArrayOffsetAccessor: ParallelFieldOffsetAccessor<Self, MaybeInPlaceByteArray>,
+    SizeFieldOffsetAccessor: ParallelFieldOffsetAccessor<Self, SizeFieldType>,
+> {
+    _marker_size_type: PhantomData<SizeFieldType>,
+    _marker_size_field_getter_setter: PhantomData<SizeFieldGetterSetter>,
+    _marker_byte_array_accessor: PhantomData<ByteArrayOffsetAccessor>,
+    _marker_size_field_accessor: PhantomData<SizeFieldOffsetAccessor>,
+}
+
+impl<
+        SizeFieldType,
+        SizeFieldGetterSetter: SizeFieldConverterTrait<SizeFieldType>,
+        ByteArrayOffsetAccessor: ParallelFieldOffsetAccessor<Self, MaybeInPlaceByteArray>,
+        SizeFieldOffsetAccessor: ParallelFieldOffsetAccessor<Self, SizeFieldType>,
+    > Drop
+    for FieldsOffsetMaybeInPlaceByteArrayMemoryManager<
+        SizeFieldType,
+        SizeFieldGetterSetter,
+        ByteArrayOffsetAccessor,
+        SizeFieldOffsetAccessor,
+    >
+{
+    fn drop(&mut self) {
+        // Safe because on destruction it's not necessary to set size to 0
+        unsafe {
+            self.drop_value();
         }
     }
 }
@@ -74,19 +165,18 @@ impl MaybeInPlaceByteArray {
         .into_boxed_slice()
     }
 
-    fn new(mut value: Box<[u8]>, size: usize) -> Self {
+    pub fn new(mut value: Box<[u8]>, size: usize) -> Self {
         if size > Self::MAX_INPLACE_SIZE {
             let ptr = value.as_mut_ptr();
             Box::into_raw(value);
             Self { ptr }
         } else {
-            let mut x = Self {
-                in_place: Default::default(),
-            };
+            let mut in_place: [u8; Self::MAX_INPLACE_SIZE];
             unsafe {
-                x.in_place[0..size].copy_from_slice(&*value);
+                in_place = std::mem::uninitialized();
             }
-            x
+            in_place[0..size].copy_from_slice(&*value);
+            Self { in_place }
         }
     }
 
@@ -110,11 +200,75 @@ impl MaybeInPlaceByteArray {
             x
         }
     }
+
+    pub fn clone(&self, size: usize) -> Self {
+        if size > Self::MAX_INPLACE_SIZE {
+            // Safety guaranteed by condition.
+            Self::copy_from(unsafe { self.ptr_slice(size) }, size)
+        } else {
+            Self {
+                in_place: unsafe { self.in_place }.clone(),
+            }
+        }
+    }
+}
+
+pub trait ParallelFieldOffsetAccessor<FromFieldType, TargetFieldType> {
+    fn get(m: &FromFieldType) -> &TargetFieldType;
+    fn get_mut(m: &mut FromFieldType) -> &mut TargetFieldType;
+}
+
+pub trait SizeFieldConverterTrait<SizeFieldType> {
+    fn is_size_over_limit(size: usize) -> bool;
+    fn get(size_field: &SizeFieldType) -> usize;
+    fn set(size_field: &mut SizeFieldType, size: usize);
+}
+
+#[derive(Default)]
+pub struct TrivialSizeFieldConverterU16 {}
+
+impl SizeFieldConverterTrait<u16> for TrivialSizeFieldConverterU16 {
+    fn is_size_over_limit(size: usize) -> bool { size > std::u16::MAX as usize }
+
+    fn get(size_field: &u16) -> usize { (*size_field) as usize }
+
+    fn set(size_field: &mut u16, size: usize) { *size_field = size as u16; }
+}
+
+impl<
+        SizeFieldType,
+        SizeFieldGetterSetter: SizeFieldConverterTrait<SizeFieldType>,
+        ByteArrayOffsetAccessor: ParallelFieldOffsetAccessor<Self, MaybeInPlaceByteArray>,
+        SizeFieldOffsetAccessor: ParallelFieldOffsetAccessor<Self, SizeFieldType>,
+    > MaybeInPlaceByteArrayMemoryManagerTrait
+    for FieldsOffsetMaybeInPlaceByteArrayMemoryManager<
+        SizeFieldType,
+        SizeFieldGetterSetter,
+        ByteArrayOffsetAccessor,
+        SizeFieldOffsetAccessor,
+    >
+{
+    fn get_size(&self) -> usize {
+        SizeFieldGetterSetter::get(SizeFieldOffsetAccessor::get(self))
+    }
+
+    fn set_size(&mut self, size: usize) {
+        SizeFieldGetterSetter::set(
+            SizeFieldOffsetAccessor::get_mut(self),
+            size,
+        );
+    }
+
+    fn get_in_place_byte_array(&self) -> &MaybeInPlaceByteArray {
+        ByteArrayOffsetAccessor::get(self)
+    }
+
+    fn get_in_place_byte_array_mut(&mut self) -> &mut MaybeInPlaceByteArray {
+        ByteArrayOffsetAccessor::get_mut(self)
+    }
 }
 
 #[allow(unused)]
 impl MaybeInPlaceByteArray {
     pub const MAX_INPLACE_SIZE: usize = 8;
-    pub const MAX_SIZE_U16: usize = 0xffff;
-    pub const MAX_SIZE_U32: usize = 0xffffffff;
 }

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/maybe_in_place_byte_array_macro.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/maybe_in_place_byte_array_macro.rs
@@ -1,0 +1,112 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+macro_rules! make_parallel_field_maybe_in_place_byte_array_memory_manager {
+    (
+        $accessor_type:tt$(<$($generics:tt),+>$( where <$($constrain_item:tt: $constrain:tt),*>)?)?,
+        $struct_type:path,
+        $manager_field:ident,
+        $byte_array_field:ident,
+        $size_field:ident :
+        $size_type:tt,
+        $size_getter_setter_type:tt,
+    ) => {
+        #[derive(Default, Clone)]
+        pub struct $accessor_type$($(<$($constrain_item: $constrain)*>)?)? (
+            $($(std::marker::PhantomData<$generics>,)+)?
+        );
+
+        impl$($(<$($constrain_item: $constrain)*>)?)?
+            ParallelFieldOffsetAccessor<
+                FieldsOffsetMaybeInPlaceByteArrayMemoryManager<
+                    $size_type,
+                    $size_getter_setter_type,
+                    $accessor_type$(<$($generics,)+>)?,
+                    $accessor_type$(<$($generics,)+>)?,
+                >,
+                MaybeInPlaceByteArray,
+            > for $accessor_type$(<$($generics,)+>)?
+        {
+            fn get(
+                m: &FieldsOffsetMaybeInPlaceByteArrayMemoryManager<
+                    $size_type,
+                    $size_getter_setter_type,
+                    $accessor_type$(<$($generics,)+>)?,
+                    $accessor_type$(<$($generics,)+>)?,
+                >,
+            ) -> &MaybeInPlaceByteArray
+            {
+                unsafe {
+                    &*(((m as *const _ as usize)
+                        - memoffset::offset_of!($struct_type, $manager_field)
+                        + memoffset::offset_of!($struct_type, $byte_array_field))
+                        as *const MaybeInPlaceByteArray)
+                }
+            }
+
+            fn get_mut(
+                m: &mut FieldsOffsetMaybeInPlaceByteArrayMemoryManager<
+                    $size_type,
+                    $size_getter_setter_type,
+                    $accessor_type$(<$($generics,)+>)?,
+                    $accessor_type$(<$($generics,)+>)?,
+                >,
+            ) -> &mut MaybeInPlaceByteArray
+            {
+                unsafe {
+                    &mut *(((m as *mut _ as usize)
+                        - memoffset::offset_of!($struct_type, $manager_field)
+                        + memoffset::offset_of!($struct_type, $byte_array_field))
+                        as *mut MaybeInPlaceByteArray)
+                }
+            }
+        }
+
+        impl$($(<$($constrain_item: $constrain)*>)?)?
+            ParallelFieldOffsetAccessor<
+                FieldsOffsetMaybeInPlaceByteArrayMemoryManager<
+                    $size_type,
+                    $size_getter_setter_type,
+                    $accessor_type$(<$($generics,)+>)?,
+                    $accessor_type$(<$($generics,)+>)?,
+                >,
+                $size_type,
+            > for $accessor_type$(<$($generics,)+>)?
+        {
+            fn get(
+                m: &FieldsOffsetMaybeInPlaceByteArrayMemoryManager<
+                    $size_type,
+                    $size_getter_setter_type,
+                    $accessor_type$(<$($generics,)+>)?,
+                    $accessor_type$(<$($generics,)+>)?,
+                >,
+            ) -> &$size_type
+            {
+                unsafe {
+                    &*(((m as *const _ as usize)
+                        - memoffset::offset_of!($struct_type, $manager_field)
+                        + memoffset::offset_of!($struct_type, $size_field))
+                        as *const $size_type)
+                }
+            }
+
+            fn get_mut(
+                m: &mut FieldsOffsetMaybeInPlaceByteArrayMemoryManager<
+                    $size_type,
+                    $size_getter_setter_type,
+                    $accessor_type$(<$($generics,)+>)?,
+                    $accessor_type$(<$($generics,)+>)?,
+                >,
+            ) -> &mut $size_type
+            {
+                unsafe {
+                    &mut *(((m as *mut _ as usize)
+                        - memoffset::offset_of!($struct_type, $manager_field)
+                        + memoffset::offset_of!($struct_type, $size_field))
+                        as *mut $size_type)
+                }
+            }
+        }
+    };
+}

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/mod.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/mod.rs
@@ -2,6 +2,9 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
+#[macro_use]
+pub(self) mod maybe_in_place_byte_array_macro;
+
 pub mod children_table;
 pub(self) mod compressed_path;
 pub mod cow_node_ref;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/506)
<!-- Reviewable:end -->
