### PR TITLE
Consider blame when verifying state roots

### DIFF
--- a/core/src/consensus/consensus_inner/mod.rs
+++ b/core/src/consensus/consensus_inner/mod.rs
@@ -514,6 +514,11 @@ impl ConsensusGraphInner {
     }
 
     #[inline]
+    pub fn get_cur_era_genesis_height(&self) -> u64 {
+        self.cur_era_genesis_height
+    }
+
+    #[inline]
     fn get_era_genesis_block_with_parent(
         &self, parent: usize, offset: u64,
     ) -> usize {

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -723,6 +723,21 @@ impl ConsensusGraph {
             .and_then(|index| Some(inner.arena[inner.pivot_chain[index]].hash))
     }
 
+    pub fn first_epoch_with_correct_state_of(&self, epoch: u64) -> Option<u64> {
+        // TODO(thegaram): change logic to work with arbitrary height, not just
+        // the ones from the current era (i.e. use epoch instead of pivot index)
+        let inner = self.inner.read();
+
+        // for now, make sure to avoid underflow
+        let pivot_index = match epoch {
+            h if h < inner.get_cur_era_genesis_height() => return None,
+            h => inner.height_to_pivot_index(h),
+        };
+
+        let trusted = inner.find_first_index_with_correct_state_of(pivot_index);
+        trusted.map(|index| inner.pivot_index_to_height(index))
+    }
+
     /// construct_pivot_state() rebuild pivot chain state info from db
     /// avoiding intermediate redundant computation triggered by
     /// on_new_block().

--- a/core/src/light_protocol/error.rs
+++ b/core/src/light_protocol/error.rs
@@ -58,6 +58,11 @@ error_chain! {
             display("Send status failed"),
         }
 
+        UnableToProduceProof {
+            description("Unable to produce proof"),
+            display("Unable to produce proof"),
+        }
+
         UnexpectedMessage {
             description("Unexpected message"),
             display("Unexpected message"),
@@ -121,6 +126,11 @@ pub fn handle(io: &NetworkContext, peer: PeerId, msg_id: MsgId, e: Error) {
         // NOTE: in order to let other protocols run,
         // we should not disconnect on protocol failure
         | ErrorKind::SendStatusFailed
+
+        // NOTE: if we do not have a confirmed (non-blamed) block
+        // with the info needed to produce a state root proof, we
+        // should not disconnect the peer
+        | ErrorKind::UnableToProduceProof
 
         // NOTE: to help with backward-compatibility, we
         // should not disconnect on `UnknownMessage`

--- a/core/src/light_protocol/handler/query.rs
+++ b/core/src/light_protocol/handler/query.rs
@@ -19,14 +19,14 @@ use futures::{
 };
 
 use cfx_types::H256;
-use primitives::{BlockHeader, EpochNumber, StateRoot};
+use primitives::{BlockHeader, BlockHeaderBuilder, EpochNumber, StateRoot};
 
 use crate::{
     consensus::ConsensusGraph,
     light_protocol::{
         message::{
             GetStateEntry, GetStateRoot, StateEntry as GetStateEntryResponse,
-            StateRoot as GetStateRootResponse,
+            StateRoot as GetStateRootResponse, StateRootWithProof,
         },
         Error, ErrorKind,
     },
@@ -81,12 +81,6 @@ impl QueryHandler {
         header.ok_or(ErrorKind::InternalError.into())
     }
 
-    #[inline]
-    fn get_local_state_root_hash(&self, epoch: u64) -> Result<H256, Error> {
-        let h = self.get_local_header(epoch + DEFERRED_STATE_EPOCH_COUNT)?;
-        Ok(h.deferred_state_root().clone())
-    }
-
     fn validate_pivot_hash(&self, epoch: u64, hash: H256) -> Result<(), Error> {
         match self.get_local_pivot_hash(epoch)? {
             h if h == hash => Ok(()),
@@ -99,18 +93,82 @@ impl QueryHandler {
         }
     }
 
+    // 1. When validating a state root, we first find the witness - the block
+    //    header that can be used to verify the state root. This selection is
+    //    done based on the blame fields.
+    // 2. Then we validate the integrity of the provided hash set against the
+    //    deferred state root field of the witness.
+    // 3. Finally, we validate the state root against the corresponding state
+    //    root hash provided.
     fn validate_state_root(
-        &self, epoch: u64, state_root: &StateRoot,
+        &self, epoch: u64, state_root: &StateRootWithProof,
     ) -> Result<(), Error> {
-        let hash = state_root.compute_state_root_hash();
+        // find the first header that can verify the state root requested
+        let witness = self.consensus.first_epoch_with_correct_state_of(epoch);
 
-        match self.get_local_state_root_hash(epoch)? {
-            h if h == hash => Ok(()),
-            h => {
-                info!("State root mismatch: local={}, response={}", h, hash);
-                return Err(ErrorKind::InvalidStateRoot.into());
+        let witness = match witness {
+            Some(epoch) => epoch,
+            None => {
+                warn!("Unable to verify state proof for epoch {}", epoch);
+                return Err(ErrorKind::UnableToProduceProof.into());
             }
+        };
+
+        let witness_header = self.get_local_header(witness)?;
+        let blame = witness_header.blame() as u64;
+
+        // assumption: the target state root can be verified by the witness
+        assert!(witness - epoch - DEFERRED_STATE_EPOCH_COUNT <= blame);
+
+        // validate the number of hashes provided against local witness blame
+        if state_root.proof.len() as u64 != blame + 1 {
+            info!(
+                "Invalid number of hashes provided: expected={}, received={}",
+                blame + 1,
+                state_root.proof.len()
+            );
+            return Err(ErrorKind::InvalidStateRoot.into());
         }
+
+        // compute witness deferred state root hash from the hashes provided
+        let received_witness_root_hash = match blame {
+            0 => state_root.proof[0],
+            _ => {
+                let hashes = state_root.proof.clone();
+                BlockHeaderBuilder::compute_blame_state_root_vec_root(hashes)
+            }
+        };
+
+        // validate against local witness deferred state root hash
+        let local_witness_root_hash = *witness_header.deferred_state_root();
+
+        if received_witness_root_hash != local_witness_root_hash {
+            info!(
+                "Witness root hash mismatch: local={}, received={}",
+                local_witness_root_hash, received_witness_root_hash
+            );
+            return Err(ErrorKind::InvalidStateRoot.into());
+        }
+
+        // TODO(thegaram): at this point, we can cache all the hashes received
+        // and reuse them later
+
+        // find hash corresponding to the state root requested
+        let index = (witness - epoch - DEFERRED_STATE_EPOCH_COUNT) as usize;
+        let received_root_hash = state_root.proof[index];
+
+        // validate state root against the hash provided
+        let computed_root_hash = state_root.root.compute_state_root_hash();
+
+        if received_root_hash != computed_root_hash {
+            info!(
+                "State root hash mismatch: received={}, computed={}",
+                received_root_hash, computed_root_hash
+            );
+            return Err(ErrorKind::InvalidStateRoot.into());
+        }
+
+        Ok(())
     }
 
     fn next_request_id(&self) -> RequestId {
@@ -150,7 +208,7 @@ impl QueryHandler {
         self.validate_pivot_hash(req.epoch, resp.pivot_hash)?;
         self.validate_state_root(req.epoch, &resp.state_root)?;
 
-        sender.complete(QueryResult::StateRoot(resp.state_root));
+        sender.complete(QueryResult::StateRoot(resp.state_root.root));
         // note: in case of early return, `sender` will be cancelled
 
         Ok(())
@@ -172,9 +230,9 @@ impl QueryHandler {
         if !resp.proof.is_valid(
             &req.key,
             resp.entry.as_ref().map(|v| &**v),
-            resp.state_root.delta_root,
-            resp.state_root.intermediate_delta_root,
-            resp.state_root.snapshot_root,
+            resp.state_root.root.delta_root,
+            resp.state_root.root.intermediate_delta_root,
+            resp.state_root.root.snapshot_root,
         ) {
             info!("Invalid proof from peer={}", peer);
             return Err(ErrorKind::InvalidProof.into());

--- a/core/src/light_protocol/message/mod.rs
+++ b/core/src/light_protocol/message/mod.rs
@@ -11,5 +11,5 @@ pub use node_type::NodeType;
 pub use protocol::{
     BlockHashes, BlockHeaders, GetBlockHashesByEpoch, GetBlockHeaders,
     GetStateEntry, GetStateRoot, NewBlockHashes, SendRawTx, StateEntry,
-    StateRoot, StatusPing, StatusPong,
+    StateRoot, StateRootWithProof, StatusPing, StatusPong,
 };

--- a/core/src/light_protocol/message/protocol.rs
+++ b/core/src/light_protocol/message/protocol.rs
@@ -2,15 +2,23 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
+use cfx_types::H256;
+use rlp_derive::{RlpDecodable, RlpEncodable};
+
 use super::NodeType;
 use crate::{message::RequestId, storage::StateProof};
-use cfx_types::H256;
+
 use primitives::{
     BlockHeader as PrimitiveBlockHeader, StateRoot as PrimitiveStateRoot,
 };
-use rlp_derive::{RlpDecodable, RlpEncodable};
 
-#[derive(Clone, Debug, PartialEq, RlpEncodable, RlpDecodable)]
+#[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
+pub struct StateRootWithProof {
+    pub root: PrimitiveStateRoot,
+    pub proof: Vec<H256>, // witness + blamed deferred state root hashes
+}
+
+#[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
 pub struct StatusPing {
     pub genesis_hash: H256,
     pub network_id: u8,
@@ -18,7 +26,7 @@ pub struct StatusPing {
     pub protocol_version: u8,
 }
 
-#[derive(Clone, Debug, PartialEq, RlpEncodable, RlpDecodable)]
+#[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
 pub struct StatusPong {
     pub best_epoch: u64,
     pub genesis_hash: H256,
@@ -28,7 +36,7 @@ pub struct StatusPong {
     pub terminals: Vec<H256>,
 }
 
-#[derive(Clone, Debug, PartialEq, RlpEncodable, RlpDecodable)]
+#[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
 pub struct GetStateRoot {
     pub request_id: RequestId,
     pub epoch: u64,
@@ -38,10 +46,10 @@ pub struct GetStateRoot {
 pub struct StateRoot {
     pub request_id: RequestId,
     pub pivot_hash: H256,
-    pub state_root: PrimitiveStateRoot,
+    pub state_root: StateRootWithProof,
 }
 
-#[derive(Clone, Debug, PartialEq, RlpEncodable, RlpDecodable)]
+#[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
 pub struct GetStateEntry {
     pub request_id: RequestId,
     pub epoch: u64,
@@ -52,7 +60,7 @@ pub struct GetStateEntry {
 pub struct StateEntry {
     pub request_id: RequestId,
     pub pivot_hash: H256,
-    pub state_root: PrimitiveStateRoot,
+    pub state_root: StateRootWithProof,
     pub entry: Option<Vec<u8>>,
     pub proof: StateProof,
 }

--- a/core/src/light_protocol/query_provider.rs
+++ b/core/src/light_protocol/query_provider.rs
@@ -9,7 +9,9 @@ use rlp::Rlp;
 use std::sync::{Arc, Weak};
 
 use cfx_types::H256;
-use primitives::{BlockHeader, EpochNumber, TransactionWithSignature};
+use primitives::{
+    BlockHeader, EpochNumber, StateRoot, TransactionWithSignature,
+};
 
 use crate::{
     consensus::ConsensusGraph,
@@ -21,7 +23,9 @@ use crate::{
     parameters::light::{MAX_EPOCHS_TO_SEND, MAX_HEADERS_TO_SEND},
     statedb::StateDb,
     storage::{
-        state_manager::StateManagerTrait, SnapshotAndEpochIdRef, StateProof,
+        state::{State, StateTrait},
+        state_manager::StateManagerTrait,
+        SnapshotAndEpochIdRef, StateProof,
     },
     sync::SynchronizationGraph,
     TransactionPool,
@@ -151,24 +155,20 @@ impl QueryProvider {
     }
 
     #[inline]
-    fn get_local_pivot_hash(&self, epoch: u64) -> Result<H256, Error> {
+    fn pivot_hash_of(&self, epoch: u64) -> Result<H256, Error> {
         let epoch = EpochNumber::Number(epoch);
-        let pivot_hash = self.consensus.get_hash_from_epoch_number(epoch)?;
-        Ok(pivot_hash)
+        Ok(self.consensus.get_hash_from_epoch_number(epoch)?)
     }
 
     #[inline]
-    fn get_local_header(&self, epoch: u64) -> Result<Arc<BlockHeader>, Error> {
-        let epoch = EpochNumber::Number(epoch);
-        let hash = self.consensus.get_hash_from_epoch_number(epoch)?;
-        let header = self.consensus.data_man.block_header_by_hash(&hash);
+    fn pivot_header_of(&self, epoch: u64) -> Result<Arc<BlockHeader>, Error> {
+        let pivot = self.pivot_hash_of(epoch)?;
+        let header = self.consensus.data_man.block_header_by_hash(&pivot);
         header.ok_or(ErrorKind::InternalError.into())
     }
 
     #[inline]
-    fn get_local_state_root(
-        &self, epoch: u64,
-    ) -> Result<StateRootWithProof, Error> {
+    fn headers_needed_to_verify(&self, epoch: u64) -> Result<Vec<u64>, Error> {
         // find the first header that can verify the state root requested
         let witness = self.consensus.first_epoch_with_correct_state_of(epoch);
 
@@ -180,56 +180,81 @@ impl QueryProvider {
             }
         };
 
-        let witness_header = self.get_local_header(witness)?;
-        let blame = witness_header.blame() as u64;
+        let blame = self.pivot_header_of(witness)?.blame() as u64;
 
         // assumption: the state root requested can be verified by the witness
-        assert!(witness - epoch - DEFERRED_STATE_EPOCH_COUNT <= blame);
+        assert!(witness <= epoch + DEFERRED_STATE_EPOCH_COUNT + blame);
 
-        // find the state root requested
-        let root = self
-            .get_local_header(epoch + DEFERRED_STATE_EPOCH_COUNT)?
-            .state_root_with_aux_info
-            .state_root
-            .clone();
-
-        // collect all hashes required to verify `witness.deferred_state_root`
-        // NOTE: this iterator will short-circuit on the first failure
-        let proof = (0..(blame + 1))
+        // collect all header heights that were used to compute DSR of `witness`
+        Ok((0..(blame + 1))
             .map(|ii| {
-                Ok(self
-                    .get_local_header(witness - ii)?
-                    .state_root_with_aux_info
-                    .state_root
-                    .compute_state_root_hash())
+                // assumption: majority will not approve incorrect blame fields
+                assert!(witness >= ii);
+                witness - ii
             })
+            .collect())
+    }
+
+    #[inline]
+    fn state_of(&self, epoch: u64) -> Result<State, Error> {
+        let pivot = self.pivot_hash_of(epoch)?;
+
+        let state = self
+            .consensus
+            .data_man
+            .storage_manager
+            .get_state_no_commit(SnapshotAndEpochIdRef::new(&pivot, None));
+
+        match state {
+            Ok(Some(state)) => Ok(state),
+            _ => Err(ErrorKind::InternalError.into()),
+        }
+    }
+
+    #[inline]
+    fn state_root_of(&self, epoch: u64) -> Result<StateRoot, Error> {
+        match self.state_of(epoch)?.get_state_root() {
+            Ok(Some(root)) => Ok(root.state_root),
+            _ => Err(ErrorKind::InternalError.into()),
+        }
+    }
+
+    #[inline]
+    fn correct_deferred_state_root_hash_of(
+        &self, height: u64,
+    ) -> Result<H256, Error> {
+        let epoch = height.saturating_sub(DEFERRED_STATE_EPOCH_COUNT);
+        let root = self.state_root_of(epoch)?;
+        Ok(root.compute_state_root_hash())
+    }
+
+    #[inline]
+    fn state_root_with_proof_at(
+        &self, epoch: u64,
+    ) -> Result<StateRootWithProof, Error> {
+        let root = self.state_root_of(epoch)?;
+
+        let proof = self
+            .headers_needed_to_verify(epoch)?
+            .into_iter()
+            .map(|h| self.correct_deferred_state_root_hash_of(h))
             .collect::<Result<Vec<H256>, Error>>()?;
 
         Ok(StateRootWithProof { root, proof })
     }
 
     #[inline]
-    fn get_local_state_entry(
-        &self, hash: H256, key: &Vec<u8>,
+    fn state_entry_at(
+        &self, epoch: u64, key: &Vec<u8>,
     ) -> Result<(Option<Vec<u8>>, StateProof), Error> {
-        let maybe_state = self
-            .consensus
-            .data_man
-            .storage_manager
-            .get_state_no_commit(SnapshotAndEpochIdRef::new(&hash, None))
-            .map_err(|e| format!("Failed to get state, err={:?}", e))?;
+        let state = self.state_of(epoch)?;
 
-        match maybe_state {
-            None => Err(ErrorKind::InternalError.into()),
-            Some(state) => {
-                let (value, proof) = StateDb::new(state)
-                    .get_raw_with_proof(key)
-                    .or(Err(ErrorKind::InternalError))?;
+        let (value, proof) = StateDb::new(state)
+            .get_raw_with_proof(key)
+            .or(Err(ErrorKind::InternalError))?;
 
-                let value = value.map(|x| x.to_vec());
-                Ok((value, proof))
-            }
-        }
+        let value = value.map(|x| x.to_vec());
+        Ok((value, proof))
     }
 
     fn send_status(
@@ -306,8 +331,8 @@ impl QueryProvider {
         info!("on_get_state_root req={:?}", req);
         let request_id = req.request_id;
 
-        let pivot_hash = self.get_local_pivot_hash(req.epoch)?;
-        let state_root = self.get_local_state_root(req.epoch)?;
+        let pivot_hash = self.pivot_hash_of(req.epoch)?;
+        let state_root = self.state_root_with_proof_at(req.epoch)?;
 
         let msg: Box<dyn Message> = Box::new(GetStateRootResponse {
             request_id,
@@ -326,10 +351,9 @@ impl QueryProvider {
         info!("on_get_state_entry req={:?}", req);
         let request_id = req.request_id;
 
-        let pivot_hash = self.get_local_pivot_hash(req.epoch)?;
-        let state_root = self.get_local_state_root(req.epoch)?;
-        let (entry, proof) =
-            self.get_local_state_entry(pivot_hash, &req.key)?;
+        let pivot_hash = self.pivot_hash_of(req.epoch)?;
+        let state_root = self.state_root_with_proof_at(req.epoch)?;
+        let (entry, proof) = self.state_entry_at(req.epoch, &req.key)?;
         let entry = entry.map(|x| x.to_vec());
 
         let msg: Box<dyn Message> = Box::new(GetStateEntryResponse {


### PR DESCRIPTION
**Overview**

- Consider blame in `light_protocol::QueryProvider::get_local_state_root`.
- Consider blame in `light_protocol::handler::Query::validate_state_root`.
- Add tests.

**Details**

When validating state roots received for `epoch`, we'd normally check them against the deferred state root in the header of `epoch + DEFERRED_STATE_EPOCH_COUNT`. However, the deferred state roots - even on the pivot chain - are not guaranteed to be correct.

To gain more confidence, we have to look at the blame fields. We need to find the first trustworthy block starting from `epoch + DEFERRED_STATE_EPOCH_COUNT` based on its blame ratio. If `blame > 0`, the deferred state root of this block will be computed as

```
hash(hash(delta_root, intermediate_root, snapshot_root), block[me - 1].deferred_state_root, block[me - 2].deferred_state_root, ..., block[me - blame].deferred_state_root)
```

... instead of just

```
hash(delta_root, intermediate_root, snapshot_root)
```

This means that this block will carry a commitment to the correct state roots of all blamed blocks in its deferred state root field. If we trust this field (based on blaming), we can validate the missing state root too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/553)
<!-- Reviewable:end -->
