### PR TITLE
Add tags for P2P node

### DIFF
--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/trie_node.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/trie_node.rs
@@ -819,8 +819,8 @@ impl<CacheAlgoDataT: CacheAlgoDataTrait> Debug
 
 use super::{
     super::{
-        super::errors::*, cache::algorithm::CacheAlgoDataTrait,
-        node_ref::*, slab::*,
+        super::errors::*, cache::algorithm::CacheAlgoDataTrait, node_ref::*,
+        slab::*,
     },
     children_table::*,
     compressed_path::*,

--- a/network/src/error.rs
+++ b/network/src/error.rs
@@ -14,6 +14,7 @@ pub enum DisconnectReason {
     WrongEndpointInfo,
     IpLimited,
     UpdateNodeIdFailed,
+    Blacklisted,
     Unknown,
 }
 
@@ -25,6 +26,7 @@ impl DisconnectReason {
             2 => DisconnectReason::WrongEndpointInfo,
             3 => DisconnectReason::IpLimited,
             4 => DisconnectReason::UpdateNodeIdFailed,
+            5 => DisconnectReason::Blacklisted,
             _ => DisconnectReason::Unknown,
         }
     }
@@ -38,6 +40,7 @@ impl fmt::Display for DisconnectReason {
             DisconnectReason::WrongEndpointInfo => "wrong node id",
             DisconnectReason::IpLimited => "IP limited",
             DisconnectReason::UpdateNodeIdFailed => "Update node id failed",
+            DisconnectReason::Blacklisted => "blacklisted",
             DisconnectReason::Unknown => "unknown",
         };
 

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -244,6 +244,9 @@ pub trait NetworkContext {
     ) -> Result<(), Error>;
 
     fn dispatch_work(&self, work_type: HandlerWorkType);
+
+    fn insert_peer_node_tag(&self, peer: PeerId, key: &str, value: &str);
+    fn remove_peer_node_tag(&self, peer: PeerId, key: &str);
 }
 
 #[derive(Debug, Clone)]

--- a/network/src/node_database.rs
+++ b/network/src/node_database.rs
@@ -236,6 +236,16 @@ impl NodeDatabase {
         })
     }
 
+    pub fn get_mut(&mut self, id: &NodeId) -> Option<&mut Node> {
+        if let Some(node) = self.trusted_nodes.get_mut(id) {
+            Some(node)
+        } else if let Some(node) = self.untrusted_nodes.get_mut(id) {
+            Some(node)
+        } else {
+            None
+        }
+    }
+
     pub fn get_with_trusty(&self, id: &NodeId) -> Option<(bool, &Node)> {
         if let Some(node) = self.trusted_nodes.get(id) {
             Some((true, node))

--- a/network/src/node_table.rs
+++ b/network/src/node_table.rs
@@ -239,6 +239,14 @@ pub struct Node {
     // does not need to be made persistent.
     pub last_connected: Option<NodeContact>,
     pub stream_token: Option<StreamToken>,
+    // Generally, it is used by protocol handler layer to attach
+    // some tags to node, so as to:
+    // 1. Sampling nodes with special tags, e.g.
+    //     - archive nodes first
+    //     - good credit nodes first
+    //     - good network nodes first
+    // 2. Refuse incoming connection from node with special tags.
+    pub tags: HashMap<String, String>,
 }
 
 impl Node {
@@ -249,7 +257,16 @@ impl Node {
             last_contact: None,
             last_connected: None,
             stream_token: None,
+            tags: Default::default(),
         }
+    }
+
+    pub fn set_blacklisted(&mut self) {
+        self.tags.insert("blacklisted".into(), true.to_string());
+    }
+
+    pub fn is_blacklisted(&self) -> bool {
+        self.tags.contains_key("blacklisted".into())
     }
 }
 
@@ -290,6 +307,7 @@ impl FromStr for Node {
             last_contact: None,
             last_connected: None,
             stream_token: None,
+            tags: Default::default(),
         })
     }
 }
@@ -855,6 +873,7 @@ mod json {
     pub struct Node {
         pub url: String,
         pub last_contact: Option<NodeContact>,
+        pub tags: HashMap<String, String>,
     }
 
     impl Node {
@@ -863,6 +882,7 @@ mod json {
                 Ok(mut node) => {
                     node.last_contact =
                         self.last_contact.map(NodeContact::into_node_contact);
+                    node.tags = self.tags;
                     Some(node)
                 }
                 _ => None,
@@ -886,6 +906,7 @@ mod json {
             Node {
                 url: format!("{}", node),
                 last_contact,
+                tags: node.tags.clone(),
             }
         }
     }


### PR DESCRIPTION
1. Allow to set node as blacklisted, and refuse its incoming TCP connection.
2. Allow network protocol handler layer to set custom node tag, so as to sampling nodes with desired tags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/518)
<!-- Reviewable:end -->
