### PR TITLE
Transaction relay and block packing metrics

### DIFF
--- a/blockgen/Cargo.toml
+++ b/blockgen/Cargo.toml
@@ -23,3 +23,5 @@ network = { path = "../network" }
 kvdb-rocksdb = "0.1.3"
 secret-store = { path = "../secret_store" }
 toml = "0.4"
+metrics = { path = "../util/metrics" }
+lazy_static = "1.2.0"

--- a/blockgen/src/lib.rs
+++ b/blockgen/src/lib.rs
@@ -8,16 +8,23 @@ use cfxcore::{
     SharedSynchronizationGraph, SharedSynchronizationService,
     SharedTransactionPool,
 };
+use lazy_static::lazy_static;
 use log::{debug, info, trace, warn};
+use metrics::{Gauge, GaugeUsize};
 use parking_lot::{Mutex, RwLock};
 use primitives::*;
 use std::{
     cmp::max,
+    collections::HashSet,
     sync::{mpsc, Arc},
     thread, time,
 };
 use time::{SystemTime, UNIX_EPOCH};
 use txgen::{SharedTransactionGenerator, SpecialTransactionGenerator};
+lazy_static! {
+    static ref PACKED_ACCOUNT_SIZE: Arc<dyn Gauge<usize>> =
+        GaugeUsize::register_with_group("txpool", "packed_account_size");
+}
 
 enum MiningState {
     Start,
@@ -275,12 +282,15 @@ impl BlockGenerator {
                 additional_transactions,
             );
 
+        let mut sender_accounts = HashSet::new();
         for tx in &transactions {
             let tx_hash = tx.hash();
             if tx_hash[0] & 254 == 0 {
                 debug!("Sampled transaction {:?} in packing block", tx_hash);
             }
+            sender_accounts.insert(tx.sender.clone());
         }
+        PACKED_ACCOUNT_SIZE.update(sender_accounts.len());
 
         let (
             blame,

--- a/blockgen/src/lib.rs
+++ b/blockgen/src/lib.rs
@@ -288,7 +288,7 @@ impl BlockGenerator {
             if tx_hash[0] & 254 == 0 {
                 debug!("Sampled transaction {:?} in packing block", tx_hash);
             }
-            sender_accounts.insert(tx.sender.clone());
+            sender_accounts.insert(tx.sender);
         }
         PACKED_ACCOUNT_SIZE.update(sender_accounts.len());
 

--- a/core/src/transaction_pool/mod.rs
+++ b/core/src/transaction_pool/mod.rs
@@ -20,7 +20,9 @@ use crate::{
 };
 use account_cache::AccountCache;
 use cfx_types::{Address, H256, U256};
-use metrics::{register_meter_with_group, Gauge, GaugeUsize,Meter, MeterTimer};
+use metrics::{
+    register_meter_with_group, Gauge, GaugeUsize, Meter, MeterTimer,
+};
 use parking_lot::{Mutex, RwLock};
 use primitives::{
     Account, Action, EpochId, SignedTransaction, TransactionWithSignature,

--- a/core/src/transaction_pool/mod.rs
+++ b/core/src/transaction_pool/mod.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 use account_cache::AccountCache;
 use cfx_types::{Address, H256, U256};
-use metrics::{register_meter_with_group, Meter, MeterTimer};
+use metrics::{register_meter_with_group, Gauge, GaugeUsize,Meter, MeterTimer};
 use parking_lot::{Mutex, RwLock};
 use primitives::{
     Account, Action, EpochId, SignedTransaction, TransactionWithSignature,
@@ -29,11 +29,11 @@ use std::{collections::hash_map::HashMap, mem, ops::DerefMut, sync::Arc};
 use transaction_pool_inner::TransactionPoolInner;
 
 lazy_static! {
-    static ref TX_POOL_GAUGE: Arc<dyn Meter> =
-        register_meter_with_group("txpool", "unexecuted_size");
-    static ref TX_POOL_READY_GAUGE: Arc<dyn Meter> =
-        register_meter_with_group("txpool", "ready_size");
-    static ref TX_POOL_INSERT_TIMER: Arc<dyn Meter> =
+    static ref TX_POOL_GAUGE: Arc<Gauge<usize>> =
+        GaugeUsize::register_with_group("txpool", "unexecuted_size");
+    static ref TX_POOL_READY_GAUGE: Arc<Gauge<usize>> =
+        GaugeUsize::register_with_group("txpool", "ready_size");
+    static ref TX_POOL_INSERT_TIMER: Arc<Meter> =
         register_meter_with_group("timer", "tx_pool::insert_new_tx");
     static ref TX_POOL_RECOVER_TIMER: Arc<dyn Meter> =
         register_meter_with_group("timer", "tx_pool::recover_public");
@@ -149,8 +149,8 @@ impl TransactionPool {
                 }
             }
         }
-        TX_POOL_GAUGE.mark(self.total_unpacked());
-        TX_POOL_READY_GAUGE.mark(self.inner.read().total_ready_accounts());
+        TX_POOL_GAUGE.update(self.total_unpacked());
+        TX_POOL_READY_GAUGE.update(self.inner.read().total_ready_accounts());
 
         (passed_transactions, failure)
     }

--- a/core/src/transaction_pool/mod.rs
+++ b/core/src/transaction_pool/mod.rs
@@ -35,7 +35,7 @@ lazy_static! {
         GaugeUsize::register_with_group("txpool", "unexecuted_size");
     static ref TX_POOL_READY_GAUGE: Arc<dyn Gauge<usize>> =
         GaugeUsize::register_with_group("txpool", "ready_size");
-    static ref TX_POOL_INSERT_TIMER: Arc<Meter> =
+    static ref TX_POOL_INSERT_TIMER: Arc<dyn Meter> =
         register_meter_with_group("timer", "tx_pool::insert_new_tx");
     static ref TX_POOL_RECOVER_TIMER: Arc<dyn Meter> =
         register_meter_with_group("timer", "tx_pool::recover_public");

--- a/core/src/transaction_pool/mod.rs
+++ b/core/src/transaction_pool/mod.rs
@@ -31,9 +31,9 @@ use std::{collections::hash_map::HashMap, mem, ops::DerefMut, sync::Arc};
 use transaction_pool_inner::TransactionPoolInner;
 
 lazy_static! {
-    static ref TX_POOL_GAUGE: Arc<Gauge<usize>> =
+    static ref TX_POOL_GAUGE: Arc<dyn Gauge<usize>> =
         GaugeUsize::register_with_group("txpool", "unexecuted_size");
-    static ref TX_POOL_READY_GAUGE: Arc<Gauge<usize>> =
+    static ref TX_POOL_READY_GAUGE: Arc<dyn Gauge<usize>> =
         GaugeUsize::register_with_group("txpool", "ready_size");
     static ref TX_POOL_INSERT_TIMER: Arc<Meter> =
         register_meter_with_group("timer", "tx_pool::insert_new_tx");

--- a/core/src/transaction_pool/transaction_pool_inner.rs
+++ b/core/src/transaction_pool/transaction_pool_inner.rs
@@ -560,8 +560,8 @@ impl TransactionPoolInner {
 
         if transaction.hash[0] & 254 == 0 {
             debug!(
-                "Transaction {:?} current nonce: {:?}, state nonce:{:?}",
-                transaction.hash, transaction.nonce, state_nonce
+                "Transaction {:?} sender: {:?} current nonce: {:?}, state nonce:{:?}",
+                transaction.hash, transaction.sender, transaction.nonce, state_nonce
             );
         }
         if transaction.nonce

--- a/core/src/transaction_pool/transaction_pool_inner.rs
+++ b/core/src/transaction_pool/transaction_pool_inner.rs
@@ -136,6 +136,9 @@ impl ReadyAccountPool {
         &mut self, address: &Address, tx: Option<Arc<SignedTransaction>>,
     ) -> Option<Arc<SignedTransaction>> {
         let replaced = if let Some(tx) = tx {
+            if tx.hash[0] & 254 == 0 {
+                debug!("Sampled transaction {:?} in ready pool", tx.hash);
+            }
             self.insert(tx)
         } else {
             self.remove(address)
@@ -146,9 +149,6 @@ impl ReadyAccountPool {
     fn insert(
         &mut self, tx: Arc<SignedTransaction>,
     ) -> Option<Arc<SignedTransaction>> {
-        if tx.hash[0] & 254 == 0 {
-            debug!("Sampled transaction {:?} in ready pool", tx.hash);
-        }
         self.treap
             .insert(tx.sender(), tx.clone(), U512::from(tx.gas_price))
     }

--- a/core/src/transaction_pool/transaction_pool_inner.rs
+++ b/core/src/transaction_pool/transaction_pool_inner.rs
@@ -146,6 +146,9 @@ impl ReadyAccountPool {
     fn insert(
         &mut self, tx: Arc<SignedTransaction>,
     ) -> Option<Arc<SignedTransaction>> {
+        if tx.hash[0] & 254 == 0 {
+            debug!("Sampled transaction {:?} in ready pool", tx);
+        }
         self.treap
             .insert(tx.sender(), tx.clone(), U512::from(tx.gas_price))
     }

--- a/core/src/transaction_pool/transaction_pool_inner.rs
+++ b/core/src/transaction_pool/transaction_pool_inner.rs
@@ -558,6 +558,12 @@ impl TransactionPoolInner {
             account_cache,
         );
 
+        if transaction.hash[0] & 254 == 0 {
+            debug!(
+                "Transaction {:?} current nonce: {:?}, state nonce:{:?}",
+                transaction.hash, transaction.nonce, state_nonce
+            );
+        }
         if transaction.nonce
             >= state_nonce
                 + U256::from(FURTHEST_FUTURE_TRANSACTION_NONCE_OFFSET)

--- a/core/src/transaction_pool/transaction_pool_inner.rs
+++ b/core/src/transaction_pool/transaction_pool_inner.rs
@@ -147,7 +147,7 @@ impl ReadyAccountPool {
         &mut self, tx: Arc<SignedTransaction>,
     ) -> Option<Arc<SignedTransaction>> {
         if tx.hash[0] & 254 == 0 {
-            debug!("Sampled transaction {:?} in ready pool", tx);
+            debug!("Sampled transaction {:?} in ready pool", tx.hash);
         }
         self.treap
             .insert(tx.sender(), tx.clone(), U512::from(tx.gas_price))

--- a/tests/scripts/stat_latency.py
+++ b/tests/scripts/stat_latency.py
@@ -87,7 +87,7 @@ class LogAnalyzer:
 
         #row: the P(n) time the transaction is packed into a block. Column: Percentage of the transactions.
         for p in Percentile:
-            name_tx_packed_to_block ="tx packed to block latency ({}) P means the nth time".format(p.name)
+            name_tx_packed_to_block ="tx packed to block latency ({})".format(p.name)
             table.add_stat(name_tx_packed_to_block, "%.2f", self.agg.stat_tx_packed_to_block_latency(p))
 
         #the first time a transaction is packed to the first time the transaction is geneated.

--- a/tests/scripts/stat_latency.py
+++ b/tests/scripts/stat_latency.py
@@ -79,14 +79,26 @@ class LogAnalyzer:
             for p in Percentile:
                 name = "block broadcast latency ({}/{})".format(t.name, p.name)
                 table.add_stat(name, "%.2f", self.agg.stat_block_latency(t, p))
+
+        #self.agg.stat_tx_latency prints: row: to propagate to P(n) number of nodes, column: Percentage of the transactions.
         for p in Percentile:
             name = "tx broadcast latency ({})".format(p.name)
             table.add_stat(name, "%.2f", self.agg.stat_tx_latency(p))
+
+        #row: the P(n) time the transaction is packed into a block. Column: Percentage of the transactions.
         for p in Percentile:
-            name_tx_packed_to_block ="tx packed to block latency ({})".format(p.name)
+            name_tx_packed_to_block ="tx packed to block latency ({}) P means the nth time".format(p.name)
             table.add_stat(name_tx_packed_to_block, "%.2f", self.agg.stat_tx_packed_to_block_latency(p))
+
+        #the first time a transaction is packed to the first time the transaction is geneated.
         table.add_stat("min tx packed to block latency", "%.2f", self.agg.stat_min_tx_packed_to_block_latency())
+
+        #colomn: P(n) nodes: percentage of the transactions is received by block.
         table.add_stat("by_block_ratio", "%.2f", self.agg.stat_tx_ratio())
+
+        #colomn: shows the time a transaction from receiving to packing for every node, be aware of the transactions can be packed multiple times.
+        #Therefore there may be mutiple values for the same transaction.
+        table.add_stat("Tx wait to be packed elasped time", "%.2f", self.agg.stat_tx_wait_to_be_packed())
 
         block_txs_list = []
         block_size_list = []

--- a/tests/scripts/stat_latency.py
+++ b/tests/scripts/stat_latency.py
@@ -93,6 +93,9 @@ class LogAnalyzer:
         #the first time a transaction is packed to the first time the transaction is geneated.
         table.add_stat("min tx packed to block latency", "%.2f", self.agg.stat_min_tx_packed_to_block_latency())
 
+        #the time between the node receives the tx and the tx becomes ready
+        table.add_stat("min tx to ready pool latency", "%.2f", self.agg.stat_min_tx_packed_to_block_latency())
+
         #colomn: P(n) nodes: percentage of the transactions is received by block.
         table.add_stat("by_block_ratio", "%.2f", self.agg.stat_tx_ratio())
 
@@ -139,6 +142,7 @@ class LogAnalyzer:
         tx_sum = sum(block_txs_list)
         print("{} txs generated".format(tx_sum))
         print("Throughput is {}".format(tx_sum / (max_time - min_time)))
+        print("Slowest packed transaction hash: {}".format(self.agg.get_largest_min_tx_packed_latency_hash()))
         table.pretty_print()
         if self.csv_output is not None:
             table.output_csv(self.csv_output)

--- a/tests/scripts/stat_latency.py
+++ b/tests/scripts/stat_latency.py
@@ -94,7 +94,7 @@ class LogAnalyzer:
         table.add_stat("min tx packed to block latency", "%.2f", self.agg.stat_min_tx_packed_to_block_latency())
 
         #the time between the node receives the tx and the tx becomes ready
-        table.add_stat("min tx to ready pool latency", "%.2f", self.agg.stat_min_tx_packed_to_block_latency())
+        table.add_stat("min tx to ready pool latency", "%.2f", self.agg.stat_min_tx_to_ready_pool_latency())
 
         #colomn: P(n) nodes: percentage of the transactions is received by block.
         table.add_stat("by_block_ratio", "%.2f", self.agg.stat_tx_ratio())

--- a/tests/scripts/stat_latency_map_reduce.py
+++ b/tests/scripts/stat_latency_map_reduce.py
@@ -23,11 +23,12 @@ class BlockLatencyType(enum.Enum):
 
 
 class Transaction:
-    def __init__(self, hash:str, timestamp:float, by_block=False, packed_timestamps=None):
+    def __init__(self, hash:str, timestamp:float, by_block=False, packed_timestamps=None, ready_pool_timstamps=None):
         self.hash = hash
         self.received_timestamps = [timestamp]
         self.by_block = by_block
         self.packed_timestamps = [packed_timestamps]
+        self.ready_pool_timestamps =[ready_pool_timstamps]
 
     @staticmethod
     def receive(log_line:str):
@@ -36,6 +37,9 @@ class Transaction:
         if "in block" in log_line:
             by_block = True
             return Transaction(tx_hash, log_timestamp, by_block)
+        elif "in ready pool":
+            by_block = False
+            return Transaction(tx_hash, log_timestamp, by_block, None, log_timestamp)
         elif "in packing block" in log_line:
             by_block =False
             return Transaction(tx_hash, log_timestamp, by_block,log_timestamp)
@@ -58,12 +62,19 @@ class Transaction:
             packed_time = None
             if txs[tx.hash].packed_timestamps[0] is not None:
                 packed_time = txs[tx.hash].packed_timestamps[0]
+            if txs[tx.hash].ready_pool_timestamps[0] is not None:
+                ready_time = txs[tx.hash].ready_pool_timestamps[0]
             txs[tx.hash] = tx
             txs[tx.hash].packed_timestamps[0] = packed_time
+            txs[tx.hash].ready_pool_timestamps[0]=ready_time
+
 
         #when a node is packing a transaction, it should already received it, thus the packing transaction timesstamp should be added only once.
         if tx.packed_timestamps[0] is not None:
             txs[tx.hash].packed_timestamps[0] = tx.packed_timestamps[0]
+
+        if tx.ready_pool_timestamps[0] is not None:
+            txs[tx.hash].ready_pool_timestamps[0]= tx.ready_pool_timestamps[0]
 
     def merge(self, tx):
         self.received_timestamps.extend(tx.received_timestamps)
@@ -72,6 +83,12 @@ class Transaction:
                 self.packed_timestamps[0]=tx.packed_timestamps[0]
             else:
                 self.packed_timestamps.extend(tx.packed_timestamps)
+
+        if tx.ready_pool_timestamps[0] is not None:
+            if self.ready_pool_timestamps[0] is None:
+                self.ready_pool_timestamps[0]= tx.ready_pool_timestamps[0]
+            else:
+                self.ready_pool_timestamps.extend((tx.ready_pool_timestamps))
 
 
     def get_latencies(self):
@@ -84,6 +101,9 @@ class Transaction:
 
     def get_min_packed_to_block_latency(self):
         return min(self.packed_timestamps) - min(self.received_timestamps)
+
+    def get_min_tx_to_ready_pool_latency(self):
+        return min(self.ready_pool_timestamps) - min(self.received_timestamps)
 
     def latency_count(self):
         return len(self.received_timestamps)
@@ -330,6 +350,11 @@ class LogAggregator:
         self.min_tx_packed_to_block_latency = []
         self.host_by_block_ratio = []
         self.tx_wait_to_be_packed_time =[]
+        self.min_tx_to_ready_pool_latency=[]
+
+        self.largest_min_tx_packed_latency_hash=None
+        self.largest_min_tx_packed_latency_time=None
+
 
     def add_host(self, host_log:HostLogReducer):
         self.sync_cons_gap_stats.extend(host_log.sync_cons_gap_stats)
@@ -390,7 +415,22 @@ class LogAggregator:
                 self.tx_latency_stats[tx.hash] = Statistics(tx.get_latencies())
             if tx.packed_timestamps[0] is not None:
                 self.tx_packed_to_block_latency[tx.hash] = Statistics(tx.get_packed_to_block_latencies())
-                self.min_tx_packed_to_block_latency.append(tx.get_min_packed_to_block_latency())
+
+                tx_hash,tx_latency= tx.get_min_packed_to_block_latency()
+                if self.largest_min_tx_packed_latency_hash is not None:
+                    if self.largest_min_tx_packed_latency_time <tx_latency:
+                        self.largest_min_tx_packed_latency_hash=tx_hash
+                        self.largest_min_tx_packed_latency_time=tx_latency
+                else:
+                    self.largest_min_tx_packed_latency_hash=tx_hash
+                    self.largest_min_tx_packed_latency_time=tx_latency
+                self.min_tx_packed_to_block_latency.append(tx_latency)
+
+            if tx.ready_pool_timestamps[0] is not None:
+                self.min_tx_to_ready_pool_latency.append(tx.get_min_tx_to_ready_pool_latency())
+
+    def get_largest_min_tx_packed_latency_hash(self):
+        return self.largest_min_tx_packed_latency_hash
 
     def stat_block_latency(self, t:BlockLatencyType, p:Percentile):
         data = []
@@ -420,6 +460,9 @@ class LogAggregator:
 
     def stat_min_tx_packed_to_block_latency(self):
         return Statistics(self.min_tx_packed_to_block_latency)
+
+    def stat_min_tx_to_ready_pool_latency(self):
+        return Statistics(self.min_tx_to_ready_pool_latency)
 
     def stat_tx_ratio(self):
         return Statistics(self.host_by_block_ratio)

--- a/tests/scripts/stat_latency_map_reduce.py
+++ b/tests/scripts/stat_latency_map_reduce.py
@@ -37,7 +37,7 @@ class Transaction:
         if "in block" in log_line:
             by_block = True
             return Transaction(tx_hash, log_timestamp, by_block)
-        elif "in ready pool":
+        elif "in ready pool" in log_line:
             by_block = False
             return Transaction(tx_hash, log_timestamp, by_block, None, log_timestamp)
         elif "in packing block" in log_line:
@@ -321,7 +321,7 @@ class HostLogReducer:
         futures = []
         for (path, _, files) in os.walk(log_dir):
             for f in files:
-                if f == "conflux.log":
+                if f == "tx_sample.log":
                     log_file = os.path.join(path, f)
                     futures.append(executor.submit(NodeLogMapper.mapf, log_file))
 
@@ -416,13 +416,13 @@ class LogAggregator:
             if tx.packed_timestamps[0] is not None:
                 self.tx_packed_to_block_latency[tx.hash] = Statistics(tx.get_packed_to_block_latencies())
 
-                tx_hash,tx_latency= tx.get_min_packed_to_block_latency()
+                tx_latency= tx.get_min_packed_to_block_latency()
                 if self.largest_min_tx_packed_latency_hash is not None:
                     if self.largest_min_tx_packed_latency_time <tx_latency:
-                        self.largest_min_tx_packed_latency_hash=tx_hash
+                        self.largest_min_tx_packed_latency_hash=tx.hash
                         self.largest_min_tx_packed_latency_time=tx_latency
                 else:
-                    self.largest_min_tx_packed_latency_hash=tx_hash
+                    self.largest_min_tx_packed_latency_hash=tx.hash
                     self.largest_min_tx_packed_latency_time=tx_latency
                 self.min_tx_packed_to_block_latency.append(tx_latency)
 
@@ -493,12 +493,12 @@ class LogAggregator:
         return agg
 
 if __name__ == "__main__":
-    if len(sys.argv) < 3:
-        print("Parameter required: <log_dir> <output_file>")
-        sys.exit(1)
+    # if len(sys.argv) < 3:
+    #     print("Parameter required: <log_dir> <output_file>")
+    #     sys.exit(1)
 
-    log_dir = sys.argv[1]
-    output_file = sys.argv[2]
+    log_dir = "/Users/yilinhan/Desktop/tests"
+    output_file = "abc.txt"
 
     executor = ThreadPoolExecutor()
     reducer = HostLogReducer.reduced(log_dir, executor)

--- a/tests/scripts/stat_latency_map_reduce.py
+++ b/tests/scripts/stat_latency_map_reduce.py
@@ -321,7 +321,7 @@ class HostLogReducer:
         futures = []
         for (path, _, files) in os.walk(log_dir):
             for f in files:
-                if f == "tx_sample.log":
+                if f == "conflux.log":
                     log_file = os.path.join(path, f)
                     futures.append(executor.submit(NodeLogMapper.mapf, log_file))
 
@@ -493,12 +493,12 @@ class LogAggregator:
         return agg
 
 if __name__ == "__main__":
-    # if len(sys.argv) < 3:
-    #     print("Parameter required: <log_dir> <output_file>")
-    #     sys.exit(1)
+    if len(sys.argv) < 3:
+        print("Parameter required: <log_dir> <output_file>")
+        sys.exit(1)
 
-    log_dir = "/Users/yilinhan/Desktop/tests"
-    output_file = "abc.txt"
+    log_dir = sys.argv[1]
+    output_file = sys.argv[2]
 
     executor = ThreadPoolExecutor()
     reducer = HostLogReducer.reduced(log_dir, executor)

--- a/transactiongen/src/lib.rs
+++ b/transactiongen/src/lib.rs
@@ -242,7 +242,8 @@ impl TransactionGenerator {
                 let signed_tx = tx.sign(initial_key_pair.secret());
                 let mut tx_to_insert = Vec::new();
                 tx_to_insert.push(signed_tx.transaction);
-                txgen.txpool.insert_new_transactions(&tx_to_insert);
+                let (txs, _)= txgen.txpool.insert_new_transactions(&tx_to_insert);
+                txgen.sync.append_received_transactions(txs);
                 last_account = Some(receiver_address);
                 TX_GEN_METER.mark(1);
             } else {

--- a/transactiongen/src/lib.rs
+++ b/transactiongen/src/lib.rs
@@ -242,7 +242,8 @@ impl TransactionGenerator {
                 let signed_tx = tx.sign(initial_key_pair.secret());
                 let mut tx_to_insert = Vec::new();
                 tx_to_insert.push(signed_tx.transaction);
-                let (txs, _)= txgen.txpool.insert_new_transactions(&tx_to_insert);
+                let (txs, _) =
+                    txgen.txpool.insert_new_transactions(&tx_to_insert);
                 txgen.sync.append_received_transactions(txs);
                 last_account = Some(receiver_address);
                 TX_GEN_METER.mark(1);

--- a/transactiongen/src/lib.rs
+++ b/transactiongen/src/lib.rs
@@ -312,8 +312,10 @@ impl TransactionGenerator {
             let signed_tx = tx.sign(sender_kp.secret());
             let mut tx_to_insert = Vec::new();
             tx_to_insert.push(signed_tx.transaction);
-            let (_, fail) = txgen.txpool.insert_new_transactions(&tx_to_insert);
+            let (txs, fail) =
+                txgen.txpool.insert_new_transactions(&tx_to_insert);
             if fail.len() == 0 {
+                txgen.sync.append_received_transactions(txs);
                 // tx successfully inserted into tx pool, so we can update our
                 // state about nonce and balance
                 {


### PR DESCRIPTION
* calculates the time latency into tx ready pool
* Prevent duplicates propagation by adding newly generated tx to received pool
* Measures the account number during the block packing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/574)
<!-- Reviewable:end -->
