### PR TITLE
Add trie path proofs

### DIFF
--- a/core/src/light_protocol/handler/query.rs
+++ b/core/src/light_protocol/handler/query.rs
@@ -239,13 +239,11 @@ impl QueryHandler {
         self.validate_state_root(req.epoch, &resp.state_root)?;
 
         // validate proof
-        if !resp.proof.is_valid(
-            &req.key,
-            resp.entry.as_ref().map(|v| &**v),
-            resp.state_root.root.delta_root,
-            resp.state_root.root.intermediate_delta_root,
-            resp.state_root.root.snapshot_root,
-        ) {
+        let key = &req.key;
+        let value = resp.entry.as_ref().map(|v| &**v);
+        let root = resp.state_root.root;
+
+        if !resp.proof.is_valid_kv(key, value, root) {
             info!("Invalid proof from peer={}", peer);
             return Err(ErrorKind::InvalidStateProof.into());
         }


### PR DESCRIPTION
**Overview**

Before, trie proofs could only be used to

- verify that a trie contains a *given value* under a given key, or
- verify that a trie contains *no value* under a given key.

This PR adds the ability to verify trie paths to certain node hashes. That is, a proof can verify that the trie *does* or *does not* contain a node with a given hash value under a given path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/566)
<!-- Reviewable:end -->
