### PR TITLE
Bugfix: consider deferred count when searching for trusted blame blocks

### DIFF
--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -719,7 +719,7 @@ impl ConsensusGraph {
     pub fn get_trusted_blame_block(&self) -> Option<H256> {
         let inner = self.inner.read();
         inner
-            .find_the_first_with_correct_state_of(0)
+            .find_first_index_with_correct_state_of(0)
             .and_then(|index| Some(inner.arena[inner.pivot_chain[index]].hash))
     }
 


### PR DESCRIPTION
**Overview**

- Fix logic in `consensus::inner::find_the_first_with_correct_state_of`. When looking for the first block that has the (verifiably) correct state of an earlier block, we need to take `DEFERRED_STATE_EPOCH_COUNT` into consideration.
- Refactor `find_the_first_with_correct_state_of`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/547)
<!-- Reviewable:end -->
