### PR TITLE
Light node tx relay

### DIFF
--- a/client/src/archive/mod.rs
+++ b/client/src/archive/mod.rs
@@ -204,6 +204,7 @@ impl ArchiveClient {
             consensus.clone(),
             sync_graph.clone(),
             Arc::downgrade(&network),
+            txpool.clone(),
         ));
         light_provider.clone().register(network.clone()).unwrap();
 

--- a/client/src/full/mod.rs
+++ b/client/src/full/mod.rs
@@ -204,6 +204,7 @@ impl FullClient {
             consensus.clone(),
             sync_graph.clone(),
             Arc::downgrade(&network),
+            txpool.clone(),
         ));
         light_provider.clone().register(network.clone()).unwrap();
 

--- a/client/src/rpc/impls/light.rs
+++ b/client/src/rpc/impls/light.rs
@@ -121,7 +121,11 @@ impl RpcImpl {
 
         debug!("Deserialized tx: {:?}", tx);
 
-        match /* success = */ self.light.relay_raw_tx(raw) {
+        // TODO(thegaram): consider adding a light node specific tx pool;
+        // light nodes would track those txs and maintain their statuses
+        // for future queries
+
+        match /* success = */ self.light.send_raw_tx(raw) {
             true => Ok(tx.hash().into()),
             false => Err(RpcError::invalid_params("Unable to relay tx")),
         }

--- a/client/src/rpc/impls/light.rs
+++ b/client/src/rpc/impls/light.rs
@@ -8,6 +8,7 @@ use std::{collections::BTreeMap, net::SocketAddr, sync::Arc};
 
 use cfx_types::{H160, H256};
 use cfxcore::{light_protocol::QueryService, ConsensusGraph, PeerInfo};
+use primitives::TransactionWithSignature;
 
 use network::{
     node_table::{Node, NodeId},
@@ -38,22 +39,46 @@ impl RpcImpl {
         RpcImpl { consensus, light }
     }
 
+    fn epoch_to_height(&self, epoch: EpochNumber) -> Result<u64, String> {
+        // NOTE: The epoch returned by consensus.best_state_epoch_number() is
+        // not guaranteed to exist, so we use the previous one instead. This
+        // way, the block `best_with_state_root + DEFERRED_STATE_EPOCH_COUNT`
+        // exists and we can safely use its `deferred_state_root` field for
+        // state validation.
+        let best_with_state_root = self.consensus.best_state_epoch_number() - 1;
+
+        match epoch {
+            EpochNumber::Earliest => Ok(0),
+            EpochNumber::LatestMined => Ok(best_with_state_root),
+            EpochNumber::LatestState => Ok(best_with_state_root),
+            EpochNumber::Num(num) => {
+                if num > best_with_state_root {
+                    return Err(format!(
+                        "Epoch number too large. Received: {}. Largest: {}.",
+                        num, best_with_state_root
+                    ));
+                }
+                Ok(num)
+            }
+        }
+    }
+
     fn balance(
         &self, address: RpcH160, num: Option<EpochNumber>,
     ) -> RpcResult<RpcU256> {
+        let address: H160 = address.into();
         let num = num.unwrap_or(EpochNumber::LatestState).into();
 
+        info!(
+            "RPC Request: cfx_getBalance address={:?} num={:?}",
+            address, num
+        );
+
         let epoch = self
-            .consensus
-            .get_height_from_epoch_number(num)
+            .epoch_to_height(num)
             .map_err(RpcError::invalid_params)?;
 
-        let address: H160 = address.into();
-
-        info!(
-            "RPC Request: cfx_getBalance address={:?} epoch={:?}",
-            address, epoch
-        );
+        debug!("Epoch number is {}", epoch);
 
         let balance = self
             .light
@@ -84,10 +109,22 @@ impl RpcImpl {
         unimplemented!()
     }
 
-    #[allow(unused_variables)]
     fn send_raw_transaction(&self, raw: Bytes) -> RpcResult<RpcH256> {
-        // TODO
-        unimplemented!()
+        info!("RPC Request: cfx_sendRawTransaction bytes={:?}", raw);
+        let raw: Vec<u8> = raw.into_vec();
+
+        // decode tx so that we have its hash
+        // this way we also avoid spamming peers with invalid txs
+        let tx: TransactionWithSignature = rlp::decode(&raw.clone())
+            .map_err(|e| format!("Failed to decode tx: {:?}", e))
+            .map_err(RpcError::invalid_params)?;
+
+        debug!("Deserialized tx: {:?}", tx);
+
+        match /* success = */ self.light.relay_raw_tx(raw) {
+            true => Ok(tx.hash().into()),
+            false => Err(RpcError::invalid_params("Unable to relay tx")),
+        }
     }
 }
 

--- a/core/src/light_protocol/handler/handler.rs
+++ b/core/src/light_protocol/handler/handler.rs
@@ -15,7 +15,7 @@ use crate::{
     consensus::ConsensusGraph,
     light_protocol::{
         handle_error,
-        message::{msgid, NodeType, StatusPing, StatusPong},
+        message::{msgid, NodeType, RelayRawTx, StatusPing, StatusPong},
         peers::Peers,
         Error, ErrorKind, LIGHT_PROTOCOL_VERSION,
     },
@@ -185,6 +185,14 @@ impl Handler {
         // NOTE: `start_sync` acquires read locks on peer states so
         // we need to make sure to release locks before calling it
         self.sync.start_sync(io);
+        Ok(())
+    }
+
+    pub fn relay_raw_tx(
+        &self, io: &NetworkContext, peer: PeerId, raw: Vec<u8>,
+    ) -> Result<(), Error> {
+        let msg: Box<dyn Message> = Box::new(RelayRawTx { raw });
+        msg.send(io, peer)?;
         Ok(())
     }
 }

--- a/core/src/light_protocol/handler/handler.rs
+++ b/core/src/light_protocol/handler/handler.rs
@@ -15,7 +15,7 @@ use crate::{
     consensus::ConsensusGraph,
     light_protocol::{
         handle_error,
-        message::{msgid, NodeType, RelayRawTx, StatusPing, StatusPong},
+        message::{msgid, NodeType, SendRawTx, StatusPing, StatusPong},
         peers::Peers,
         Error, ErrorKind, LIGHT_PROTOCOL_VERSION,
     },
@@ -188,10 +188,10 @@ impl Handler {
         Ok(())
     }
 
-    pub fn relay_raw_tx(
+    pub fn send_raw_tx(
         &self, io: &NetworkContext, peer: PeerId, raw: Vec<u8>,
     ) -> Result<(), Error> {
-        let msg: Box<dyn Message> = Box::new(RelayRawTx { raw });
+        let msg: Box<dyn Message> = Box::new(SendRawTx { raw });
         msg.send(io, peer)?;
         Ok(())
     }

--- a/core/src/light_protocol/handler/sync/mod.rs
+++ b/core/src/light_protocol/handler/sync/mod.rs
@@ -90,6 +90,9 @@ impl SyncHandler {
         next_request_id: Arc<AtomicU64>, peers: Arc<Peers<FullPeerState>>,
     ) -> Self
     {
+        // TODO(thegaram): At this point the light node does not persist
+        // anything. Need to make sure we persist the checkpoint hashes,
+        // along with a Merkle-root for headers in each era.
         graph.recover_graph_from_db(true /* header_only */);
 
         let duplicate_count = AtomicU64::new(0);

--- a/core/src/light_protocol/handler/sync/mod.rs
+++ b/core/src/light_protocol/handler/sync/mod.rs
@@ -133,7 +133,7 @@ impl SyncHandler {
             None => true,
             Some(epoch) => {
                 let my_epoch = self.consensus.best_epoch_number();
-                my_epoch < epoch - CATCH_UP_EPOCH_LAG_THRESHOLD
+                my_epoch + CATCH_UP_EPOCH_LAG_THRESHOLD < epoch
             }
         }
     }

--- a/core/src/light_protocol/message/message.rs
+++ b/core/src/light_protocol/message/message.rs
@@ -20,6 +20,7 @@ build_msgid! {
     BLOCK_HEADERS = 0x08
     NEW_BLOCK_HASHES = 0x09
     STATUS_PONG = 0x0a
+    RELAY_RAW_TX = 0x0b
 
     INVALID = 0xff
 }
@@ -36,6 +37,7 @@ build_msg_impl! { BlockHashes, msgid::BLOCK_HASHES, "BlockHashes" }
 build_msg_impl! { GetBlockHeaders, msgid::GET_BLOCK_HEADERS, "GetBlockHeaders" }
 build_msg_impl! { BlockHeaders, msgid::BLOCK_HEADERS, "BlockHeaders" }
 build_msg_impl! { NewBlockHashes, msgid::NEW_BLOCK_HASHES, "NewBlockHashes" }
+build_msg_impl! { RelayRawTx, msgid::RELAY_RAW_TX, "RelayRawTx" }
 
 // generate `impl HasRequestId for _` for each request type
 build_has_request_id_impl! { GetStateRoot }

--- a/core/src/light_protocol/message/message.rs
+++ b/core/src/light_protocol/message/message.rs
@@ -20,7 +20,7 @@ build_msgid! {
     BLOCK_HEADERS = 0x08
     NEW_BLOCK_HASHES = 0x09
     STATUS_PONG = 0x0a
-    RELAY_RAW_TX = 0x0b
+    SEND_RAW_TX = 0x0b
 
     INVALID = 0xff
 }
@@ -37,7 +37,7 @@ build_msg_impl! { BlockHashes, msgid::BLOCK_HASHES, "BlockHashes" }
 build_msg_impl! { GetBlockHeaders, msgid::GET_BLOCK_HEADERS, "GetBlockHeaders" }
 build_msg_impl! { BlockHeaders, msgid::BLOCK_HEADERS, "BlockHeaders" }
 build_msg_impl! { NewBlockHashes, msgid::NEW_BLOCK_HASHES, "NewBlockHashes" }
-build_msg_impl! { RelayRawTx, msgid::RELAY_RAW_TX, "RelayRawTx" }
+build_msg_impl! { SendRawTx, msgid::SEND_RAW_TX, "SendRawTx" }
 
 // generate `impl HasRequestId for _` for each request type
 build_has_request_id_impl! { GetStateRoot }

--- a/core/src/light_protocol/message/mod.rs
+++ b/core/src/light_protocol/message/mod.rs
@@ -10,6 +10,6 @@ pub use message::msgid;
 pub use node_type::NodeType;
 pub use protocol::{
     BlockHashes, BlockHeaders, GetBlockHashesByEpoch, GetBlockHeaders,
-    GetStateEntry, GetStateRoot, NewBlockHashes, RelayRawTx, StateEntry,
+    GetStateEntry, GetStateRoot, NewBlockHashes, SendRawTx, StateEntry,
     StateRoot, StatusPing, StatusPong,
 };

--- a/core/src/light_protocol/message/mod.rs
+++ b/core/src/light_protocol/message/mod.rs
@@ -10,6 +10,6 @@ pub use message::msgid;
 pub use node_type::NodeType;
 pub use protocol::{
     BlockHashes, BlockHeaders, GetBlockHashesByEpoch, GetBlockHeaders,
-    GetStateEntry, GetStateRoot, NewBlockHashes, StateEntry, StateRoot,
-    StatusPing, StatusPong,
+    GetStateEntry, GetStateRoot, NewBlockHashes, RelayRawTx, StateEntry,
+    StateRoot, StatusPing, StatusPong,
 };

--- a/core/src/light_protocol/message/protocol.rs
+++ b/core/src/light_protocol/message/protocol.rs
@@ -85,3 +85,8 @@ pub struct BlockHeaders {
 pub struct NewBlockHashes {
     pub hashes: Vec<H256>,
 }
+
+#[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
+pub struct RelayRawTx {
+    pub raw: Vec<u8>,
+}

--- a/core/src/light_protocol/message/protocol.rs
+++ b/core/src/light_protocol/message/protocol.rs
@@ -87,6 +87,6 @@ pub struct NewBlockHashes {
 }
 
 #[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
-pub struct RelayRawTx {
+pub struct SendRawTx {
     pub raw: Vec<u8>,
 }

--- a/core/src/light_protocol/query_provider.rs
+++ b/core/src/light_protocol/query_provider.rs
@@ -35,7 +35,7 @@ use super::{
         msgid, BlockHashes as GetBlockHashesResponse,
         BlockHeaders as GetBlockHeadersResponse, GetBlockHashesByEpoch,
         GetBlockHeaders, GetStateEntry, GetStateRoot, NewBlockHashes, NodeType,
-        RelayRawTx, StateEntry as GetStateEntryResponse,
+        SendRawTx, StateEntry as GetStateEntryResponse,
         StateRoot as GetStateRootResponse, StatusPing, StatusPong,
     },
     peers::Peers,
@@ -140,7 +140,7 @@ impl QueryProvider {
             msgid::GET_STATE_ENTRY => self.on_get_state_entry(io, peer, &rlp),
             msgid::GET_BLOCK_HASHES_BY_EPOCH => self.on_get_block_hashes_by_epoch(io, peer, &rlp),
             msgid::GET_BLOCK_HEADERS => self.on_get_block_headers(io, peer, &rlp),
-            msgid::RELAY_RAW_TX => self.on_relay_raw_tx(io, peer, &rlp),
+            msgid::SEND_RAW_TX => self.on_send_raw_tx(io, peer, &rlp),
             _ => Err(ErrorKind::UnknownMessage.into()),
         }
     }
@@ -355,11 +355,11 @@ impl QueryProvider {
         Ok(())
     }
 
-    fn on_relay_raw_tx(
+    fn on_send_raw_tx(
         &self, _io: &NetworkContext, _peer: PeerId, rlp: &Rlp,
     ) -> Result<(), Error> {
-        let req: RelayRawTx = rlp.as_val()?;
-        info!("on_relay_raw_tx req={:?}", req);
+        let req: SendRawTx = rlp.as_val()?;
+        info!("on_send_raw_tx req={:?}", req);
         let tx: TransactionWithSignature = rlp::decode(&req.raw)?;
 
         let (passed, failed) = self.tx_pool.insert_new_transactions(&vec![tx]);

--- a/core/src/light_protocol/query_provider.rs
+++ b/core/src/light_protocol/query_provider.rs
@@ -9,7 +9,9 @@ use rlp::Rlp;
 use std::sync::{Arc, Weak};
 
 use cfx_types::H256;
-use primitives::{BlockHeader, EpochNumber, StateRoot};
+use primitives::{
+    BlockHeader, EpochNumber, StateRoot, TransactionWithSignature,
+};
 
 use crate::{
     consensus::ConsensusGraph,
@@ -24,6 +26,7 @@ use crate::{
         state_manager::StateManagerTrait, SnapshotAndEpochIdRef, StateProof,
     },
     sync::SynchronizationGraph,
+    TransactionPool,
 };
 
 use super::{
@@ -32,8 +35,8 @@ use super::{
         msgid, BlockHashes as GetBlockHashesResponse,
         BlockHeaders as GetBlockHeadersResponse, GetBlockHashesByEpoch,
         GetBlockHeaders, GetStateEntry, GetStateRoot, NewBlockHashes, NodeType,
-        StateEntry as GetStateEntryResponse, StateRoot as GetStateRootResponse,
-        StatusPing, StatusPong,
+        RelayRawTx, StateEntry as GetStateEntryResponse,
+        StateRoot as GetStateRootResponse, StatusPing, StatusPong,
     },
     peers::Peers,
     Error, ErrorKind, LIGHT_PROTOCOL_ID, LIGHT_PROTOCOL_VERSION,
@@ -59,12 +62,15 @@ pub struct QueryProvider {
 
     // collection of all peers available
     peers: Peers<LightPeerState>,
+
+    // shared transaction pool
+    tx_pool: Arc<TransactionPool>,
 }
 
 impl QueryProvider {
     pub fn new(
         consensus: Arc<ConsensusGraph>, graph: Arc<SynchronizationGraph>,
-        network: Weak<NetworkService>,
+        network: Weak<NetworkService>, tx_pool: Arc<TransactionPool>,
     ) -> Self
     {
         let peers = Peers::new();
@@ -74,6 +80,7 @@ impl QueryProvider {
             graph,
             network,
             peers,
+            tx_pool,
         }
     }
 
@@ -133,6 +140,7 @@ impl QueryProvider {
             msgid::GET_STATE_ENTRY => self.on_get_state_entry(io, peer, &rlp),
             msgid::GET_BLOCK_HASHES_BY_EPOCH => self.on_get_block_hashes_by_epoch(io, peer, &rlp),
             msgid::GET_BLOCK_HEADERS => self.on_get_block_headers(io, peer, &rlp),
+            msgid::RELAY_RAW_TX => self.on_relay_raw_tx(io, peer, &rlp),
             _ => Err(ErrorKind::UnknownMessage.into()),
         }
     }
@@ -345,6 +353,41 @@ impl QueryProvider {
 
         msg.send(io, peer)?;
         Ok(())
+    }
+
+    fn on_relay_raw_tx(
+        &self, _io: &NetworkContext, _peer: PeerId, rlp: &Rlp,
+    ) -> Result<(), Error> {
+        let req: RelayRawTx = rlp.as_val()?;
+        info!("on_relay_raw_tx req={:?}", req);
+        let tx: TransactionWithSignature = rlp::decode(&req.raw)?;
+
+        let (passed, failed) = self.tx_pool.insert_new_transactions(&vec![tx]);
+
+        match (passed.len(), failed.len()) {
+            (0, 0) => {
+                info!("Tx already inserted, ignoring");
+                Ok(())
+            }
+            (0, 1) => {
+                let err = failed.values().next().expect("Not empty");
+                warn!("Failed to insert tx: {}", err);
+                Ok(())
+            }
+            (1, 0) => {
+                info!("Tx inserted successfully");
+                // TODO(thegaram): consider relaying to peers
+                Ok(())
+            }
+            _ => {
+                // NOTE: this should not happen
+                error!(
+                    "insert_new_transactions failed: {:?}, {:?}",
+                    passed, failed
+                );
+                Err(ErrorKind::InternalError.into())
+            }
+        }
     }
 
     fn broadcast(

--- a/core/src/light_protocol/query_service.rs
+++ b/core/src/light_protocol/query_service.rs
@@ -143,15 +143,17 @@ impl QueryService {
     }
 
     /// Relay raw transaction to all peers.
-    pub fn relay_raw_tx(&self, raw: Vec<u8>) -> bool {
-        debug!("relay_raw_tx raw={:?}", raw);
+    // TODO(thegaram): consider returning TxStatus instead of bool,
+    // e.g. Failed, Sent/Pending, Confirmed, etc.
+    pub fn send_raw_tx(&self, raw: Vec<u8>) -> bool {
+        debug!("send_raw_tx raw={:?}", raw);
 
         let mut success = false;
 
         for peer in self.handler.peers.all_peers_shuffled() {
             // relay to peer
             let res = self.network.with_context(LIGHT_PROTOCOL_ID, |io| {
-                self.handler.relay_raw_tx(io, peer, raw.clone())
+                self.handler.send_raw_tx(io, peer, raw.clone())
             });
 
             // check error

--- a/tests/light/sync_test.py
+++ b/tests/light/sync_test.py
@@ -1,15 +1,10 @@
 #!/usr/bin/env python3
 
-from eth_utils import decode_hex, encode_hex
-
 # allow imports from parent directory
 # source: https://stackoverflow.com/a/11158224
-import os, sys, inspect
-currentdir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
-parentdir = os.path.dirname(currentdir)
-sys.path.append(parentdir)
+import os, sys
+sys.path.insert(1, os.path.join(sys.path[0], '..'))
 
-from test_framework.blocktools import create_block, create_transaction
 from test_framework.test_framework import ConfluxTestFramework
 from test_framework.mininode import *
 from test_framework.util import *
@@ -24,7 +19,7 @@ class LightSyncTest(ConfluxTestFramework):
         self.num_nodes = 3
 
     def setup_network(self):
-        self.add_nodes(3)
+        self.add_nodes(self.num_nodes)
 
         self.start_node(FULLNODE0, ["--archive"])
         self.start_node(FULLNODE1, ["--archive"])

--- a/tests/light/tx_relay_test.py
+++ b/tests/light/tx_relay_test.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+# allow imports from parent directory
+# source: https://stackoverflow.com/a/11158224
+import os, sys
+sys.path.insert(1, os.path.join(sys.path[0], '..'))
+
+from conflux.rpc import RpcClient
+from test_framework.test_framework import ConfluxTestFramework
+from test_framework.mininode import *
+from test_framework.util import *
+
+FULLNODE0 = 0
+FULLNODE1 = 1
+LIGHTNODE = 2
+
+class TxRelayTest(ConfluxTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 3
+
+    def setup_network(self):
+        self.add_nodes(self.num_nodes)
+
+        self.start_node(FULLNODE0, ["--archive"])
+        self.start_node(FULLNODE1, ["--archive"])
+        self.start_node(LIGHTNODE, ["--light"], wait_for_recovery=False)
+
+        # set up RPC clients
+        self.rpc = [None] * self.num_nodes
+        self.rpc[FULLNODE0] = RpcClient(self.nodes[FULLNODE0])
+        self.rpc[FULLNODE1] = RpcClient(self.nodes[FULLNODE1])
+        self.rpc[LIGHTNODE] = RpcClient(self.nodes[LIGHTNODE])
+
+        # connect archive nodes
+        connect_nodes(self.nodes, FULLNODE0, FULLNODE1)
+
+        # connect light node to archive nodes
+        connect_nodes(self.nodes, LIGHTNODE, FULLNODE0)
+        connect_nodes(self.nodes, LIGHTNODE, FULLNODE1)
+
+        # wait for phase changes to complete
+        self.nodes[FULLNODE0].wait_for_phase(["NormalSyncPhase"])
+        self.nodes[FULLNODE1].wait_for_phase(["NormalSyncPhase"])
+
+    def run_test(self):
+        num_txs = 20
+        txs = []
+
+        # send transactions
+        self.log.info(f"Sending {num_txs} txs through the light node...")
+        for nonce in range(0, num_txs):
+            # generate random account and value
+            receiver, _ = self.rpc[LIGHTNODE].rand_account()
+            value = random.randint(1000, 100000)
+
+            # send tx from genesis account
+            tx = self.rpc[LIGHTNODE].new_tx(receiver=receiver, value=value, nonce=nonce)
+            hash = self.rpc[LIGHTNODE].send_tx(tx)
+
+            self.log.info(f"sent {value: <5} to {receiver}, tx: {hash}")
+            txs.append((hash, receiver, value))
+
+        # wait for txs to be mined
+        for (hash, _, _) in txs:
+            self.log.info(f"waiting for tx {hash}")
+            self.rpc[FULLNODE0].wait_for_receipt(hash)
+            self.rpc[FULLNODE1].wait_for_receipt(hash)
+
+        self.log.info(f"Pass 1 - all txs relayed\n")
+        self.log.info(f"Checking the resulting account balances through the light node...")
+
+        # sync blocks to make sure the light client has the header with the latest state
+        self.log.info(f"syncing blocks")
+        sync_blocks(self.nodes)
+
+        # check balances for each address on all nodes
+        for (_, receiver, value) in txs:
+            node0_balance = self.rpc[FULLNODE0].get_balance(receiver)
+            node1_balance = self.rpc[FULLNODE1].get_balance(receiver)
+            node2_balance = self.rpc[LIGHTNODE].get_balance(receiver)
+
+            assert_equal(node0_balance, value)
+            assert_equal(node1_balance, value)
+            assert_equal(node2_balance, value)
+
+            self.log.info(f"account {receiver} correct")
+
+        self.log.info(f"Pass 2 - balances retrieved correctly\n")
+
+
+if __name__ == "__main__":
+    TxRelayTest().main()


### PR DESCRIPTION
**Overview**

- Make light nodes able to forward transactions to the main network. Raw transactions received through RPC are relayed to all (full node) peers.
- Fix wrong assumption in light node `cfx_getBalance` RPC. Now we make sure that the state root of the requested epoch exists on-chain.
- Fix underflow bug in light node catch-up mode calculation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/544)
<!-- Reviewable:end -->
