### PR TITLE
Refactor around TrieNode for merging snapshot MPT with delta MPT.

### DIFF
--- a/core/src/state/account_entry.rs
+++ b/core/src/state/account_entry.rs
@@ -276,7 +276,7 @@ impl OverlayAccount {
                 if !code.is_empty() {
                     db.set_raw(
                         &db.code_key(&self.address, &self.code_hash),
-                        &code.as_ref(),
+                        code.as_ref().clone().into_boxed_slice(),
                     )?;
                 }
             }

--- a/core/src/statedb/mod.rs
+++ b/core/src/statedb/mod.rs
@@ -119,10 +119,12 @@ impl<'a> StateDb<'a> {
             key.as_ref(),
             ::rlp::encode(value)
         );
-        self.set_raw(key, &::rlp::encode(value))
+        self.set_raw(key, ::rlp::encode(value).into_boxed_slice())
     }
 
-    pub fn set_raw(&mut self, key: &StorageKey, value: &[u8]) -> Result<()> {
+    pub fn set_raw(
+        &mut self, key: &StorageKey, value: Box<[u8]>,
+    ) -> Result<()> {
         match self.storage.set(key.as_ref(), value) {
             Ok(_) => Ok(()),
             Err(StorageError(StorageErrorKind::MPTKeyNotFound, _)) => Ok(()),

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/children_table.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/children_table.rs
@@ -2,13 +2,161 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use super::node_ref::NodeRefDeltaMptCompact;
-use rlp::*;
-use std::{fmt::*, marker::PhantomData, mem, ptr::null_mut, slice};
-
 pub trait NodeRefTrait:
-    Clone + Encodable + Decodable + PartialEq + Debug
+    Copy + Clone + Encodable + Decodable + PartialEq + Debug
 {
+}
+
+impl NodeRefTrait for MerkleHash {}
+
+#[derive(Clone)]
+pub struct VanillaChildrenTable<NodeRefT: NodeRefTrait> {
+    table: [NodeRefT; CHILDREN_COUNT],
+    children_count: u8,
+}
+
+impl From<ChildrenMerkleTable> for VanillaChildrenTable<MerkleHash> {
+    fn from(x: ChildrenMerkleTable) -> Self {
+        let mut children_count = 0;
+        for merkle in &x {
+            if !merkle.eq(ChildrenTableItem::<MerkleHash>::no_child()) {
+                children_count += 1;
+            }
+        }
+        Self {
+            table: x,
+            children_count,
+        }
+    }
+}
+
+impl From<MaybeMerkleTable> for VanillaChildrenTable<MerkleHash> {
+    fn from(x: MaybeMerkleTable) -> Self {
+        match x {
+            None => Self::default(),
+            Some(t) => t.into(),
+        }
+    }
+}
+
+pub trait DefaultChildrenItem<NodeRefT: NodeRefTrait> {
+    fn no_child() -> &'static NodeRefT;
+}
+
+pub struct ChildrenTableItem<NodeRefT: NodeRefTrait> {
+    _marker: PhantomData<NodeRefT>,
+}
+
+impl DefaultChildrenItem<MerkleHash> for ChildrenTableItem<MerkleHash> {
+    fn no_child() -> &'static MerkleHash { &MERKLE_NULL_NODE }
+}
+
+impl<NodeRefT: NodeRefTrait> WrappedCreateFrom<NodeRefT, NodeRefT>
+    for ChildrenTableItem<NodeRefT>
+{
+    fn take(x: NodeRefT) -> NodeRefT { x }
+}
+
+impl<'x, NodeRefT: NodeRefTrait> WrappedCreateFrom<&'x NodeRefT, NodeRefT>
+    for ChildrenTableItem<NodeRefT>
+{
+    fn take(x: &'x NodeRefT) -> NodeRefT { x.clone() }
+
+    fn take_from(dest: &mut NodeRefT, x: &'x NodeRefT) { dest.clone_from(x); }
+}
+
+impl<NodeRefT: 'static + NodeRefTrait> Default
+    for VanillaChildrenTable<NodeRefT>
+where ChildrenTableItem<NodeRefT>: DefaultChildrenItem<NodeRefT>
+{
+    fn default() -> Self {
+        Self {
+            children_count: 0,
+            table: [ChildrenTableItem::<NodeRefT>::no_child().clone();
+                CHILDREN_COUNT],
+        }
+    }
+}
+
+impl<NodeRefT: 'static + NodeRefTrait> VanillaChildrenTable<NodeRefT>
+where ChildrenTableItem<NodeRefT>: DefaultChildrenItem<NodeRefT>
+{
+    // FIXME: put most method in a trait.
+
+    pub fn new_from_one_child(child_index: u8, child: &NodeRefT) -> Self {
+        let mut table = VanillaChildrenTable::default();
+        table.children_count = 1;
+        table.table[child_index as usize] = child.clone();
+        table
+    }
+
+    pub fn get_children_table(&self) -> &[NodeRefT; CHILDREN_COUNT] {
+        &self.table
+    }
+
+    pub fn get_children_count(&self) -> u8 { self.children_count }
+
+    pub fn get_children_count_mut(&mut self) -> &mut u8 {
+        &mut self.children_count
+    }
+
+    pub fn get_child(&self, child_index: u8) -> Option<&NodeRefT> {
+        let child_ref =
+            unsafe { self.table.get_unchecked(child_index as usize) };
+        if child_ref.eq(ChildrenTableItem::<NodeRefT>::no_child()) {
+            None
+        } else {
+            Some(child_ref)
+        }
+    }
+
+    pub unsafe fn get_child_mut_unchecked(
+        &mut self, child_index: u8,
+    ) -> &mut NodeRefT {
+        self.table.get_unchecked_mut(child_index as usize)
+    }
+
+    pub fn iter(&self) -> VanillaChildrenTableIterator<NodeRefT> {
+        VanillaChildrenTableIterator {
+            next_child_index: 0,
+            table: &self.table,
+        }
+    }
+}
+
+pub struct VanillaChildrenTableIterator<'a, NodeRefT: NodeRefTrait> {
+    next_child_index: u8,
+    table: &'a [NodeRefT; CHILDREN_COUNT],
+}
+
+impl<'a, NodeRefT: 'static + NodeRefTrait> Iterator
+    for VanillaChildrenTableIterator<'a, NodeRefT>
+where ChildrenTableItem<NodeRefT>: DefaultChildrenItem<NodeRefT>
+{
+    type Item = (u8, &'a NodeRefT);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while (self.next_child_index as usize) < CHILDREN_COUNT {
+            let child_index = self.next_child_index;
+            let child_ref = unsafe {
+                self.table.get_unchecked(self.next_child_index as usize)
+            };
+            self.next_child_index = child_index + 1;
+            if !child_ref.eq(ChildrenTableItem::<NodeRefT>::no_child()) {
+                return Some((child_index, child_ref));
+            }
+        }
+        None
+    }
+}
+
+impl<'a, NodeRefT: NodeRefTrait> ChildrenTableIteratorStartIndex
+    for VanillaChildrenTableIterator<'a, NodeRefT>
+{
+    fn set_start_index(mut self, index: u8) -> Self {
+        self.next_child_index = index;
+        self
+    }
 }
 
 /// NodeRefT for delta MPT and persistent MPT can be different.
@@ -286,7 +434,11 @@ impl<NodeRefT: NodeRefTrait> PartialEq for CompactedChildrenTable<NodeRefT> {
     fn eq(&self, other: &Self) -> bool { self.to_ref() == other.to_ref() }
 }
 
-trait CompactedChildrenTableIteratorTrait {
+pub trait ChildrenTableIteratorStartIndex {
+    fn set_start_index(self, index: u8) -> Self;
+}
+
+trait CompactedChildrenTableIteratorTrait: ChildrenTableIteratorStartIndex {
     type NodeRefT: NodeRefTrait;
     type RefType;
 
@@ -303,10 +455,16 @@ trait CompactedChildrenTableIteratorTrait {
     fn advance_elements(&mut self);
 }
 
-trait CompactedChildrenTableIteratorNonSkipNextTrait:
+trait CompactedChildrenTableIteratorNonSkipImplTrait:
     CompactedChildrenTableIteratorTrait
 {
-    fn next(&mut self, child_index: u8) -> Option<(u8, Option<Self::RefType>)> {
+    fn set_start_index_impl(&mut self, index: u8) {
+        self.set_next_child_index(index);
+    }
+
+    fn next_impl(
+        &mut self, child_index: u8,
+    ) -> Option<(u8, Option<Self::RefType>)> {
         if child_index as usize == CHILDREN_COUNT {
             return None;
         }
@@ -327,10 +485,19 @@ trait CompactedChildrenTableIteratorNonSkipNextTrait:
     }
 }
 
-trait CompactedChildrenTableIteratorNextTrait:
+trait CompactedChildrenTableIteratorImplTrait:
     CompactedChildrenTableIteratorTrait
 {
-    fn next(&mut self) -> Option<(u8, Self::RefType)> {
+    fn set_start_index_impl(&mut self, index: u8) {
+        self.set_bitmap(
+            self.get_bitmap()
+                & !CompactedChildrenTable::<Self::NodeRefT>::lower_bits(
+                    index.into(),
+                ),
+        );
+    }
+
+    fn next_impl(&mut self) -> Option<(u8, Self::RefType)> {
         let ret;
         if self.get_bitmap() != 0 {
             ret = Some((
@@ -385,7 +552,7 @@ impl<'a, NodeRefT: NodeRefTrait> CompactedChildrenTableIteratorTrait
     }
 }
 
-impl<'a, NodeRefT: NodeRefTrait> CompactedChildrenTableIteratorNonSkipNextTrait
+impl<'a, NodeRefT: NodeRefTrait> CompactedChildrenTableIteratorNonSkipImplTrait
     for CompactedChildrenTableIteratorNonSkip<'a, NodeRefT>
 {
 }
@@ -396,10 +563,16 @@ impl<'a, NodeRefT: NodeRefTrait> Iterator
     type Item = (u8, Option<&'a NodeRefT>);
 
     fn next(&mut self) -> Option<Self::Item> {
-        <Self as CompactedChildrenTableIteratorNonSkipNextTrait>::next(
-            self,
-            self.next_child_index,
-        )
+        self.next_impl(self.next_child_index)
+    }
+}
+
+impl<'a, NodeRefT: NodeRefTrait> ChildrenTableIteratorStartIndex
+    for CompactedChildrenTableIteratorNonSkip<'a, NodeRefT>
+{
+    fn set_start_index(mut self, index: u8) -> Self {
+        self.set_start_index_impl(index);
+        self
     }
 }
 
@@ -436,7 +609,7 @@ impl<'a, NodeRefT: NodeRefTrait> CompactedChildrenTableIteratorTrait
     }
 }
 
-impl<'a, NodeRefT: NodeRefTrait> CompactedChildrenTableIteratorNonSkipNextTrait
+impl<'a, NodeRefT: NodeRefTrait> CompactedChildrenTableIteratorNonSkipImplTrait
     for CompactedChildrenTableIteratorNonSkipMut<'a, NodeRefT>
 {
 }
@@ -447,10 +620,16 @@ impl<'a, NodeRefT: NodeRefTrait> Iterator
     type Item = (u8, Option<&'a mut NodeRefT>);
 
     fn next(&mut self) -> Option<Self::Item> {
-        <Self as CompactedChildrenTableIteratorNonSkipNextTrait>::next(
-            self,
-            self.next_child_index,
-        )
+        self.next_impl(self.next_child_index)
+    }
+}
+
+impl<'a, NodeRefT: NodeRefTrait> ChildrenTableIteratorStartIndex
+    for CompactedChildrenTableIteratorNonSkipMut<'a, NodeRefT>
+{
+    fn set_start_index(mut self, index: u8) -> Self {
+        self.set_start_index_impl(index);
+        self
     }
 }
 
@@ -482,7 +661,7 @@ impl<'a, NodeRefT: NodeRefTrait> CompactedChildrenTableIteratorTrait
     }
 }
 
-impl<'a, NodeRefT: NodeRefTrait> CompactedChildrenTableIteratorNextTrait
+impl<'a, NodeRefT: NodeRefTrait> CompactedChildrenTableIteratorImplTrait
     for CompactedChildrenTableIterator<'a, NodeRefT>
 {
 }
@@ -492,8 +671,15 @@ impl<'a, NodeRefT: NodeRefTrait> Iterator
 {
     type Item = (u8, &'a NodeRefT);
 
-    fn next(&mut self) -> Option<Self::Item> {
-        <Self as CompactedChildrenTableIteratorNextTrait>::next(self)
+    fn next(&mut self) -> Option<Self::Item> { self.next_impl() }
+}
+
+impl<'a, NodeRefT: NodeRefTrait> ChildrenTableIteratorStartIndex
+    for CompactedChildrenTableIterator<'a, NodeRefT>
+{
+    fn set_start_index(mut self, index: u8) -> Self {
+        self.set_start_index_impl(index);
+        self
     }
 }
 
@@ -527,7 +713,7 @@ impl<'a, NodeRefT: NodeRefTrait> CompactedChildrenTableIteratorTrait
     }
 }
 
-impl<'a, NodeRefT: NodeRefTrait> CompactedChildrenTableIteratorNextTrait
+impl<'a, NodeRefT: NodeRefTrait> CompactedChildrenTableIteratorImplTrait
     for CompactedChildrenTableIteratorMut<'a, NodeRefT>
 {
 }
@@ -537,8 +723,15 @@ impl<'a, NodeRefT: NodeRefTrait> Iterator
 {
     type Item = (u8, &'a mut NodeRefT);
 
-    fn next(&mut self) -> Option<Self::Item> {
-        <Self as CompactedChildrenTableIteratorNextTrait>::next(self)
+    fn next(&mut self) -> Option<Self::Item> { self.next_impl() }
+}
+
+impl<'a, NodeRefT: NodeRefTrait> ChildrenTableIteratorStartIndex
+    for CompactedChildrenTableIteratorMut<'a, NodeRefT>
+{
+    fn set_start_index(mut self, index: u8) -> Self {
+        self.set_start_index_impl(index);
+        self
     }
 }
 
@@ -603,3 +796,12 @@ impl<NodeRefT: NodeRefTrait> Decodable for ChildrenTable<NodeRefT> {
         })
     }
 }
+
+use super::{
+    merkle::{ChildrenMerkleTable, MaybeMerkleTable},
+    node_ref::NodeRefDeltaMptCompact,
+    WrappedCreateFrom,
+};
+use primitives::{MerkleHash, MERKLE_NULL_NODE};
+use rlp::*;
+use std::{fmt::*, marker::PhantomData, mem, ptr::null_mut, slice};

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/children_table.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/children_table.rs
@@ -78,6 +78,7 @@ where ChildrenTableItem<NodeRefT>: DefaultChildrenItem<NodeRefT>
     }
 }
 
+#[allow(unused)]
 impl<NodeRefT: 'static + NodeRefTrait> VanillaChildrenTable<NodeRefT>
 where ChildrenTableItem<NodeRefT>: DefaultChildrenItem<NodeRefT>
 {

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/compressed_path.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/compressed_path.rs
@@ -141,6 +141,7 @@ impl CompressedPathRaw {
         }
     }
 
+    // FIXME: check what's the nibble order in Ethereum's proof.
     pub fn first_nibble(x: u8) -> u8 { x & Self::BITS_0_3_MASK }
 
     pub fn second_nibble(x: u8) -> u8 { (x & Self::BITS_4_7_MASK) >> 4 }

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/compressed_path.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/compressed_path.rs
@@ -141,7 +141,6 @@ impl CompressedPathRaw {
         }
     }
 
-    // FIXME: check what's the nibble order in Ethereum's proof.
     pub fn first_nibble(x: u8) -> u8 { x & Self::BITS_0_3_MASK }
 
     pub fn second_nibble(x: u8) -> u8 { (x & Self::BITS_4_7_MASK) >> 4 }

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/mod.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/mod.rs
@@ -71,6 +71,6 @@ pub use self::{
     cow_node_ref::CowNodeRef,
     node_ref::{NodeRefDeltaMpt, NodeRefDeltaMptCompact},
     subtrie_visitor::SubTrieVisitor,
-    trie_node::TrieNode,
+    trie_node::{MemOptimizedTrieNode, TrieNodeTrait, VanillaTrieNode},
 };
 use std::cell::UnsafeCell;

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/node_ref.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/node_ref.rs
@@ -37,7 +37,7 @@ impl NodeRefDeltaMptCompact {
 }
 
 impl MaybeNodeRefDeltaMptCompact {
-    const NULL: u32 = 0;
+    pub const NULL: u32 = 0;
     pub const NULL_NODE: MaybeNodeRefDeltaMptCompact =
         MaybeNodeRefDeltaMptCompact { value: Self::NULL };
 

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/tests/rlp_encode_decode.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/tests/rlp_encode_decode.rs
@@ -86,16 +86,16 @@ fn test_trie_node_encode_decode() {
     }
 
     // TrieNode without compressed path.
-    let x = TrieNode::<CacheAlgoDataDeltaMpt>::new(
+    let x = MemOptimizedTrieNode::<CacheAlgoDataDeltaMpt>::new(
         &Default::default(),
         children_table,
         Some(b"asdf".to_vec().into_boxed_slice()),
         Default::default(),
     );
     let rlp_bytes = x.rlp_bytes();
-    let rlp_parsed = TrieNode::<CacheAlgoDataDeltaMpt>::decode(&Rlp::new(
-        rlp_bytes.as_slice(),
-    ))
+    let rlp_parsed = MemOptimizedTrieNode::<CacheAlgoDataDeltaMpt>::decode(
+        &Rlp::new(rlp_bytes.as_slice()),
+    )
     .unwrap();
 
     assert_eq!(rlp_parsed, x);

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/trie_node.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/trie_node.rs
@@ -300,7 +300,9 @@ make_parallel_field_maybe_in_place_byte_array_memory_manager!(
     TrieNodeValueSizeFieldConverter,
 );
 
-impl<CacheAlgoDataT: CacheAlgoDataTrait> Clone for MemOptimizedTrieNode<CacheAlgoDataT> {
+impl<CacheAlgoDataT: CacheAlgoDataTrait> Clone
+    for MemOptimizedTrieNode<CacheAlgoDataT>
+{
     fn clone(&self) -> Self {
         Self::new(
             &self.merkle_hash,
@@ -459,11 +461,7 @@ impl<CacheAlgoDataT: CacheAlgoDataTrait> MemOptimizedTrieNode<CacheAlgoDataT> {
                 .path
                 .get_slice(self.get_compressed_path_size() as usize)
                 .into(),
-            value: self
-                .value_clone()
-                .into_option()
-                .map(Into::into)
-                .unwrap_or_default(),
+            value: self.value_clone().into_option().map(|b| b.to_vec()),
             children_table: Default::default(),
             merkle_hash: self.merkle_hash,
         }

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/trie_node.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/trie_node.rs
@@ -173,6 +173,7 @@ where ChildrenTableItem<NodeRefT>: DefaultChildrenItem<NodeRefT>
     }
 }
 
+#[allow(unused)]
 impl<NodeRefT: NodeRefTrait> VanillaTrieNode<NodeRefT> {
     pub fn new(
         merkle: &MerkleHash, children_table: VanillaChildrenTable<NodeRefT>,
@@ -194,6 +195,7 @@ impl<NodeRefT: NodeRefTrait> VanillaTrieNode<NodeRefT> {
     }
 }
 
+#[allow(unused)]
 impl VanillaTrieNode<MerkleHash> {
     pub fn get_children_merkle(&self) -> MaybeMerkleTableRef {
         if self.get_children_count() > 0 {

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/trie_node.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/trie_node.rs
@@ -2,32 +2,239 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-// TODO(yz): statically check the size to be "around" 64B + 64B (merkle_hash)
-// TODO(yz): TrieNode should leave one byte so that it can be used to indicate a
-// free slot in memory region, in order to implement EntryTrait.
+/// Methods that a trie node type should implement in general.
+/// Note that merkle hash isn't necessarily stored together with
+/// a trie node because the merkle hash is mainly used when
+/// obtaining a proof or computed when committing a block.
+/// Merkle hash maybe stored in different way for IO optimizations.
+pub trait TrieNodeTrait: Default {
+    type NodeRefType: NodeRefTrait;
+    type ChildrenTableType;
+
+    fn compressed_path_ref(&self) -> CompressedPathRef;
+
+    fn has_value(&self) -> bool;
+
+    fn get_children_count(&self) -> u8;
+
+    fn value_as_slice(&self) -> MptValue<&[u8]>;
+
+    fn set_compressed_path(&mut self, compressed_path: CompressedPathRaw);
+
+    /// Unsafe because it's assumed that the child_index is valid but the child
+    /// doesn't exist.
+    unsafe fn add_new_child_unchecked<T>(&mut self, child_index: u8, child: T)
+    where ChildrenTableItem<Self::NodeRefType>:
+            WrappedCreateFrom<T, Self::NodeRefType>;
+
+    /// Unsafe because it's assumed that the child_index already exists.
+    unsafe fn replace_child_unchecked<T>(&mut self, child_index: u8, child: T)
+    where ChildrenTableItem<Self::NodeRefType>:
+            WrappedCreateFrom<T, Self::NodeRefType>;
+
+    /// Unsafe because it's assumed that the child_index already exists.
+    unsafe fn delete_child_unchecked(&mut self, child_index: u8);
+
+    /// Delete value when we know that it already exists.
+    unsafe fn delete_value_unchecked(&mut self) -> Box<[u8]>;
+
+    fn replace_value_valid(
+        &mut self, valid_value: Box<[u8]>,
+    ) -> MptValue<Box<[u8]>>;
+
+    fn get_children_table_ref(&self) -> &Self::ChildrenTableType;
+
+    fn compute_merkle(
+        &self, children_merkles: MaybeMerkleTableRef,
+    ) -> MerkleHash {
+        compute_merkle(
+            self.compressed_path_ref(),
+            children_merkles,
+            self.value_as_slice().into_option(),
+        )
+    }
+}
+
+// This trie node isn't memory efficient.
+#[derive(Clone)]
+pub struct VanillaTrieNode<NodeRefT: NodeRefTrait> {
+    compressed_path: CompressedPathRaw,
+    maybe_value: Option<Box<[u8]>>,
+    children_table: VanillaChildrenTable<NodeRefT>,
+    merkle_hash: MerkleHash,
+}
+
+impl<NodeRefT: 'static + NodeRefTrait> Default for VanillaTrieNode<NodeRefT>
+where ChildrenTableItem<NodeRefT>: DefaultChildrenItem<NodeRefT>
+{
+    fn default() -> Self {
+        Self {
+            compressed_path: Default::default(),
+            maybe_value: None,
+            children_table: Default::default(),
+            merkle_hash: MERKLE_NULL_NODE,
+        }
+    }
+}
+
+impl<'node, NodeRefT: 'static + NodeRefTrait> GetChildTrait<'node>
+    for VanillaTrieNode<NodeRefT>
+where ChildrenTableItem<NodeRefT>: DefaultChildrenItem<NodeRefT>
+{
+    type ChildIdType = &'node NodeRefT;
+
+    fn get_child(&'node self, child_index: u8) -> Option<&'node NodeRefT> {
+        self.children_table.get_child(child_index)
+    }
+}
+
+impl<NodeRefT: 'static + NodeRefTrait> TrieNodeTrait
+    for VanillaTrieNode<NodeRefT>
+where ChildrenTableItem<NodeRefT>: DefaultChildrenItem<NodeRefT>
+{
+    type ChildrenTableType = VanillaChildrenTable<NodeRefT>;
+    type NodeRefType = NodeRefT;
+
+    fn compressed_path_ref(&self) -> CompressedPathRef {
+        self.compressed_path.as_ref()
+    }
+
+    fn has_value(&self) -> bool { self.maybe_value.is_some() }
+
+    fn get_children_count(&self) -> u8 {
+        self.children_table.get_children_count()
+    }
+
+    fn value_as_slice(&self) -> MptValue<&[u8]> {
+        match &self.maybe_value {
+            None => MptValue::None,
+            Some(v) => {
+                if v.len() == 0 {
+                    MptValue::TombStone
+                } else {
+                    MptValue::Some(v.as_ref())
+                }
+            }
+        }
+    }
+
+    fn set_compressed_path(&mut self, compressed_path: CompressedPathRaw) {
+        self.compressed_path = compressed_path;
+    }
+
+    unsafe fn add_new_child_unchecked<T>(&mut self, child_index: u8, child: T)
+    where ChildrenTableItem<NodeRefT>: WrappedCreateFrom<T, NodeRefT> {
+        ChildrenTableItem::<NodeRefT>::take_from(
+            self.children_table.get_child_mut_unchecked(child_index),
+            child,
+        );
+        *self.children_table.get_children_count_mut() += 1;
+    }
+
+    unsafe fn replace_child_unchecked<T>(&mut self, child_index: u8, child: T)
+    where ChildrenTableItem<NodeRefT>: WrappedCreateFrom<T, NodeRefT> {
+        ChildrenTableItem::<NodeRefT>::take_from(
+            self.children_table.get_child_mut_unchecked(child_index),
+            child,
+        );
+    }
+
+    unsafe fn delete_child_unchecked(&mut self, child_index: u8) {
+        ChildrenTableItem::<NodeRefT>::take_from(
+            self.children_table.get_child_mut_unchecked(child_index),
+            ChildrenTableItem::<NodeRefT>::no_child(),
+        );
+        *self.children_table.get_children_count_mut() -= 1;
+    }
+
+    unsafe fn delete_value_unchecked(&mut self) -> Box<[u8]> {
+        self.maybe_value.take().unwrap()
+    }
+
+    fn replace_value_valid(
+        &mut self, valid_value: Box<[u8]>,
+    ) -> MptValue<Box<[u8]>> {
+        let old_value = self.maybe_value.replace(valid_value);
+
+        match old_value {
+            None => MptValue::None,
+            Some(v) => {
+                if v.len() == 0 {
+                    MptValue::TombStone
+                } else {
+                    MptValue::Some(v)
+                }
+            }
+        }
+    }
+
+    fn get_children_table_ref(&self) -> &VanillaChildrenTable<NodeRefT> {
+        &self.children_table
+    }
+}
+
+impl<NodeRefT: NodeRefTrait> VanillaTrieNode<NodeRefT> {
+    pub fn new(
+        merkle: &MerkleHash, children_table: VanillaChildrenTable<NodeRefT>,
+        maybe_value: Option<Box<[u8]>>, compressed_path: CompressedPathRaw,
+    ) -> Self
+    {
+        Self {
+            compressed_path,
+            maybe_value,
+            children_table,
+            merkle_hash: merkle.clone(),
+        }
+    }
+
+    pub fn get_merkle(&self) -> &MerkleHash { &self.merkle_hash }
+
+    pub fn set_merkle(&mut self, merkle: &MerkleHash) {
+        self.merkle_hash = merkle.clone();
+    }
+}
+
+impl VanillaTrieNode<MerkleHash> {
+    pub fn get_children_merkle(&self) -> MaybeMerkleTableRef {
+        if self.get_children_count() > 0 {
+            Some(&self.children_table.get_children_table())
+        } else {
+            None
+        }
+    }
+}
+
 /// A node consists of an optional compressed path (concept of Patricia
 /// Trie), an optional ChildrenTable (if the node is intermediate), an
 /// optional value attached, and the Merkle hash for subtree.
 #[derive(Default)]
-pub struct TrieNode<CacheAlgoDataT: CacheAlgoDataTrait> {
-    /// CompactPath section. The CompactPath if defined as separate struct
-    /// would consume 16B, while the current layout plus the
-    /// previous u8 field consumes 16B in total and keep integers
-    /// aligned.
+pub struct MemOptimizedTrieNode<CacheAlgoDataT: CacheAlgoDataTrait> {
+    /// Slab entry section. We keep a next vacant index of slab in case if the
+    /// slot is vacant. By keeping the next vacant index, we save extra 8B
+    /// space per trie node.
+    ///
+    /// The next vacant index is xor()ed by
+    /// NodeRefDeltaMptCompact::PERSISTENT_KEY_BIT so that 0 can be
+    /// reserved for "occupied" label.
+    slab_next_vacant_index: u32,
 
-    /// Can be: "no mask" (0x00), "second half" (second_nibble), "first half"
-    /// (first_nibble). When there is only one half-byte in path and it's
-    /// the "first half", both path_begin_mask and path_end_mask are set.
-    /// This field is not used in comparison because matching one more
-    /// half-byte at the beginning doesn't matter.
-    // TODO(yz): remove since it's unused, now it's always 0.
-    _path_begin_mask: u8,
-    /// Can be: "no mask" (0x00), "first half" (first_nibble).
-    /// When there is only one half-byte in path and it's the "second half",
-    /// only path_begin_mask is set, path_end_mask is set to "no mask",
-    /// because the first byte of path actually keeps the missing
-    /// "first half" so that it still matches to the corresponding byte of the
-    /// key.
+    ///
+    ///
+    /// CompactPath section. The CompactPath if defined as separate struct
+    /// would consume 16B, while the current expanded layout plus other u8
+    /// and u16 fields consumes 24B instead of 32B.
+
+    /// Conceptually, path_begin_mask can be: "no mask" (0x00), "second half"
+    /// (second_nibble), "first half" (first_nibble).
+    /// path_end_mask can be: "no mask" (0x00), "first half" (first_nibble).
+    ///
+    /// When there is only one half-byte in path and it's the "first half",
+    /// path_end_mask is set. When there is only one half-byte in path and
+    /// it's the "second half", compressed_path is set to one full byte
+    /// with the missing "first half", and path_end_mask is set to "no
+    /// mask". In comparison it still matches the corresponding byte of the
+    /// key. We don't store path_begin_mask because it isn't used at all in
+    /// comparison.
     path_end_mask: u8,
     /// 4 bits per step.
     /// We limit the maximum key steps by u16.
@@ -41,7 +248,7 @@ pub struct TrieNode<CacheAlgoDataT: CacheAlgoDataTrait> {
     >,
 
     // End of CompactPath section
-    // TODO(yz): maybe unpack the fields from ChildrenTableDeltaMpt to save
+    // TODO(yz): Unpack the fields from ChildrenTableDeltaMpt to save
     // memory. In this case create temporary ChildrenTableDeltaMpt for
     // update / iteration.
     pub(super) children_table: ChildrenTableDeltaMpt,
@@ -58,15 +265,24 @@ pub struct TrieNode<CacheAlgoDataT: CacheAlgoDataTrait> {
         MemOptimizedTrieNodeValueMemoryManager<CacheAlgoDataT>,
     >,
 
+    // TODO(yz): we don't have to store MerkleHash directly in TrieNode,
+    // because it's only used in proof and committing.
     /// The merkle hash without the compressed path.
-    pub(in super::super) merkle_hash: MerkleHash,
+    merkle_hash: MerkleHash,
 
     pub(in super::super) cache_algo_data: CacheAlgoDataT,
 }
 
+#[test]
+fn test_mem_optimized_trie_node_size() {
+    assert_eq!(std::mem::size_of::<TrieNodeDeltaMpt>(), 80);
+    // TrieNodeDeltaMpt itself as Slab entry saves space.
+    assert_ne!(std::mem::size_of::<Entry<TrieNodeDeltaMpt>>(), 80)
+}
+
 make_parallel_field_maybe_in_place_byte_array_memory_manager!(
     MemOptimizedTrieNodePathMemoryManager<CacheAlgoDataT> where <CacheAlgoDataT: CacheAlgoDataTrait>,
-    TrieNode<CacheAlgoDataT>,
+    MemOptimizedTrieNode<CacheAlgoDataT>,
     path_memory_manager,
     path,
     path_size: u16,
@@ -75,14 +291,14 @@ make_parallel_field_maybe_in_place_byte_array_memory_manager!(
 
 make_parallel_field_maybe_in_place_byte_array_memory_manager!(
     MemOptimizedTrieNodeValueMemoryManager<CacheAlgoDataT> where <CacheAlgoDataT: CacheAlgoDataTrait>,
-    TrieNode<CacheAlgoDataT>,
+    MemOptimizedTrieNode<CacheAlgoDataT>,
     value_memory_manager,
     value,
     value_size: u32,
     TrieNodeValueSizeFieldConverter,
 );
 
-impl<CacheAlgoDataT: CacheAlgoDataTrait> Clone for TrieNode<CacheAlgoDataT> {
+impl<CacheAlgoDataT: CacheAlgoDataTrait> Clone for MemOptimizedTrieNode<CacheAlgoDataT> {
     fn clone(&self) -> Self {
         Self::new(
             &self.merkle_hash,
@@ -115,14 +331,14 @@ make_parallel_field_maybe_in_place_byte_array_memory_manager!(
 /// It's Send because TrieNode is move only and it's impossible to change any
 /// part of it without &mut.
 unsafe impl<CacheAlgoDataT: CacheAlgoDataTrait> Send
-    for TrieNode<CacheAlgoDataT>
+    for MemOptimizedTrieNode<CacheAlgoDataT>
 {
 }
 /// Compiler is not sure about the pointer in MaybeInPlaceByteArray fields.
 /// We do not allow a &TrieNode to be able to change anything the pointer
 /// is pointing to, therefore TrieNode is Sync.
 unsafe impl<CacheAlgoDataT: CacheAlgoDataTrait> Sync
-    for TrieNode<CacheAlgoDataT>
+    for MemOptimizedTrieNode<CacheAlgoDataT>
 {
 }
 
@@ -154,7 +370,7 @@ impl SizeFieldConverterTrait<u32> for TrieNodeValueSizeFieldConverter {
     fn set(size_field: &mut u32, size: usize) { *size_field = size as u32; }
 }
 
-impl<CacheAlgoDataT: CacheAlgoDataTrait> TrieNode<CacheAlgoDataT> {
+impl<CacheAlgoDataT: CacheAlgoDataTrait> MemOptimizedTrieNode<CacheAlgoDataT> {
     pub fn get_compressed_path_size(&self) -> u16 { self.path_size }
 
     pub fn compressed_path_ref(&self) -> CompressedPathRef {
@@ -175,30 +391,6 @@ impl<CacheAlgoDataT: CacheAlgoDataTrait> TrieNode<CacheAlgoDataT> {
         let path_slice = new_path.path_slice;
         self.path =
             MaybeInPlaceByteArray::copy_from(path_slice, path_slice.len());
-    }
-
-    pub fn set_compressed_path(&mut self, mut path: CompressedPathRaw) {
-        self.path_end_mask = path.end_mask();
-
-        path.byte_array_memory_manager
-            .move_to(&mut self.path_memory_manager);
-    }
-
-    pub fn has_value(&self) -> bool { self.value_size > 0 }
-
-    fn get_children_count(&self) -> u8 {
-        self.children_table.get_children_count()
-    }
-
-    pub fn value_as_slice(&self) -> MptValue<&[u8]> {
-        let size = self.value_size;
-        if size == 0 {
-            MptValue::None
-        } else if size == TrieNodeValueSizeFieldConverter::VALUE_TOMBSTONE {
-            MptValue::TombStone
-        } else {
-            MptValue::Some(self.value.get_slice(size as usize))
-        }
     }
 
     pub fn value_clone(&self) -> MptValue<Box<[u8]>> {
@@ -230,22 +422,6 @@ impl<CacheAlgoDataT: CacheAlgoDataTrait> TrieNode<CacheAlgoDataT> {
             self.value_size = 0;
         }
         maybe_value
-    }
-
-    pub fn replace_value_valid(
-        &mut self, valid_value: &[u8],
-    ) -> MptValue<Box<[u8]>> {
-        let old_value = self.value_into_boxed_slice();
-        let value_size = valid_value.len();
-        if value_size == 0 {
-            self.value_size = TrieNodeValueSizeFieldConverter::VALUE_TOMBSTONE;
-        } else {
-            self.value =
-                MaybeInPlaceByteArray::copy_from(valid_value, value_size);
-            self.value_size = value_size as u32;
-        }
-
-        old_value
     }
 
     pub fn check_value_size(value: &[u8]) -> Result<()> {
@@ -286,28 +462,121 @@ impl<CacheAlgoDataT: CacheAlgoDataTrait> TrieNode<CacheAlgoDataT> {
                 .into_option()
                 .map(Into::into)
                 .unwrap_or_default(),
-            children_table: vec![],
+            children_table: Default::default(),
             merkle_hash: self.merkle_hash,
         }
     }
 }
 
-impl<CacheAlgoDataT: CacheAlgoDataTrait> TrieNode<CacheAlgoDataT> {
-    pub fn walk<'key, AM: AccessMode>(
-        &self, key: KeyPart<'key>,
-    ) -> WalkStop<'key, NodeRefDeltaMpt> {
-        walk::<AM, NodeRefDeltaMpt>(
-            key,
-            self.compressed_path_ref(),
-            self.path_end_mask,
-            &|index| self.get_child(index).map(Into::into),
-        )
+impl<CacheAlgoDataT: CacheAlgoDataTrait> TrieNodeTrait
+    for MemOptimizedTrieNode<CacheAlgoDataT>
+{
+    type ChildrenTableType = ChildrenTableDeltaMpt;
+    type NodeRefType = NodeRefDeltaMptCompact;
+
+    fn compressed_path_ref(&self) -> CompressedPathRef {
+        let size = self.path_size;
+        CompressedPathRef {
+            path_slice: self.path.get_slice(size as usize),
+            end_mask: self.path_end_mask,
+        }
+    }
+
+    fn has_value(&self) -> bool { self.value_size > 0 }
+
+    fn get_children_count(&self) -> u8 {
+        self.children_table.get_children_count()
+    }
+
+    fn value_as_slice(&self) -> MptValue<&[u8]> {
+        let size = self.value_size;
+        if size == 0 {
+            MptValue::None
+        } else if size == TrieNodeValueSizeFieldConverter::VALUE_TOMBSTONE {
+            MptValue::TombStone
+        } else {
+            MptValue::Some(self.value.get_slice(size as usize))
+        }
+    }
+
+    fn set_compressed_path(&mut self, mut path: CompressedPathRaw) {
+        self.path_end_mask = path.end_mask();
+
+        path.byte_array_memory_manager
+            .move_to(&mut self.path_memory_manager);
+    }
+
+    unsafe fn add_new_child_unchecked<T>(&mut self, child_index: u8, child: T)
+    where ChildrenTableItem<NodeRefDeltaMptCompact>:
+            WrappedCreateFrom<T, NodeRefDeltaMptCompact> {
+        self.children_table = CompactedChildrenTable::insert_child_unchecked(
+            self.children_table.to_ref(),
+            child_index,
+            ChildrenTableItem::<NodeRefDeltaMptCompact>::take(child),
+        );
+    }
+
+    unsafe fn replace_child_unchecked<T>(&mut self, child_index: u8, child: T)
+    where ChildrenTableItem<NodeRefDeltaMptCompact>:
+            WrappedCreateFrom<T, NodeRefDeltaMptCompact> {
+        self.children_table.set_child_unchecked(
+            child_index,
+            ChildrenTableItem::<NodeRefDeltaMptCompact>::take(child),
+        );
+    }
+
+    unsafe fn delete_child_unchecked(&mut self, child_index: u8) {
+        self.children_table = CompactedChildrenTable::delete_child_unchecked(
+            self.children_table.to_ref(),
+            child_index,
+        );
+    }
+
+    unsafe fn delete_value_unchecked(&mut self) -> Box<[u8]> {
+        self.value_into_boxed_slice().unwrap()
+    }
+
+    fn replace_value_valid(
+        &mut self, valid_value: Box<[u8]>,
+    ) -> MptValue<Box<[u8]>> {
+        let old_value = self.value_into_boxed_slice();
+        let value_size = valid_value.len();
+        if value_size == 0 {
+            self.value_size = TrieNodeValueSizeFieldConverter::VALUE_TOMBSTONE;
+        } else {
+            self.value = MaybeInPlaceByteArray::new(valid_value, value_size);
+            self.value_size = value_size as u32;
+        }
+
+        old_value
+    }
+
+    fn get_children_table_ref(&self) -> &ChildrenTableDeltaMpt {
+        &self.children_table
     }
 }
 
-/// The actions for the logical trie. Since we maintain a multiple version trie
-/// the action must be translated into trie node operations, which may vary
-/// depends on whether the node is owned by current version, etc.
+impl<'node, CacheAlgoDataT: CacheAlgoDataTrait> GetChildTrait<'node>
+    for MemOptimizedTrieNode<CacheAlgoDataT>
+{
+    type ChildIdType = NodeRefDeltaMptCompact;
+
+    fn get_child(
+        &'node self, child_index: u8,
+    ) -> Option<NodeRefDeltaMptCompact> {
+        self.children_table.get_child(child_index)
+    }
+}
+
+impl<CacheAlgoDataT: CacheAlgoDataTrait> MemOptimizedTrieNode<CacheAlgoDataT> {
+    pub fn walk<'key, 'node, AM: AccessMode>(
+        &'node self, key: KeyPart<'key>,
+    ) -> WalkStop<'key, NodeRefDeltaMptCompact> {
+        walk::<AM, _>(key, &self.compressed_path_ref(), self)
+    }
+}
+
+/// The action variants after a value deletion.
 pub enum TrieNodeAction {
     Modify,
     Delete,
@@ -317,21 +586,22 @@ pub enum TrieNodeAction {
     },
 }
 
-/// Update
-impl<CacheAlgoDataT: CacheAlgoDataTrait> TrieNode<CacheAlgoDataT> {
+/// The actual TrieNode type used in DeltaMpt.
+/// We'd like to keep as many of them as possible in memory.
+impl<CacheAlgoDataT: CacheAlgoDataTrait> MemOptimizedTrieNode<CacheAlgoDataT> {
     pub fn new(
         merkle: &MerkleHash, children_table: ChildrenTableDeltaMpt,
         maybe_value: Option<Box<[u8]>>, compressed_path: CompressedPathRaw,
-    ) -> TrieNode<CacheAlgoDataT>
+    ) -> MemOptimizedTrieNode<CacheAlgoDataT>
     {
-        let mut ret = TrieNode::default();
+        let mut ret = MemOptimizedTrieNode::default();
 
         ret.merkle_hash = *merkle;
         ret.children_table = children_table;
         match maybe_value {
             None => {}
             Some(value) => {
-                ret.replace_value_valid(value.as_ref());
+                ret.replace_value_valid(value);
             }
         }
         ret.set_compressed_path(compressed_path);
@@ -347,12 +617,12 @@ impl<CacheAlgoDataT: CacheAlgoDataTrait> TrieNode<CacheAlgoDataT> {
     /// 1. precondition on children_table;
     /// 2. delete value assumes that self contains some value.
     pub unsafe fn copy_and_replace_fields(
-        &self, new_value: Option<Option<&[u8]>>,
+        &self, new_value: Option<Option<Box<[u8]>>>,
         new_path: Option<CompressedPathRaw>,
         children_table: Option<ChildrenTableDeltaMpt>,
-    ) -> TrieNode<CacheAlgoDataT>
+    ) -> MemOptimizedTrieNode<CacheAlgoDataT>
     {
-        let mut ret = TrieNode::default();
+        let mut ret = MemOptimizedTrieNode::default();
 
         match new_value {
             Some(maybe_value) => match maybe_value {
@@ -382,11 +652,6 @@ impl<CacheAlgoDataT: CacheAlgoDataTrait> TrieNode<CacheAlgoDataT> {
         }
 
         ret
-    }
-
-    /// Delete value when we know that it already exists.
-    pub unsafe fn delete_value_unchecked(&mut self) -> Box<[u8]> {
-        self.value_into_boxed_slice().unwrap()
     }
 
     /// Returns: old_value, is_self_about_to_delete, replacement_node_for_self
@@ -426,41 +691,11 @@ impl<CacheAlgoDataT: CacheAlgoDataTrait> TrieNode<CacheAlgoDataT> {
         unsafe { unreachable_unchecked() }
     }
 
-    fn get_child(&self, child_index: u8) -> Option<NodeRefDeltaMptCompact> {
-        self.children_table.get_child(child_index)
-    }
-
     pub unsafe fn set_first_child_unchecked(
         &mut self, child_index: u8, child: NodeRefDeltaMptCompact,
     ) {
         self.children_table =
             ChildrenTableDeltaMpt::new_from_one_child(child_index, child);
-    }
-
-    pub unsafe fn add_new_child_unchecked(
-        &mut self, child_index: u8, child: NodeRefDeltaMptCompact,
-    ) {
-        self.children_table = CompactedChildrenTable::insert_child_unchecked(
-            self.children_table.to_ref(),
-            child_index,
-            child,
-        );
-    }
-
-    /// Unsafe because it's assumed that the child_index already exists.
-    pub unsafe fn delete_child_unchecked(&mut self, child_index: u8) {
-        self.children_table = CompactedChildrenTable::delete_child_unchecked(
-            self.children_table.to_ref(),
-            child_index,
-        );
-    }
-
-    /// Unsafe because it's assumed that the child_index already exists.
-    pub unsafe fn replace_child_unchecked(
-        &mut self, child_index: u8, new_child_node: NodeRefDeltaMptCompact,
-    ) {
-        self.children_table
-            .set_child_unchecked(child_index, new_child_node);
     }
 
     /// Returns old_child, is_self_about_to_delete, replacement_node_for_self
@@ -478,10 +713,65 @@ impl<CacheAlgoDataT: CacheAlgoDataTrait> TrieNode<CacheAlgoDataT> {
         }
         return TrieNodeAction::Modify;
     }
+
+    pub fn get_merkle(&self) -> &MerkleHash { &self.merkle_hash }
+
+    pub fn set_merkle(&mut self, merkle: &MerkleHash) {
+        self.merkle_hash = merkle.clone();
+    }
+}
+
+impl<CacheAlgoDataT: CacheAlgoDataTrait> EntryTrait
+    for MemOptimizedTrieNode<CacheAlgoDataT>
+{
+    type EntryType = MemOptimizedTrieNode<CacheAlgoDataT>;
+
+    fn from_value(value: Self) -> Self { value }
+
+    fn from_vacant_index(next: usize) -> Self {
+        Self {
+            slab_next_vacant_index: (next as u32)
+                ^ NodeRefDeltaMptCompact::DIRTY_SLOT_LIMIT,
+            children_table: Default::default(),
+            merkle_hash: Default::default(),
+            path_end_mask: 0,
+            path_size: 0,
+            path: Default::default(),
+            path_memory_manager: Default::default(),
+            value_size: 0,
+            value: Default::default(),
+            value_memory_manager: Default::default(),
+            cache_algo_data: Default::default(),
+        }
+    }
+
+    fn is_vacant(&self) -> bool {
+        // A valid next vacant index can't be 0.
+        self.slab_next_vacant_index != MaybeNodeRefDeltaMptCompact::NULL
+    }
+
+    fn take_occupied_and_replace_with_vacant_index(
+        &mut self, next: usize,
+    ) -> MemOptimizedTrieNode<CacheAlgoDataT> {
+        std::mem::replace(self, Self::from_vacant_index(next))
+    }
+
+    fn get_next_vacant_index(&self) -> usize {
+        (self.slab_next_vacant_index ^ NodeRefDeltaMptCompact::DIRTY_SLOT_LIMIT)
+            as usize
+    }
+
+    fn get_occupied_ref(&self) -> &MemOptimizedTrieNode<CacheAlgoDataT> { self }
+
+    fn get_occupied_mut(
+        &mut self,
+    ) -> &mut MemOptimizedTrieNode<CacheAlgoDataT> {
+        self
+    }
 }
 
 impl<CacheAlgoDataT: CacheAlgoDataTrait> Encodable
-    for TrieNode<CacheAlgoDataT>
+    for MemOptimizedTrieNode<CacheAlgoDataT>
 {
     fn rlp_append(&self, s: &mut RlpStream) {
         // Format: [ merkle, children_table ([] or [*16], value (maybe empty) ]
@@ -501,7 +791,7 @@ impl<CacheAlgoDataT: CacheAlgoDataTrait> Encodable
 }
 
 impl<CacheAlgoDataT: CacheAlgoDataTrait> Decodable
-    for TrieNode<CacheAlgoDataT>
+    for MemOptimizedTrieNode<CacheAlgoDataT>
 {
     fn decode(rlp: &Rlp) -> ::std::result::Result<Self, DecoderError> {
         let compressed_path;
@@ -511,7 +801,7 @@ impl<CacheAlgoDataT: CacheAlgoDataTrait> Decodable
             compressed_path = rlp.val_at(3)?;
         }
 
-        Ok(TrieNode::new(
+        Ok(MemOptimizedTrieNode::new(
             &rlp.val_at::<Vec<u8>>(0)?.as_slice().into(),
             rlp.val_at::<ChildrenTableManagedDeltaMpt>(1)?.into(),
             rlp.val_at::<Option<Vec<u8>>>(2)?
@@ -522,7 +812,7 @@ impl<CacheAlgoDataT: CacheAlgoDataTrait> Decodable
 }
 
 impl<CacheAlgoDataT: CacheAlgoDataTrait> PartialEq
-    for TrieNode<CacheAlgoDataT>
+    for MemOptimizedTrieNode<CacheAlgoDataT>
 {
     fn eq(&self, other: &Self) -> bool {
         self.value_as_slice() == other.value_as_slice()
@@ -532,9 +822,12 @@ impl<CacheAlgoDataT: CacheAlgoDataTrait> PartialEq
     }
 }
 
-impl<CacheAlgoDataT: CacheAlgoDataTrait> Debug for TrieNode<CacheAlgoDataT> {
+impl<CacheAlgoDataT: CacheAlgoDataTrait> Debug
+    for MemOptimizedTrieNode<CacheAlgoDataT>
+{
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        write!(f, "TrieNode{{ merkle: {:?}, value: {:?}, children_table: {:?}, compressed_path: {:?} }}",
+        write!(f,
+               "TrieNode{{ merkle: {:?}, value: {:?}, children_table: {:?}, compressed_path: {:?} }}",
                self.merkle_hash, self.value_as_slice(),
                &self.children_table, self.compressed_path_ref())
     }
@@ -543,15 +836,18 @@ impl<CacheAlgoDataT: CacheAlgoDataTrait> Debug for TrieNode<CacheAlgoDataT> {
 use super::{
     super::{
         super::errors::*, cache::algorithm::CacheAlgoDataTrait, node_ref::*,
+        slab::*,
     },
     children_table::*,
     compressed_path::*,
     maybe_in_place_byte_array::*,
+    merkle::{compute_merkle, MaybeMerkleTableRef},
     mpt_value::MptValue,
     trie_proof::TrieProofNode,
-    walk::{access_mode::AccessMode, walk, KeyPart, WalkStop},
+    walk::{access_mode::AccessMode, walk, GetChildTrait, KeyPart, WalkStop},
+    WrappedCreateFrom,
 };
-use primitives::MerkleHash;
+use primitives::{MerkleHash, MERKLE_NULL_NODE};
 use rlp::*;
 use std::{
     fmt::{Debug, Formatter},

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/trie_node.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/trie_node.rs
@@ -64,6 +64,24 @@ pub struct TrieNode<CacheAlgoDataT: CacheAlgoDataTrait> {
     pub(in super::super) cache_algo_data: CacheAlgoDataT,
 }
 
+make_parallel_field_maybe_in_place_byte_array_memory_manager!(
+    MemOptimizedTrieNodePathMemoryManager<CacheAlgoDataT> where <CacheAlgoDataT: CacheAlgoDataTrait>,
+    TrieNode<CacheAlgoDataT>,
+    path_memory_manager,
+    path,
+    path_size: u16,
+    TrivialSizeFieldConverterU16,
+);
+
+make_parallel_field_maybe_in_place_byte_array_memory_manager!(
+    MemOptimizedTrieNodeValueMemoryManager<CacheAlgoDataT> where <CacheAlgoDataT: CacheAlgoDataTrait>,
+    TrieNode<CacheAlgoDataT>,
+    value_memory_manager,
+    value,
+    value_size: u32,
+    TrieNodeValueSizeFieldConverter,
+);
+
 impl<CacheAlgoDataT: CacheAlgoDataTrait> Clone for TrieNode<CacheAlgoDataT> {
     fn clone(&self) -> Self {
         Self::new(

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/trie_node.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/trie_node.rs
@@ -275,6 +275,8 @@ pub struct MemOptimizedTrieNode<CacheAlgoDataT: CacheAlgoDataTrait> {
     pub(in super::super) cache_algo_data: CacheAlgoDataT,
 }
 
+#[cfg(test)]
+use super::super::node_memory_manager::TrieNodeDeltaMpt;
 #[test]
 fn test_mem_optimized_trie_node_size() {
     assert_eq!(std::mem::size_of::<TrieNodeDeltaMpt>(), 80);
@@ -312,24 +314,6 @@ impl<CacheAlgoDataT: CacheAlgoDataTrait> Clone
         )
     }
 }
-
-make_parallel_field_maybe_in_place_byte_array_memory_manager!(
-    MemOptimizedTrieNodePathMemoryManager<CacheAlgoDataT> where <CacheAlgoDataT: CacheAlgoDataTrait>,
-    TrieNode<CacheAlgoDataT>,
-    path_memory_manager,
-    path,
-    path_size: u16,
-    TrivialSizeFieldConverterU16,
-);
-
-make_parallel_field_maybe_in_place_byte_array_memory_manager!(
-    MemOptimizedTrieNodeValueMemoryManager<CacheAlgoDataT> where <CacheAlgoDataT: CacheAlgoDataTrait>,
-    TrieNode<CacheAlgoDataT>,
-    value_memory_manager,
-    value,
-    value_size: u32,
-    TrieNodeValueSizeFieldConverter,
-);
 
 /// Compiler is not sure about the pointer in MaybeInPlaceByteArray fields.
 /// It's Send because TrieNode is move only and it's impossible to change any
@@ -835,8 +819,8 @@ impl<CacheAlgoDataT: CacheAlgoDataTrait> Debug
 
 use super::{
     super::{
-        super::errors::*, cache::algorithm::CacheAlgoDataTrait, node_ref::*,
-        slab::*,
+        super::errors::*, cache::algorithm::CacheAlgoDataTrait,
+        node_ref::*, slab::*,
     },
     children_table::*,
     compressed_path::*,

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/trie_proof.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/trie_proof.rs
@@ -155,7 +155,7 @@ mod tests {
             let mut node = TrieProofNode::default();
             node.path_end_mask = 0x0f;
             node.path = vec![0x00, 0x01, 0x02];
-            node.value = vec![0x03, 0x04, 0x05];
+            node.value = Some(vec![0x03, 0x04, 0x05]);
             node.children_table = [KECCAK_EMPTY; 16].to_vec();
             node.merkle_hash = node.merkle();
             node
@@ -186,7 +186,7 @@ mod tests {
         let leaf1 = {
             let mut node = TrieProofNode::default();
             node.path = vec![0x02];
-            node.value = value1.clone();
+            node.value = Some(value1.clone());
             node.merkle_hash = node.merkle();
             node
         };
@@ -194,7 +194,7 @@ mod tests {
         let leaf2 = {
             let mut node = TrieProofNode::default();
             node.path = vec![0x03];
-            node.value = value2.clone();
+            node.value = Some(value2.clone());
             node.merkle_hash = node.merkle();
             node
         };

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/mod.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/mod.rs
@@ -128,7 +128,8 @@ impl MultiVersionMerklePatriciaTrie {
                         self.node_memory_manager.get_cache_manager(),
                         &mut false,
                     )?
-                    .merkle_hash,
+                    .get_merkle()
+                    .clone(),
             )),
             None => Ok(None),
         }

--- a/core/src/storage/impls/state.rs
+++ b/core/src/storage/impls/state.rs
@@ -159,8 +159,7 @@ impl<'a> StateTrait for State<'a> {
         self.get_from_all_tries(access_key, true)
     }
 
-    // FIXME: re-implement all other methods.
-    fn set(&mut self, access_key: &[u8], value: &[u8]) -> Result<()> {
+    fn set(&mut self, access_key: &[u8], value: Box<[u8]>) -> Result<()> {
         self.pre_modification();
 
         let root_node = self.get_or_create_root_node()?;

--- a/core/src/storage/state.rs
+++ b/core/src/storage/state.rs
@@ -32,7 +32,7 @@ pub trait StateTrait {
     fn get_with_proof(
         &self, access_key: &[u8],
     ) -> Result<(Option<Box<[u8]>>, StateProof)>;
-    fn set(&mut self, access_key: &[u8], value: &[u8]) -> Result<()>;
+    fn set(&mut self, access_key: &[u8], value: Box<[u8]>) -> Result<()>;
     fn delete(&mut self, access_key: &[u8]) -> Result<Option<Box<[u8]>>>;
     // Delete everything prefixed by access_key and return deleted key value
     // pairs.

--- a/core/src/storage/tests/state.rs
+++ b/core/src/storage/tests/state.rs
@@ -62,7 +62,9 @@ fn test_set_get() {
     println!("Testing with {} set operations.", keys.len());
 
     for key in &keys {
-        state.set(key, key).expect("Failed to insert key.");
+        state
+            .set(key, key[..].into())
+            .expect("Failed to insert key.");
     }
 
     rng.shuffle(keys.as_mut());
@@ -98,7 +100,9 @@ fn test_get_set_at_second_commit() {
     println!("Setting state_0 with {} keys.", keys_0.len());
 
     for key in keys_0 {
-        state_0.set(key, key).expect("Failed to insert key.");
+        state_0
+            .set(key, key[..].into())
+            .expect("Failed to insert key.");
     }
 
     let mut epoch_id_0 = H256::default();;
@@ -114,7 +118,7 @@ fn test_get_set_at_second_commit() {
     for key in keys_1_new {
         let value = vec![&key[..], &key[..]].concat();
         state_1
-            .set(key, value.as_slice())
+            .set(key, value.into())
             .expect("Failed to insert key.");
     }
 
@@ -131,7 +135,7 @@ fn test_get_set_at_second_commit() {
         assert_eq!(equal, true);
         let value = vec![&key[..], &key[..]].concat();
         state_1
-            .set(key, value.as_slice())
+            .set(key, value.into())
             .expect("Failed to insert key.");
     }
 
@@ -186,7 +190,9 @@ fn test_set_delete() {
 
     // Insert part 1 and commit.
     for key in keys_0.iter() {
-        state.set(key, key).expect("Failed to insert key.");
+        state
+            .set(key, key[..].into())
+            .expect("Failed to insert key.");
     }
     let mut epoch_id = H256::default();
     epoch_id[0] = 1;
@@ -199,7 +205,9 @@ fn test_set_delete() {
         .unwrap()
         .unwrap();
     for key in keys_1.iter() {
-        state.set(key, key).expect("Failed to insert key.");
+        state
+            .set(key, key[..].into())
+            .expect("Failed to insert key.");
     }
 
     rng.shuffle(keys.as_mut());
@@ -241,7 +249,7 @@ fn test_set_delete_all() {
     // Insert part 1 and commit.
     for key in keys_0.iter() {
         state
-            .set(vec![&key[..], &key[..]].concat().as_slice(), key)
+            .set(vec![&key[..], &key[..]].concat().as_slice(), key[..].into())
             .expect("Failed to insert key.");
     }
     let mut epoch_id = H256::default();
@@ -256,7 +264,7 @@ fn test_set_delete_all() {
         .unwrap();
     for key in keys_1.iter() {
         state
-            .set(vec![&key[..], &key[..]].concat().as_slice(), key)
+            .set(vec![&key[..], &key[..]].concat().as_slice(), key[..].into())
             .expect("Failed to insert key.");
     }
 
@@ -327,7 +335,7 @@ fn test_set_order() {
         let actual_key = vec![key_slice; 3].concat();
         let actual_value = vec![key_slice; 1 + (key[0] % 21) as usize].concat();
         state_0
-            .set(&actual_key, &actual_value)
+            .set(&actual_key, actual_value.into())
             .expect("Failed to insert key.");
     }
     let _merkle_0 = state_0.compute_state_root().unwrap();
@@ -341,7 +349,7 @@ fn test_set_order() {
         let actual_key = vec![key_slice; 3].concat();
         let actual_value = vec![key_slice; 1 + (key[0] % 32) as usize].concat();
         state_1
-            .set(&actual_key, &actual_value)
+            .set(&actual_key, actual_value.into())
             .expect("Failed to insert key.");
     }
     let merkle_1 = state_1.compute_state_root().unwrap();
@@ -355,7 +363,7 @@ fn test_set_order() {
         let actual_key = vec![key_slice; 3].concat();
         let actual_value = vec![key_slice; 1 + (key[0] % 32) as usize].concat();
         state_2
-            .set(&actual_key, &actual_value)
+            .set(&actual_key, actual_value.into())
             .expect("Failed to insert key.");
     }
     let merkle_2 = state_2.compute_state_root().unwrap();
@@ -385,7 +393,7 @@ fn test_set_order_concurrent() {
         let actual_key = vec![key_slice; 3].concat();
         let actual_value = vec![key_slice; 1 + (key[0] % 21) as usize].concat();
         state_0
-            .set(&actual_key, &actual_value)
+            .set(&actual_key, actual_value.into())
             .expect("Failed to insert key.");
     }
     let _merkle_0 = state_0.compute_state_root().unwrap();
@@ -407,7 +415,7 @@ fn test_set_order_concurrent() {
         let actual_key = vec![key_slice; 3].concat();
         let actual_value = vec![key_slice; 1 + (key[0] % 32) as usize].concat();
         state_1
-            .set(&actual_key, &actual_value)
+            .set(&actual_key, actual_value.into())
             .expect("Failed to insert key.");
     }
     let merkle_1 = state_1.compute_state_root().unwrap();
@@ -446,7 +454,7 @@ fn test_set_order_concurrent() {
                 let actual_value =
                     vec![key_slice; 1 + (key[0] % 32) as usize].concat();
                 state_2
-                    .set(&actual_key, &actual_value)
+                    .set(&actual_key, actual_value.into())
                     .expect("Failed to insert key.");
             }
             let merkle_2 = state_2.compute_state_root().unwrap();
@@ -480,7 +488,9 @@ fn test_proofs() {
         .collect();
 
     for key in &keys {
-        state.set(key, key).expect("Failed to insert key.");
+        state
+            .set(key, key[..].into())
+            .expect("Failed to insert key.");
     }
 
     let mut epoch_id = H256::default();


### PR DESCRIPTION
* Add a new plain VanillaTrieNode for snapshot mpt;
* Adding start_index for children iteration for merging snapshot_mpt with delta_mpt;
* Change TrieNode value interface to deal with Box<[u8]> instead of &[u8]
* Fix some trie node proof logic because empty value != value of 0 len in delta mpt. None means no value, empty string means TOMBSTONE(value of snapshot mpt deleted in delta mpt).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/509)
<!-- Reviewable:end -->
