### PR TITLE
Add tx receipt retrieval logic to light node

### DIFF
--- a/core/src/light_protocol/error.rs
+++ b/core/src/light_protocol/error.rs
@@ -38,9 +38,19 @@ error_chain! {
             display("Invalid message format"),
         }
 
-        InvalidProof {
-            description("Invalid proof"),
-            display("Invalid proof"),
+        InvalidLedgerProof {
+            description("Invalid ledger proof"),
+            display("Invalid ledger proof"),
+        }
+
+        InvalidReceipts {
+            description("Invalid receipts"),
+            display("Invalid receipts"),
+        }
+
+        InvalidStateProof {
+            description("Invalid state proof"),
+            display("Invalid state proof"),
         }
 
         InvalidStateRoot {
@@ -146,7 +156,9 @@ pub fn handle(io: &dyn NetworkContext, peer: PeerId, msg_id: MsgId, e: Error) {
         }
 
         ErrorKind::InvalidMessageFormat
-        | ErrorKind::InvalidProof
+        | ErrorKind::InvalidLedgerProof
+        | ErrorKind::InvalidReceipts
+        | ErrorKind::InvalidStateProof
         | ErrorKind::InvalidStateRoot
         | ErrorKind::ValidationFailed
         | ErrorKind::Decoder(_) => op = Some(UpdateNodeOperation::Remove),

--- a/core/src/light_protocol/handler/handler.rs
+++ b/core/src/light_protocol/handler/handler.rs
@@ -121,6 +121,7 @@ impl Handler {
             msgid::STATUS_PONG => self.on_status(io, peer, &rlp),
             msgid::STATE_ROOT => self.query.on_state_root(io, peer, &rlp),
             msgid::STATE_ENTRY => self.query.on_state_entry(io, peer, &rlp),
+            msgid::RECEIPTS => self.query.on_receipts(io, peer, &rlp),
             msgid::BLOCK_HASHES => self.sync.on_block_hashes(io, peer, &rlp),
             msgid::BLOCK_HEADERS => self.sync.on_block_headers(io, peer, &rlp),
             msgid::NEW_BLOCK_HASHES => self.sync.on_new_block_hashes(io, peer, &rlp),

--- a/core/src/light_protocol/handler/ledger_proof.rs
+++ b/core/src/light_protocol/handler/ledger_proof.rs
@@ -16,7 +16,7 @@ pub enum LedgerProof {
 impl Index<usize> for LedgerProof {
     type Output = H256;
 
-    fn index(&self, ii: usize) -> &H256 {
+    fn index(&self, ii: usize) -> &Self::Output {
         let hashes = match self {
             LedgerProof::StateRoot(hs) => hs,
             LedgerProof::ReceiptsRoot(hs) => hs,

--- a/core/src/light_protocol/handler/ledger_proof.rs
+++ b/core/src/light_protocol/handler/ledger_proof.rs
@@ -1,0 +1,73 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use cfx_types::H256;
+use primitives::{BlockHeader, BlockHeaderBuilder};
+use std::{ops::Index, sync::Arc};
+
+use crate::light_protocol::{Error, ErrorKind};
+
+pub enum LedgerProof {
+    StateRoot(Vec<H256>),
+    ReceiptsRoot(Vec<H256>),
+}
+
+impl Index<usize> for LedgerProof {
+    type Output = H256;
+
+    fn index(&self, ii: usize) -> &H256 {
+        let hashes = match self {
+            LedgerProof::StateRoot(hs) => hs,
+            LedgerProof::ReceiptsRoot(hs) => hs,
+        };
+
+        &hashes[ii]
+    }
+}
+
+impl LedgerProof {
+    pub fn validate(&self, witness: Arc<BlockHeader>) -> Result<(), Error> {
+        // extract proof hashes and corresponding local root hash
+        let (hashes, local_root_hash) = match self {
+            LedgerProof::StateRoot(hashes) => {
+                (hashes, *witness.deferred_state_root())
+            }
+            LedgerProof::ReceiptsRoot(hashes) => {
+                (hashes, *witness.deferred_receipts_root())
+            }
+        };
+
+        // validate the number of hashes provided against local witness blame
+        let blame = witness.blame() as u64;
+
+        if hashes.len() as u64 != blame + 1 {
+            info!(
+                "Invalid number of hashes provided: expected={}, received={}",
+                blame + 1,
+                hashes.len()
+            );
+            return Err(ErrorKind::InvalidLedgerProof.into());
+        }
+
+        // compute witness deferred root hash from the hashes provided
+        let received_root_hash = match blame {
+            0 => hashes[0],
+            _ => {
+                let hashes = hashes.clone();
+                BlockHeaderBuilder::compute_blame_state_root_vec_root(hashes)
+            }
+        };
+
+        // validate against local witness deferred state root hash
+        if received_root_hash != local_root_hash {
+            info!(
+                "Witness root hash mismatch: local={:?}, received={}",
+                local_root_hash, received_root_hash
+            );
+            return Err(ErrorKind::InvalidLedgerProof.into());
+        }
+
+        Ok(())
+    }
+}

--- a/core/src/light_protocol/handler/mod.rs
+++ b/core/src/light_protocol/handler/mod.rs
@@ -3,6 +3,7 @@
 // See http://www.gnu.org/licenses/
 
 mod handler;
+mod ledger_proof;
 mod query;
 mod sync;
 

--- a/core/src/light_protocol/message/message.rs
+++ b/core/src/light_protocol/message/message.rs
@@ -21,6 +21,8 @@ build_msgid! {
     NEW_BLOCK_HASHES = 0x09
     STATUS_PONG = 0x0a
     SEND_RAW_TX = 0x0b
+    GET_RECEIPTS = 0x0c
+    RECEIPTS = 0x0d
 
     INVALID = 0xff
 }
@@ -38,7 +40,10 @@ build_msg_impl! { GetBlockHeaders, msgid::GET_BLOCK_HEADERS, "GetBlockHeaders" }
 build_msg_impl! { BlockHeaders, msgid::BLOCK_HEADERS, "BlockHeaders" }
 build_msg_impl! { NewBlockHashes, msgid::NEW_BLOCK_HASHES, "NewBlockHashes" }
 build_msg_impl! { SendRawTx, msgid::SEND_RAW_TX, "SendRawTx" }
+build_msg_impl! { GetReceipts, msgid::GET_RECEIPTS, "GetReceipts" }
+build_msg_impl! { Receipts, msgid::RECEIPTS, "Receipts" }
 
 // generate `impl HasRequestId for _` for each request type
 build_has_request_id_impl! { GetStateRoot }
 build_has_request_id_impl! { GetStateEntry }
+build_has_request_id_impl! { GetReceipts }

--- a/core/src/light_protocol/message/mod.rs
+++ b/core/src/light_protocol/message/mod.rs
@@ -10,6 +10,7 @@ pub use message::msgid;
 pub use node_type::NodeType;
 pub use protocol::{
     BlockHashes, BlockHeaders, GetBlockHashesByEpoch, GetBlockHeaders,
-    GetStateEntry, GetStateRoot, NewBlockHashes, SendRawTx, StateEntry,
-    StateRoot, StateRootWithProof, StatusPing, StatusPong,
+    GetReceipts, GetStateEntry, GetStateRoot, NewBlockHashes, Receipts,
+    ReceiptsWithProof, SendRawTx, StateEntry, StateRoot, StateRootWithProof,
+    StatusPing, StatusPong,
 };

--- a/core/src/light_protocol/message/protocol.rs
+++ b/core/src/light_protocol/message/protocol.rs
@@ -3,13 +3,15 @@
 // See http://www.gnu.org/licenses/
 
 use cfx_types::H256;
+use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 use rlp_derive::{RlpDecodable, RlpEncodable};
 
 use super::NodeType;
 use crate::{message::RequestId, storage::StateProof};
 
 use primitives::{
-    BlockHeader as PrimitiveBlockHeader, StateRoot as PrimitiveStateRoot,
+    BlockHeader as PrimitiveBlockHeader, Receipt as PrimitiveReceipt,
+    StateRoot as PrimitiveStateRoot,
 };
 
 #[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
@@ -97,4 +99,50 @@ pub struct NewBlockHashes {
 #[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
 pub struct SendRawTx {
     pub raw: Vec<u8>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ReceiptsWithProof {
+    pub receipts: Vec<Vec<PrimitiveReceipt>>,
+    pub proof: Vec<H256>, // witness + blamed deferred receipts root hashes
+}
+
+impl Encodable for ReceiptsWithProof {
+    fn rlp_append(&self, stream: &mut RlpStream) {
+        stream.begin_list(2);
+
+        stream.begin_list(self.receipts.len());
+        for r in &self.receipts {
+            stream.append_list(r);
+        }
+
+        stream.append_list(&self.proof);
+    }
+}
+
+impl Decodable for ReceiptsWithProof {
+    fn decode(rlp: &Rlp) -> Result<ReceiptsWithProof, DecoderError> {
+        let receipts = rlp
+            .at(0)?
+            .into_iter()
+            .map(|x| Ok(x.as_list()?))
+            .collect::<Result<_, _>>()?;
+
+        let proof = rlp.list_at(1)?;
+
+        Ok(ReceiptsWithProof { receipts, proof })
+    }
+}
+
+#[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
+pub struct GetReceipts {
+    pub request_id: RequestId,
+    pub epoch: u64,
+}
+
+#[derive(Clone, Debug, RlpEncodable, RlpDecodable)]
+pub struct Receipts {
+    pub request_id: RequestId,
+    pub pivot_hash: H256,
+    pub receipts: ReceiptsWithProof,
 }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -29,6 +29,7 @@ pub use crate::{
     block_header::{BlockHeader, BlockHeaderBuilder},
     epoch::{EpochId, EpochNumber},
     log_entry::LogEntry,
+    receipt::Receipt,
     state_root::*,
     transaction::{
         Action, SignedTransaction, Transaction, TransactionWithSignature,


### PR DESCRIPTION
**Overview**

Light nodes need to verify the retrieved transactions receipts. The verification logic is similar to that of state root queries:

1. Retrieve the correct `deferred_receipts_root` hash value of the corresponding epoch, based on the blame field and a collection of hashes.
2. Retrieve all receipts of the given epoch.
3. Compute the receipts root hash and compare it to the value retrieved in step 1.

Note that the current implementation uses a flat array (not a Merkle tree) to derive `deferred_receipts_root`. This means that we need to retrieve all receipts of an epoch for verification, even if we're only interested in a single receipt.

**Use cases**

1. Log filtering. The light client retrieves all receipts from epochs with matching bloom filter and checks them for matches one by one.
2. Transaction status. The light client retrieves a transaction and its hash using the tx hash.

**Terminology**

- **State proof**: Proof that a given value exists (or does not exist) under the given key in the state trie.
- **Ledger proof**: Proof of certain values, whose hash is stored in the block header (e.g. state root).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/561)
<!-- Reviewable:end -->
