### PR TITLE
light-node: add ping-pong handshake

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -2,7 +2,10 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
+// Recursion limit raised for error_chain
+#![recursion_limit = "128"]
 #![allow(deprecated)]
+
 extern crate cfx_bytes as bytes;
 extern crate core;
 extern crate elastic_array;

--- a/core/src/light_protocol/error.rs
+++ b/core/src/light_protocol/error.rs
@@ -58,6 +58,16 @@ error_chain! {
             display("Send status failed"),
         }
 
+        UnexpectedMessage {
+            description("Unexpected message"),
+            display("Unexpected message"),
+        }
+
+        UnexpectedPeerType {
+            description("Unexpected peer type"),
+            display("Unexpected peer type"),
+        }
+
         UnexpectedRequestId {
             description("Unexpected request id"),
             display("Unexpected request id"),
@@ -110,6 +120,8 @@ pub fn handle(io: &NetworkContext, peer: PeerId, msg_id: MsgId, e: Error) {
         | ErrorKind::UnknownMessage => disconnect = false,
 
         ErrorKind::GenesisMismatch
+        | ErrorKind::UnexpectedMessage
+        | ErrorKind::UnexpectedPeerType
         | ErrorKind::UnknownPeer
         | ErrorKind::Msg(_) => op = Some(UpdateNodeOperation::Failure),
 

--- a/core/src/light_protocol/message/message.rs
+++ b/core/src/light_protocol/message/message.rs
@@ -7,8 +7,9 @@ use crate::message::{HasRequestId, Message, MsgId, RequestId};
 use std::any::Any;
 
 // generate `pub mod msgid`
+// TODO(thegaram): reorder message ids
 build_msgid! {
-    STATUS = 0x00
+    STATUS_PING = 0x00
     GET_STATE_ROOT = 0x01
     STATE_ROOT = 0x02
     GET_STATE_ENTRY = 0x03
@@ -18,12 +19,14 @@ build_msgid! {
     GET_BLOCK_HEADERS = 0x07
     BLOCK_HEADERS = 0x08
     NEW_BLOCK_HASHES = 0x09
+    STATUS_PONG = 0x0a
 
     INVALID = 0xff
 }
 
 // generate `impl Message for _` for each message type
-build_msg_impl! { Status, msgid::STATUS, "Status" }
+build_msg_impl! { StatusPing, msgid::STATUS_PING, "StatusPing" }
+build_msg_impl! { StatusPong, msgid::STATUS_PONG, "StatusPong" }
 build_msg_impl! { GetStateRoot, msgid::GET_STATE_ROOT, "GetStateRoot" }
 build_msg_impl! { StateRoot, msgid::STATE_ROOT, "StateRoot" }
 build_msg_impl! { GetStateEntry, msgid::GET_STATE_ENTRY, "GetStateEntry" }

--- a/core/src/light_protocol/message/mod.rs
+++ b/core/src/light_protocol/message/mod.rs
@@ -10,5 +10,6 @@ pub use message::msgid;
 pub use node_type::NodeType;
 pub use protocol::{
     BlockHashes, BlockHeaders, GetBlockHashesByEpoch, GetBlockHeaders,
-    GetStateEntry, GetStateRoot, NewBlockHashes, StateEntry, StateRoot, Status,
+    GetStateEntry, GetStateRoot, NewBlockHashes, StateEntry, StateRoot,
+    StatusPing, StatusPong,
 };

--- a/core/src/light_protocol/message/protocol.rs
+++ b/core/src/light_protocol/message/protocol.rs
@@ -11,7 +11,15 @@ use primitives::{
 use rlp_derive::{RlpDecodable, RlpEncodable};
 
 #[derive(Clone, Debug, PartialEq, RlpEncodable, RlpDecodable)]
-pub struct Status {
+pub struct StatusPing {
+    pub genesis_hash: H256,
+    pub network_id: u8,
+    pub node_type: NodeType,
+    pub protocol_version: u8,
+}
+
+#[derive(Clone, Debug, PartialEq, RlpEncodable, RlpDecodable)]
+pub struct StatusPong {
     pub best_epoch: u64,
     pub genesis_hash: H256,
     pub network_id: u8,

--- a/core/src/light_protocol/query_provider.rs
+++ b/core/src/light_protocol/query_provider.rs
@@ -3,6 +3,7 @@
 // See http://www.gnu.org/licenses/
 
 use io::TimerToken;
+use parking_lot::RwLock;
 use rand::Rng;
 use rlp::Rlp;
 use std::sync::{Arc, Weak};
@@ -31,7 +32,7 @@ use super::{
         BlockHeaders as GetBlockHeadersResponse, GetBlockHashesByEpoch,
         GetBlockHeaders, GetStateEntry, GetStateRoot, NewBlockHashes, NodeType,
         StateEntry as GetStateEntryResponse, StateRoot as GetStateRootResponse,
-        Status,
+        StatusPing, StatusPong,
     },
     peers::Peers,
     Error, ErrorKind, LIGHT_PROTOCOL_ID, LIGHT_PROTOCOL_VERSION,
@@ -40,6 +41,12 @@ use crate::parameters::consensus::DEFERRED_STATE_EPOCH_COUNT;
 
 pub const MAX_EPOCHS_TO_SEND: usize = 128;
 pub const MAX_HEADERS_TO_SEND: usize = 512;
+
+#[derive(Default)]
+pub struct LightPeerState {
+    pub handshake_completed: bool,
+    pub protocol_version: u8,
+}
 
 pub struct QueryProvider {
     // shared consensus graph
@@ -53,7 +60,7 @@ pub struct QueryProvider {
     network: Weak<NetworkService>,
 
     // collection of all peers available
-    peers: Peers,
+    peers: Peers<LightPeerState>,
 }
 
 impl QueryProvider {
@@ -86,16 +93,44 @@ impl QueryProvider {
             })
     }
 
+    #[inline]
+    fn get_existing_peer_state(
+        &self, peer: &PeerId,
+    ) -> Result<Arc<RwLock<LightPeerState>>, Error> {
+        match self.peers.get(&peer) {
+            Some(state) => Ok(state),
+            None => {
+                // NOTE: this should not happen as we register
+                // all peers in `on_peer_connected`
+                error!("Received message from unknown peer={:?}", peer);
+                Err(ErrorKind::InternalError.into())
+            }
+        }
+    }
+
+    #[inline]
+    fn validate_peer_state(
+        &self, peer: PeerId, msg_id: MsgId,
+    ) -> Result<(), Error> {
+        let state = self.get_existing_peer_state(&peer)?;
+
+        if msg_id != msgid::STATUS_PING && !state.read().handshake_completed {
+            warn!("Received msg={:?} from handshaking peer={:?}", msg_id, peer);
+            return Err(ErrorKind::UnexpectedMessage.into());
+        }
+
+        Ok(())
+    }
+
     #[rustfmt::skip]
     fn dispatch_message(
         &self, io: &NetworkContext, peer: PeerId, msg_id: MsgId, rlp: Rlp,
     ) -> Result<(), Error> {
         trace!("Dispatching message: peer={:?}, msg_id={:?}", peer, msg_id);
-
-        // TODO(thegaram): check if peer is known
+        self.validate_peer_state(peer, msg_id)?;
 
         match msg_id {
-            msgid::STATUS => self.on_status(io, peer, &rlp),
+            msgid::STATUS_PING => self.on_status(io, peer, &rlp),
             msgid::GET_STATE_ROOT => self.on_get_state_root(io, peer, &rlp),
             msgid::GET_STATE_ENTRY => self.on_get_state_entry(io, peer, &rlp),
             msgid::GET_BLOCK_HASHES_BY_EPOCH => self.on_get_block_hashes_by_epoch(io, peer, &rlp),
@@ -160,7 +195,7 @@ impl QueryProvider {
             None => best_info.bounded_terminal_block_hashes.clone(),
         };
 
-        let msg: Box<dyn Message> = Box::new(Status {
+        let msg: Box<dyn Message> = Box::new(StatusPong {
             best_epoch: best_info.best_epoch_number,
             genesis_hash,
             network_id: 0x0,
@@ -187,24 +222,32 @@ impl QueryProvider {
         }
     }
 
+    #[inline]
+    fn validate_peer_type(&self, node_type: &NodeType) -> Result<(), Error> {
+        match node_type {
+            NodeType::Light => Ok(()),
+            _ => Err(ErrorKind::UnexpectedPeerType.into()),
+        }
+    }
+
     fn on_status(
-        &self, _io: &NetworkContext, peer: PeerId, rlp: &Rlp,
+        &self, io: &NetworkContext, peer: PeerId, rlp: &Rlp,
     ) -> Result<(), Error> {
-        let status: Status = rlp.as_val()?;
+        let status: StatusPing = rlp.as_val()?;
         info!("on_status peer={:?} status={:?}", peer, status);
 
+        self.validate_peer_type(&status.node_type)?;
         self.validate_genesis_hash(status.genesis_hash)?;
-        // TODO(thegaram): check protocol version
 
-        let peer_state = self.peers.insert(peer);
-        let mut state = peer_state.write();
+        if let Err(e) = self.send_status(io, peer) {
+            warn!("Failed to send status to peer={:?}: {:?}", peer, e);
+            return Err(ErrorKind::SendStatusFailed.into());
+        };
 
-        state.best_epoch = status.best_epoch;
-        state.genesis_hash = status.genesis_hash;
-        state.node_type = status.node_type;
+        let state = self.get_existing_peer_state(&peer)?;
+        let mut state = state.write();
+        state.handshake_completed = true;
         state.protocol_version = status.protocol_version;
-        state.terminals = status.terminals.into_iter().collect();
-
         Ok(())
     }
 
@@ -332,10 +375,7 @@ impl QueryProvider {
             return Ok(());
         }
 
-        let peers = self
-            .peers
-            .all_peers_satisfying(|state| state.node_type == NodeType::Light);
-
+        let peers = self.peers.all_peers_shuffled();
         let msg: Box<dyn Message> = Box::new(NewBlockHashes { hashes });
 
         match self.network.upgrade() {
@@ -379,23 +419,11 @@ impl NetworkProtocolHandler for QueryProvider {
         }
     }
 
-    fn on_peer_connected(&self, io: &NetworkContext, peer: PeerId) {
+    fn on_peer_connected(&self, _io: &NetworkContext, peer: PeerId) {
         info!("on_peer_connected: peer={:?}", peer);
 
-        match self.send_status(io, peer) {
-            Ok(_) => {
-                self.peers.insert(peer);
-            }
-            Err(e) => {
-                warn!("Error while sending status: {}", e);
-                handle_error(
-                    io,
-                    peer,
-                    msgid::INVALID,
-                    ErrorKind::SendStatusFailed.into(),
-                );
-            }
-        }
+        // insert handshaking peer, wait for StatusPing
+        self.peers.insert(peer);
     }
 
     fn on_peer_disconnected(&self, _io: &NetworkContext, peer: PeerId) {


### PR DESCRIPTION
**Overview**

Add *ping-pong* status logic to light node handlers. Handshake is initiated by a light peer by sending a `StatusPing` message. Full peers respond with a `StatusPong` message. Nodes consider a connection established once they've both sent and received the corresponding status message.

Full nodes do not initiate handshake on the light protocol. This way, we can avoid full-node-to-full-node connections.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/521)
<!-- Reviewable:end -->
