### PR TITLE
Org nodes in trusted/untrusted buckets for IP limit

### DIFF
--- a/network/src/ip/sample.rs
+++ b/network/src/ip/sample.rs
@@ -111,8 +111,5 @@ impl<T: Hash + Eq + Clone> SampleHashSet<T> {
     pub fn len(&self) -> usize { self.items.len() }
 
     #[inline]
-    pub fn contains(&self, value: &T) -> bool { self.items.contains(value) }
-
-    #[inline]
     pub fn iter(&self) -> Iter<T> { self.items.iter() }
 }


### PR DESCRIPTION
Now, trusted and untrusted nodes with same subnet are organized in the same bucket. When sample trusted nodes to establish outgoing TCP connections, any sampled bucket may have no trusted nodes. So, it's necessary to organize trusted and untrusted nodes with same subnet in different buckets. In this way, we can accurately sample trusted nodes from node database.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/578)
<!-- Reviewable:end -->
