### PR TITLE
Provide optional disconnect reason when dropping peer

### DIFF
--- a/core/src/light_protocol/error.rs
+++ b/core/src/light_protocol/error.rs
@@ -153,6 +153,6 @@ pub fn handle(io: &NetworkContext, peer: PeerId, msg_id: MsgId, e: Error) {
     };
 
     if disconnect {
-        io.disconnect_peer(peer, op);
+        io.disconnect_peer(peer, op, None);
     }
 }

--- a/core/src/sync/request_manager/request_handler.rs
+++ b/core/src/sync/request_manager/request_handler.rs
@@ -169,6 +169,7 @@ impl RequestHandler {
                         io.disconnect_peer(
                             peer_id,
                             Some(UpdateNodeOperation::Demotion),
+                            None,
                         );
                     }
                 }

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -379,7 +379,7 @@ impl SynchronizationProtocolHandler {
 
         if !handle_rlp_message(msg_id, &ctx, &rlp)? {
             warn!("Unknown message: peer={:?} msgid={:?}", peer, msg_id);
-            io.disconnect_peer(peer, Some(UpdateNodeOperation::Remove));
+            io.disconnect_peer(peer, Some(UpdateNodeOperation::Remove), None);
         }
 
         Ok(())
@@ -448,7 +448,7 @@ impl SynchronizationProtocolHandler {
         }
 
         if disconnect {
-            io.disconnect_peer(peer, op);
+            io.disconnect_peer(peer, op, None);
         }
     }
 
@@ -1347,7 +1347,7 @@ impl NetworkProtocolHandler for SynchronizationProtocolHandler {
         info!("Peer connected: peer={:?}", peer);
         if let Err(e) = self.send_status(io, peer) {
             debug!("Error sending status message: {:?}", e);
-            io.disconnect_peer(peer, Some(UpdateNodeOperation::Failure));
+            io.disconnect_peer(peer, Some(UpdateNodeOperation::Failure), None);
         } else {
             self.syn
                 .handshaking_peers
@@ -1398,6 +1398,7 @@ impl NetworkProtocolHandler for SynchronizationProtocolHandler {
                     io.disconnect_peer(
                         peer,
                         Some(UpdateNodeOperation::Failure),
+                        None,
                     );
                 }
             }

--- a/network/src/connection.rs
+++ b/network/src/connection.rs
@@ -147,7 +147,27 @@ impl<Socket: GenericSocket, Sizer: PacketSizer>
         }
     }
 
-    fn write(&mut self) -> Result<WriteStatus, Error> {
+    pub fn write_raw_data(&mut self, data: &[u8]) -> Result<usize, Error> {
+        trace!(
+            "Sending raw buffer, token = {}, data = {:?}",
+            self.token,
+            data
+        );
+
+        let size = self.socket.write(data)?;
+
+        trace!(
+            "Succeed to send socket data, token = {}, size = {}",
+            self.token,
+            size,
+        );
+
+        THROTTLING_SERVICE.write().on_dequeue(size);
+        WRITE_METER.mark(size);
+        Ok(size)
+    }
+
+    fn write_next_from_queue(&mut self) -> Result<WriteStatus, Error> {
         if self.send_queue.is_send_queue_empty(SendQueuePriority::High)
             && has_high_priority_packets()
         {
@@ -188,6 +208,10 @@ impl<Socket: GenericSocket, Sizer: PacketSizer>
         THROTTLING_SERVICE.write().on_dequeue(size);
         WRITE_METER.mark(size);
 
+        // NOTE: the line below does not work due the error:
+        // `cannot borrow `*self` as mutable more than once at a time`
+        // let size = self.write_raw_data(&buf.0)?;
+
         if pos + size < len {
             buf.1 += size;
             Ok(WriteStatus::Ongoing)
@@ -201,7 +225,7 @@ impl<Socket: GenericSocket, Sizer: PacketSizer>
     pub fn writable<Message: Sync + Send + Clone + 'static>(
         &mut self, io: &IoContext<Message>,
     ) -> Result<WriteStatus, Error> {
-        let status = self.write();
+        let status = self.write_next_from_queue();
 
         if let Ok(WriteStatus::Complete) = status {
             self.send_queue.pop_front();

--- a/network/src/connection.rs
+++ b/network/src/connection.rs
@@ -162,7 +162,6 @@ impl<Socket: GenericSocket, Sizer: PacketSizer>
             size,
         );
 
-        THROTTLING_SERVICE.write().on_dequeue(size);
         WRITE_METER.mark(size);
         Ok(size)
     }

--- a/network/src/error.rs
+++ b/network/src/error.rs
@@ -4,28 +4,68 @@
 
 use crate::io::IoError;
 use keylib;
-use rlp;
+use rlp::{self, Decodable, DecoderError, Encodable, Rlp, RlpStream};
 use std::{fmt, io, net};
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum DisconnectReason {
     DisconnectRequested,
     UselessPeer,
     WrongEndpointInfo,
     IpLimited,
     UpdateNodeIdFailed,
+    Custom(String),
     Unknown,
 }
 
 impl DisconnectReason {
-    pub fn from_u8(n: u8) -> DisconnectReason {
-        match n {
-            0 => DisconnectReason::DisconnectRequested,
-            1 => DisconnectReason::UselessPeer,
-            2 => DisconnectReason::WrongEndpointInfo,
-            3 => DisconnectReason::IpLimited,
-            4 => DisconnectReason::UpdateNodeIdFailed,
-            _ => DisconnectReason::Unknown,
+    pub fn code(&self) -> u8 {
+        match self {
+            DisconnectReason::DisconnectRequested => 0,
+            DisconnectReason::UselessPeer => 1,
+            DisconnectReason::WrongEndpointInfo => 2,
+            DisconnectReason::IpLimited => 3,
+            DisconnectReason::UpdateNodeIdFailed => 4,
+            DisconnectReason::Custom(_) => 5,
+            DisconnectReason::Unknown => 0xff,
+        }
+    }
+}
+
+impl Encodable for DisconnectReason {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        let mut raw = vec![];
+        raw.push(self.code());
+
+        if let DisconnectReason::Custom(msg) = self {
+            raw.extend(msg.bytes());
+        }
+
+        s.append_raw(&raw[..], raw.len());
+    }
+}
+
+impl Decodable for DisconnectReason {
+    fn decode(rlp: &Rlp) -> std::result::Result<Self, DecoderError> {
+        let raw = rlp.as_raw().to_vec();
+
+        if raw.is_empty() {
+            return Err(DecoderError::RlpIsTooShort);
+        }
+
+        match raw[0] {
+            0 => Ok(DisconnectReason::DisconnectRequested),
+            1 => Ok(DisconnectReason::UselessPeer),
+            2 => Ok(DisconnectReason::WrongEndpointInfo),
+            3 => Ok(DisconnectReason::IpLimited),
+            4 => Ok(DisconnectReason::UpdateNodeIdFailed),
+            5 => match std::str::from_utf8(&raw[1..]) {
+                Err(_) => {
+                    Err(DecoderError::Custom("Unable to decode message part"))
+                }
+                Ok(msg) => Ok(DisconnectReason::Custom(msg.to_owned())),
+            },
+            _ => Ok(DisconnectReason::Unknown),
         }
     }
 }
@@ -38,6 +78,7 @@ impl fmt::Display for DisconnectReason {
             DisconnectReason::WrongEndpointInfo => "wrong node id",
             DisconnectReason::IpLimited => "IP limited",
             DisconnectReason::UpdateNodeIdFailed => "Update node id failed",
+            DisconnectReason::Custom(ref msg) => &msg[..],
             DisconnectReason::Unknown => "unknown",
         };
 
@@ -152,4 +193,27 @@ impl From<keylib::crypto::Error> for Error {
 
 impl From<net::AddrParseError> for Error {
     fn from(_err: net::AddrParseError) -> Self { ErrorKind::BadAddr.into() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DisconnectReason::{self, *};
+    use rlp::{decode, encode};
+
+    fn check_rlp(r: DisconnectReason) {
+        assert_eq!(decode::<DisconnectReason>(&encode(&r)).unwrap(), r);
+    }
+
+    #[test]
+    fn test_disconnect_reason_rlp() {
+        check_rlp(DisconnectRequested);
+        check_rlp(UselessPeer);
+        check_rlp(WrongEndpointInfo);
+        check_rlp(IpLimited);
+        check_rlp(UpdateNodeIdFailed);
+        check_rlp(Unknown);
+
+        check_rlp(Custom("".to_owned()));
+        check_rlp(Custom("test test test".to_owned()));
+    }
 }

--- a/network/src/error.rs
+++ b/network/src/error.rs
@@ -19,7 +19,7 @@ pub enum DisconnectReason {
 }
 
 impl DisconnectReason {
-    pub fn code(&self) -> u8 {
+    fn code(&self) -> u8 {
         match self {
             DisconnectReason::DisconnectRequested => 0,
             DisconnectReason::UselessPeer => 1,
@@ -34,8 +34,7 @@ impl DisconnectReason {
 
 impl Encodable for DisconnectReason {
     fn rlp_append(&self, s: &mut RlpStream) {
-        let mut raw = vec![];
-        raw.push(self.code());
+        let mut raw = vec![self.code()];
 
         if let DisconnectReason::Custom(msg) = self {
             raw.extend(msg.bytes());

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -235,7 +235,10 @@ pub trait NetworkContext {
         &self, peer: PeerId, msg: Vec<u8>, priority: SendQueuePriority,
     ) -> Result<(), Error>;
 
-    fn disconnect_peer(&self, peer: PeerId, op: Option<UpdateNodeOperation>);
+    fn disconnect_peer(
+        &self, peer: PeerId, op: Option<UpdateNodeOperation>,
+        reason: Option<&'static str>,
+    );
 
     /// Register a new IO timer. 'IoHandler::timeout' will be called with the
     /// token.


### PR DESCRIPTION
**Overview**

- `network::Session::send_disconnect` sends `DisconnectReason` immediately, bypassing the send queue.
- `DisconnectReason::Custom(str)` can provide a custom string explanation. RLP (de)serialization is implemented accordingly.
- `NetworkContext.disconnect_peer` takes an optional string argument. If this is specified, the provided string is sent (blocking) to the peer before it is disconnected.

**Use cases**

Sometimes peers might be disconnected without violating the protocol. For example, if a full node's light peer limit is reached, it will reject subsequent connection requests. It is good UX to provide an explanation for these.

For protocol violation, providing a reason might also help with debugging. For instance, if another team is implementing a new Conflux client, it's useful for them to know why their connection to conflux-rust fails (e.g. wrong RLP implementation).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/529)
<!-- Reviewable:end -->
