### PR TITLE
Add python tests for IP limit

### DIFF
--- a/network/src/service.rs
+++ b/network/src/service.rs
@@ -794,6 +794,12 @@ impl NetworkServiceInner {
                     return;
                 }
             };
+
+            if !self.sessions.is_ip_allowed(&address.ip()) {
+                debug!("cannot create outgoing connection to node, id = {:?}, address = {:?}", id, address);
+                return;
+            }
+
             match TcpStream::connect(&address) {
                 Ok(socket) => {
                     trace!("{}: connecting to {:?}", id, address);

--- a/network/src/session_manager.rs
+++ b/network/src/session_manager.rs
@@ -15,7 +15,7 @@ use parking_lot::RwLock;
 use slab::Slab;
 use std::{
     collections::{HashMap, HashSet},
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
@@ -101,6 +101,11 @@ impl SessionManager {
 
     pub fn get_index_by_id(&self, id: &NodeId) -> Option<usize> {
         self.node_id_index.read().get(id).cloned()
+    }
+
+    /// Check if the specified IP address is allowed to create a new session.
+    pub fn is_ip_allowed(&self, ip: &IpAddr) -> bool {
+        self.ip_limit.read().is_allowed(ip)
     }
 
     /// Creates a new session with specified TCP socket. It is egress connection

--- a/run/default.toml
+++ b/run/default.toml
@@ -127,7 +127,7 @@ log_conf="log.yaml"
 # `session_ip_limits` limits the number of TCP connections per IP address or subnet for security consideration.
 # Its format is "n1,n2,n3,n4", where n1 is the quota of TCP connections for a single IP address, and n2/n3/n4 
 # are the quotas for subnet a/b/c. The default value is "1,8,4,2", which means:
-#   1) Onely 1 TCP connection allowed for a single IP address.
+#   1) Only 1 TCP connection allowed for a single IP address.
 #   2) 8 TCP connections allowd for subnet a, e.g. 192.xxx.xxx.xxx/8
 #   3) 4 TCP connections allowd for subnet b, e.g. 192.168.xxx.xxx/16
 #   4) 2 TCP connections allowd for subnet c, e.g. 192.169.0.xxx/24

--- a/tests/conflux/rpc.py
+++ b/tests/conflux/rpc.py
@@ -223,6 +223,9 @@ class RpcClient:
     def get_node(self, node_id: str):
         return self.node.net_node(node_id)
 
+    def add_node(self, node_id: str, ip: str, port: int):
+        self.node.addnode(node_id, "{}:{}".format(ip, port))
+
     def disconnect_peer(self, node_id: str, node_op:str=None) -> int:
         return self.node.net_disconnect_node(node_id, node_op)
 

--- a/tests/network_tests/node_db_ip_limit_test.py
+++ b/tests/network_tests/node_db_ip_limit_test.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+sys.path.insert(1, os.path.dirname(sys.path[0]))
+
+from test_framework.test_framework import ConfluxTestFramework
+from test_framework.mininode import DefaultNode
+from conflux.rpc import RpcClient
+
+class NodeDatabaseIpLimitTests(ConfluxTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+        self.conf_parameters = {
+            "subnet_quota": "2"
+        }
+
+    def setup_network(self):
+        self.setup_nodes()
+
+    def run_test(self):
+        client = RpcClient(self.nodes[0])
+
+        self.test_same_ip_replace_always(client)
+        self.test_subnet_quota(client)
+
+    def test_same_ip_replace_always(self, client: RpcClient):
+        n1 = DefaultNode()
+        client.add_node(n1.key, "192.168.0.100", 5678)
+        assert client.get_node(n1.key) is not None
+
+        n2 = DefaultNode()
+        client.add_node(n2.key, "192.168.0.100", 5678)
+        assert client.get_node(n1.key) is None
+        assert client.get_node(n2.key) is not None
+
+    def test_subnet_quota(self, client: RpcClient):
+        n1 = DefaultNode()
+        client.add_node(n1.key, "192.168.1.200", 5678)
+        assert client.get_node(n1.key) is not None
+
+        n2 = DefaultNode()
+        client.add_node(n2.key, "192.168.1.201", 5678)
+        assert client.get_node(n2.key) is not None
+
+        n3 = DefaultNode()
+        client.add_node(n3.key, "192.168.1.202", 5678)
+        assert client.get_node(n3.key) is not None
+
+        # n1 or n2 was evicted when adding n3
+        assert [client.get_node(n1.key), client.get_node(n2.key)].count(None) == 1
+
+if __name__ == "__main__":
+    NodeDatabaseIpLimitTests().main()

--- a/tests/network_tests/session_ip_limit_test.py
+++ b/tests/network_tests/session_ip_limit_test.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+sys.path.insert(1, os.path.dirname(sys.path[0]))
+
+from test_framework.test_framework import ConfluxTestFramework
+from test_framework.mininode import DefaultNode, network_thread_start
+from test_framework.util import wait_until
+from conflux.rpc import RpcClient
+
+class SessionIpLimitTests(ConfluxTestFramework):
+    def __init__(self, ip_limit_config: str, num_peers: int):
+        self.ip_limit_config = ip_limit_config
+        self.num_peers = num_peers
+        ConfluxTestFramework.__init__(self)
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+        self.conf_parameters = {
+            "session_ip_limits": "\"{}\"".format(self.ip_limit_config)
+        }
+
+    def setup_network(self):
+        self.setup_nodes()
+
+    def run_test(self):
+        peers = [DefaultNode() for _ in range(self.num_peers)]
+        for p in peers:
+            self.nodes[0].add_p2p_connection(p)
+        network_thread_start()
+
+        # One peer will be refused due to IP limit
+        wait_until(lambda: [p.had_status for p in peers].count(False) == 1, timeout=3)
+        assert len(RpcClient(self.nodes[0]).get_peers()) == self.num_peers - 1
+        for p in peers:
+            if not p.had_status:
+                wait_until(lambda: p.state == "closed", timeout=3)
+
+if __name__ == "__main__":
+    # 1 node for a single IP address
+    SessionIpLimitTests("1,8,4,2", 2).main()

--- a/tests/network_tests/session_subnet_limit_test.py
+++ b/tests/network_tests/session_subnet_limit_test.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+from session_ip_limit_test import SessionIpLimitTests
+
+if __name__ == "__main__":
+    # 2 nodes for a single subnet/C
+    SessionIpLimitTests("9,8,4,2", 3).main()


### PR DESCRIPTION
1. Add tests for IP/subnet limit of incoming TCP connections.
2. Add tests for IP/subnet limit of node database.
3. Do not create outgoing TCP stream if IP limited before creating session.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/576)
<!-- Reviewable:end -->
