### PR TITLE
support to blacklist a node and refuse connection

### DIFF
--- a/network/src/error.rs
+++ b/network/src/error.rs
@@ -14,6 +14,7 @@ pub enum DisconnectReason {
     WrongEndpointInfo,
     IpLimited,
     UpdateNodeIdFailed,
+    Blacklisted,
     Custom(String),
     Unknown,
 }
@@ -26,7 +27,8 @@ impl DisconnectReason {
             DisconnectReason::WrongEndpointInfo => 2,
             DisconnectReason::IpLimited => 3,
             DisconnectReason::UpdateNodeIdFailed => 4,
-            DisconnectReason::Custom(_) => 5,
+            DisconnectReason::Blacklisted => 5,
+            DisconnectReason::Custom(_) => 100,
             DisconnectReason::Unknown => 0xff,
         }
     }
@@ -58,7 +60,8 @@ impl Decodable for DisconnectReason {
             2 => Ok(DisconnectReason::WrongEndpointInfo),
             3 => Ok(DisconnectReason::IpLimited),
             4 => Ok(DisconnectReason::UpdateNodeIdFailed),
-            5 => match std::str::from_utf8(&raw[1..]) {
+            5 => Ok(DisconnectReason::Blacklisted),
+            100 => match std::str::from_utf8(&raw[1..]) {
                 Err(_) => {
                     Err(DecoderError::Custom("Unable to decode message part"))
                 }
@@ -77,6 +80,7 @@ impl fmt::Display for DisconnectReason {
             DisconnectReason::WrongEndpointInfo => "wrong node id",
             DisconnectReason::IpLimited => "IP limited",
             DisconnectReason::UpdateNodeIdFailed => "Update node id failed",
+            DisconnectReason::Blacklisted => "blacklisted",
             DisconnectReason::Custom(ref msg) => &msg[..],
             DisconnectReason::Unknown => "unknown",
         };

--- a/network/src/node_database.rs
+++ b/network/src/node_database.rs
@@ -10,6 +10,10 @@ use crate::{
 use io::StreamToken;
 use std::{collections::HashSet, net::IpAddr, time::Duration};
 
+const TRUSTED_NODES_FILE: &str = "trusted_nodes.json";
+const UNTRUSTED_NODES_FILE: &str = "untrusted_nodes.json";
+const BLACKLISTED_NODES_FILE: &str = "blacklisted_nodes.json";
+
 /// Node database maintains all P2P nodes in trusted and untrusted node tables,
 /// and supports to limit the number of nodes for the same IP address.
 ///
@@ -73,8 +77,22 @@ use std::{collections::HashSet, net::IpAddr, time::Duration};
 /// 2. Select node that has been contacted long time ago.
 /// 3. Randomly select one without "fresher" bias.
 pub struct NodeDatabase {
+    // Trusted nodes to establish outgoing connections.
+    // A trusted node comes in 2 ways:
+    // 1. Incoming TCP connection for a long time.
+    // 2. Received trusted neighbors from UDP discovery.
     trusted_nodes: NodeTable,
+
+    // Add or updated by incoming TCP connection or PING discovery message.
     untrusted_nodes: NodeTable,
+
+    // Blacklisted nodes are refused to connect or update via UDP discovery.
+    // Generally, node is blacklisted due to protocol mismatch in runtime.
+    blacklisted_nodes: NodeTable,
+    // Maximum duration to blacklist a node since last contact.
+    blacklisted_lifetime: Duration,
+
+    // IP address/subnet index for trusted and untrusted nodes.
     ip_limit: NodeIpLimit,
 
     // Only used for sampling trusted nodes with desired tag.
@@ -88,8 +106,9 @@ pub struct NodeDatabase {
 
 impl NodeDatabase {
     pub fn new(path: Option<String>, subnet_quota: usize) -> Self {
-        let trusted_nodes = NodeTable::new(path.clone(), true);
-        let untrusted_nodes = NodeTable::new(path.clone(), false);
+        let trusted_nodes = NodeTable::new(path.clone(), TRUSTED_NODES_FILE);
+        let untrusted_nodes =
+            NodeTable::new(path.clone(), UNTRUSTED_NODES_FILE);
         let ip_limit = NodeIpLimit::new(subnet_quota);
         let trusted_node_tag_index =
             NodeTagIndex::new_with_node_table(&trusted_nodes);
@@ -97,6 +116,8 @@ impl NodeDatabase {
         let mut db = NodeDatabase {
             trusted_nodes,
             untrusted_nodes,
+            blacklisted_nodes: NodeTable::new(path, BLACKLISTED_NODES_FILE),
+            blacklisted_lifetime: Duration::from_secs(7 * 24 * 3600),
             ip_limit,
             trusted_node_tag_index,
         };
@@ -112,6 +133,10 @@ impl NodeDatabase {
     pub fn insert_with_token(
         &mut self, entry: NodeEntry, stream_token: StreamToken,
     ) {
+        if self.evaluate_blacklisted(&entry.id) {
+            return;
+        }
+
         let mut node = Node::new(entry.id, entry.endpoint);
         node.last_contact = Some(NodeContact::success());
         node.last_connected = Some(NodeContact::success());
@@ -152,6 +177,10 @@ impl NodeDatabase {
     /// node with the specified `entry`, and promote the node to trusted if it
     /// is untrusted.
     pub fn insert_with_promotion(&mut self, entry: NodeEntry) {
+        if self.evaluate_blacklisted(&entry.id) {
+            return;
+        }
+
         let mut node = Node::new(entry.id, entry.endpoint);
         node.last_contact = Some(NodeContact::success());
 
@@ -195,6 +224,10 @@ impl NodeDatabase {
     /// Add a new trusted node if not exists, or promote the existing untrusted
     /// node.
     pub fn insert_trusted(&mut self, entry: NodeEntry) {
+        if self.evaluate_blacklisted(&entry.id) {
+            return;
+        }
+
         if self.trusted_nodes.contains(&entry.id) {
             return;
         }
@@ -249,6 +282,7 @@ impl NodeDatabase {
         })
     }
 
+    /// Get node from trusted/untrusted node tables for the specified id.
     pub fn get_with_trusty(&self, id: &NodeId) -> Option<(bool, &Node)> {
         if let Some(node) = self.trusted_nodes.get(id) {
             Some((true, node))
@@ -309,6 +343,8 @@ impl NodeDatabase {
 
         self.untrusted_nodes.save();
         self.untrusted_nodes.clear_useless();
+
+        self.blacklisted_nodes.save();
     }
 
     /// Promote untrusted nodes to trusted with the given duration.
@@ -347,18 +383,18 @@ impl NodeDatabase {
 
     /// Remove node from database for the specified id
     pub fn remove(&mut self, id: &NodeId) -> Option<Node> {
-        let node = if let Some(node) = self.trusted_nodes.remove_with_id(id) {
+        if let Some(node) = self.trusted_nodes.remove_with_id(id) {
             self.trusted_node_tag_index.remove_node(&node);
-            node
+            self.ip_limit.remove(id);
+            Some(node)
         } else if let Some(node) = self.untrusted_nodes.remove_with_id(id) {
-            node
+            self.ip_limit.remove(id);
+            Some(node)
+        } else if let Some(node) = self.blacklisted_nodes.remove_with_id(id) {
+            Some(node)
         } else {
-            return None;
-        };
-
-        self.ip_limit.remove(id);
-
-        Some(node)
+            None
+        }
     }
 
     fn init(&mut self, trusted: bool) {
@@ -459,13 +495,54 @@ impl NodeDatabase {
             value.into(),
         );
     }
+
+    /// Set the specified node to blacklisted.
+    pub fn set_blacklisted(&mut self, id: &NodeId) {
+        // update the last failure time
+        self.note_failure(id, true, false);
+
+        // move to blacklisted node table
+        if let Some(node) = self.remove(id) {
+            self.blacklisted_nodes.add_node(node, false);
+        }
+    }
+
+    /// Check if the specified node is blacklisted.
+    /// If blacklisted for a long time, it will be removed from blacklisted node
+    /// table.
+    pub fn evaluate_blacklisted(&mut self, id: &NodeId) -> bool {
+        let node = match self.blacklisted_nodes.get_mut(id) {
+            Some(node) => node,
+            None => return false,
+        };
+
+        let last_contact = match node.last_contact {
+            Some(contact) => contact.time(),
+            None => {
+                // By default, the last_contact should not be empty.
+                // If changed to None (e.g. manually), just treat
+                // the node as non-blacklisted.
+                self.blacklisted_nodes.remove_with_id(id);
+                return false;
+            }
+        };
+
+        if let Ok(elapsed) = last_contact.elapsed() {
+            if elapsed > self.blacklisted_lifetime {
+                self.blacklisted_nodes.remove_with_id(id);
+                return false;
+            }
+        }
+
+        true
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::NodeDatabase;
     use crate::node_table::{NodeEndpoint, NodeEntry, NodeId};
-    use std::str::FromStr;
+    use std::{str::FromStr, time::Duration};
 
     fn new_entry(addr: &str) -> NodeEntry {
         NodeEntry {
@@ -592,5 +669,30 @@ mod tests {
 
         assert_eq!(db.get(&entry1.id, true), None);
         assert_eq!(db.get(&entry2.id, false), None);
+    }
+
+    #[test]
+    fn test_blacklisted() {
+        let mut db = NodeDatabase::new(None, 2);
+
+        let n = new_entry("127.0.0.1:999");
+        db.insert_trusted(n.clone());
+        assert_eq!(db.get(&n.id, true).unwrap().id, n.id);
+        assert_eq!(db.evaluate_blacklisted(&n.id), false);
+
+        // set to blacklisted
+        db.set_blacklisted(&n.id);
+        assert_eq!(db.evaluate_blacklisted(&n.id), true);
+
+        // evaluate blacklisted node that exceeds the lifetime
+        let mut db2 = NodeDatabase::new(None, 2);
+        db2.blacklisted_lifetime = Duration::from_millis(1);
+        db2.insert_trusted(n.clone());
+        db.set_blacklisted(&n.id);
+        assert_eq!(db.evaluate_blacklisted(&n.id), true);
+
+        std::thread::sleep(Duration::from_millis(2));
+        assert_eq!(db.evaluate_blacklisted(&n.id), false);
+        assert_eq!(db.get(&n.id, false), None);
     }
 }

--- a/network/src/node_database.rs
+++ b/network/src/node_database.rs
@@ -683,15 +683,20 @@ mod tests {
         // set to blacklisted
         db.set_blacklisted(&n.id);
         assert_eq!(db.evaluate_blacklisted(&n.id), true);
+        assert_eq!(db.get(&n.id, false), None);
+    }
 
-        // evaluate blacklisted node that exceeds the lifetime
-        let mut db2 = NodeDatabase::new(None, 2);
-        db2.blacklisted_lifetime = Duration::from_millis(1);
-        db2.insert_trusted(n.clone());
+    #[test]
+    fn test_blacklisted_lifetime() {
+        let mut db = NodeDatabase::new(None, 2);
+
+        let n = new_entry("127.0.0.1:999");
+        db.insert_trusted(n.clone());
         db.set_blacklisted(&n.id);
-        assert_eq!(db.evaluate_blacklisted(&n.id), true);
 
+        db.blacklisted_lifetime = Duration::from_millis(1);
         std::thread::sleep(Duration::from_millis(2));
+
         assert_eq!(db.evaluate_blacklisted(&n.id), false);
         assert_eq!(db.get(&n.id, false), None);
     }

--- a/network/src/service.rs
+++ b/network/src/service.rs
@@ -1019,7 +1019,7 @@ impl NetworkServiceInner {
                             self.node_db.write().note_failure(&id, true, false);
                         }
                         UpdateNodeOperation::Remove => {
-                            self.node_db.write().remove(&id);
+                            self.node_db.write().set_blacklisted(&id);
                         }
                     }
                 }

--- a/network/src/session.rs
+++ b/network/src/session.rs
@@ -201,7 +201,7 @@ impl Session {
                 // refuse incoming session if the node is blacklisted
                 if host.node_db.write().evaluate_blacklisted(&node_id) {
                     return Err(
-                        self.disconnect(io, DisconnectReason::Blacklisted)
+                        self.send_disconnect(DisconnectReason::Blacklisted)
                     );
                 }
 

--- a/network/src/session.rs
+++ b/network/src/session.rs
@@ -197,6 +197,14 @@ impl Session {
                 let signed = &data[(32 + 65)..];
                 let signature = H520::from_slice(&data[32..(32 + 65)]);
                 let node_id = recover(&signature.into(), &keccak(signed))?;
+
+                // refuse incoming session if the node is blacklisted
+                if host.node_db.write().evaluate_blacklisted(&node_id) {
+                    return Err(
+                        self.disconnect(io, DisconnectReason::Blacklisted)
+                    );
+                }
+
                 if self.metadata.id.is_none() {
                     if let Err(reason) = host
                         .sessions


### PR DESCRIPTION
For protocol level error, a node could be blacklisted, so that:
- Incoming TCP connection will be refused during p2p handshake.
- UDP discovery will not update the last contact timestamp.

A blacklisted node will recover to normal (untrusted) one after a period of time, and allow incoming TCP connection again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/531)
<!-- Reviewable:end -->
