### PR TITLE
add tags for p2p node

### DIFF
--- a/network/src/ip/mod.rs
+++ b/network/src/ip/mod.rs
@@ -1,10 +1,14 @@
 mod bucket;
 mod node_limit;
+mod node_tag_index;
+mod sample;
 mod sessions_limit;
 mod util;
 
-pub use self::sessions_limit::{
-    new_session_ip_limit, SessionIpLimit, SessionIpLimitConfig,
+pub use self::{
+    node_limit::{NodeIpLimit, ValidateInsertResult},
+    node_tag_index::NodeTagIndex,
+    sessions_limit::{
+        new_session_ip_limit, SessionIpLimit, SessionIpLimitConfig,
+    },
 };
-
-pub use self::node_limit::{NodeIpLimit, ValidateInsertResult};

--- a/network/src/ip/node_limit.rs
+++ b/network/src/ip/node_limit.rs
@@ -55,6 +55,11 @@ impl NodeIpLimit {
     #[inline]
     pub fn is_enabled(&self) -> bool { self.subnet_quota > 0 }
 
+    pub fn subnet(&self, id: &NodeId) -> Option<u32> {
+        let ip = self.node_index.get(id)?;
+        Some(self.subnet_type.subnet(ip))
+    }
+
     /// Remove the specified node `id` and return `true` if removed
     /// successfully. If not found, return `false`.
     pub fn remove(&mut self, id: &NodeId) -> bool {

--- a/network/src/ip/node_tag_index.rs
+++ b/network/src/ip/node_tag_index.rs
@@ -1,0 +1,194 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use crate::{
+    ip::{
+        sample::{SampleHashMap, SampleHashSet},
+        util::SubnetType,
+    },
+    node_table::{NodeId, NodeTable},
+    Node,
+};
+use rand::thread_rng;
+use std::collections::{HashMap, HashSet};
+
+#[derive(Default)]
+pub struct NodeTagIndex {
+    // map<tag_key, map<tag_value, map<subnet, map<subnet, set<node_id>>>>>
+    items: HashMap<
+        String,
+        HashMap<String, SampleHashMap<u32, SampleHashSet<NodeId>>>,
+    >,
+}
+
+impl NodeTagIndex {
+    pub fn new_with_node_table(table: &NodeTable) -> Self {
+        let mut result = NodeTagIndex::default();
+
+        for id in table.all() {
+            let node = table.get(&id).expect("node not found in table");
+            for (k, v) in node.tags.iter() {
+                let ip = node.endpoint.address.ip();
+                let subnet = SubnetType::C.subnet(&ip);
+                result.insert(id, subnet, k.clone(), v.clone());
+            }
+        }
+
+        result
+    }
+
+    pub fn insert(
+        &mut self, id: NodeId, subnet: u32, key: String, value: String,
+    ) -> bool {
+        self.items
+            .entry(key)
+            .or_insert_with(|| Default::default())
+            .entry(value)
+            .or_insert_with(|| Default::default())
+            .get_mut_or_insert_with(subnet, || Default::default())
+            .insert(id)
+    }
+
+    pub fn remove(
+        &mut self, id: &NodeId, subnet: u32, key: &String, value: &String,
+    ) -> Option<()> {
+        let tag_key_values = self.items.get_mut(key)?;
+        let buckets = tag_key_values.get_mut(value)?;
+        let nodes = buckets.get_mut(&subnet)?;
+
+        if !nodes.remove(id) {
+            return None;
+        }
+
+        if nodes.is_empty() {
+            buckets.remove(&subnet);
+        }
+
+        if buckets.is_empty() {
+            tag_key_values.remove(value);
+        }
+
+        if tag_key_values.is_empty() {
+            self.items.remove(key);
+        }
+
+        Some(())
+    }
+
+    pub fn sample(
+        &self, count: u32, key: &String, value: &String,
+    ) -> Option<HashSet<NodeId>> {
+        let buckets = self.items.get(key)?.get(value)?;
+
+        let mut rng = thread_rng();
+        let mut sampled = HashSet::new();
+
+        for _ in 0..count {
+            if let Some(bucket) = buckets.sample(&mut rng) {
+                if let Some(id) = bucket.sample(&mut rng) {
+                    sampled.insert(id);
+                }
+            }
+        }
+
+        Some(sampled)
+    }
+
+    pub fn add_node(&mut self, node: &Node) {
+        if node.tags.is_empty() {
+            return;
+        }
+
+        let ip = node.endpoint.address.ip();
+        let subnet = SubnetType::C.subnet(&ip);
+
+        for (key, value) in node.tags.iter() {
+            self.insert(node.id.clone(), subnet, key.clone(), value.clone());
+        }
+    }
+
+    pub fn remove_node(&mut self, node: &Node) {
+        if node.tags.is_empty() {
+            return;
+        }
+
+        let ip = node.endpoint.address.ip();
+        let subnet = SubnetType::C.subnet(&ip);
+
+        for (key, value) in node.tags.iter() {
+            self.remove(&node.id, subnet, key, value);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{ip::NodeTagIndex, node_table::NodeId};
+
+    #[test]
+    fn test_insert() {
+        let mut index = NodeTagIndex::default();
+
+        let n1 = NodeId::random();
+        assert_eq!(
+            index.insert(n1.clone(), 38, "k1".into(), "v1".into()),
+            true
+        );
+        assert_eq!(
+            index.insert(n1.clone(), 38, "k1".into(), "v1".into()),
+            false
+        );
+        assert_eq!(
+            index.insert(n1.clone(), 38, "k1".into(), "v2".into()),
+            true
+        );
+        assert_eq!(
+            index.insert(n1.clone(), 38, "k2".into(), "v1".into()),
+            true
+        );
+        assert_eq!(
+            index.insert(n1.clone(), 39, "k1".into(), "v1".into()),
+            true
+        );
+        assert_eq!(
+            index.insert(NodeId::random(), 38, "k1".into(), "v1".into()),
+            true
+        );
+    }
+
+    #[test]
+    fn test_remove() {
+        let mut index = NodeTagIndex::default();
+
+        let n1 = NodeId::random();
+        assert_eq!(
+            index.insert(n1.clone(), 38, "k1".into(), "v1".into()),
+            true
+        );
+
+        let n2 = NodeId::random();
+        assert_eq!(index.remove(&n2, 38, &"k1".into(), &"v1".into()), None);
+        assert_eq!(index.remove(&n1, 39, &"k1".into(), &"v1".into()), None);
+        assert_eq!(index.remove(&n1, 38, &"k2".into(), &"v1".into()), None);
+        assert_eq!(index.remove(&n1, 38, &"k1".into(), &"v2".into()), None);
+        assert_eq!(index.remove(&n1, 38, &"k1".into(), &"v1".into()), Some(()));
+    }
+
+    #[test]
+    fn test_sample() {
+        let mut index = NodeTagIndex::default();
+
+        // sample nothing on empty
+        assert_eq!(index.sample(10, &"k1".into(), &"v1".into()), None);
+
+        // add index and sampled 1 node.
+        let n1 = NodeId::random();
+        assert_eq!(
+            index.insert(n1.clone(), 38, "k1".into(), "v1".into()),
+            true
+        );
+        let sampled = index.sample(1, &"k1".into(), &"v1".into());
+        assert_eq!(sampled.unwrap().into_iter().next(), Some(n1));
+    }
+}

--- a/network/src/ip/node_tag_index.rs
+++ b/network/src/ip/node_tag_index.rs
@@ -15,7 +15,7 @@ use std::collections::{HashMap, HashSet};
 
 #[derive(Default)]
 pub struct NodeTagIndex {
-    // map<tag_key, map<tag_value, map<subnet, map<subnet, set<node_id>>>>>
+    // map<tag_key, map<tag_value, map<subnet, set<node_id>>>>
     items: HashMap<
         String,
         HashMap<String, SampleHashMap<u32, SampleHashSet<NodeId>>>,

--- a/network/src/ip/sample.rs
+++ b/network/src/ip/sample.rs
@@ -1,0 +1,103 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use rand::{Rng, ThreadRng};
+use std::{collections::HashMap, hash::Hash};
+
+/// HashMap that provide sampling in O(1) complexity.
+#[derive(Default)]
+pub struct SampleHashMap<K: Hash + Eq, V> {
+    items: Vec<(K, V)>,
+    index: HashMap<K, usize>,
+}
+
+impl<K: Hash + Eq + Clone, V> SampleHashMap<K, V> {
+    pub fn get_mut(&mut self, k: &K) -> Option<&mut V> {
+        let pos = self.index.get(k)?;
+        Some(&mut self.items[*pos].1)
+    }
+
+    pub fn get_mut_or_insert_with<F: FnOnce() -> V>(
+        &mut self, k: K, default: F,
+    ) -> &mut V {
+        let pos = match self.index.get(&k) {
+            Some(pos) => *pos,
+            None => {
+                self.index.insert(k.clone(), self.items.len());
+                self.items.push((k, default()));
+                self.items.len() - 1
+            }
+        };
+
+        &mut self.items[pos].1
+    }
+
+    pub fn remove(&mut self, k: &K) -> Option<V> {
+        let index = self.index.remove(k)?;
+        let (_, removed) = self.items.swap_remove(index);
+
+        if let Some((swapped, _)) = self.items.get(index) {
+            self.index.insert(swapped.clone(), index);
+        }
+
+        Some(removed)
+    }
+
+    pub fn sample(&self, rng: &mut ThreadRng) -> Option<&V> {
+        if self.items.is_empty() {
+            return None;
+        }
+
+        let index = rng.gen_range(0, self.items.len());
+        Some(&self.items[index].1)
+    }
+
+    pub fn is_empty(&self) -> bool { self.items.is_empty() }
+}
+
+/// HashSet that provide sampling in O(1) complexity.
+#[derive(Default)]
+pub struct SampleHashSet<T: Hash + Eq> {
+    items: Vec<T>,
+    index: HashMap<T, usize>,
+}
+
+impl<T: Hash + Eq + Clone> SampleHashSet<T> {
+    pub fn insert(&mut self, value: T) -> bool {
+        if self.index.contains_key(&value) {
+            return false;
+        }
+
+        self.index.insert(value.clone(), self.items.len());
+        self.items.push(value);
+
+        true
+    }
+
+    pub fn remove(&mut self, value: &T) -> bool {
+        let index = match self.index.remove(value) {
+            Some(pos) => pos,
+            None => return false,
+        };
+
+        self.items.swap_remove(index);
+
+        if let Some(swapped) = self.items.get(index) {
+            self.index.insert(swapped.clone(), index);
+        }
+
+        true
+    }
+
+    pub fn sample(&self, rng: &mut ThreadRng) -> Option<T> {
+        if self.items.is_empty() {
+            return None;
+        }
+
+        let index = rng.gen_range(0, self.items.len());
+        Some(self.items[index].clone())
+    }
+
+    pub fn is_empty(&self) -> bool { self.items.is_empty() }
+}

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -244,6 +244,8 @@ pub trait NetworkContext {
     ) -> Result<(), Error>;
 
     fn dispatch_work(&self, work_type: HandlerWorkType);
+
+    fn insert_peer_node_tag(&self, peer: PeerId, key: &str, value: &str);
 }
 
 #[derive(Debug, Clone)]

--- a/network/src/node_table.rs
+++ b/network/src/node_table.rs
@@ -239,6 +239,14 @@ pub struct Node {
     // does not need to be made persistent.
     pub last_connected: Option<NodeContact>,
     pub stream_token: Option<StreamToken>,
+    // Generally, it is used by protocol handler layer to attach
+    // some tags to node, so as to:
+    // 1. Sampling nodes with special tags, e.g.
+    //     - archive nodes first
+    //     - good credit nodes first
+    //     - good network nodes first
+    // 2. Refuse incoming connection from node with special tags.
+    pub tags: HashMap<String, String>,
 }
 
 impl Node {
@@ -249,6 +257,7 @@ impl Node {
             last_contact: None,
             last_connected: None,
             stream_token: None,
+            tags: Default::default(),
         }
     }
 }
@@ -290,6 +299,7 @@ impl FromStr for Node {
             last_contact: None,
             last_connected: None,
             stream_token: None,
+            tags: Default::default(),
         })
     }
 }
@@ -855,6 +865,7 @@ mod json {
     pub struct Node {
         pub url: String,
         pub last_contact: Option<NodeContact>,
+        pub tags: HashMap<String, String>,
     }
 
     impl Node {
@@ -863,6 +874,7 @@ mod json {
                 Ok(mut node) => {
                     node.last_contact =
                         self.last_contact.map(NodeContact::into_node_contact);
+                    node.tags = self.tags;
                     Some(node)
                 }
                 _ => None,
@@ -886,6 +898,7 @@ mod json {
             Node {
                 url: format!("{}", node),
                 last_contact,
+                tags: node.tags.clone(),
             }
         }
     }

--- a/network/src/service.rs
+++ b/network/src/service.rs
@@ -1590,6 +1590,11 @@ impl<'a> NetworkContextTrait for NetworkContext<'a> {
             })
             .expect("Error sending network IO message");
     }
+
+    fn insert_peer_node_tag(&self, peer: PeerId, key: &str, value: &str) {
+        let id = self.network_service.get_peer_node_id(peer);
+        self.network_service.node_db.write().set_tag(id, key, value);
+    }
 }
 
 fn save_key(path: &Path, key: &Secret) {


### PR DESCRIPTION
Add tags for p2p node so as to sample trusted nodes with desired tag, e.g. Archive node desired to connect to other Archive nodes for block synchronization in catch-up mode.

Besides, network protocol handler could add any tags to p2p nodes, so that it could be able to handle node accurately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/525)
<!-- Reviewable:end -->
