### PR TITLE
Expose light node functionality on CLI

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -19,8 +19,8 @@ mod config_macro;
 pub mod archive;
 pub mod configuration;
 pub mod full;
+pub mod light;
 pub mod rpc;
-
 #[cfg(test)]
 mod tests;
 

--- a/client/src/light/mod.rs
+++ b/client/src/light/mod.rs
@@ -1,0 +1,314 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use std::{
+    any::Any,
+    sync::{Arc, Weak},
+    thread,
+    time::{Duration, Instant},
+};
+
+use cfx_types::U256;
+use ctrlc::CtrlC;
+use db::SystemDB;
+use network::NetworkService;
+use parking_lot::{Condvar, Mutex};
+use secret_store::SecretStore;
+use threadpool::ThreadPool;
+
+use cfxcore::{
+    block_data_manager::BlockDataManager, genesis,
+    light_protocol::QueryService, statistics::Statistics,
+    storage::StorageManager, transaction_pool::DEFAULT_MAX_BLOCK_GAS_LIMIT,
+    vm_factory::VmFactory, ConsensusGraph, SynchronizationGraph,
+    TransactionPool, WORKER_COMPUTATION_PARALLELISM,
+};
+
+use crate::{
+    configuration::Configuration,
+    rpc::{
+        impls::{common::RpcImpl as CommonImpl, light::RpcImpl},
+        setup_debug_rpc_apis_light, setup_public_rpc_apis_light,
+    },
+};
+
+use super::{
+    http::Server as HttpServer, tcp::Server as TcpServer, TESTNET_VERSION,
+};
+
+pub struct LightClientHandle {
+    pub consensus: Arc<ConsensusGraph>,
+    pub debug_rpc_http_server: Option<HttpServer>,
+    pub ledger_db: Weak<SystemDB>,
+    pub light: Arc<QueryService>,
+    pub rpc_http_server: Option<HttpServer>,
+    pub rpc_tcp_server: Option<TcpServer>,
+    pub secret_store: Arc<SecretStore>,
+    pub txpool: Arc<TransactionPool>,
+}
+
+impl LightClientHandle {
+    pub fn into_be_dropped(self) -> (Weak<SystemDB>, Box<Any>) {
+        (
+            self.ledger_db,
+            Box::new((
+                self.consensus,
+                self.debug_rpc_http_server,
+                self.light,
+                self.rpc_http_server,
+                self.rpc_tcp_server,
+                self.secret_store,
+                self.txpool,
+            )),
+        )
+    }
+}
+
+pub struct LightClient {}
+
+impl LightClient {
+    // Start all key components of Conflux and pass out their handles
+    pub fn start(
+        conf: Configuration, exit: Arc<(Mutex<bool>, Condvar)>,
+    ) -> Result<LightClientHandle, String> {
+        info!("Working directory: {:?}", std::env::current_dir());
+
+        if conf.raw_conf.metrics_enabled {
+            metrics::enable();
+            let reporter = metrics::FileReporter::new(
+                conf.raw_conf.metrics_output_file.clone(),
+            );
+            metrics::report_async(
+                reporter,
+                Duration::from_millis(conf.raw_conf.metrics_report_interval_ms),
+            );
+        }
+
+        let worker_thread_pool = Arc::new(Mutex::new(ThreadPool::with_name(
+            "Tx Recover".into(),
+            WORKER_COMPUTATION_PARALLELISM,
+        )));
+
+        let network_config = conf.net_config()?;
+        let cache_config = conf.cache_config();
+
+        let db_config = conf.db_config();
+        let ledger_db = db::open_database(
+            conf.raw_conf.db_dir.as_ref().unwrap(),
+            &db_config,
+        )
+        .map_err(|e| format!("Failed to open database {:?}", e))?;
+
+        let secret_store = Arc::new(SecretStore::new());
+        let storage_manager = Arc::new(StorageManager::new(
+            ledger_db.clone(),
+            conf.storage_config(),
+        ));
+        {
+            let storage_manager_log_weak_ptr = Arc::downgrade(&storage_manager);
+            let exit_clone = exit.clone();
+            thread::spawn(move || loop {
+                let mut exit_lock = exit_clone.0.lock();
+                if exit_clone
+                    .1
+                    .wait_for(&mut exit_lock, Duration::from_millis(5000))
+                    .timed_out()
+                {
+                    let manager = storage_manager_log_weak_ptr.upgrade();
+                    match manager {
+                        None => return,
+                        Some(manager) => manager.log_usage(),
+                    };
+                } else {
+                    return;
+                }
+            });
+        }
+
+        let genesis_accounts = if conf.raw_conf.test_mode {
+            match conf.raw_conf.genesis_accounts {
+                Some(ref file) => genesis::load_file(file)?,
+                None => genesis::default(secret_store.as_ref()),
+            }
+        } else {
+            genesis::default(secret_store.as_ref())
+        };
+
+        // FIXME: move genesis block to a dedicated directory near all conflux
+        // FIXME: parameters.
+        let genesis_block = storage_manager.initialize(
+            genesis_accounts,
+            DEFAULT_MAX_BLOCK_GAS_LIMIT.into(),
+            TESTNET_VERSION.into(),
+            U256::zero(),
+        );
+        debug!("Initialize genesis_block={:?}", genesis_block);
+
+        let data_man = Arc::new(BlockDataManager::new(
+            cache_config,
+            Arc::new(genesis_block),
+            ledger_db.clone(),
+            storage_manager,
+            worker_thread_pool,
+            conf.data_mananger_config(),
+        ));
+
+        let txpool = Arc::new(TransactionPool::with_capacity(
+            conf.raw_conf.tx_pool_size,
+            data_man.clone(),
+        ));
+
+        let statistics = Arc::new(Statistics::new());
+
+        let vm = VmFactory::new(1024 * 32);
+        let pow_config = conf.pow_config();
+        let consensus = Arc::new(ConsensusGraph::new(
+            conf.consensus_config(),
+            vm.clone(),
+            txpool.clone(),
+            statistics.clone(),
+            data_man.clone(),
+            pow_config.clone(),
+        ));
+
+        let _protocol_config = conf.protocol_config();
+        let verification_config = conf.verification_config();
+
+        let sync_graph = Arc::new(SynchronizationGraph::new(
+            consensus.clone(),
+            verification_config,
+            pow_config,
+            false,
+        ));
+
+        let network = {
+            let mut network = NetworkService::new(network_config);
+            network.start().unwrap();
+            Arc::new(network)
+        };
+
+        let light = Arc::new(QueryService::new(
+            consensus.clone(),
+            sync_graph.clone(),
+            network.clone(),
+        ));
+        light.register().unwrap();
+
+        let rpc_impl = Arc::new(RpcImpl::new(consensus.clone(), light.clone()));
+
+        let common_impl = Arc::new(CommonImpl::new(
+            exit,
+            consensus.clone(),
+            network.clone(),
+            txpool.clone(),
+        ));
+
+        let debug_rpc_http_server = super::rpc::new_http(
+            super::rpc::HttpConfiguration::new(
+                Some((127, 0, 0, 1)),
+                conf.raw_conf.jsonrpc_local_http_port,
+                conf.raw_conf.jsonrpc_cors.clone(),
+                conf.raw_conf.jsonrpc_http_keep_alive,
+            ),
+            setup_debug_rpc_apis_light(common_impl.clone(), rpc_impl.clone()),
+        )?;
+
+        let rpc_tcp_server = super::rpc::new_tcp(
+            super::rpc::TcpConfiguration::new(
+                None,
+                conf.raw_conf.jsonrpc_tcp_port,
+            ),
+            if conf.raw_conf.test_mode {
+                setup_debug_rpc_apis_light(
+                    common_impl.clone(),
+                    rpc_impl.clone(),
+                )
+            } else {
+                setup_public_rpc_apis_light(
+                    common_impl.clone(),
+                    rpc_impl.clone(),
+                )
+            },
+        )?;
+
+        let rpc_http_server = super::rpc::new_http(
+            super::rpc::HttpConfiguration::new(
+                None,
+                conf.raw_conf.jsonrpc_http_port,
+                conf.raw_conf.jsonrpc_cors.clone(),
+                conf.raw_conf.jsonrpc_http_keep_alive,
+            ),
+            if conf.raw_conf.test_mode {
+                setup_debug_rpc_apis_light(
+                    common_impl.clone(),
+                    rpc_impl.clone(),
+                )
+            } else {
+                setup_public_rpc_apis_light(
+                    common_impl.clone(),
+                    rpc_impl.clone(),
+                )
+            },
+        )?;
+
+        Ok(LightClientHandle {
+            consensus,
+            debug_rpc_http_server,
+            ledger_db: Arc::downgrade(&ledger_db),
+            light,
+            rpc_http_server,
+            rpc_tcp_server,
+            secret_store,
+            txpool,
+        })
+    }
+
+    /// Use a Weak pointer to ensure that other Arc pointers are released
+    fn wait_for_drop<T>(w: Weak<T>) {
+        let sleep_duration = Duration::from_secs(1);
+        let warn_timeout = Duration::from_secs(5);
+        let max_timeout = Duration::from_secs(10);
+        let instant = Instant::now();
+        let mut warned = false;
+        while instant.elapsed() < max_timeout {
+            if w.upgrade().is_none() {
+                return;
+            }
+            if !warned && instant.elapsed() > warn_timeout {
+                warned = true;
+                warn!("Shutdown is taking longer than expected.");
+            }
+            thread::sleep(sleep_duration);
+        }
+        eprintln!("Shutdown timeout reached, exiting uncleanly.");
+    }
+
+    pub fn close(handle: LightClientHandle) {
+        let (ledger_db, to_drop) = handle.into_be_dropped();
+        drop(to_drop);
+
+        // Make sure ledger_db is properly dropped, so rocksdb can be closed
+        // cleanly
+        LightClient::wait_for_drop(ledger_db);
+    }
+
+    pub fn run_until_closed(
+        exit: Arc<(Mutex<bool>, Condvar)>, keep_alive: LightClientHandle,
+    ) {
+        CtrlC::set_handler({
+            let e = exit.clone();
+            move || {
+                *e.0.lock() = true;
+                e.1.notify_all();
+            }
+        });
+
+        let mut lock = exit.0.lock();
+        if !*lock {
+            let _ = exit.1.wait(&mut lock);
+        }
+
+        LightClient::close(keep_alive);
+    }
+}

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -23,6 +23,10 @@ use self::{
     impls::{
         cfx::{CfxHandler, DebugRpcImpl, RpcImpl, TestRpcImpl},
         common::RpcImpl as CommonImpl,
+        light::{
+            CfxHandler as LightCfxHandler, DebugRpcImpl as LightDebugRpcImpl,
+            RpcImpl as LightImpl, TestRpcImpl as LightTestRpcImpl,
+        },
     },
     traits::cfx::{debug::DebugRpc, public::Cfx, test::TestRpc},
 };
@@ -103,6 +107,32 @@ pub fn setup_debug_rpc_apis(
     let cfx = CfxHandler::new(common.clone(), rpc.clone()).to_delegate();
     let test = TestRpcImpl::new(common.clone(), rpc.clone()).to_delegate();
     let debug = DebugRpcImpl::new(common.clone(), rpc).to_delegate();
+
+    // extend_with maps each method in RpcImpl object into a RPC handler
+    let mut handler = IoHandler::new();
+    handler.extend_with(cfx);
+    handler.extend_with(test);
+    handler.extend_with(debug);
+    handler
+}
+
+pub fn setup_public_rpc_apis_light(
+    common: Arc<CommonImpl>, rpc: Arc<LightImpl>,
+) -> IoHandler {
+    let cfx = LightCfxHandler::new(common.clone(), rpc.clone()).to_delegate();
+
+    // extend_with maps each method in RpcImpl object into a RPC handler
+    let mut handler = IoHandler::new();
+    handler.extend_with(cfx);
+    handler
+}
+
+pub fn setup_debug_rpc_apis_light(
+    common: Arc<CommonImpl>, rpc: Arc<LightImpl>,
+) -> IoHandler {
+    let cfx = LightCfxHandler::new(common.clone(), rpc.clone()).to_delegate();
+    let test = LightTestRpcImpl::new(common.clone(), rpc.clone()).to_delegate();
+    let debug = LightDebugRpcImpl::new(common.clone(), rpc).to_delegate();
 
     // extend_with maps each method in RpcImpl object into a RPC handler
     let mut handler = IoHandler::new();

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -70,7 +70,7 @@ pub mod test_helpers;
 
 pub use crate::{
     consensus::{BestInformation, ConsensusGraph, SharedConsensusGraph},
-    light_protocol::QueryService,
+    light_protocol::{QueryProvider, QueryService},
     sync::{
         SharedSynchronizationGraph, SharedSynchronizationService,
         SynchronizationGraph, SynchronizationService,

--- a/core/src/light_protocol/error.rs
+++ b/core/src/light_protocol/error.rs
@@ -109,6 +109,13 @@ pub fn handle(io: &NetworkContext, peer: PeerId, msg_id: MsgId, e: Error) {
     match e.0 {
         ErrorKind::NoResponse
         | ErrorKind::InternalError
+
+        // NOTE: we should be tolerant of non-critical errors,
+        // e.g. do not disconnect on requesting non-existing epoch
+        | ErrorKind::Msg(_)
+
+        // NOTE: this can happen in normal scenarios
+        // where the pivot chain has not converged
         | ErrorKind::PivotHashMismatch
 
         // NOTE: in order to let other protocols run,
@@ -122,8 +129,7 @@ pub fn handle(io: &NetworkContext, peer: PeerId, msg_id: MsgId, e: Error) {
         ErrorKind::GenesisMismatch
         | ErrorKind::UnexpectedMessage
         | ErrorKind::UnexpectedPeerType
-        | ErrorKind::UnknownPeer
-        | ErrorKind::Msg(_) => op = Some(UpdateNodeOperation::Failure),
+        | ErrorKind::UnknownPeer => op = Some(UpdateNodeOperation::Failure),
 
         ErrorKind::UnexpectedRequestId | ErrorKind::UnexpectedResponse => {
             op = Some(UpdateNodeOperation::Demotion)

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,9 @@ extern crate log4rs;
 extern crate parking_lot;
 
 use clap::{App, Arg};
-use client::{archive::ArchiveClient, configuration::Configuration};
+use client::{
+    archive::ArchiveClient, configuration::Configuration, light::LightClient,
+};
 use log::{info, LevelFilter};
 use log4rs::{
     append::{console::ConsoleAppender, file::FileAppender},
@@ -312,9 +314,9 @@ fn main() -> Result<(), String> {
     if matches.is_present("light") {
         //FIXME: implement light client later
         info!("Starting light client...");
-        let client_handle = ArchiveClient::start(conf, exit.clone())
+        let client_handle = LightClient::start(conf, exit.clone())
             .map_err(|e| format!("failed to start light client: {:?}", e))?;
-        ArchiveClient::run_until_closed(exit, client_handle);
+        LightClient::run_until_closed(exit, client_handle);
     } else if matches.is_present("archive") {
         info!("Starting archive client...");
         let client_handle = ArchiveClient::start(conf, exit.clone())


### PR DESCRIPTION
**Overview**

Expose `cfx_getBalance` on the light node RPC.

Add `client::light::LightClient` and use it when starting a light client in `src/main.rs` (`conflux --light`). This is mostly the same as full clients, except

- It has no block-/tx-generator and no `SynchronizationProtocolHandler` instance.
- Instead of `QueryProvider`, we have `QueryService`, responsible for light sync and queries.
- We use light RPC instead of full RPC.

**Example run**

1. Start a full node:
```
$ ../target/release/conflux --archive --log-level debug --public-address localhost:1111 --port 1111 --test-mode true --start-mining true --mining-author 0000000000000000000000000000000000000000
...
DEBUG network::service - Self node id: [FULL_NODE_ID]
```

2. Start a light node and let it connect to the full node:
```
$ ./target/release/conflux --light --log-level debug --public-address localhost:1112 --port 1112 --test-mode true --bootnodes cfxnode://[FULL_NODE_ID]@localhost:1111 --jsonrpc-http-port 11120
```

3. Make RPC queries:
<pre>
# query <b>full</b> node for balance at epoch <b>0x00</b>
$ curl -X POST --data '{"jsonrpc":"2.0","method":"cfx_getBalance","params":["0x0000000000000000000000000000000000000000", "0x0"],"id":1}' -H "Content-Type: application/json" http://localhost:11110
{"jsonrpc":"2.0","result":"<b>0x0</b>","id":1}

# query <b>light</b> node for balance at epoch <b>0x00</b>
# curl -X POST --data '{"jsonrpc":"2.0","method":"cfx_getBalance","params":["0x0000000000000000000000000000000000000000", "0x0"],"id":1}' -H "Content-Type: application/json" http://localhost:11120
{"jsonrpc":"2.0","result":"<b>0x0</b>","id":1}

# query <b>full</b> node for balance at epoch <b>0x40</b>
curl -X POST --data '{"jsonrpc":"2.0","method":"cfx_getBalance","params":["0x0000000000000000000000000000000000000000", "0x40"],"id":1}' -H "Content-Type: application/json" http://localhost:11110
{"jsonrpc":"2.0","result":"<b>0x9e908782af919400000</b>","id":1}

# query <b>light</b> node for balance at epoch <b>0x40</b>
curl -X POST --data '{"jsonrpc":"2.0","method":"cfx_getBalance","params":["0x0000000000000000000000000000000000000000", "0x40"],"id":1}' -H "Content-Type: application/json" http://localhost:11120
{"jsonrpc":"2.0","result":"<b>0x9e908782af919400000</b>","id":1}
</pre>

The corresponding light node logs:
```
INFO  client::rpc::impls::light - RPC Request: cfx_getBalance address=0x0000000000000000000000000000000000000000 epoch=64
INFO  cfxcore::light_protocol::query_service - get_account epoch=64 address=0x0000000000000000000000000000000000000000
INFO  cfxcore::light_protocol::query_service - query_account peer=0 epoch=64 address=0x0000000000000000000000000000000000000000
INFO  cfxcore::light_protocol::query_service - query_state_root epoch=64
DEBUG cfxcore::message - Send message(GetStateRoot) to 0x563b16789ffa8b294edd48e2024f2e872f91a2ed5da33bab200739e47b6c3cc86305b3d36f4d7f35bc24b81151d904d58c8d93e1bd8f88938d787ac8fe933320

...

INFO  cfxcore::light_protocol::handler::query - on_state_root resp=StateRoot {
    request_id: 9,
    pivot_hash: 0x11a2b2837c8fc41c369dd37a9986527b3f935e04e2e1b5a75255596b4239760f,
    state_root: StateRoot {
        snapshot_root: 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
        intermediate_delta_root: 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
        delta_root: 0xaec180f3bcba29aa83375681c4846c602c5a0c8ec072dc692a21381879e07f89
    }
}

INFO  cfxcore::light_protocol::query_service - query_state_entry epoch=64 key=[59, 213, 51, 141, 30, 218, 102, 145, 239, 29, 215, 92, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
DEBUG cfxcore::message - Send message(GetStateEntry) to 0x563b16789ffa8b294edd48e2024f2e872f91a2ed5da33bab200739e47b6c3cc86305b3d36f4d7f35bc24b81151d904d58c8d93e1bd8f88938d787ac8fe933320

...

INFO  cfxcore::light_protocol::handler::query - on_state_entry resp=StateEntry {
    request_id: 10,
    pivot_hash: 0x11a2b2837c8fc41c369dd37a9986527b3f935e04e2e1b5a75255596b4239760f,
    state_root: StateRoot {
        snapshot_root: 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
        intermediate_delta_root: 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
        delta_root: 0xaec180f3bcba29aa83375681c4846c602c5a0c8ec072dc692a21381879e07f89
    },
    entry: Some([248, 66, 148, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 138, 9, 233, 8, 120, 42, 249, 25, 64, 0, 0, 128, 160, 197, 210, 70, 1, 134, 247, 35, 60, 146, 126, 125, 178, 220, 199, 3, 192, 229, 0, 182, 83, 202, 130, 39, 59, 123, 250, 216, 4, 93, 133, 164, 112]),
    proof: StateProof {
        delta_proof: Some(TrieProof {
            nodes: [
                TrieProofNode(VanillaTrieNode {
                    compressed_path: CompressedPathRef { path_slice: [], end_mask: 0 },
                    maybe_value: None,
                    children_table: VanillaChildrenTable {
                        table: [
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0x7de926d7f5a8ecfae073c08a42de67f6afbe86f0ad8f0ca0d9f2cfdccca4ac5c,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xfd1a1b47ee95a03c7bd69d94ea8dad141595200c3635fe9ea7f2b4acba38c7fc,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0x7abe7eaaf390d26b66f8a9b0ddc6e8aa2e36c64aa5768373f31ffba35b6ede5b
                        ],
                        children_count: 3 },
                    merkle_hash: 0xaec180f3bcba29aa83375681c4846c602c5a0c8ec072dc692a21381879e07f89
                }),
                TrieProofNode(VanillaTrieNode {
                    compressed_path: CompressedPathRef { path_slice: [59, 213, 51, 141, 30, 218, 102, 145, 239, 29, 215, 92, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], end_mask: 0 },
                    maybe_value: Some([248, 66, 148, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 138, 9, 233, 8, 120, 42, 249, 25, 64, 0, 0, 128, 160, 197, 210, 70, 1, 134, 247, 35, 60, 146, 126, 125, 178, 220, 199, 3, 192, 229, 0, 182, 83, 202, 130, 39, 59, 123, 250, 216, 4, 93, 133, 164, 112]),
                    children_table: VanillaChildrenTable {
                        table: [
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470,
                            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
                        ],
                        children_count: 0
                    },
                    merkle_hash: 0xfd1a1b47ee95a03c7bd69d94ea8dad141595200c3635fe9ea7f2b4acba38c7fc
                })
            ]
        }),
        intermediate_proof: None,
        snapshot_proof: None
    }
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/535)
<!-- Reviewable:end -->
