### PR TITLE
Separate full and light node RPC

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -43,6 +43,7 @@ tempdir = "0.3"
 rustc-hex= "1.0"
 threadpool = "1.0"
 metrics = { path = "../util/metrics" }
+delegate = "0.2.0"
 
 [dev-dependencies]
 criterion = "0.2"

--- a/client/src/archive/mod.rs
+++ b/client/src/archive/mod.rs
@@ -17,7 +17,8 @@ use cfxcore::{
 };
 
 use crate::rpc::{
-    impls::cfx::RpcImpl, setup_debug_rpc_apis, setup_public_rpc_apis,
+    impls::{cfx::RpcImpl, common::RpcImpl as CommonImpl},
+    setup_debug_rpc_apis, setup_public_rpc_apis,
 };
 use cfx_types::{Address, U256};
 use cfxcore::block_data_manager::BlockDataManager;
@@ -289,8 +290,13 @@ impl ArchiveClient {
             sync.clone(),
             blockgen.clone(),
             txpool.clone(),
+        ));
+
+        let common_impl = Arc::new(CommonImpl::new(
             exit,
+            consensus.clone(),
             network.clone(),
+            txpool.clone(),
         ));
 
         let debug_rpc_http_server = super::rpc::new_http(
@@ -300,7 +306,7 @@ impl ArchiveClient {
                 conf.raw_conf.jsonrpc_cors.clone(),
                 conf.raw_conf.jsonrpc_http_keep_alive,
             ),
-            setup_debug_rpc_apis(rpc_impl.clone()),
+            setup_debug_rpc_apis(common_impl.clone(), rpc_impl.clone()),
         )?;
 
         let rpc_tcp_server = super::rpc::new_tcp(
@@ -309,9 +315,9 @@ impl ArchiveClient {
                 conf.raw_conf.jsonrpc_tcp_port,
             ),
             if conf.raw_conf.test_mode {
-                setup_debug_rpc_apis(rpc_impl.clone())
+                setup_debug_rpc_apis(common_impl.clone(), rpc_impl.clone())
             } else {
-                setup_public_rpc_apis(rpc_impl.clone())
+                setup_public_rpc_apis(common_impl.clone(), rpc_impl.clone())
             },
         )?;
 
@@ -323,9 +329,9 @@ impl ArchiveClient {
                 conf.raw_conf.jsonrpc_http_keep_alive,
             ),
             if conf.raw_conf.test_mode {
-                setup_debug_rpc_apis(rpc_impl.clone())
+                setup_debug_rpc_apis(common_impl.clone(), rpc_impl.clone())
             } else {
-                setup_public_rpc_apis(rpc_impl.clone())
+                setup_public_rpc_apis(common_impl.clone(), rpc_impl.clone())
             },
         )?;
 

--- a/client/src/full/mod.rs
+++ b/client/src/full/mod.rs
@@ -17,7 +17,8 @@ use cfxcore::{
 };
 
 use crate::rpc::{
-    impls::cfx::RpcImpl, setup_debug_rpc_apis, setup_public_rpc_apis,
+    impls::{cfx::RpcImpl, common::RpcImpl as CommonImpl},
+    setup_debug_rpc_apis, setup_public_rpc_apis,
 };
 use cfx_types::{Address, U256};
 use cfxcore::block_data_manager::BlockDataManager;
@@ -289,8 +290,13 @@ impl FullClient {
             sync.clone(),
             blockgen.clone(),
             txpool.clone(),
+        ));
+
+        let common_impl = Arc::new(CommonImpl::new(
             exit,
+            consensus.clone(),
             network.clone(),
+            txpool.clone(),
         ));
 
         let debug_rpc_http_server = super::rpc::new_http(
@@ -300,7 +306,7 @@ impl FullClient {
                 conf.raw_conf.jsonrpc_cors.clone(),
                 conf.raw_conf.jsonrpc_http_keep_alive,
             ),
-            setup_debug_rpc_apis(rpc_impl.clone()),
+            setup_debug_rpc_apis(common_impl.clone(), rpc_impl.clone()),
         )?;
 
         let rpc_tcp_server = super::rpc::new_tcp(
@@ -309,9 +315,9 @@ impl FullClient {
                 conf.raw_conf.jsonrpc_tcp_port,
             ),
             if conf.raw_conf.test_mode {
-                setup_debug_rpc_apis(rpc_impl.clone())
+                setup_debug_rpc_apis(common_impl.clone(), rpc_impl.clone())
             } else {
-                setup_public_rpc_apis(rpc_impl.clone())
+                setup_public_rpc_apis(common_impl.clone(), rpc_impl.clone())
             },
         )?;
 
@@ -323,9 +329,9 @@ impl FullClient {
                 conf.raw_conf.jsonrpc_http_keep_alive,
             ),
             if conf.raw_conf.test_mode {
-                setup_debug_rpc_apis(rpc_impl.clone())
+                setup_debug_rpc_apis(common_impl.clone(), rpc_impl.clone())
             } else {
-                setup_public_rpc_apis(rpc_impl.clone())
+                setup_public_rpc_apis(common_impl.clone(), rpc_impl.clone())
             },
         )?;
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -2,7 +2,9 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
+#![recursion_limit = "512"]
 #![allow(deprecated)]
+
 use jsonrpc_http_server as http;
 use jsonrpc_tcp_server as tcp;
 

--- a/client/src/rpc/impls.rs
+++ b/client/src/rpc/impls.rs
@@ -3,3 +3,5 @@
 // See http://www.gnu.org/licenses/
 
 pub mod cfx;
+pub mod common;
+pub mod light;

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -2,11 +2,13 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
+use delegate::delegate;
+
 use crate::rpc::{
     traits::cfx::{debug::DebugRpc, public::Cfx, test::TestRpc},
     types::{
         BlameInfo, Block as RpcBlock, Bytes, EpochNumber, Filter as RpcFilter,
-        Log as RpcLog, Receipt as RpcReceipt, Receipt, Status as RpcStatus,
+        Log as RpcLog, Receipt as RpcReceipt, Status as RpcStatus,
         Transaction as RpcTransaction, H160 as RpcH160, H256 as RpcH256,
         U256 as RpcU256, U64 as RpcU64,
     },
@@ -19,37 +21,29 @@ use cfxcore::{
 };
 use jsonrpc_core::{Error as RpcError, Result as RpcResult};
 use network::{
-    get_high_priority_packets,
-    node_table::{Node, NodeEndpoint, NodeEntry, NodeId},
-    throttling::{self, THROTTLING_SERVICE},
-    NetworkService, SessionDetails,
+    node_table::{Node, NodeId},
+    throttling, SessionDetails,
 };
-use parking_lot::{Condvar, Mutex};
 use primitives::{
     filter::FilterError, Action, SignedTransaction, Transaction,
     TransactionWithSignature,
 };
 use rlp::Rlp;
-use std::{
-    collections::{BTreeMap, HashSet},
-    net::SocketAddr,
-    sync::Arc,
-};
+use std::{collections::BTreeMap, net::SocketAddr, sync::Arc};
+
+use super::common::RpcImpl as CommonImpl;
 
 pub struct RpcImpl {
     pub consensus: SharedConsensusGraph,
     sync: SharedSynchronizationService,
     block_gen: Arc<BlockGenerator>,
     tx_pool: SharedTransactionPool,
-    exit: Arc<(Mutex<bool>, Condvar)>,
-    network: Arc<NetworkService>,
 }
 
 impl RpcImpl {
     pub fn new(
         consensus: SharedConsensusGraph, sync: SharedSynchronizationService,
         block_gen: Arc<BlockGenerator>, tx_pool: SharedTransactionPool,
-        exit: Arc<(Mutex<bool>, Condvar)>, network: Arc<NetworkService>,
     ) -> Self
     {
         RpcImpl {
@@ -57,159 +51,7 @@ impl RpcImpl {
             sync,
             block_gen,
             tx_pool,
-            exit,
-            network,
         }
-    }
-
-    fn best_block_hash(&self) -> RpcResult<RpcH256> {
-        info!("RPC Request: cfx_getBestBlockHash()");
-        Ok(self.consensus.best_block_hash().into())
-    }
-
-    fn gas_price(&self) -> RpcResult<RpcU256> {
-        info!("RPC Request: cfx_gasPrice()");
-        Ok(self.consensus.gas_price().unwrap_or(0.into()).into())
-    }
-
-    fn epoch_number(
-        &self, epoch_num: Option<EpochNumber>,
-    ) -> RpcResult<RpcU256> {
-        let epoch_num = epoch_num.unwrap_or(EpochNumber::LatestMined);
-        info!("RPC Request: cfx_epochNumber({:?})", epoch_num);
-        match self
-            .consensus
-            .get_height_from_epoch_number(epoch_num.into())
-        {
-            Ok(height) => Ok(height.into()),
-            Err(e) => Err(RpcError::invalid_params(e)),
-        }
-    }
-
-    fn block_by_epoch_number(
-        &self, epoch_num: EpochNumber, include_txs: bool,
-    ) -> RpcResult<RpcBlock> {
-        let inner = &*self.consensus.inner.read();
-        info!("RPC Request: cfx_getBlockByEpochNumber epoch_number={:?} include_txs={:?}", epoch_num, include_txs);
-        let epoch_height = self
-            .consensus
-            .get_height_from_epoch_number(epoch_num.into())
-            .map_err(|err| RpcError::invalid_params(err))?;
-        inner
-            .get_hash_from_epoch_number(epoch_height)
-            .map_err(|err| RpcError::invalid_params(err))
-            .and_then(|hash| {
-                let block = self
-                    .consensus
-                    .data_man
-                    .block_by_hash(&hash, false)
-                    .unwrap();
-                Ok(RpcBlock::new(&*block, inner, include_txs))
-            })
-    }
-
-    fn block_by_hash(
-        &self, hash: RpcH256, include_txs: bool,
-    ) -> RpcResult<Option<RpcBlock>> {
-        let hash: H256 = hash.into();
-        info!(
-            "RPC Request: cfx_getBlockByHash hash={:?} include_txs={:?}",
-            hash, include_txs
-        );
-        let inner = &*self.consensus.inner.read();
-
-        if let Some(block) = self.consensus.data_man.block_by_hash(&hash, false)
-        {
-            let result_block = Some(RpcBlock::new(&*block, inner, include_txs));
-            Ok(result_block)
-        } else {
-            Ok(None)
-        }
-    }
-
-    fn block_by_hash_with_pivot_assumption(
-        &self, block_hash: RpcH256, pivot_hash: RpcH256, epoch_number: RpcU64,
-    ) -> RpcResult<RpcBlock> {
-        let inner = &*self.consensus.inner.read();
-
-        let block_hash: H256 = block_hash.into();
-        let pivot_hash: H256 = pivot_hash.into();
-        let epoch_number = epoch_number.as_usize() as u64;
-        info!(
-            "RPC Request: cfx_getBlockByHashWithPivotAssumption block_hash={:?} pivot_hash={:?} epoch_number={:?}",
-            block_hash, pivot_hash, epoch_number
-        );
-
-        inner
-            .check_block_pivot_assumption(&pivot_hash, epoch_number)
-            .map_err(|err| RpcError::invalid_params(err))
-            .and_then(|_| {
-                if let Some(block) =
-                    self.consensus.data_man.block_by_hash(&block_hash, false)
-                {
-                    debug!("Build RpcBlock {}", block.hash());
-                    let result_block = RpcBlock::new(&*block, inner, true);
-                    Ok(result_block)
-                } else {
-                    Err(RpcError::invalid_params(
-                        "Error: can not find expected block".to_owned(),
-                    ))
-                }
-            })
-    }
-
-    fn chain(&self) -> RpcResult<Vec<RpcBlock>> {
-        info!("RPC Request: cfx_getChain");
-        let inner = &*self.consensus.inner.read();
-        Ok(inner
-            .all_blocks_with_topo_order()
-            .iter()
-            .map(|x| {
-                RpcBlock::new(
-                    self.consensus
-                        .data_man
-                        .block_by_hash(x, false)
-                        .expect("Error to get block by hash")
-                        .as_ref(),
-                    inner,
-                    true,
-                )
-            })
-            .collect())
-    }
-
-    fn transaction_by_hash(
-        &self, hash: RpcH256,
-    ) -> RpcResult<Option<RpcTransaction>> {
-        let hash: H256 = hash.into();
-        info!("RPC Request: cfx_getTransactionByHash({:?})", hash);
-
-        if let Some((transaction, receipt, tx_address)) =
-            self.consensus.get_transaction_info_by_hash(&hash)
-        {
-            Ok(Some(RpcTransaction::from_signed(
-                &transaction,
-                Some(Receipt::new(transaction.clone(), receipt, tx_address)),
-            )))
-        } else {
-            if let Some(transaction) = self.tx_pool.get_transaction(&hash) {
-                return Ok(Some(RpcTransaction::from_signed(
-                    &transaction,
-                    None,
-                )));
-            }
-
-            Ok(None)
-        }
-    }
-
-    fn blocks_by_epoch(&self, num: EpochNumber) -> RpcResult<Vec<RpcH256>> {
-        info!("RPC Request: cfx_getBlocks epoch_number={:?}", num);
-
-        self.consensus
-            .block_hashes_by_epoch(num.into())
-            .map_err(|err| RpcError::invalid_params(err))
-            .and_then(|vec| Ok(vec.into_iter().map(|x| x.into()).collect()))
     }
 
     fn balance(
@@ -261,21 +103,6 @@ impl RpcImpl {
     //            .map_err(|err| RpcError::invalid_params(err))
     //    }
 
-    fn transaction_count(
-        &self, address: RpcH160, num: Option<EpochNumber>,
-    ) -> RpcResult<RpcU256> {
-        let num = num.unwrap_or(EpochNumber::LatestState);
-        info!(
-            "RPC Request: cfx_getTransactionCount address={:?} epoch_num={:?}",
-            address, num
-        );
-
-        self.consensus
-            .transaction_count(address.into(), num.into())
-            .map_err(|err| RpcError::invalid_params(err))
-            .map(|x| x.into())
-    }
-
     fn send_raw_transaction(&self, raw: Bytes) -> RpcResult<RpcH256> {
         info!("RPC Request: cfx_sendRawTransaction bytes={:?}", raw);
         Rlp::new(&raw.into_vec())
@@ -312,76 +139,6 @@ impl RpcImpl {
             })
     }
 
-    fn say_hello(&self) -> RpcResult<String> { Ok("Hello, world".into()) }
-
-    fn get_best_block_hash(&self) -> RpcResult<H256> {
-        info!("RPC Request: get_best_block_hash()");
-        Ok(self.consensus.best_block_hash())
-    }
-
-    fn get_block_count(&self) -> RpcResult<u64> {
-        info!("RPC Request: get_block_count()");
-        Ok(self.consensus.block_count())
-    }
-
-    fn get_goodput(&self) -> RpcResult<isize> {
-        info!("RPC Request: get_goodput");
-        let mut set = HashSet::new();
-        let mut min = std::u64::MAX;
-        let mut max: u64 = 0;
-        for key in self.consensus.inner.read().hash_to_arena_indices.keys() {
-            if let Some(block) =
-                self.consensus.data_man.block_by_hash(key, false)
-            {
-                let timestamp = block.block_header.timestamp();
-                if timestamp < min && timestamp > 0 {
-                    min = timestamp;
-                }
-                if timestamp > max {
-                    max = timestamp;
-                }
-                for transaction in &block.transactions {
-                    set.insert(transaction.hash());
-                }
-            }
-        }
-        if max != min {
-            Ok(set.len() as isize / (max - min) as isize)
-        } else {
-            Ok(-1)
-        }
-    }
-
-    fn add_peer(&self, node_id: NodeId, address: SocketAddr) -> RpcResult<()> {
-        let node = NodeEntry {
-            id: node_id,
-            endpoint: NodeEndpoint {
-                address,
-                udp_port: address.port(),
-            },
-        };
-        info!("RPC Request: add_peer({:?})", node.clone());
-        match self.network.add_peer(node) {
-            Ok(x) => Ok(x),
-            Err(_) => Err(RpcError::internal_error()),
-        }
-    }
-
-    fn drop_peer(&self, node_id: NodeId, address: SocketAddr) -> RpcResult<()> {
-        let node = NodeEntry {
-            id: node_id,
-            endpoint: NodeEndpoint {
-                address,
-                udp_port: address.port(),
-            },
-        };
-        info!("RPC Request: drop_peer({:?})", node.clone());
-        match self.network.drop_peer(node) {
-            Ok(_) => Ok(()),
-            Err(_) => Err(RpcError::internal_error()),
-        }
-    }
-
     fn generate(
         &self, num_blocks: usize, num_txs: usize,
     ) -> RpcResult<Vec<H256>> {
@@ -398,7 +155,7 @@ impl RpcImpl {
 
     fn generate_fixed_block(
         &self, parent_hash: H256, referee: Vec<H256>, num_txs: usize,
-        difficulty: u64, adaptive: bool,
+        adaptive: bool, difficulty: Option<u64>,
     ) -> RpcResult<H256>
     {
         info!(
@@ -409,7 +166,7 @@ impl RpcImpl {
             parent_hash,
             referee,
             num_txs,
-            difficulty,
+            difficulty.unwrap_or(0),
             adaptive,
         ) {
             Ok(hash) => Ok(hash),
@@ -452,7 +209,7 @@ impl RpcImpl {
 
     fn generate_custom_block(
         &self, parent_hash: H256, referee: Vec<H256>, raw_txs: Bytes,
-        adaptive: bool,
+        adaptive: Option<bool>,
     ) -> RpcResult<H256>
     {
         info!("RPC Request: generate_custom_block()");
@@ -463,7 +220,7 @@ impl RpcImpl {
             parent_hash,
             referee,
             transactions,
-            adaptive,
+            adaptive.unwrap_or(false),
         ) {
             Ok(hash) => Ok(hash),
             Err(e) => Err(RpcError::invalid_params(e)),
@@ -526,66 +283,6 @@ impl RpcImpl {
                 .deferred_logs_bloom_hash
                 .and_then(|x| Some(x.into())),
         ))
-    }
-
-    fn get_peer_info(&self) -> RpcResult<Vec<PeerInfo>> {
-        info!("RPC Request: get_peer_info");
-        match self.network.get_peer_info() {
-            None => Ok(Vec::new()),
-            Some(peers) => Ok(peers),
-        }
-    }
-
-    fn stop(&self) -> RpcResult<()> {
-        *self.exit.0.lock() = true;
-        self.exit.1.notify_all();
-
-        Ok(())
-    }
-
-    fn get_nodeid(&self, challenge: Vec<u8>) -> RpcResult<Vec<u8>> {
-        match self.network.sign_challenge(challenge) {
-            Ok(r) => Ok(r),
-            Err(_) => Err(RpcError::internal_error()),
-        }
-    }
-
-    fn get_status(&self) -> RpcResult<RpcStatus> {
-        let best_hash = self.consensus.best_block_hash();
-        let block_number = self.consensus.block_count();
-        let tx_count = self.tx_pool.total_unpacked();
-        if let Some(epoch_number) =
-            self.consensus.get_block_epoch_number(&best_hash)
-        {
-            Ok(RpcStatus {
-                best_hash: RpcH256::from(best_hash),
-                epoch_number,
-                block_number,
-                pending_tx_number: tx_count,
-            })
-        } else {
-            Err(RpcError::internal_error())
-        }
-    }
-
-    fn add_latency(&self, id: NodeId, latency_ms: f64) -> RpcResult<()> {
-        match self.network.add_latency(id, latency_ms) {
-            Ok(_) => Ok(()),
-            Err(_) => Err(RpcError::internal_error()),
-        }
-    }
-
-    /// The first element is true if the tx is executed in a confirmed block.
-    /// The second element indicate the execution result (standin
-    /// for receipt)
-    fn get_transaction_receipt(
-        &self, tx_hash: H256,
-    ) -> RpcResult<Option<RpcReceipt>> {
-        let maybe_receipt =
-            self.consensus.get_transaction_info_by_hash(&tx_hash).map(
-                |(tx, receipt, address)| RpcReceipt::new(tx, receipt, address),
-            );
-        Ok(maybe_receipt)
     }
 
     fn call(
@@ -654,141 +351,6 @@ impl RpcImpl {
             .map(|x| x.into())
     }
 
-    fn txpool_status(&self) -> RpcResult<BTreeMap<String, usize>> {
-        let (ready_len, deferred_len, received_len, unexecuted_len) =
-            self.tx_pool.stats();
-
-        let mut ret: BTreeMap<String, usize> = BTreeMap::new();
-        ret.insert("ready".into(), ready_len);
-        ret.insert("deferred".into(), deferred_len);
-        ret.insert("received".into(), received_len);
-        ret.insert("unexecuted".into(), unexecuted_len);
-
-        Ok(ret)
-    }
-
-    fn tx_inspect(&self, hash: RpcH256) -> RpcResult<BTreeMap<String, String>> {
-        let mut ret: BTreeMap<String, String> = BTreeMap::new();
-        let hash: H256 = hash.into();
-        if let Some(tx) = self.tx_pool.get_transaction(&hash) {
-            ret.insert("exist".into(), "true".into());
-            if self.tx_pool.check_tx_packed_in_deferred_pool(&hash) {
-                ret.insert("packed".into(), "true".into());
-            } else {
-                ret.insert("packed".into(), "false".into());
-            }
-            let (local_nonce, local_balance) =
-                self.tx_pool.get_local_account_info(&tx.sender());
-            let (state_nonce, state_balance) =
-                self.tx_pool.get_state_account_info(&tx.sender());
-            ret.insert(
-                "local nonce".into(),
-                serde_json::to_string(&local_nonce).unwrap(),
-            );
-            ret.insert(
-                "local balance".into(),
-                serde_json::to_string(&local_balance).unwrap(),
-            );
-            ret.insert(
-                "state nonce".into(),
-                serde_json::to_string(&state_nonce).unwrap(),
-            );
-            ret.insert(
-                "state balance".into(),
-                serde_json::to_string(&state_balance).unwrap(),
-            );
-        } else {
-            ret.insert("exist".into(), "false".into());
-        }
-        Ok(ret)
-    }
-
-    fn txpool_inspect(
-        &self,
-    ) -> RpcResult<
-        BTreeMap<String, BTreeMap<String, BTreeMap<usize, Vec<String>>>>,
-    > {
-        let (ready_txs, deferred_txs) = self.tx_pool.content();
-        let converter = |tx: Arc<SignedTransaction>| -> String {
-            let to = match tx.action {
-                Action::Create => "<Create contract>".into(),
-                Action::Call(addr) => format!("{:?}", addr),
-            };
-
-            format!(
-                "{}: {:?} wei + {:?} gas * {:?} wei",
-                to, tx.value, tx.gas, tx.gas_price
-            )
-        };
-
-        let mut ret: BTreeMap<
-            String,
-            BTreeMap<String, BTreeMap<usize, Vec<String>>>,
-        > = BTreeMap::new();
-        ret.insert("ready".into(), grouped_txs(ready_txs, converter));
-        ret.insert("deferred".into(), grouped_txs(deferred_txs, converter));
-
-        Ok(ret)
-    }
-
-    fn txpool_content(
-        &self,
-    ) -> RpcResult<
-        BTreeMap<
-            String,
-            BTreeMap<String, BTreeMap<usize, Vec<RpcTransaction>>>,
-        >,
-    > {
-        let (ready_txs, deferred_txs) = self.tx_pool.content();
-        let converter = |tx: Arc<SignedTransaction>| -> RpcTransaction {
-            RpcTransaction::from_signed(&tx, None)
-        };
-
-        let mut ret: BTreeMap<
-            String,
-            BTreeMap<String, BTreeMap<usize, Vec<RpcTransaction>>>,
-        > = BTreeMap::new();
-        ret.insert("ready".into(), grouped_txs(ready_txs, converter));
-        ret.insert("deferred".into(), grouped_txs(deferred_txs, converter));
-
-        Ok(ret)
-    }
-
-    fn clear_tx_pool(&self) -> RpcResult<()> {
-        self.tx_pool.clear_tx_pool();
-        Ok(())
-    }
-
-    fn net_throttling(&self) -> RpcResult<throttling::Service> {
-        Ok(THROTTLING_SERVICE.read().clone())
-    }
-
-    fn net_node(&self, id: NodeId) -> RpcResult<Option<(String, Node)>> {
-        match self.network.get_node(&id) {
-            None => Ok(None),
-            Some((trusted, node)) => {
-                if trusted {
-                    Ok(Some(("trusted".into(), node)))
-                } else {
-                    Ok(Some(("untrusted".into(), node)))
-                }
-            }
-        }
-    }
-
-    fn net_sessions(
-        &self, node_id: Option<NodeId>,
-    ) -> RpcResult<Vec<SessionDetails>> {
-        match self.network.get_detailed_sessions(node_id.into()) {
-            None => Ok(Vec::new()),
-            Some(sessions) => Ok(sessions),
-        }
-    }
-
-    fn net_high_priority_packets(&self) -> RpcResult<usize> {
-        Ok(get_high_priority_packets())
-    }
-
     fn current_sync_phase(&self) -> RpcResult<String> {
         Ok(self.sync.current_sync_phase().name().into())
     }
@@ -799,308 +361,112 @@ impl RpcImpl {
     }
 }
 
-fn grouped_txs<T, F>(
-    txs: Vec<Arc<SignedTransaction>>, converter: F,
-) -> BTreeMap<String, BTreeMap<usize, Vec<T>>>
-where F: Fn(Arc<SignedTransaction>) -> T {
-    let mut addr_grouped_txs: BTreeMap<String, BTreeMap<usize, Vec<T>>> =
-        BTreeMap::new();
-
-    for tx in txs {
-        let addr = format!("{:?}", tx.sender());
-        let addr_entry: &mut BTreeMap<usize, Vec<T>> =
-            addr_grouped_txs.entry(addr).or_insert(BTreeMap::new());
-
-        let nonce = tx.nonce().as_usize();
-        let nonce_entry: &mut Vec<T> =
-            addr_entry.entry(nonce).or_insert(Vec::new());
-
-        nonce_entry.push(converter(tx));
-    }
-
-    addr_grouped_txs
-}
-
+#[allow(dead_code)]
 pub struct CfxHandler {
+    common: Arc<CommonImpl>,
     rpc_impl: Arc<RpcImpl>,
 }
 
 impl CfxHandler {
-    pub fn new(rpc_impl: Arc<RpcImpl>) -> Self { CfxHandler { rpc_impl } }
+    pub fn new(common: Arc<CommonImpl>, rpc_impl: Arc<RpcImpl>) -> Self {
+        CfxHandler { common, rpc_impl }
+    }
 }
 
 impl Cfx for CfxHandler {
-    fn best_block_hash(&self) -> RpcResult<RpcH256> {
-        self.rpc_impl.best_block_hash()
-    }
+    delegate! {
+        target self.common {
+            fn best_block_hash(&self) -> RpcResult<RpcH256>;
+            fn block_by_epoch_number(&self, epoch_num: EpochNumber, include_txs: bool) -> RpcResult<RpcBlock>;
+            fn block_by_hash_with_pivot_assumption(&self, block_hash: RpcH256, pivot_hash: RpcH256, epoch_number: RpcU64) -> RpcResult<RpcBlock>;
+            fn block_by_hash(&self, hash: RpcH256, include_txs: bool) -> RpcResult<Option<RpcBlock>>;
+            fn blocks_by_epoch(&self, num: EpochNumber) -> RpcResult<Vec<RpcH256>>;
+            fn epoch_number(&self, epoch_num: Option<EpochNumber>) -> RpcResult<RpcU256>;
+            fn gas_price(&self) -> RpcResult<RpcU256>;
+            fn transaction_by_hash(&self, hash: RpcH256) -> RpcResult<Option<RpcTransaction>>;
+            fn transaction_count(&self, address: RpcH160, num: Option<EpochNumber>) -> RpcResult<RpcU256>;
+        }
 
-    fn estimate_gas(&self, rpc_tx: RpcTransaction) -> RpcResult<RpcU256> {
-        self.rpc_impl.estimate_gas(rpc_tx)
-    }
-
-    fn gas_price(&self) -> RpcResult<RpcU256> { self.rpc_impl.gas_price() }
-
-    fn epoch_number(
-        &self, epoch_num: Option<EpochNumber>,
-    ) -> RpcResult<RpcU256> {
-        self.rpc_impl.epoch_number(epoch_num)
-    }
-
-    fn block_by_epoch_number(
-        &self, epoch_num: EpochNumber, include_txs: bool,
-    ) -> RpcResult<RpcBlock> {
-        self.rpc_impl.block_by_epoch_number(epoch_num, include_txs)
-    }
-
-    fn block_by_hash(
-        &self, hash: RpcH256, include_txs: bool,
-    ) -> RpcResult<Option<RpcBlock>> {
-        self.rpc_impl.block_by_hash(hash, include_txs)
-    }
-
-    fn block_by_hash_with_pivot_assumption(
-        &self, block_hash: RpcH256, pivot_hash: RpcH256, epoch_number: RpcU64,
-    ) -> RpcResult<RpcBlock> {
-        self.rpc_impl.block_by_hash_with_pivot_assumption(
-            block_hash,
-            pivot_hash,
-            epoch_number,
-        )
-    }
-
-    fn transaction_by_hash(
-        &self, hash: RpcH256,
-    ) -> RpcResult<Option<RpcTransaction>> {
-        self.rpc_impl.transaction_by_hash(hash)
-    }
-
-    fn blocks_by_epoch(&self, num: EpochNumber) -> RpcResult<Vec<RpcH256>> {
-        self.rpc_impl.blocks_by_epoch(num)
-    }
-
-    fn balance(
-        &self, address: RpcH160, num: Option<EpochNumber>,
-    ) -> RpcResult<RpcU256> {
-        self.rpc_impl.balance(address, num)
-    }
-
-    //    fn account(
-    //        &self, address: RpcH160, include_txs: bool, num_txs: RpcU64,
-    //        epoch_num: Option<EpochNumber>,
-    //    ) -> RpcResult<Account>
-    //    {
-    //        self.rpc_impl
-    //            .account(address, include_txs, num_txs, epoch_num)
-    //    }
-
-    fn transaction_count(
-        &self, address: RpcH160, num: Option<EpochNumber>,
-    ) -> RpcResult<RpcU256> {
-        self.rpc_impl.transaction_count(address, num)
-    }
-
-    fn send_raw_transaction(&self, raw: Bytes) -> RpcResult<RpcH256> {
-        self.rpc_impl.send_raw_transaction(raw)
-    }
-
-    fn call(
-        &self, rpc_tx: RpcTransaction, epoch: Option<EpochNumber>,
-    ) -> RpcResult<Bytes> {
-        self.rpc_impl.call(rpc_tx, epoch)
-    }
-
-    fn get_logs(&self, filter: RpcFilter) -> RpcResult<Vec<RpcLog>> {
-        self.rpc_impl.get_logs(filter)
+        target self.rpc_impl {
+            fn balance(&self, address: RpcH160, num: Option<EpochNumber>) -> RpcResult<RpcU256>;
+            fn call(&self, rpc_tx: RpcTransaction, epoch: Option<EpochNumber>) -> RpcResult<Bytes>;
+            fn estimate_gas(&self, rpc_tx: RpcTransaction) -> RpcResult<RpcU256>;
+            fn get_logs(&self, filter: RpcFilter) -> RpcResult<Vec<RpcLog>>;
+            fn send_raw_transaction(&self, raw: Bytes) -> RpcResult<RpcH256>;
+        }
     }
 }
 
+#[allow(dead_code)]
 pub struct TestRpcImpl {
+    common: Arc<CommonImpl>,
     rpc_impl: Arc<RpcImpl>,
 }
 
 impl TestRpcImpl {
-    pub fn new(rpc_impl: Arc<RpcImpl>) -> Self { TestRpcImpl { rpc_impl } }
+    pub fn new(common: Arc<CommonImpl>, rpc_impl: Arc<RpcImpl>) -> Self {
+        TestRpcImpl { common, rpc_impl }
+    }
 }
 
 impl TestRpc for TestRpcImpl {
-    fn say_hello(&self) -> RpcResult<String> { self.rpc_impl.say_hello() }
+    delegate! {
+        target self.common {
+            fn add_latency(&self, id: NodeId, latency_ms: f64) -> RpcResult<()>;
+            fn add_peer(&self, node_id: NodeId, address: SocketAddr) -> RpcResult<()>;
+            fn chain(&self) -> RpcResult<Vec<RpcBlock>>;
+            fn drop_peer(&self, node_id: NodeId, address: SocketAddr) -> RpcResult<()>;
+            fn get_best_block_hash(&self) -> RpcResult<H256>;
+            fn get_block_count(&self) -> RpcResult<u64>;
+            fn get_goodput(&self) -> RpcResult<isize>;
+            fn get_nodeid(&self, challenge: Vec<u8>) -> RpcResult<Vec<u8>>;
+            fn get_peer_info(&self) -> RpcResult<Vec<PeerInfo>>;
+            fn get_status(&self) -> RpcResult<RpcStatus>;
+            fn get_transaction_receipt(&self, tx_hash: H256) -> RpcResult<Option<RpcReceipt>>;
+            fn say_hello(&self) -> RpcResult<String>;
+            fn stop(&self) -> RpcResult<()>;
+        }
 
-    fn get_best_block_hash(&self) -> RpcResult<H256> {
-        self.rpc_impl.get_best_block_hash()
-    }
-
-    fn get_block_count(&self) -> RpcResult<u64> {
-        self.rpc_impl.get_block_count()
-    }
-
-    fn get_goodput(&self) -> RpcResult<isize> { self.rpc_impl.get_goodput() }
-
-    fn add_peer(&self, node_id: NodeId, address: SocketAddr) -> RpcResult<()> {
-        self.rpc_impl.add_peer(node_id, address)
-    }
-
-    fn drop_peer(&self, node_id: NodeId, address: SocketAddr) -> RpcResult<()> {
-        self.rpc_impl.drop_peer(node_id, address)
-    }
-
-    fn chain(&self) -> RpcResult<Vec<RpcBlock>> { self.rpc_impl.chain() }
-
-    fn generate(
-        &self, num_blocks: usize, num_txs: usize,
-    ) -> RpcResult<Vec<H256>> {
-        self.rpc_impl.generate(num_blocks, num_txs)
-    }
-
-    fn generate_fixed_block(
-        &self, parent_hash: H256, referee: Vec<H256>, num_txs: usize,
-        adaptive: bool, difficulty: Option<u64>,
-    ) -> RpcResult<H256>
-    {
-        Ok(self.rpc_impl.generate_fixed_block(
-            parent_hash,
-            referee,
-            num_txs,
-            difficulty.unwrap_or(0),
-            adaptive,
-        )?)
-    }
-
-    fn generate_one_block(
-        &self, num_txs: usize, block_size_limit: usize,
-    ) -> RpcResult<H256> {
-        self.rpc_impl.generate_one_block(num_txs, block_size_limit)
-    }
-
-    fn generate_one_block_special(
-        &self, num_txs: usize, block_size_limit: usize, num_txs_simple: usize,
-        num_txs_erc20: usize,
-    ) -> RpcResult<()>
-    {
-        self.rpc_impl.generate_one_block_special(
-            num_txs,
-            block_size_limit,
-            num_txs_simple,
-            num_txs_erc20,
-        )
-    }
-
-    fn generate_custom_block(
-        &self, parent_hash: H256, referee: Vec<H256>, raw_txs: Bytes,
-        adaptive: Option<bool>,
-    ) -> RpcResult<H256>
-    {
-        self.rpc_impl.generate_custom_block(
-            parent_hash,
-            referee,
-            raw_txs,
-            adaptive.unwrap_or(false),
-        )
-    }
-
-    fn generate_block_with_fake_txs(
-        &self, raw_txs_without_data: Bytes, tx_data_len: Option<usize>,
-    ) -> RpcResult<H256> {
-        self.rpc_impl
-            .generate_block_with_fake_txs(raw_txs_without_data, tx_data_len)
-    }
-
-    fn get_peer_info(&self) -> RpcResult<Vec<PeerInfo>> {
-        self.rpc_impl.get_peer_info()
-    }
-
-    fn stop(&self) -> RpcResult<()> { self.rpc_impl.stop() }
-
-    fn get_nodeid(&self, challenge: Vec<u8>) -> RpcResult<Vec<u8>> {
-        self.rpc_impl.get_nodeid(challenge)
-    }
-
-    fn get_status(&self) -> RpcResult<RpcStatus> { self.rpc_impl.get_status() }
-
-    fn add_latency(&self, id: NodeId, latency_ms: f64) -> RpcResult<()> {
-        self.rpc_impl.add_latency(id, latency_ms)
-    }
-
-    /// The first element is true if the tx is executed in a confirmed block.
-    /// The second element indicate the execution result (standin
-    /// for receipt)
-    fn get_transaction_receipt(
-        &self, tx_hash: H256,
-    ) -> RpcResult<Option<RpcReceipt>> {
-        self.rpc_impl.get_transaction_receipt(tx_hash)
-    }
-
-    fn generate_block_with_blame_info(
-        &self, num_txs: usize, block_size_limit: usize, blame_info: BlameInfo,
-    ) -> RpcResult<H256> {
-        self.rpc_impl.generate_block_with_blame_info(
-            num_txs,
-            block_size_limit,
-            blame_info,
-        )
-    }
-
-    fn expire_block_gc(&self, timeout: u64) -> RpcResult<()> {
-        self.rpc_impl.expire_block_gc(timeout)
+        target self.rpc_impl {
+            fn expire_block_gc(&self, timeout: u64) -> RpcResult<()>;
+            fn generate_block_with_blame_info(&self, num_txs: usize, block_size_limit: usize, blame_info: BlameInfo) -> RpcResult<H256>;
+            fn generate_block_with_fake_txs(&self, raw_txs_without_data: Bytes, tx_data_len: Option<usize>) -> RpcResult<H256>;
+            fn generate_custom_block(&self, parent_hash: H256, referee: Vec<H256>, raw_txs: Bytes, adaptive: Option<bool>) -> RpcResult<H256>;
+            fn generate_fixed_block(&self, parent_hash: H256, referee: Vec<H256>, num_txs: usize, adaptive: bool, difficulty: Option<u64>) -> RpcResult<H256>;
+            fn generate_one_block_special(&self, num_txs: usize, block_size_limit: usize, num_txs_simple: usize, num_txs_erc20: usize) -> RpcResult<()>;
+            fn generate_one_block(&self, num_txs: usize, block_size_limit: usize) -> RpcResult<H256>;
+            fn generate(&self, num_blocks: usize, num_txs: usize) -> RpcResult<Vec<H256>>;
+        }
     }
 }
 
 pub struct DebugRpcImpl {
+    common: Arc<CommonImpl>,
     rpc_impl: Arc<RpcImpl>,
 }
 
 impl DebugRpcImpl {
-    pub fn new(rpc_impl: Arc<RpcImpl>) -> Self { DebugRpcImpl { rpc_impl } }
+    pub fn new(common: Arc<CommonImpl>, rpc_impl: Arc<RpcImpl>) -> Self {
+        DebugRpcImpl { common, rpc_impl }
+    }
 }
 
 impl DebugRpc for DebugRpcImpl {
-    fn txpool_status(&self) -> RpcResult<BTreeMap<String, usize>> {
-        self.rpc_impl.txpool_status()
-    }
+    delegate! {
+        target self.common {
+            fn clear_tx_pool(&self) -> RpcResult<()>;
+            fn net_high_priority_packets(&self) -> RpcResult<usize>;
+            fn net_node(&self, id: NodeId) -> RpcResult<Option<(String, Node)>>;
+            fn net_sessions(&self, node_id: Option<NodeId>) -> RpcResult<Vec<SessionDetails>>;
+            fn net_throttling(&self) -> RpcResult<throttling::Service>;
+            fn tx_inspect(&self, hash: RpcH256) -> RpcResult<BTreeMap<String, String>>;
+            fn txpool_content(&self) -> RpcResult<BTreeMap<String, BTreeMap<String, BTreeMap<usize, Vec<RpcTransaction>>>>>;
+            fn txpool_inspect(&self) -> RpcResult<BTreeMap<String, BTreeMap<String, BTreeMap<usize, Vec<String>>>>>;
+            fn txpool_status(&self) -> RpcResult<BTreeMap<String, usize>>;
+        }
 
-    fn tx_inspect(&self, hash: RpcH256) -> RpcResult<BTreeMap<String, String>> {
-        self.rpc_impl.tx_inspect(hash)
-    }
-
-    fn txpool_inspect(
-        &self,
-    ) -> RpcResult<
-        BTreeMap<String, BTreeMap<String, BTreeMap<usize, Vec<String>>>>,
-    > {
-        self.rpc_impl.txpool_inspect()
-    }
-
-    fn txpool_content(
-        &self,
-    ) -> RpcResult<
-        BTreeMap<
-            String,
-            BTreeMap<String, BTreeMap<usize, Vec<RpcTransaction>>>,
-        >,
-    > {
-        self.rpc_impl.txpool_content()
-    }
-
-    fn clear_tx_pool(&self) -> RpcResult<()> { self.rpc_impl.clear_tx_pool() }
-
-    fn net_throttling(&self) -> RpcResult<throttling::Service> {
-        self.rpc_impl.net_throttling()
-    }
-
-    fn net_node(&self, id: NodeId) -> RpcResult<Option<(String, Node)>> {
-        self.rpc_impl.net_node(id)
-    }
-
-    fn net_sessions(
-        &self, node_id: Option<NodeId>,
-    ) -> RpcResult<Vec<SessionDetails>> {
-        self.rpc_impl.net_sessions(node_id)
-    }
-
-    fn net_high_priority_packets(&self) -> RpcResult<usize> {
-        self.rpc_impl.net_high_priority_packets()
-    }
-
-    fn current_sync_phase(&self) -> RpcResult<String> {
-        self.rpc_impl.current_sync_phase()
+        target self.rpc_impl {
+            fn current_sync_phase(&self) -> RpcResult<String>;
+        }
     }
 }

--- a/client/src/rpc/impls/common.rs
+++ b/client/src/rpc/impls/common.rs
@@ -1,0 +1,518 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use std::{
+    collections::{BTreeMap, HashSet},
+    net::SocketAddr,
+    sync::Arc,
+};
+
+use jsonrpc_core::{Error as RpcError, Result as RpcResult};
+use parking_lot::{Condvar, Mutex};
+
+use cfx_types::H256;
+use cfxcore::{PeerInfo, SharedConsensusGraph, SharedTransactionPool};
+use primitives::{Action, SignedTransaction};
+
+use network::{
+    get_high_priority_packets,
+    node_table::{Node, NodeEndpoint, NodeEntry, NodeId},
+    throttling::{self, THROTTLING_SERVICE},
+    NetworkService, SessionDetails,
+};
+
+use crate::rpc::types::{
+    Block as RpcBlock, EpochNumber, Receipt as RpcReceipt, Receipt,
+    Status as RpcStatus, Transaction as RpcTransaction, H160 as RpcH160,
+    H256 as RpcH256, U256 as RpcU256, U64 as RpcU64,
+};
+
+fn grouped_txs<T, F>(
+    txs: Vec<Arc<SignedTransaction>>, converter: F,
+) -> BTreeMap<String, BTreeMap<usize, Vec<T>>>
+where F: Fn(Arc<SignedTransaction>) -> T {
+    let mut addr_grouped_txs: BTreeMap<String, BTreeMap<usize, Vec<T>>> =
+        BTreeMap::new();
+
+    for tx in txs {
+        let addr = format!("{:?}", tx.sender());
+        let addr_entry: &mut BTreeMap<usize, Vec<T>> =
+            addr_grouped_txs.entry(addr).or_insert(BTreeMap::new());
+
+        let nonce = tx.nonce().as_usize();
+        let nonce_entry: &mut Vec<T> =
+            addr_entry.entry(nonce).or_insert(Vec::new());
+
+        nonce_entry.push(converter(tx));
+    }
+
+    addr_grouped_txs
+}
+
+pub struct RpcImpl {
+    exit: Arc<(Mutex<bool>, Condvar)>,
+    consensus: SharedConsensusGraph,
+    network: Arc<NetworkService>,
+    tx_pool: SharedTransactionPool,
+}
+
+impl RpcImpl {
+    pub fn new(
+        exit: Arc<(Mutex<bool>, Condvar)>, consensus: SharedConsensusGraph,
+        network: Arc<NetworkService>, tx_pool: SharedTransactionPool,
+    ) -> Self
+    {
+        RpcImpl {
+            exit,
+            consensus,
+            network,
+            tx_pool,
+        }
+    }
+}
+
+// Cfx RPC implementation
+impl RpcImpl {
+    pub fn best_block_hash(&self) -> RpcResult<RpcH256> {
+        info!("RPC Request: cfx_getBestBlockHash()");
+        Ok(self.consensus.best_block_hash().into())
+    }
+
+    pub fn gas_price(&self) -> RpcResult<RpcU256> {
+        info!("RPC Request: cfx_gasPrice()");
+        Ok(self.consensus.gas_price().unwrap_or(0.into()).into())
+    }
+
+    pub fn epoch_number(
+        &self, epoch_num: Option<EpochNumber>,
+    ) -> RpcResult<RpcU256> {
+        let epoch_num = epoch_num.unwrap_or(EpochNumber::LatestMined);
+        info!("RPC Request: cfx_epochNumber({:?})", epoch_num);
+        match self
+            .consensus
+            .get_height_from_epoch_number(epoch_num.into())
+        {
+            Ok(height) => Ok(height.into()),
+            Err(e) => Err(RpcError::invalid_params(e)),
+        }
+    }
+
+    pub fn block_by_epoch_number(
+        &self, epoch_num: EpochNumber, include_txs: bool,
+    ) -> RpcResult<RpcBlock> {
+        let inner = &*self.consensus.inner.read();
+        info!("RPC Request: cfx_getBlockByEpochNumber epoch_number={:?} include_txs={:?}", epoch_num, include_txs);
+        let epoch_height = self
+            .consensus
+            .get_height_from_epoch_number(epoch_num.into())
+            .map_err(|err| RpcError::invalid_params(err))?;
+        inner
+            .get_hash_from_epoch_number(epoch_height)
+            .map_err(|err| RpcError::invalid_params(err))
+            .and_then(|hash| {
+                let block = self
+                    .consensus
+                    .data_man
+                    .block_by_hash(&hash, false)
+                    .unwrap();
+                Ok(RpcBlock::new(&*block, inner, include_txs))
+            })
+    }
+
+    pub fn block_by_hash(
+        &self, hash: RpcH256, include_txs: bool,
+    ) -> RpcResult<Option<RpcBlock>> {
+        let hash: H256 = hash.into();
+        info!(
+            "RPC Request: cfx_getBlockByHash hash={:?} include_txs={:?}",
+            hash, include_txs
+        );
+        let inner = &*self.consensus.inner.read();
+
+        if let Some(block) = self.consensus.data_man.block_by_hash(&hash, false)
+        {
+            let result_block = Some(RpcBlock::new(&*block, inner, include_txs));
+            Ok(result_block)
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn block_by_hash_with_pivot_assumption(
+        &self, block_hash: RpcH256, pivot_hash: RpcH256, epoch_number: RpcU64,
+    ) -> RpcResult<RpcBlock> {
+        let inner = &*self.consensus.inner.read();
+
+        let block_hash: H256 = block_hash.into();
+        let pivot_hash: H256 = pivot_hash.into();
+        let epoch_number = epoch_number.as_usize() as u64;
+        info!(
+            "RPC Request: cfx_getBlockByHashWithPivotAssumption block_hash={:?} pivot_hash={:?} epoch_number={:?}",
+            block_hash, pivot_hash, epoch_number
+        );
+
+        inner
+            .check_block_pivot_assumption(&pivot_hash, epoch_number)
+            .map_err(|err| RpcError::invalid_params(err))
+            .and_then(|_| {
+                if let Some(block) =
+                    self.consensus.data_man.block_by_hash(&block_hash, false)
+                {
+                    debug!("Build RpcBlock {}", block.hash());
+                    let result_block = RpcBlock::new(&*block, inner, true);
+                    Ok(result_block)
+                } else {
+                    Err(RpcError::invalid_params(
+                        "Error: can not find expected block".to_owned(),
+                    ))
+                }
+            })
+    }
+
+    pub fn transaction_by_hash(
+        &self, hash: RpcH256,
+    ) -> RpcResult<Option<RpcTransaction>> {
+        let hash: H256 = hash.into();
+        info!("RPC Request: cfx_getTransactionByHash({:?})", hash);
+
+        if let Some((transaction, receipt, tx_address)) =
+            self.consensus.get_transaction_info_by_hash(&hash)
+        {
+            Ok(Some(RpcTransaction::from_signed(
+                &transaction,
+                Some(Receipt::new(transaction.clone(), receipt, tx_address)),
+            )))
+        } else {
+            if let Some(transaction) = self.tx_pool.get_transaction(&hash) {
+                return Ok(Some(RpcTransaction::from_signed(
+                    &transaction,
+                    None,
+                )));
+            }
+
+            Ok(None)
+        }
+    }
+
+    pub fn blocks_by_epoch(&self, num: EpochNumber) -> RpcResult<Vec<RpcH256>> {
+        info!("RPC Request: cfx_getBlocks epoch_number={:?}", num);
+
+        self.consensus
+            .block_hashes_by_epoch(num.into())
+            .map_err(|err| RpcError::invalid_params(err))
+            .and_then(|vec| Ok(vec.into_iter().map(|x| x.into()).collect()))
+    }
+
+    pub fn transaction_count(
+        &self, address: RpcH160, num: Option<EpochNumber>,
+    ) -> RpcResult<RpcU256> {
+        let num = num.unwrap_or(EpochNumber::LatestState);
+        info!(
+            "RPC Request: cfx_getTransactionCount address={:?} epoch_num={:?}",
+            address, num
+        );
+
+        self.consensus
+            .transaction_count(address.into(), num.into())
+            .map_err(|err| RpcError::invalid_params(err))
+            .map(|x| x.into())
+    }
+}
+
+// Test RPC implementation
+impl RpcImpl {
+    pub fn add_latency(&self, id: NodeId, latency_ms: f64) -> RpcResult<()> {
+        match self.network.add_latency(id, latency_ms) {
+            Ok(_) => Ok(()),
+            Err(_) => Err(RpcError::internal_error()),
+        }
+    }
+
+    pub fn add_peer(
+        &self, node_id: NodeId, address: SocketAddr,
+    ) -> RpcResult<()> {
+        let node = NodeEntry {
+            id: node_id,
+            endpoint: NodeEndpoint {
+                address,
+                udp_port: address.port(),
+            },
+        };
+        info!("RPC Request: add_peer({:?})", node.clone());
+        match self.network.add_peer(node) {
+            Ok(x) => Ok(x),
+            Err(_) => Err(RpcError::internal_error()),
+        }
+    }
+
+    pub fn chain(&self) -> RpcResult<Vec<RpcBlock>> {
+        info!("RPC Request: cfx_getChain");
+        let inner = &*self.consensus.inner.read();
+        Ok(inner
+            .all_blocks_with_topo_order()
+            .iter()
+            .map(|x| {
+                RpcBlock::new(
+                    self.consensus
+                        .data_man
+                        .block_by_hash(x, false)
+                        .expect("Error to get block by hash")
+                        .as_ref(),
+                    inner,
+                    true,
+                )
+            })
+            .collect())
+    }
+
+    pub fn drop_peer(
+        &self, node_id: NodeId, address: SocketAddr,
+    ) -> RpcResult<()> {
+        let node = NodeEntry {
+            id: node_id,
+            endpoint: NodeEndpoint {
+                address,
+                udp_port: address.port(),
+            },
+        };
+        info!("RPC Request: drop_peer({:?})", node.clone());
+        match self.network.drop_peer(node) {
+            Ok(_) => Ok(()),
+            Err(_) => Err(RpcError::internal_error()),
+        }
+    }
+
+    pub fn get_best_block_hash(&self) -> RpcResult<H256> {
+        info!("RPC Request: get_best_block_hash()");
+        Ok(self.consensus.best_block_hash())
+    }
+
+    pub fn get_block_count(&self) -> RpcResult<u64> {
+        info!("RPC Request: get_block_count()");
+        Ok(self.consensus.block_count())
+    }
+
+    pub fn get_goodput(&self) -> RpcResult<isize> {
+        info!("RPC Request: get_goodput");
+        let mut set = HashSet::new();
+        let mut min = std::u64::MAX;
+        let mut max: u64 = 0;
+        for key in self.consensus.inner.read().hash_to_arena_indices.keys() {
+            if let Some(block) =
+                self.consensus.data_man.block_by_hash(key, false)
+            {
+                let timestamp = block.block_header.timestamp();
+                if timestamp < min && timestamp > 0 {
+                    min = timestamp;
+                }
+                if timestamp > max {
+                    max = timestamp;
+                }
+                for transaction in &block.transactions {
+                    set.insert(transaction.hash());
+                }
+            }
+        }
+        if max != min {
+            Ok(set.len() as isize / (max - min) as isize)
+        } else {
+            Ok(-1)
+        }
+    }
+
+    pub fn get_nodeid(&self, challenge: Vec<u8>) -> RpcResult<Vec<u8>> {
+        match self.network.sign_challenge(challenge) {
+            Ok(r) => Ok(r),
+            Err(_) => Err(RpcError::internal_error()),
+        }
+    }
+
+    pub fn get_peer_info(&self) -> RpcResult<Vec<PeerInfo>> {
+        info!("RPC Request: get_peer_info");
+        match self.network.get_peer_info() {
+            None => Ok(Vec::new()),
+            Some(peers) => Ok(peers),
+        }
+    }
+
+    pub fn get_status(&self) -> RpcResult<RpcStatus> {
+        let best_hash = self.consensus.best_block_hash();
+        let block_number = self.consensus.block_count();
+        let tx_count = self.tx_pool.total_unpacked();
+        if let Some(epoch_number) =
+            self.consensus.get_block_epoch_number(&best_hash)
+        {
+            Ok(RpcStatus {
+                best_hash: RpcH256::from(best_hash),
+                epoch_number,
+                block_number,
+                pending_tx_number: tx_count,
+            })
+        } else {
+            Err(RpcError::internal_error())
+        }
+    }
+
+    /// The first element is true if the tx is executed in a confirmed block.
+    /// The second element indicate the execution result (standin
+    /// for receipt)
+    pub fn get_transaction_receipt(
+        &self, tx_hash: H256,
+    ) -> RpcResult<Option<RpcReceipt>> {
+        let maybe_receipt =
+            self.consensus.get_transaction_info_by_hash(&tx_hash).map(
+                |(tx, receipt, address)| RpcReceipt::new(tx, receipt, address),
+            );
+        Ok(maybe_receipt)
+    }
+
+    pub fn say_hello(&self) -> RpcResult<String> { Ok("Hello, world".into()) }
+
+    pub fn stop(&self) -> RpcResult<()> {
+        *self.exit.0.lock() = true;
+        self.exit.1.notify_all();
+
+        Ok(())
+    }
+}
+
+// Debug RPC implementation
+impl RpcImpl {
+    pub fn clear_tx_pool(&self) -> RpcResult<()> {
+        self.tx_pool.clear_tx_pool();
+        Ok(())
+    }
+
+    pub fn net_high_priority_packets(&self) -> RpcResult<usize> {
+        Ok(get_high_priority_packets())
+    }
+
+    pub fn net_node(&self, id: NodeId) -> RpcResult<Option<(String, Node)>> {
+        match self.network.get_node(&id) {
+            None => Ok(None),
+            Some((trusted, node)) => {
+                if trusted {
+                    Ok(Some(("trusted".into(), node)))
+                } else {
+                    Ok(Some(("untrusted".into(), node)))
+                }
+            }
+        }
+    }
+
+    pub fn net_sessions(
+        &self, node_id: Option<NodeId>,
+    ) -> RpcResult<Vec<SessionDetails>> {
+        match self.network.get_detailed_sessions(node_id.into()) {
+            None => Ok(Vec::new()),
+            Some(sessions) => Ok(sessions),
+        }
+    }
+
+    pub fn net_throttling(&self) -> RpcResult<throttling::Service> {
+        Ok(THROTTLING_SERVICE.read().clone())
+    }
+
+    pub fn tx_inspect(
+        &self, hash: RpcH256,
+    ) -> RpcResult<BTreeMap<String, String>> {
+        let mut ret: BTreeMap<String, String> = BTreeMap::new();
+        let hash: H256 = hash.into();
+        if let Some(tx) = self.tx_pool.get_transaction(&hash) {
+            ret.insert("exist".into(), "true".into());
+            if self.tx_pool.check_tx_packed_in_deferred_pool(&hash) {
+                ret.insert("packed".into(), "true".into());
+            } else {
+                ret.insert("packed".into(), "false".into());
+            }
+            let (local_nonce, local_balance) =
+                self.tx_pool.get_local_account_info(&tx.sender());
+            let (state_nonce, state_balance) =
+                self.tx_pool.get_state_account_info(&tx.sender());
+            ret.insert(
+                "local nonce".into(),
+                serde_json::to_string(&local_nonce).unwrap(),
+            );
+            ret.insert(
+                "local balance".into(),
+                serde_json::to_string(&local_balance).unwrap(),
+            );
+            ret.insert(
+                "state nonce".into(),
+                serde_json::to_string(&state_nonce).unwrap(),
+            );
+            ret.insert(
+                "state balance".into(),
+                serde_json::to_string(&state_balance).unwrap(),
+            );
+        } else {
+            ret.insert("exist".into(), "false".into());
+        }
+        Ok(ret)
+    }
+
+    pub fn txpool_content(
+        &self,
+    ) -> RpcResult<
+        BTreeMap<
+            String,
+            BTreeMap<String, BTreeMap<usize, Vec<RpcTransaction>>>,
+        >,
+    > {
+        let (ready_txs, deferred_txs) = self.tx_pool.content();
+        let converter = |tx: Arc<SignedTransaction>| -> RpcTransaction {
+            RpcTransaction::from_signed(&tx, None)
+        };
+
+        let mut ret: BTreeMap<
+            String,
+            BTreeMap<String, BTreeMap<usize, Vec<RpcTransaction>>>,
+        > = BTreeMap::new();
+        ret.insert("ready".into(), grouped_txs(ready_txs, converter));
+        ret.insert("deferred".into(), grouped_txs(deferred_txs, converter));
+
+        Ok(ret)
+    }
+
+    pub fn txpool_inspect(
+        &self,
+    ) -> RpcResult<
+        BTreeMap<String, BTreeMap<String, BTreeMap<usize, Vec<String>>>>,
+    > {
+        let (ready_txs, deferred_txs) = self.tx_pool.content();
+        let converter = |tx: Arc<SignedTransaction>| -> String {
+            let to = match tx.action {
+                Action::Create => "<Create contract>".into(),
+                Action::Call(addr) => format!("{:?}", addr),
+            };
+
+            format!(
+                "{}: {:?} wei + {:?} gas * {:?} wei",
+                to, tx.value, tx.gas, tx.gas_price
+            )
+        };
+
+        let mut ret: BTreeMap<
+            String,
+            BTreeMap<String, BTreeMap<usize, Vec<String>>>,
+        > = BTreeMap::new();
+        ret.insert("ready".into(), grouped_txs(ready_txs, converter));
+        ret.insert("deferred".into(), grouped_txs(deferred_txs, converter));
+
+        Ok(ret)
+    }
+
+    pub fn txpool_status(&self) -> RpcResult<BTreeMap<String, usize>> {
+        let (ready_len, deferred_len, received_len, unexecuted_len) =
+            self.tx_pool.stats();
+
+        let mut ret: BTreeMap<String, usize> = BTreeMap::new();
+        ret.insert("ready".into(), ready_len);
+        ret.insert("deferred".into(), deferred_len);
+        ret.insert("received".into(), received_len);
+        ret.insert("unexecuted".into(), unexecuted_len);
+
+        Ok(ret)
+    }
+}

--- a/client/src/rpc/impls/light.rs
+++ b/client/src/rpc/impls/light.rs
@@ -1,0 +1,191 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use delegate::delegate;
+use jsonrpc_core::{Error as RpcError, Result as RpcResult};
+use std::{collections::BTreeMap, net::SocketAddr, sync::Arc};
+
+use cfx_types::H256;
+use cfxcore::PeerInfo;
+
+use network::{
+    node_table::{Node, NodeId},
+    throttling, SessionDetails,
+};
+
+use crate::rpc::{
+    traits::cfx::{debug::DebugRpc, public::Cfx, test::TestRpc},
+    types::{
+        BlameInfo, Block as RpcBlock, Bytes, EpochNumber, Filter as RpcFilter,
+        Log as RpcLog, Receipt as RpcReceipt, Status as RpcStatus,
+        Transaction as RpcTransaction, H160 as RpcH160, H256 as RpcH256,
+        U256 as RpcU256, U64 as RpcU64,
+    },
+};
+
+use super::common::RpcImpl as CommonImpl;
+
+pub struct RpcImpl {}
+
+impl RpcImpl {
+    pub fn new() -> Self { RpcImpl {} }
+
+    #[allow(unused_variables)]
+    fn balance(
+        &self, address: RpcH160, num: Option<EpochNumber>,
+    ) -> RpcResult<RpcU256> {
+        // TODO
+        unimplemented!()
+    }
+
+    #[allow(unused_variables)]
+    fn call(
+        &self, rpc_tx: RpcTransaction, epoch: Option<EpochNumber>,
+    ) -> RpcResult<Bytes> {
+        // TODO
+        unimplemented!()
+    }
+
+    #[allow(unused_variables)]
+    fn estimate_gas(&self, rpc_tx: RpcTransaction) -> RpcResult<RpcU256> {
+        // TODO
+        unimplemented!()
+    }
+
+    #[allow(unused_variables)]
+    fn get_logs(&self, filter: RpcFilter) -> RpcResult<Vec<RpcLog>> {
+        // TODO
+        unimplemented!()
+    }
+
+    #[allow(unused_variables)]
+    fn send_raw_transaction(&self, raw: Bytes) -> RpcResult<RpcH256> {
+        // TODO
+        unimplemented!()
+    }
+}
+
+// macro for reducing boilerplate for unsupported methods
+macro_rules! not_supported {
+    () => {};
+    ( fn $fn:ident ( &self $(, $name:ident : $type:ty)* ) $( -> $ret:ty )? ; $($tail:tt)* ) => {
+        #[allow(unused_variables)]
+        fn $fn ( &self $(, $name : $type)* ) $( -> $ret )? {
+            Err(RpcError::method_not_found())
+        }
+
+        not_supported!($($tail)*);
+    };
+}
+
+#[allow(dead_code)]
+pub struct CfxHandler {
+    common: Arc<CommonImpl>,
+    rpc_impl: Arc<RpcImpl>,
+}
+
+impl CfxHandler {
+    pub fn new(common: Arc<CommonImpl>, rpc_impl: Arc<RpcImpl>) -> Self {
+        CfxHandler { common, rpc_impl }
+    }
+}
+
+impl Cfx for CfxHandler {
+    delegate! {
+        target self.common {
+            fn best_block_hash(&self) -> RpcResult<RpcH256>;
+            fn block_by_epoch_number(&self, epoch_num: EpochNumber, include_txs: bool) -> RpcResult<RpcBlock>;
+            fn block_by_hash_with_pivot_assumption(&self, block_hash: RpcH256, pivot_hash: RpcH256, epoch_number: RpcU64) -> RpcResult<RpcBlock>;
+            fn block_by_hash(&self, hash: RpcH256, include_txs: bool) -> RpcResult<Option<RpcBlock>>;
+            fn blocks_by_epoch(&self, num: EpochNumber) -> RpcResult<Vec<RpcH256>>;
+            fn epoch_number(&self, epoch_num: Option<EpochNumber>) -> RpcResult<RpcU256>;
+            fn gas_price(&self) -> RpcResult<RpcU256>;
+            fn transaction_by_hash(&self, hash: RpcH256) -> RpcResult<Option<RpcTransaction>>;
+            fn transaction_count(&self, address: RpcH160, num: Option<EpochNumber>) -> RpcResult<RpcU256>;
+        }
+
+        target self.rpc_impl {
+            fn balance(&self, address: RpcH160, num: Option<EpochNumber>) -> RpcResult<RpcU256>;
+            fn call(&self, rpc_tx: RpcTransaction, epoch: Option<EpochNumber>) -> RpcResult<Bytes>;
+            fn estimate_gas(&self, rpc_tx: RpcTransaction) -> RpcResult<RpcU256>;
+            fn get_logs(&self, filter: RpcFilter) -> RpcResult<Vec<RpcLog>>;
+            fn send_raw_transaction(&self, raw: Bytes) -> RpcResult<RpcH256>;
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub struct TestRpcImpl {
+    common: Arc<CommonImpl>,
+    rpc_impl: Arc<RpcImpl>,
+}
+
+impl TestRpcImpl {
+    pub fn new(common: Arc<CommonImpl>, rpc_impl: Arc<RpcImpl>) -> Self {
+        TestRpcImpl { common, rpc_impl }
+    }
+}
+
+impl TestRpc for TestRpcImpl {
+    delegate! {
+        target self.common {
+            fn add_latency(&self, id: NodeId, latency_ms: f64) -> RpcResult<()>;
+            fn add_peer(&self, node_id: NodeId, address: SocketAddr) -> RpcResult<()>;
+            fn chain(&self) -> RpcResult<Vec<RpcBlock>>;
+            fn drop_peer(&self, node_id: NodeId, address: SocketAddr) -> RpcResult<()>;
+            fn get_best_block_hash(&self) -> RpcResult<H256>;
+            fn get_block_count(&self) -> RpcResult<u64>;
+            fn get_goodput(&self) -> RpcResult<isize>;
+            fn get_nodeid(&self, challenge: Vec<u8>) -> RpcResult<Vec<u8>>;
+            fn get_peer_info(&self) -> RpcResult<Vec<PeerInfo>>;
+            fn get_status(&self) -> RpcResult<RpcStatus>;
+            fn get_transaction_receipt(&self, tx_hash: H256) -> RpcResult<Option<RpcReceipt>>;
+            fn say_hello(&self) -> RpcResult<String>;
+            fn stop(&self) -> RpcResult<()>;
+        }
+    }
+
+    not_supported! {
+        fn expire_block_gc(&self, timeout: u64) -> RpcResult<()>;
+        fn generate_block_with_blame_info(&self, num_txs: usize, block_size_limit: usize, blame_info: BlameInfo) -> RpcResult<H256>;
+        fn generate_block_with_fake_txs(&self, raw_txs_without_data: Bytes, tx_data_len: Option<usize>) -> RpcResult<H256>;
+        fn generate_custom_block(&self, parent_hash: H256, referee: Vec<H256>, raw_txs: Bytes, adaptive: Option<bool>) -> RpcResult<H256>;
+        fn generate_fixed_block(&self, parent_hash: H256, referee: Vec<H256>, num_txs: usize, adaptive: bool, difficulty: Option<u64>) -> RpcResult<H256>;
+        fn generate_one_block_special(&self, num_txs: usize, block_size_limit: usize, num_txs_simple: usize, num_txs_erc20: usize) -> RpcResult<()>;
+        fn generate_one_block(&self, num_txs: usize, block_size_limit: usize) -> RpcResult<H256>;
+        fn generate(&self, num_blocks: usize, num_txs: usize) -> RpcResult<Vec<H256>>;
+    }
+}
+
+#[allow(dead_code)]
+pub struct DebugRpcImpl {
+    common: Arc<CommonImpl>,
+    rpc_impl: Arc<RpcImpl>,
+}
+
+impl DebugRpcImpl {
+    pub fn new(common: Arc<CommonImpl>, rpc_impl: Arc<RpcImpl>) -> Self {
+        DebugRpcImpl { common, rpc_impl }
+    }
+}
+
+impl DebugRpc for DebugRpcImpl {
+    delegate! {
+        target self.common {
+            fn clear_tx_pool(&self) -> RpcResult<()>;
+            fn net_high_priority_packets(&self) -> RpcResult<usize>;
+            fn net_node(&self, id: NodeId) -> RpcResult<Option<(String, Node)>>;
+            fn net_sessions(&self, node_id: Option<NodeId>) -> RpcResult<Vec<SessionDetails>>;
+            fn net_throttling(&self) -> RpcResult<throttling::Service>;
+            fn tx_inspect(&self, hash: RpcH256) -> RpcResult<BTreeMap<String, String>>;
+            fn txpool_content(&self) -> RpcResult<BTreeMap<String, BTreeMap<String, BTreeMap<usize, Vec<RpcTransaction>>>>>;
+            fn txpool_inspect(&self) -> RpcResult<BTreeMap<String, BTreeMap<String, BTreeMap<usize, Vec<String>>>>>;
+            fn txpool_status(&self) -> RpcResult<BTreeMap<String, usize>>;
+        }
+    }
+
+    not_supported! {
+        fn current_sync_phase(&self) -> RpcResult<String>;
+    }
+}


### PR DESCRIPTION
**Overview**

Add separate light node RPC.

The main challenge is to share implementation of common methods, while also allowing full and light node RPC's to diverge. For instance, the `generate*` methods in the test RPC cannot be supported by light nodes; all other methods, however, can share the implementation with full nodes.

I tried many approaches to achieve this but none worked well. Now it seems the current delegation-based RPC gives us the most flexibility.

RPC methods are implemented in `common::RpcImpl`, `cfx::RpcImpl`, and `light::RpcImpl`. Handlers (like `cfx::TestRpc`) delegate calls to the correct implementation. The `delegate!` and `not_supported!` macros are used to reduce boilerplate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/533)
<!-- Reviewable:end -->
