### PR TITLE
optimize the performance for computing epoch sets

### DIFF
--- a/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
+++ b/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
@@ -90,35 +90,100 @@ impl ConsensusNewBlockHandler {
         let new_era_height = inner.arena[new_era_block_arena_index].height;
         let new_era_stable_height =
             new_era_height + inner.inner_conf.era_epoch_count;
+        let stable_era_genesis =
+            inner.get_pivot_block_arena_index(new_era_stable_height);
         // We first compute the set of blocks inside the new era and we
         // recompute the past_weight inside the stable height.
         let mut new_era_block_arena_index_set = HashSet::new();
-        new_era_block_arena_index_set.clear();
+        let mut stable_genesis_future_set =
+            BitSet::with_capacity(inner.arena.len() as u32);
         let mut queue = VecDeque::new();
         queue.push_back(new_era_block_arena_index);
-        inner.arena[new_era_block_arena_index].past_weight = 0;
         new_era_block_arena_index_set.insert(new_era_block_arena_index);
+        stable_genesis_future_set.add(stable_era_genesis as u32);
         while let Some(x) = queue.pop_front() {
+            inner.arena[x].past_weight = 0;
+            let parent_inside_stable =
+                stable_genesis_future_set.contains(x as u32);
             let children = inner.arena[x].children.clone();
             for child in children.iter() {
                 queue.push_back(*child);
                 new_era_block_arena_index_set.insert(*child);
-                if inner.arena[*child].height <= new_era_stable_height
-                    || inner.arena[*child].data.partial_invalid
-                {
-                    inner.arena[*child].past_weight = 0;
+                if parent_inside_stable {
+                    stable_genesis_future_set.add(*child as u32);
+                }
+            }
+        }
+        // recompute past_weight under stable_genesis
+        let mut stack = Vec::new();
+        let mut visited = BitSet::with_capacity(inner.arena.len() as u32);
+        stack.push((0, stable_era_genesis, Vec::new()));
+        while let Some((state, index, mut blockset)) = stack.pop() {
+            if state == 0 {
+                // compute blockset_in_own_view_of_epoch first
+                if !inner.arena[index].data.blockset_cleared {
+                    for index in
+                        &inner.arena[index].data.blockset_in_own_view_of_epoch
+                    {
+                        if stable_genesis_future_set.contains(*index as u32)
+                            && !visited.contains(*index as u32)
+                        {
+                            visited.add(*index as u32);
+                            blockset.push(*index);
+                        }
+                    }
                 } else {
-                    let stable_era_genesis =
-                        inner.ancestor_at(*child, new_era_stable_height);
-                    let weight_in_my_epoch = inner.total_weight_in_own_epoch(
-                        &inner.arena[*child].data.blockset_in_own_view_of_epoch,
-                        false,
-                        stable_era_genesis,
-                    );
-                    inner.arena[*child].past_weight = inner.arena[x]
+                    let mut queue = VecDeque::new();
+                    for referee in &inner.arena[index].referees {
+                        if !visited.contains(*referee as u32) {
+                            visited.add(*referee as u32);
+                            queue.push_back(*referee);
+                        }
+                    }
+                    while let Some(index) = queue.pop_front() {
+                        blockset.push(index);
+                        let parent = inner.arena[index].parent;
+                        if stable_genesis_future_set.contains(parent as u32)
+                            && !visited.contains(parent as u32)
+                        {
+                            visited.add(parent as u32);
+                            queue.push_back(parent);
+                        }
+                        for referee in &inner.arena[index].referees {
+                            if stable_genesis_future_set
+                                .contains(*referee as u32)
+                                && !visited.contains(*referee as u32)
+                            {
+                                visited.add(*referee as u32);
+                                queue.push_back(*referee);
+                            }
+                        }
+                    }
+                }
+
+                // compute past_weight
+                let parent = inner.arena[index].parent;
+                if stable_genesis_future_set.contains(parent as u32) {
+                    inner.arena[index].past_weight = inner.arena[parent]
                         .past_weight
-                        + inner.block_weight(x, false)
-                        + weight_in_my_epoch;
+                        + inner.block_weight(parent, false);
+                } else {
+                    inner.arena[index].past_weight = 0;
+                }
+                for index in &blockset {
+                    inner.arena[*index].past_weight +=
+                        inner.block_weight(*index, false);
+                }
+
+                stack.push((1, index, blockset));
+                visited.add(index as u32);
+                for child in &inner.arena[index].children {
+                    stack.push((0, *child, Vec::new()));
+                }
+            } else {
+                visited.remove(index as u32);
+                for index in blockset {
+                    visited.remove(index as u32);
                 }
             }
         }
@@ -191,18 +256,6 @@ impl ConsensusNewBlockHandler {
             inner.arena[me].referees = new_referees;
             // We no longer need to consider blocks outside our era when
             // computing blockset_in_epoch
-            inner.arena[me].data.min_epoch_in_other_views =
-                if me != new_era_block_arena_index {
-                    max(
-                        inner.arena[me].data.min_epoch_in_other_views,
-                        new_era_height + 1,
-                    )
-                } else {
-                    new_era_height
-                };
-            assert!(
-                inner.arena[me].data.max_epoch_in_other_views >= new_era_height
-            );
             inner.arena[me]
                 .data
                 .blockset_in_own_view_of_epoch
@@ -211,6 +264,9 @@ impl ConsensusNewBlockHandler {
         // Now we are ready to cleanup outside blocks in inner data structures
         inner.legacy_refs = new_legacy_refs;
         inner.arena[new_era_block_arena_index].parent = NULL;
+        inner
+            .pastset_cache
+            .intersect_update(&outside_block_arena_indices);
         for index in outside_block_arena_indices {
             let hash = inner.arena[index].hash;
             inner.hash_to_arena_indices.remove(&hash);
@@ -549,6 +605,7 @@ impl ConsensusNewBlockHandler {
         epoch_number: u64,
     )
     {
+        assert!(!inner.arena[pivot_arena_index].data.blockset_cleared);
         let block_set = mem::replace(
             &mut inner.arena[pivot_arena_index]
                 .data
@@ -947,6 +1004,20 @@ impl ConsensusNewBlockHandler {
         self.data_man.insert_terminals_to_db(&terminals);
     }
 
+    fn try_clear_blockset_in_own_view_of_epoch(
+        inner: &mut ConsensusGraphInner, me: usize,
+    ) {
+        if inner.arena[me].data.blockset_in_own_view_of_epoch.len() as u64
+            > BLOCKSET_IN_OWN_VIEW_OF_EPOCH_CAP
+        {
+            inner.arena[me].data.blockset_in_own_view_of_epoch =
+                Default::default();
+            inner.arena[me].data.ordered_executable_epoch_blocks =
+                Default::default();
+            inner.arena[me].data.blockset_cleared = true;
+        }
+    }
+
     /// The top level function invoked by ConsensusGraph to insert a new block.
     pub fn on_new_block(
         &self, inner: &mut ConsensusGraphInner, meter: &ConfirmationMeter,
@@ -1036,6 +1107,7 @@ impl ConsensusNewBlockHandler {
             );
 
             if !fully_valid {
+                // for partial_invalid block, no need to store it in memory
                 inner.arena[me].data.blockset_in_own_view_of_epoch =
                     Default::default();
                 inner.arena[me].data.ordered_executable_epoch_blocks =
@@ -1058,6 +1130,9 @@ impl ConsensusNewBlockHandler {
 
         if pending {
             inner.arena[me].data.pending = true;
+            ConsensusNewBlockHandler::try_clear_blockset_in_own_view_of_epoch(
+                inner, me,
+            );
             debug!("Block {} (hash = {}) is pending", me, inner.arena[me].hash);
         } else if !fully_valid {
             inner.arena[me].data.partial_invalid = true;
@@ -1116,12 +1191,16 @@ impl ConsensusNewBlockHandler {
                         {
                             // Reset the epoch_number of the discarded fork
                             ConsensusNewBlockHandler::reset_epoch_number_in_epoch(
-                                    inner,
-                                    discarded_idx,
-                                )
+                                inner,
+                                discarded_idx,
+                            );
+                            ConsensusNewBlockHandler::try_clear_blockset_in_own_view_of_epoch(inner, discarded_idx);
                         }
                         let mut u = new;
                         loop {
+                            if inner.arena[u].data.blockset_cleared {
+                                inner.collect_blockset_in_own_view_of_epoch(u);
+                            }
                             inner.pivot_chain.push(u);
                             ConsensusNewBlockHandler::set_epoch_number_in_epoch(
                                 inner,
@@ -1190,6 +1269,8 @@ impl ConsensusNewBlockHandler {
                 }
                 inner.recompute_metadata(fork_at, last_pivot_to_update);
             } else {
+                // pivot chain not extend and not change
+                ConsensusNewBlockHandler::try_clear_blockset_in_own_view_of_epoch(inner, me);
                 inner.recompute_metadata(
                     inner.get_pivot_height(),
                     last_pivot_to_update,

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -5,6 +5,7 @@
 mod anticone_cache;
 pub mod consensus_inner;
 mod debug;
+mod pastset_cache;
 
 use super::consensus::consensus_inner::{
     confirmation_meter::ConfirmationMeter,

--- a/core/src/consensus/pastset_cache.rs
+++ b/core/src/consensus/pastset_cache.rs
@@ -1,0 +1,54 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use hibitset::BitSet;
+use std::collections::{HashMap, HashSet};
+
+const MAX_PASTSET_CACHE_CAP: usize = 256;
+
+#[derive(Default)]
+pub struct PastSetCache {
+    cache: HashMap<usize, (BitSet, u64)>,
+    entry: u64,
+}
+
+impl PastSetCache {
+    pub fn update(&mut self, me: usize, pastset: BitSet) {
+        if self.cache.len() == MAX_PASTSET_CACHE_CAP {
+            let mut evict = 0;
+            let mut min_entry = self.entry;
+            for (index, (_, entry)) in self.cache.iter() {
+                if *entry < min_entry {
+                    min_entry = *entry;
+                    evict = *index;
+                }
+            }
+            assert!(min_entry != self.entry);
+            self.cache.remove(&evict);
+        }
+        self.cache.insert(me, (pastset, self.entry));
+        self.entry += 1;
+    }
+
+    pub fn get(&mut self, me: usize, update_cache: bool) -> Option<&BitSet> {
+        if let Some(v) = self.cache.get_mut(&me) {
+            if update_cache {
+                v.1 = self.entry;
+                self.entry += 1;
+            }
+            Some(&v.0)
+        } else {
+            None
+        }
+    }
+
+    pub fn intersect_update(&mut self, outside_era_blockset: &HashSet<usize>) {
+        self.cache.retain(|me, (s, _)| {
+            for index in outside_era_blockset.iter() {
+                s.remove(*index as u32);
+            }
+            !outside_era_blockset.contains(me)
+        });
+    }
+}

--- a/core/src/consensus/pastset_cache.rs
+++ b/core/src/consensus/pastset_cache.rs
@@ -45,10 +45,14 @@ impl PastSetCache {
 
     pub fn intersect_update(&mut self, outside_era_blockset: &HashSet<usize>) {
         self.cache.retain(|me, (s, _)| {
-            for index in outside_era_blockset.iter() {
-                s.remove(*index as u32);
+            if outside_era_blockset.contains(me) {
+                false
+            } else {
+                for index in outside_era_blockset.iter() {
+                    s.remove(*index as u32);
+                }
+                true
             }
-            !outside_era_blockset.contains(me)
         });
     }
 }

--- a/core/src/parameters.rs
+++ b/core/src/parameters.rs
@@ -39,10 +39,9 @@ pub mod consensus_internal {
     // Here is the delay for us to recycle those orphaned blocks in the boundary
     // of eras.
     pub const ERA_RECYCLE_TRANSACTION_DELAY: u64 = 20;
-    /// This is the bound for `min/max_epoch_in_other_views`. If we have more
-    /// than this number, we will use the brute_force O(n) algorithm to collect
-    /// blockset instead.
-    pub const EPOCH_IN_OTHER_VIEWS_GAP_BOUND: u64 = 1000;
+    // This is the cap of the size of `blockset_in_own_view_of_epoch`. If we
+    // have more than this number, we will not store it in memory
+    pub const BLOCKSET_IN_OWN_VIEW_OF_EPOCH_CAP: u64 = 1000;
 
     // FIXME Use another method to prevent DDoS attacks if attackers control the
     // pivot chain A block can blame up to BLAME_BOUND ancestors that their


### PR DESCRIPTION
1. Maintain a pastset cache to help to fast compute `blockset_in_own_view_of_epoch`. The extra memory used is `O(n)`.
2. To avoid out of memory attack, if the size of `blockset_in_own_view_of_epoch` exceeds a pre-defined limit (1000 in current code), we don't store it in memory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/564)
<!-- Reviewable:end -->
