### PR TITLE
Relay new block hashes to light nodes

### DIFF
--- a/client/src/full/mod.rs
+++ b/client/src/full/mod.rs
@@ -9,10 +9,11 @@ pub use crate::configuration::Configuration;
 use blockgen::BlockGenerator;
 
 use cfxcore::{
-    genesis, statistics::Statistics, storage::StorageManager,
-    sync::SyncPhaseType, transaction_pool::DEFAULT_MAX_BLOCK_GAS_LIMIT,
-    vm_factory::VmFactory, ConsensusGraph, SynchronizationGraph,
-    SynchronizationService, TransactionPool, WORKER_COMPUTATION_PARALLELISM,
+    genesis, light_protocol::QueryProvider, statistics::Statistics,
+    storage::StorageManager, sync::SyncPhaseType,
+    transaction_pool::DEFAULT_MAX_BLOCK_GAS_LIMIT, vm_factory::VmFactory,
+    ConsensusGraph, SynchronizationGraph, SynchronizationService,
+    TransactionPool, WORKER_COMPUTATION_PARALLELISM,
 };
 
 use crate::rpc::{
@@ -198,6 +199,10 @@ impl FullClient {
             Arc::new(network)
         };
 
+        let light_provider =
+            Arc::new(QueryProvider::new(consensus.clone(), sync_graph.clone()));
+        light_provider.clone().register(network.clone()).unwrap();
+
         let initial_sync_phase = SyncPhaseType::CatchUpRecoverBlockHeaderFromDB;
         let sync = Arc::new(SynchronizationService::new(
             true,
@@ -205,6 +210,7 @@ impl FullClient {
             sync_graph.clone(),
             protocol_config,
             initial_sync_phase,
+            light_provider,
         ));
         sync.register().unwrap();
 

--- a/core/src/light_protocol/error.rs
+++ b/core/src/light_protocol/error.rs
@@ -53,6 +53,11 @@ error_chain! {
             display("Pivot hash mismatch"),
         }
 
+        SendStatusFailed {
+            description("Send status failed"),
+            display("Send status failed"),
+        }
+
         UnexpectedRequestId {
             description("Unexpected request id"),
             display("Unexpected request id"),
@@ -92,11 +97,16 @@ pub fn handle(io: &NetworkContext, peer: PeerId, msg_id: MsgId, e: Error) {
     // NOTE: do not use wildcard; this way, the compiler
     // will help covering all the cases.
     match e.0 {
-        // NOTE: to help with backward-compatibility, we
-        // should not disconnect on `UnknownMessage`
         ErrorKind::NoResponse
         | ErrorKind::InternalError
         | ErrorKind::PivotHashMismatch
+
+        // NOTE: in order to let other protocols run,
+        // we should not disconnect on protocol failure
+        | ErrorKind::SendStatusFailed
+
+        // NOTE: to help with backward-compatibility, we
+        // should not disconnect on `UnknownMessage`
         | ErrorKind::UnknownMessage => disconnect = false,
 
         ErrorKind::GenesisMismatch

--- a/core/src/light_protocol/handler/mod.rs
+++ b/core/src/light_protocol/handler/mod.rs
@@ -3,7 +3,6 @@
 // See http://www.gnu.org/licenses/
 
 mod handler;
-mod peers;
 mod query;
 mod sync;
 

--- a/core/src/light_protocol/message/message.rs
+++ b/core/src/light_protocol/message/message.rs
@@ -17,6 +17,7 @@ build_msgid! {
     BLOCK_HASHES = 0x06
     GET_BLOCK_HEADERS = 0x07
     BLOCK_HEADERS = 0x08
+    NEW_BLOCK_HASHES = 0x09
 
     INVALID = 0xff
 }
@@ -31,6 +32,7 @@ build_msg_impl! { GetBlockHashesByEpoch, msgid::GET_BLOCK_HASHES_BY_EPOCH, "GetB
 build_msg_impl! { BlockHashes, msgid::BLOCK_HASHES, "BlockHashes" }
 build_msg_impl! { GetBlockHeaders, msgid::GET_BLOCK_HEADERS, "GetBlockHeaders" }
 build_msg_impl! { BlockHeaders, msgid::BLOCK_HEADERS, "BlockHeaders" }
+build_msg_impl! { NewBlockHashes, msgid::NEW_BLOCK_HASHES, "NewBlockHashes" }
 
 // generate `impl HasRequestId for _` for each request type
 build_has_request_id_impl! { GetStateRoot }

--- a/core/src/light_protocol/message/mod.rs
+++ b/core/src/light_protocol/message/mod.rs
@@ -3,10 +3,12 @@
 // See http://www.gnu.org/licenses/
 
 mod message;
+mod node_type;
 mod protocol;
 
 pub use message::msgid;
+pub use node_type::NodeType;
 pub use protocol::{
     BlockHashes, BlockHeaders, GetBlockHashesByEpoch, GetBlockHeaders,
-    GetStateEntry, GetStateRoot, StateEntry, StateRoot, Status,
+    GetStateEntry, GetStateRoot, NewBlockHashes, StateEntry, StateRoot, Status,
 };

--- a/core/src/light_protocol/message/node_type.rs
+++ b/core/src/light_protocol/message/node_type.rs
@@ -1,0 +1,51 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+
+#[derive(Clone, Debug, PartialEq)]
+#[repr(u8)]
+pub enum NodeType {
+    Full,
+    Light,
+    Unknown,
+}
+
+impl Default for NodeType {
+    fn default() -> NodeType { NodeType::Unknown }
+}
+
+impl From<u8> for NodeType {
+    fn from(raw: u8) -> NodeType {
+        match raw {
+            0 => NodeType::Full,
+            1 => NodeType::Light,
+            _ => NodeType::Unknown,
+        }
+    }
+}
+
+impl From<&NodeType> for u8 {
+    fn from(node_type: &NodeType) -> u8 {
+        match node_type {
+            NodeType::Full => 0,
+            NodeType::Light => 1,
+            NodeType::Unknown => 0xff,
+        }
+    }
+}
+
+impl Encodable for NodeType {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        let raw: u8 = self.into();
+        s.append_internal(&raw);
+    }
+}
+
+impl Decodable for NodeType {
+    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+        let raw: u8 = rlp.as_val()?;
+        Ok(NodeType::from(raw))
+    }
+}

--- a/core/src/light_protocol/message/protocol.rs
+++ b/core/src/light_protocol/message/protocol.rs
@@ -2,6 +2,7 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
+use super::NodeType;
 use crate::{message::RequestId, storage::StateProof};
 use cfx_types::H256;
 use primitives::{
@@ -11,10 +12,11 @@ use rlp_derive::{RlpDecodable, RlpEncodable};
 
 #[derive(Clone, Debug, PartialEq, RlpEncodable, RlpDecodable)]
 pub struct Status {
-    pub protocol_version: u8,
-    pub network_id: u8,
-    pub genesis_hash: H256,
     pub best_epoch: u64,
+    pub genesis_hash: H256,
+    pub network_id: u8,
+    pub node_type: NodeType,
+    pub protocol_version: u8,
     pub terminals: Vec<H256>,
 }
 
@@ -69,4 +71,9 @@ pub struct GetBlockHeaders {
 pub struct BlockHeaders {
     pub request_id: RequestId,
     pub headers: Vec<PrimitiveBlockHeader>,
+}
+
+#[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
+pub struct NewBlockHashes {
+    pub hashes: Vec<H256>,
 }

--- a/core/src/light_protocol/mod.rs
+++ b/core/src/light_protocol/mod.rs
@@ -5,6 +5,7 @@
 mod error;
 mod handler;
 mod message;
+mod peers;
 mod query_provider;
 mod query_service;
 

--- a/core/src/light_protocol/query_provider.rs
+++ b/core/src/light_protocol/query_provider.rs
@@ -3,6 +3,7 @@
 // See http://www.gnu.org/licenses/
 
 use io::TimerToken;
+use rand::Rng;
 use rlp::Rlp;
 use std::sync::Arc;
 
@@ -12,7 +13,10 @@ use primitives::{BlockHeader, EpochNumber, StateRoot};
 use crate::{
     consensus::ConsensusGraph,
     message::{Message, MsgId},
-    network::{NetworkContext, NetworkProtocolHandler, NetworkService, PeerId},
+    network::{
+        throttling::THROTTLING_SERVICE, NetworkContext, NetworkProtocolHandler,
+        NetworkService, PeerId,
+    },
     statedb::StateDb,
     storage::{
         state_manager::StateManagerTrait, SnapshotAndEpochIdRef, StateProof,
@@ -25,10 +29,11 @@ use super::{
     message::{
         msgid, BlockHashes as GetBlockHashesResponse,
         BlockHeaders as GetBlockHeadersResponse, GetBlockHashesByEpoch,
-        GetBlockHeaders, GetStateEntry, GetStateRoot,
+        GetBlockHeaders, GetStateEntry, GetStateRoot, NewBlockHashes, NodeType,
         StateEntry as GetStateEntryResponse, StateRoot as GetStateRootResponse,
         Status,
     },
+    peers::Peers,
     Error, ErrorKind, LIGHT_PROTOCOL_ID, LIGHT_PROTOCOL_VERSION,
 };
 use crate::parameters::consensus::DEFERRED_STATE_EPOCH_COUNT;
@@ -39,13 +44,20 @@ pub const MAX_HEADERS_TO_SEND: usize = 512;
 pub struct QueryProvider {
     consensus: Arc<ConsensusGraph>,
     graph: Arc<SynchronizationGraph>,
+    peers: Peers,
 }
 
 impl QueryProvider {
     pub fn new(
         consensus: Arc<ConsensusGraph>, graph: Arc<SynchronizationGraph>,
     ) -> Self {
-        QueryProvider { consensus, graph }
+        let peers = Peers::new();
+
+        QueryProvider {
+            consensus,
+            graph,
+            peers,
+        }
     }
 
     pub fn register(
@@ -68,7 +80,10 @@ impl QueryProvider {
     ) -> Result<(), Error> {
         trace!("Dispatching message: peer={:?}, msg_id={:?}", peer, msg_id);
 
+        // TODO(thegaram): check if peer is known
+
         match msg_id {
+            msgid::STATUS => self.on_status(io, peer, &rlp),
             msgid::GET_STATE_ROOT => self.on_get_state_root(io, peer, &rlp),
             msgid::GET_STATE_ENTRY => self.on_get_state_entry(io, peer, &rlp),
             msgid::GET_BLOCK_HASHES_BY_EPOCH => self.on_get_block_hashes_by_epoch(io, peer, &rlp),
@@ -134,14 +149,50 @@ impl QueryProvider {
         };
 
         let msg: Box<dyn Message> = Box::new(Status {
-            protocol_version: LIGHT_PROTOCOL_VERSION,
-            network_id: 0x0,
-            genesis_hash,
             best_epoch: best_info.best_epoch_number,
+            genesis_hash,
+            network_id: 0x0,
+            node_type: NodeType::Full,
+            protocol_version: LIGHT_PROTOCOL_VERSION,
             terminals,
         });
 
         msg.send(io, peer)?;
+        Ok(())
+    }
+
+    #[inline]
+    fn validate_genesis_hash(&self, genesis: H256) -> Result<(), Error> {
+        match self.consensus.data_man.true_genesis_block.hash() {
+            h if h == genesis => Ok(()),
+            h => {
+                debug!(
+                    "Genesis mismatch (ours: {:?}, theirs: {:?})",
+                    h, genesis
+                );
+                Err(ErrorKind::GenesisMismatch.into())
+            }
+        }
+    }
+
+    fn on_status(
+        &self, _io: &NetworkContext, peer: PeerId, rlp: &Rlp,
+    ) -> Result<(), Error> {
+        let status: Status = rlp.as_val()?;
+        info!("on_status peer={:?} status={:?}", peer, status);
+
+        self.validate_genesis_hash(status.genesis_hash)?;
+        // TODO(thegaram): check protocol version
+
+        let peer_state = self.peers.insert(peer);
+        let mut state = peer_state.write();
+
+        state.best_epoch = status.best_epoch;
+        state.genesis_hash = status.genesis_hash;
+        state.node_type = status.node_type;
+        state.protocol_version = status.protocol_version;
+        state.terminals = status.terminals.into_iter().collect();
+
         Ok(())
     }
 
@@ -236,6 +287,49 @@ impl QueryProvider {
         msg.send(io, peer)?;
         Ok(())
     }
+
+    fn broadcast(
+        &self, io: &NetworkContext, mut peers: Vec<PeerId>, msg: &Message,
+    ) -> Result<(), Error> {
+        let throttle_ratio = THROTTLING_SERVICE.read().get_throttling_ratio();
+        let total = peers.len();
+        let allowed = (total as f64 * throttle_ratio) as usize;
+
+        if total > allowed {
+            debug!(
+                "Apply throttling for broadcast, total: {}, allowed: {}",
+                total, allowed
+            );
+            rand::thread_rng().shuffle(&mut peers);
+            peers.truncate(allowed);
+        }
+
+        for id in peers {
+            msg.send(io, id)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn relay_hashes(
+        &self, io: &NetworkContext, hashes: Vec<H256>,
+    ) -> Result<(), Error> {
+        if hashes.is_empty() {
+            return Ok(());
+        }
+
+        let peers = self
+            .peers
+            .all_peers_satisfying(|state| state.node_type == NodeType::Light);
+
+        let msg: Box<dyn Message> = Box::new(NewBlockHashes { hashes });
+
+        if let Err(e) = self.broadcast(io, peers, msg.as_ref()) {
+            warn!("Error broadcasting blocks: {:?}", e);
+        };
+
+        Ok(())
+    }
 }
 
 impl NetworkProtocolHandler for QueryProvider {
@@ -263,13 +357,25 @@ impl NetworkProtocolHandler for QueryProvider {
     fn on_peer_connected(&self, io: &NetworkContext, peer: PeerId) {
         info!("on_peer_connected: peer={:?}", peer);
 
-        if let Err(e) = self.send_status(io, peer) {
-            warn!("Error while sending status: {}", e);
+        match self.send_status(io, peer) {
+            Ok(_) => {
+                self.peers.insert(peer);
+            }
+            Err(e) => {
+                warn!("Error while sending status: {}", e);
+                handle_error(
+                    io,
+                    peer,
+                    msgid::INVALID,
+                    ErrorKind::SendStatusFailed.into(),
+                );
+            }
         }
     }
 
     fn on_peer_disconnected(&self, _io: &NetworkContext, peer: PeerId) {
         info!("on_peer_disconnected: peer={:?}", peer);
+        self.peers.remove(&peer);
     }
 
     fn on_timeout(&self, _io: &NetworkContext, _timer: TimerToken) {

--- a/core/src/sync/synchronization_service.rs
+++ b/core/src/sync/synchronization_service.rs
@@ -6,6 +6,7 @@ use super::{
     Error, SharedSynchronizationGraph, SynchronizationProtocolHandler,
 };
 use crate::{
+    light_protocol::QueryProvider,
     parameters::sync::SYNCHRONIZATION_PROTOCOL_VERSION,
     sync::{
         synchronization_phases::SyncPhaseType,
@@ -28,7 +29,7 @@ impl SynchronizationService {
         is_full_node: bool, network: Arc<NetworkService>,
         sync_graph: SharedSynchronizationGraph,
         protocol_config: ProtocolConfiguration,
-        initial_sync_phase: SyncPhaseType,
+        initial_sync_phase: SyncPhaseType, light_provider: Arc<QueryProvider>,
     ) -> Self
     {
         let sync_handler = Arc::new(SynchronizationProtocolHandler::new(
@@ -36,6 +37,7 @@ impl SynchronizationService {
             protocol_config,
             initial_sync_phase,
             sync_graph,
+            light_provider,
         ));
 
         SynchronizationService {


### PR DESCRIPTION
**Overview**

- Add status message to both `light_protocol::Provider` (full node side) and `light_protocol::Handler` (light node side). The status message specifies the sender's node type.
- Relay new block hashes from `SynchronizationProtocolHandler` to `light_protocol::QueryProvider`. The provider will broadcast these to all light node peers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/512)
<!-- Reviewable:end -->
