### PR TITLE
Add on-demand tx retrieval to light node

### DIFF
--- a/client/src/rpc/impls/common.rs
+++ b/client/src/rpc/impls/common.rs
@@ -23,9 +23,9 @@ use network::{
 };
 
 use crate::rpc::types::{
-    Block as RpcBlock, EpochNumber, Receipt as RpcReceipt, Receipt,
-    Status as RpcStatus, Transaction as RpcTransaction, H160 as RpcH160,
-    H256 as RpcH256, U256 as RpcU256, U64 as RpcU64,
+    Block as RpcBlock, EpochNumber, Receipt as RpcReceipt, Status as RpcStatus,
+    Transaction as RpcTransaction, H160 as RpcH160, H256 as RpcH256,
+    U256 as RpcU256, U64 as RpcU64,
 };
 
 fn grouped_txs<T, F>(
@@ -168,31 +168,6 @@ impl RpcImpl {
                     ))
                 }
             })
-    }
-
-    pub fn transaction_by_hash(
-        &self, hash: RpcH256,
-    ) -> RpcResult<Option<RpcTransaction>> {
-        let hash: H256 = hash.into();
-        info!("RPC Request: cfx_getTransactionByHash({:?})", hash);
-
-        if let Some((transaction, receipt, tx_address)) =
-            self.consensus.get_transaction_info_by_hash(&hash)
-        {
-            Ok(Some(RpcTransaction::from_signed(
-                &transaction,
-                Some(Receipt::new(transaction.clone(), receipt, tx_address)),
-            )))
-        } else {
-            if let Some(transaction) = self.tx_pool.get_transaction(&hash) {
-                return Ok(Some(RpcTransaction::from_signed(
-                    &transaction,
-                    None,
-                )));
-            }
-
-            Ok(None)
-        }
     }
 
     pub fn blocks_by_epoch(&self, num: EpochNumber) -> RpcResult<Vec<RpcH256>> {

--- a/client/src/rpc/impls/light.rs
+++ b/client/src/rpc/impls/light.rs
@@ -130,6 +130,17 @@ impl RpcImpl {
             false => Err(RpcError::invalid_params("Unable to relay tx")),
         }
     }
+
+    pub fn transaction_by_hash(
+        &self, hash: RpcH256,
+    ) -> RpcResult<Option<RpcTransaction>> {
+        info!("RPC Request: cfx_getTransactionByHash({:?})", hash);
+
+        // TODO(thegaram): try to retrieve from local tx pool or cache first
+
+        let maybe_tx = self.light.get_tx(hash.into());
+        Ok(maybe_tx.map(|tx| RpcTransaction::from_signed(&tx, None)))
+    }
 }
 
 // macro for reducing boilerplate for unsupported methods
@@ -167,7 +178,6 @@ impl Cfx for CfxHandler {
             fn blocks_by_epoch(&self, num: EpochNumber) -> RpcResult<Vec<RpcH256>>;
             fn epoch_number(&self, epoch_num: Option<EpochNumber>) -> RpcResult<RpcU256>;
             fn gas_price(&self) -> RpcResult<RpcU256>;
-            fn transaction_by_hash(&self, hash: RpcH256) -> RpcResult<Option<RpcTransaction>>;
             fn transaction_count(&self, address: RpcH160, num: Option<EpochNumber>) -> RpcResult<RpcU256>;
         }
 
@@ -177,6 +187,7 @@ impl Cfx for CfxHandler {
             fn estimate_gas(&self, rpc_tx: RpcTransaction) -> RpcResult<RpcU256>;
             fn get_logs(&self, filter: RpcFilter) -> RpcResult<Vec<RpcLog>>;
             fn send_raw_transaction(&self, raw: Bytes) -> RpcResult<RpcH256>;
+            fn transaction_by_hash(&self, hash: RpcH256) -> RpcResult<Option<RpcTransaction>>;
         }
     }
 }

--- a/core/src/light_protocol/error.rs
+++ b/core/src/light_protocol/error.rs
@@ -58,6 +58,11 @@ error_chain! {
             display("Invalid state root"),
         }
 
+        InvalidTxSignature {
+            description("Invalid tx signature"),
+            display("Invalid tx signature"),
+        }
+
         PivotHashMismatch {
             description("Pivot hash mismatch"),
             display("Pivot hash mismatch"),
@@ -160,6 +165,7 @@ pub fn handle(io: &dyn NetworkContext, peer: PeerId, msg_id: MsgId, e: Error) {
         | ErrorKind::InvalidReceipts
         | ErrorKind::InvalidStateProof
         | ErrorKind::InvalidStateRoot
+        | ErrorKind::InvalidTxSignature
         | ErrorKind::ValidationFailed
         | ErrorKind::Decoder(_) => op = Some(UpdateNodeOperation::Remove),
 

--- a/core/src/light_protocol/handler/handler.rs
+++ b/core/src/light_protocol/handler/handler.rs
@@ -122,6 +122,7 @@ impl Handler {
             msgid::STATE_ROOT => self.query.on_state_root(io, peer, &rlp),
             msgid::STATE_ENTRY => self.query.on_state_entry(io, peer, &rlp),
             msgid::RECEIPTS => self.query.on_receipts(io, peer, &rlp),
+            msgid::TXS => self.query.on_txs(io, peer, &rlp),
             msgid::BLOCK_HASHES => self.sync.on_block_hashes(io, peer, &rlp),
             msgid::BLOCK_HEADERS => self.sync.on_block_headers(io, peer, &rlp),
             msgid::NEW_BLOCK_HASHES => self.sync.on_new_block_hashes(io, peer, &rlp),

--- a/core/src/light_protocol/handler/query.rs
+++ b/core/src/light_protocol/handler/query.rs
@@ -20,17 +20,19 @@ use futures::{
 
 use cfx_types::H256;
 use primitives::{
-    BlockHeader, BlockHeaderBuilder, EpochNumber, Receipt, StateRoot,
+    BlockHeader, BlockHeaderBuilder, EpochNumber, Receipt, SignedTransaction,
+    StateRoot,
 };
 
 use crate::{
     consensus::ConsensusGraph,
     light_protocol::{
         message::{
-            GetReceipts, GetStateEntry, GetStateRoot,
+            GetReceipts, GetStateEntry, GetStateRoot, GetTxs,
             Receipts as GetReceiptsResponse, ReceiptsWithProof,
             StateEntry as GetStateEntryResponse,
             StateRoot as GetStateRootResponse, StateRootWithProof,
+            Txs as GetTxsResponse,
         },
         Error, ErrorKind,
     },
@@ -49,6 +51,7 @@ pub enum QueryResult {
     StateEntry(Option<Vec<u8>>),
     StateRoot(StateRoot),
     Receipts(Vec<Vec<Receipt>>),
+    Txs(Vec<SignedTransaction>),
 }
 
 struct PendingRequest {
@@ -269,6 +272,21 @@ impl QueryHandler {
         self.validate_receipts(req.epoch, &resp.receipts)?;
 
         sender.complete(QueryResult::Receipts(resp.receipts.receipts));
+        // note: in case of early return, `sender` will be cancelled
+
+        Ok(())
+    }
+
+    pub(super) fn on_txs(
+        &self, _io: &dyn NetworkContext, peer: PeerId, rlp: &Rlp,
+    ) -> Result<(), Error> {
+        let resp: GetTxsResponse = rlp.as_val()?;
+        info!("on_txs resp={:?}", resp);
+
+        let id = resp.request_id;
+        let (_req, sender) = self.match_request::<GetTxs>(peer, id)?;
+
+        sender.complete(QueryResult::Txs(resp.txs));
         // note: in case of early return, `sender` will be cancelled
 
         Ok(())

--- a/core/src/light_protocol/message/message.rs
+++ b/core/src/light_protocol/message/message.rs
@@ -23,6 +23,8 @@ build_msgid! {
     SEND_RAW_TX = 0x0b
     GET_RECEIPTS = 0x0c
     RECEIPTS = 0x0d
+    GET_TXS = 0x0e
+    TXS = 0x0f
 
     INVALID = 0xff
 }
@@ -42,8 +44,11 @@ build_msg_impl! { NewBlockHashes, msgid::NEW_BLOCK_HASHES, "NewBlockHashes" }
 build_msg_impl! { SendRawTx, msgid::SEND_RAW_TX, "SendRawTx" }
 build_msg_impl! { GetReceipts, msgid::GET_RECEIPTS, "GetReceipts" }
 build_msg_impl! { Receipts, msgid::RECEIPTS, "Receipts" }
+build_msg_impl! { GetTxs, msgid::GET_TXS, "GetTxs" }
+build_msg_impl! { Txs, msgid::TXS, "Txs" }
 
 // generate `impl HasRequestId for _` for each request type
 build_has_request_id_impl! { GetStateRoot }
 build_has_request_id_impl! { GetStateEntry }
 build_has_request_id_impl! { GetReceipts }
+build_has_request_id_impl! { GetTxs }

--- a/core/src/light_protocol/message/mod.rs
+++ b/core/src/light_protocol/message/mod.rs
@@ -10,7 +10,7 @@ pub use message::msgid;
 pub use node_type::NodeType;
 pub use protocol::{
     BlockHashes, BlockHeaders, GetBlockHashesByEpoch, GetBlockHeaders,
-    GetReceipts, GetStateEntry, GetStateRoot, NewBlockHashes, Receipts,
+    GetReceipts, GetStateEntry, GetStateRoot, GetTxs, NewBlockHashes, Receipts,
     ReceiptsWithProof, SendRawTx, StateEntry, StateRoot, StateRootWithProof,
-    StatusPing, StatusPong,
+    StatusPing, StatusPong, Txs,
 };

--- a/core/src/light_protocol/message/protocol.rs
+++ b/core/src/light_protocol/message/protocol.rs
@@ -11,7 +11,7 @@ use crate::{message::RequestId, storage::StateProof};
 
 use primitives::{
     BlockHeader as PrimitiveBlockHeader, Receipt as PrimitiveReceipt,
-    StateRoot as PrimitiveStateRoot,
+    SignedTransaction, StateRoot as PrimitiveStateRoot,
 };
 
 #[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
@@ -145,4 +145,15 @@ pub struct Receipts {
     pub request_id: RequestId,
     pub pivot_hash: H256,
     pub receipts: ReceiptsWithProof,
+}
+#[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
+pub struct GetTxs {
+    pub request_id: RequestId,
+    pub hashes: Vec<H256>,
+}
+
+#[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
+pub struct Txs {
+    pub request_id: RequestId,
+    pub txs: Vec<SignedTransaction>,
 }

--- a/core/src/parameters.rs
+++ b/core/src/parameters.rs
@@ -158,9 +158,10 @@ pub mod light {
     /// `GetBlockHashesByEpoch` request.
     pub const NUM_WAITING_HEADERS_THRESHOLD: usize = 1000;
 
-    /// Maximum number of epochs/headers to send to a light peer in a response.
+    /// Max number of epochs/headers/txs to send to a light peer in a response.
     pub const MAX_EPOCHS_TO_SEND: usize = 128;
     pub const MAX_HEADERS_TO_SEND: usize = 512;
+    pub const MAX_TXS_TO_SEND: usize = 1024;
 }
 
 pub const WORKER_COMPUTATION_PARALLELISM: usize = 8;


### PR DESCRIPTION
**Overview**

Light nodes will only store a small subset of all transactions: ones sent into the network through the light node, and ones that had been queried before. This PR adds on-demand retrieval of signed transactions from full nodes and exposes this on the light node RPC (`cfx_getTransactionByHash`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/565)
<!-- Reviewable:end -->
