### PR TITLE
Add witness and bloom sync to light node

### DIFF
--- a/core/src/consensus/consensus_inner/mod.rs
+++ b/core/src/consensus/consensus_inner/mod.rs
@@ -655,7 +655,12 @@ impl ConsensusGraphInner {
         // cannot have any information about the state root of `pivot_index`
         let from = pivot_index + DEFERRED_STATE_EPOCH_COUNT as usize;
 
-        // get pivot index of first trusted block based on the blame fields
+        self.find_first_trusted_starting_from(from)
+    }
+
+    pub fn find_first_trusted_starting_from(
+        &self, from: usize,
+    ) -> Option<usize> {
         let mut trusted_index =
             match self.find_first_with_trusted_blame_starting_from(from) {
                 None => return None,

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -741,18 +741,20 @@ impl ConsensusGraph {
             .and_then(|index| Some(inner.arena[inner.pivot_chain[index]].hash))
     }
 
-    pub fn first_epoch_with_correct_state_of(&self, epoch: u64) -> Option<u64> {
+    pub fn first_trusted_header_starting_from(
+        &self, height: u64,
+    ) -> Option<u64> {
         // TODO(thegaram): change logic to work with arbitrary height, not just
         // the ones from the current era (i.e. use epoch instead of pivot index)
         let inner = self.inner.read();
 
         // for now, make sure to avoid underflow
-        let pivot_index = match epoch {
+        let pivot_index = match height {
             h if h < inner.get_cur_era_genesis_height() => return None,
             h => inner.height_to_pivot_index(h),
         };
 
-        let trusted = inner.find_first_index_with_correct_state_of(pivot_index);
+        let trusted = inner.find_first_trusted_starting_from(pivot_index);
         trusted.map(|index| inner.pivot_index_to_height(index))
     }
 

--- a/core/src/light_protocol/common/mod.rs
+++ b/core/src/light_protocol/common/mod.rs
@@ -5,9 +5,21 @@
 mod ledger_info;
 mod ledger_proof;
 mod peers;
+mod unique_id;
 mod validate;
 
 pub use ledger_info::LedgerInfo;
 pub use ledger_proof::LedgerProof;
 pub use peers::Peers;
+pub use unique_id::UniqueId;
 pub use validate::Validate;
+
+use std::cmp;
+
+pub fn max_of_collection<I, T: Ord>(collection: I) -> Option<T>
+where I: Iterator<Item = T> {
+    collection.fold(None, |max_so_far, x| match max_so_far {
+        None => Some(x),
+        Some(max_so_far) => Some(cmp::max(max_so_far, x)),
+    })
+}

--- a/core/src/light_protocol/common/unique_id.rs
+++ b/core/src/light_protocol/common/unique_id.rs
@@ -1,0 +1,22 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+pub struct UniqueId {
+    next: AtomicU64,
+}
+
+impl UniqueId {
+    pub fn new() -> Self {
+        UniqueId {
+            next: AtomicU64::new(0),
+        }
+    }
+
+    #[inline]
+    pub fn next(&self) -> u64 {
+        self.next.fetch_add(1, Ordering::Relaxed).into()
+    }
+}

--- a/core/src/light_protocol/error.rs
+++ b/core/src/light_protocol/error.rs
@@ -33,14 +33,19 @@ error_chain! {
             display("Internal error"),
         }
 
-        InvalidMessageFormat {
-            description("Invalid message format"),
-            display("Invalid message format"),
+        InvalidBloom {
+            description("Invalid bloom"),
+            display("Invalid bloom"),
         }
 
         InvalidLedgerProof {
             description("Invalid ledger proof"),
             display("Invalid ledger proof"),
+        }
+
+        InvalidMessageFormat {
+            description("Invalid message format"),
+            display("Invalid message format"),
         }
 
         InvalidReceipts {
@@ -160,8 +165,9 @@ pub fn handle(io: &dyn NetworkContext, peer: PeerId, msg_id: MsgId, e: Error) {
             op = Some(UpdateNodeOperation::Demotion)
         }
 
-        ErrorKind::InvalidMessageFormat
+        ErrorKind::InvalidBloom
         | ErrorKind::InvalidLedgerProof
+        | ErrorKind::InvalidMessageFormat
         | ErrorKind::InvalidReceipts
         | ErrorKind::InvalidStateProof
         | ErrorKind::InvalidStateRoot

--- a/core/src/light_protocol/handler/mod.rs
+++ b/core/src/light_protocol/handler/mod.rs
@@ -12,18 +12,14 @@ use sync::SyncHandler;
 use io::TimerToken;
 use parking_lot::RwLock;
 use rlp::Rlp;
-use std::{
-    collections::HashSet,
-    sync::{atomic::AtomicU64, Arc},
-    time::Duration,
-};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use cfx_types::H256;
 
 use crate::{
     consensus::ConsensusGraph,
     light_protocol::{
-        common::{Peers, Validate},
+        common::{Peers, UniqueId, Validate},
         handle_error,
         message::{msgid, NodeType, SendRawTx, StatusPing, StatusPong},
         Error, ErrorKind, LIGHT_PROTOCOL_VERSION,
@@ -69,15 +65,14 @@ impl Handler {
         consensus: Arc<ConsensusGraph>, graph: Arc<SynchronizationGraph>,
     ) -> Self {
         let peers = Arc::new(Peers::new());
-        let next_request_id = Arc::new(AtomicU64::new(0));
+        let request_id = Arc::new(UniqueId::new());
 
-        let query =
-            QueryHandler::new(consensus.clone(), next_request_id.clone());
+        let query = QueryHandler::new(consensus.clone(), request_id.clone());
 
         let sync = SyncHandler::new(
             consensus.clone(),
             graph,
-            next_request_id,
+            request_id,
             peers.clone(),
         );
 
@@ -143,7 +138,9 @@ impl Handler {
             // messages related to sync
             msgid::BLOCK_HASHES => self.sync.on_block_hashes(io, peer, &rlp),
             msgid::BLOCK_HEADERS => self.sync.on_block_headers(io, peer, &rlp),
+            msgid::BLOOMS => self.sync.on_blooms(io, peer, &rlp),
             msgid::NEW_BLOCK_HASHES => self.sync.on_new_block_hashes(io, peer, &rlp),
+            msgid::WITNESS_INFO => self.sync.on_witness_info(io, peer, &rlp),
 
             // messages related to queries
             msgid::RECEIPTS => self.query.on_receipts(io, peer, &rlp),

--- a/core/src/light_protocol/handler/query.rs
+++ b/core/src/light_protocol/handler/query.rs
@@ -4,13 +4,7 @@
 
 use parking_lot::RwLock;
 use rlp::Rlp;
-use std::{
-    collections::BTreeMap,
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
-};
+use std::{collections::BTreeMap, sync::Arc};
 
 extern crate futures;
 use futures::{
@@ -23,7 +17,7 @@ use primitives::{Receipt, SignedTransaction, StateRoot};
 use crate::{
     consensus::ConsensusGraph,
     light_protocol::{
-        common::Validate,
+        common::{UniqueId, Validate},
         message::{
             GetReceipts, GetStateEntry, GetStateRoot, GetTxs,
             Receipts as GetReceiptsResponse,
@@ -51,11 +45,11 @@ struct PendingRequest {
 }
 
 pub struct QueryHandler {
-    // next request id to be used when sending messages
-    next_request_id: Arc<AtomicU64>,
-
     // set of queries sent but not received yet
     pending: RwLock<BTreeMap<(PeerId, RequestId), PendingRequest>>,
+
+    // series of unique request ids
+    request_ids: Arc<UniqueId>,
 
     // helper API for validating ledger and state information
     validate: Validate,
@@ -63,20 +57,16 @@ pub struct QueryHandler {
 
 impl QueryHandler {
     pub fn new(
-        consensus: Arc<ConsensusGraph>, next_request_id: Arc<AtomicU64>,
+        consensus: Arc<ConsensusGraph>, request_ids: Arc<UniqueId>,
     ) -> Self {
         let pending = RwLock::new(BTreeMap::new());
         let validate = Validate::new(consensus.clone());
 
         QueryHandler {
-            next_request_id,
             pending,
+            request_ids,
             validate,
         }
-    }
-
-    fn next_request_id(&self) -> RequestId {
-        self.next_request_id.fetch_add(1, Ordering::Relaxed).into()
     }
 
     fn match_request<T>(
@@ -187,7 +177,7 @@ impl QueryHandler {
     ) -> Result<QueryResult, Error>
     where T: Message + HasRequestId + Clone + 'static {
         // set request id
-        let id = self.next_request_id();
+        let id = self.request_ids.next();
         req.set_request_id(id);
 
         // set up channel and store request

--- a/core/src/light_protocol/handler/query.rs
+++ b/core/src/light_protocol/handler/query.rs
@@ -49,7 +49,7 @@ pub struct QueryHandler {
     pending: RwLock<BTreeMap<(PeerId, RequestId), PendingRequest>>,
 
     // series of unique request ids
-    request_ids: Arc<UniqueId>,
+    request_id_allocator: Arc<UniqueId>,
 
     // helper API for validating ledger and state information
     validate: Validate,
@@ -57,14 +57,14 @@ pub struct QueryHandler {
 
 impl QueryHandler {
     pub fn new(
-        consensus: Arc<ConsensusGraph>, request_ids: Arc<UniqueId>,
+        consensus: Arc<ConsensusGraph>, request_id_allocator: Arc<UniqueId>,
     ) -> Self {
         let pending = RwLock::new(BTreeMap::new());
         let validate = Validate::new(consensus.clone());
 
         QueryHandler {
             pending,
-            request_ids,
+            request_id_allocator,
             validate,
         }
     }
@@ -177,7 +177,7 @@ impl QueryHandler {
     ) -> Result<QueryResult, Error>
     where T: Message + HasRequestId + Clone + 'static {
         // set request id
-        let id = self.request_ids.next();
+        let id = self.request_id_allocator.next();
         req.set_request_id(id);
 
         // set up channel and store request

--- a/core/src/light_protocol/handler/sync/blooms.rs
+++ b/core/src/light_protocol/handler/sync/blooms.rs
@@ -82,7 +82,7 @@ impl HasKey<u64> for MissingBloom {
 
 pub(super) struct Blooms {
     // series of unique request ids
-    request_ids: Arc<UniqueId>,
+    request_id_allocator: Arc<UniqueId>,
 
     // sync and request manager
     sync_manager: SyncManager<u64, MissingBloom>,
@@ -98,7 +98,7 @@ pub(super) struct Blooms {
 impl Blooms {
     pub fn new(
         consensus: Arc<ConsensusGraph>, peers: Arc<Peers<FullPeerState>>,
-        request_ids: Arc<UniqueId>,
+        request_id_allocator: Arc<UniqueId>,
     ) -> Self
     {
         let sync_manager = SyncManager::new(peers.clone());
@@ -106,7 +106,7 @@ impl Blooms {
         let verified = RwLock::new(HashMap::new());
 
         Blooms {
-            request_ids,
+            request_id_allocator,
             sync_manager,
             validate,
             verified,
@@ -160,7 +160,7 @@ impl Blooms {
         }
 
         let msg: Box<dyn Message> = Box::new(GetBlooms {
-            request_id: self.request_ids.next(),
+            request_id: self.request_id_allocator.next(),
             epochs,
         });
 

--- a/core/src/light_protocol/handler/sync/blooms.rs
+++ b/core/src/light_protocol/handler/sync/blooms.rs
@@ -1,0 +1,181 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use std::{
+    cmp,
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use cfx_types::Bloom;
+use parking_lot::RwLock;
+
+use crate::{
+    consensus::ConsensusGraph,
+    light_protocol::{
+        common::{Peers, UniqueId, Validate},
+        handler::FullPeerState,
+        message::{BloomWithEpoch, GetBlooms},
+        Error,
+    },
+    message::Message,
+    network::{NetworkContext, PeerId},
+    parameters::light::{
+        BLOOM_REQUEST_BATCH_SIZE, BLOOM_REQUEST_TIMEOUT_MS,
+        MAX_BLOOMS_IN_FLIGHT,
+    },
+};
+
+use super::sync_manager::{HasKey, SyncManager};
+
+#[derive(Debug)]
+struct Statistics {
+    in_flight: usize,
+    verified: usize,
+    waiting: usize,
+}
+
+#[derive(Clone, Debug, Eq)]
+pub(super) struct MissingBloom {
+    pub epoch: u64,
+    pub since: Instant,
+}
+
+impl MissingBloom {
+    pub fn new(epoch: u64) -> Self {
+        MissingBloom {
+            epoch,
+            since: Instant::now(),
+        }
+    }
+}
+
+impl PartialEq for MissingBloom {
+    fn eq(&self, other: &Self) -> bool { self.epoch == other.epoch }
+}
+
+// MissingBloom::cmp is used for prioritizing bloom requests
+impl Ord for MissingBloom {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        if self.eq(other) {
+            return cmp::Ordering::Equal;
+        }
+
+        let cmp_since = self.since.cmp(&other.since).reverse();
+        let cmp_epoch = self.epoch.cmp(&other.epoch);
+
+        cmp_since.then(cmp_epoch)
+    }
+}
+
+impl PartialOrd for MissingBloom {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl HasKey<u64> for MissingBloom {
+    fn key(&self) -> u64 { self.epoch }
+}
+
+pub(super) struct Blooms {
+    // series of unique request ids
+    request_ids: Arc<UniqueId>,
+
+    // sync and request manager
+    sync_manager: SyncManager<u64, MissingBloom>,
+
+    // helper API for validating ledger and state information
+    validate: Validate,
+
+    // bloom filters received from full node
+    // TODO(thegaram): move this into data manager
+    verified: RwLock<HashMap<u64, Bloom>>,
+}
+
+impl Blooms {
+    pub fn new(
+        consensus: Arc<ConsensusGraph>, peers: Arc<Peers<FullPeerState>>,
+        request_ids: Arc<UniqueId>,
+    ) -> Self
+    {
+        let sync_manager = SyncManager::new(peers.clone());
+        let validate = Validate::new(consensus.clone());
+        let verified = RwLock::new(HashMap::new());
+
+        Blooms {
+            request_ids,
+            sync_manager,
+            validate,
+            verified,
+        }
+    }
+
+    #[inline]
+    fn get_statistics(&self) -> Statistics {
+        Statistics {
+            in_flight: self.sync_manager.num_in_flight(),
+            verified: self.verified.read().len(),
+            waiting: self.sync_manager.num_waiting(),
+        }
+    }
+
+    #[inline]
+    pub fn request(&self, epoch: u64) {
+        let item = MissingBloom::new(epoch);
+        self.sync_manager.insert_waiting(std::iter::once(item));
+    }
+
+    #[inline]
+    pub fn receive<I>(&self, blooms: I) -> Result<(), Error>
+    where I: Iterator<Item = BloomWithEpoch> {
+        for BloomWithEpoch { epoch, bloom } in blooms {
+            info!("Validating bloom {:?} with epoch {}", bloom, epoch);
+            self.validate.bloom_with_local_info(epoch, bloom)?;
+
+            self.verified.write().insert(epoch, bloom);
+            self.sync_manager.remove_in_flight(&epoch);
+        }
+
+        Ok(())
+    }
+
+    #[inline]
+    pub fn clean_up(&self) {
+        let timeout = Duration::from_millis(BLOOM_REQUEST_TIMEOUT_MS);
+        let blooms = self.sync_manager.remove_timeout_requests(timeout);
+        self.sync_manager.insert_waiting(blooms.into_iter());
+    }
+
+    #[inline]
+    fn send_request(
+        &self, io: &dyn NetworkContext, peer: PeerId, epochs: Vec<u64>,
+    ) -> Result<(), Error> {
+        info!("send_request peer={:?} epochs={:?}", peer, epochs);
+
+        if epochs.is_empty() {
+            return Ok(());
+        }
+
+        let msg: Box<dyn Message> = Box::new(GetBlooms {
+            request_id: self.request_ids.next(),
+            epochs,
+        });
+
+        msg.send(io, peer)?;
+        Ok(())
+    }
+
+    #[inline]
+    pub fn sync(&self, io: &dyn NetworkContext) {
+        info!("bloom sync statistics: {:?}", self.get_statistics());
+
+        self.sync_manager.sync(
+            MAX_BLOOMS_IN_FLIGHT,
+            BLOOM_REQUEST_BATCH_SIZE,
+            |peer, epochs| self.send_request(io, peer, epochs),
+        );
+    }
+}

--- a/core/src/light_protocol/handler/sync/epochs.rs
+++ b/core/src/light_protocol/handler/sync/epochs.rs
@@ -69,13 +69,13 @@ pub(super) struct Epochs {
     peers: Arc<Peers<FullPeerState>>,
 
     // series of unique request ids
-    request_ids: Arc<UniqueId>,
+    request_id_allocator: Arc<UniqueId>,
 }
 
 impl Epochs {
     pub fn new(
         consensus: Arc<ConsensusGraph>, headers: Arc<Headers>,
-        peers: Arc<Peers<FullPeerState>>, request_ids: Arc<UniqueId>,
+        peers: Arc<Peers<FullPeerState>>, request_id_allocator: Arc<UniqueId>,
     ) -> Self
     {
         let in_flight = RwLock::new(HashMap::new());
@@ -87,7 +87,7 @@ impl Epochs {
             in_flight,
             latest,
             peers,
-            request_ids,
+            request_id_allocator,
         }
     }
 
@@ -170,7 +170,7 @@ impl Epochs {
             return Ok(None);
         }
 
-        let request_id = self.request_ids.next();
+        let request_id = self.request_id_allocator.next();
 
         let msg: Box<dyn Message> =
             Box::new(GetBlockHashesByEpoch { request_id, epochs });

--- a/core/src/light_protocol/handler/sync/epochs.rs
+++ b/core/src/light_protocol/handler/sync/epochs.rs
@@ -13,15 +13,29 @@ use std::{
     time::{Duration, Instant},
 };
 
-use super::{super::FullPeerState, max_of_collection, Peers};
 use crate::{
     consensus::ConsensusGraph,
-    message::RequestId,
+    light_protocol::{
+        common::{max_of_collection, Peers, UniqueId},
+        handler::FullPeerState,
+        message::GetBlockHashesByEpoch,
+        Error,
+    },
+    message::{Message, RequestId},
+    network::{NetworkContext, PeerId},
     parameters::light::{
-        EPOCH_REQUEST_TIMEOUT_MS, MAX_PARALLEL_EPOCH_REQUESTS,
-        NUM_EPOCHS_TO_REQUEST,
+        EPOCH_REQUEST_BATCH_SIZE, EPOCH_REQUEST_TIMEOUT_MS,
+        MAX_PARALLEL_EPOCH_REQUESTS, NUM_EPOCHS_TO_REQUEST,
+        NUM_WAITING_HEADERS_THRESHOLD,
     },
 };
+
+use super::headers::Headers;
+
+#[derive(Debug)]
+struct Statistics {
+    in_flight: usize,
+}
 
 #[derive(Debug)]
 struct EpochRequest {
@@ -42,6 +56,9 @@ pub(super) struct Epochs {
     // shared consensus graph
     consensus: Arc<ConsensusGraph>,
 
+    // header sync manager
+    headers: Arc<Headers>,
+
     // epochs requested but not received yet
     in_flight: RwLock<HashMap<RequestId, EpochRequest>>,
 
@@ -50,33 +67,51 @@ pub(super) struct Epochs {
 
     // collection of all peers available
     peers: Arc<Peers<FullPeerState>>,
+
+    // series of unique request ids
+    request_ids: Arc<UniqueId>,
 }
 
 impl Epochs {
     pub fn new(
-        consensus: Arc<ConsensusGraph>, peers: Arc<Peers<FullPeerState>>,
-    ) -> Self {
+        consensus: Arc<ConsensusGraph>, headers: Arc<Headers>,
+        peers: Arc<Peers<FullPeerState>>, request_ids: Arc<UniqueId>,
+    ) -> Self
+    {
+        let in_flight = RwLock::new(HashMap::new());
+        let latest = AtomicU64::new(0);
+
         Epochs {
             consensus,
-            in_flight: RwLock::new(HashMap::new()),
-            latest: AtomicU64::new(0),
+            headers,
+            in_flight,
+            latest,
             peers,
+            request_ids,
         }
     }
 
     #[inline]
-    pub fn best_peer_epoch(&self) -> u64 {
+    pub fn receive(&self, id: &RequestId) {
+        self.in_flight.write().remove(&id);
+    }
+
+    #[inline]
+    fn best_peer_epoch(&self) -> u64 {
         self.peers.fold(0, |current_best, state| {
             let best_for_peer = state.read().best_epoch;
             cmp::max(current_best, best_for_peer)
         })
     }
 
-    pub fn num_requests_in_flight(&self) -> usize {
-        self.in_flight.read().len()
+    #[inline]
+    fn get_statistics(&self) -> Statistics {
+        Statistics {
+            in_flight: self.in_flight.read().len(),
+        }
     }
 
-    pub fn insert_in_flight(&self, id: RequestId, epochs: Vec<u64>) {
+    fn insert_in_flight(&self, id: RequestId, epochs: Vec<u64>) {
         if let Some(max_epoch) = max_of_collection(epochs.iter()).cloned() {
             let mut in_flight = self.in_flight.write();
             in_flight.insert(id, EpochRequest::new(epochs));
@@ -91,12 +126,8 @@ impl Epochs {
         };
     }
 
-    pub fn remove_in_flight(&self, id: &RequestId) {
-        self.in_flight.write().remove(&id);
-    }
-
-    pub fn collect_epochs_to_request(&self) -> Vec<u64> {
-        if self.num_requests_in_flight() >= MAX_PARALLEL_EPOCH_REQUESTS {
+    fn collect_epochs_to_request(&self) -> Vec<u64> {
+        if self.in_flight.read().len() >= MAX_PARALLEL_EPOCH_REQUESTS {
             return vec![];
         }
 
@@ -126,6 +157,66 @@ impl Epochs {
         // remove requests from `in_flight`
         for id in &ids {
             in_flight.remove(&id);
+        }
+    }
+
+    #[inline]
+    fn request_epochs(
+        &self, io: &dyn NetworkContext, peer: PeerId, epochs: Vec<u64>,
+    ) -> Result<Option<RequestId>, Error> {
+        info!("request_epochs peer={:?} epochs={:?}", peer, epochs);
+
+        if epochs.is_empty() {
+            return Ok(None);
+        }
+
+        let request_id = self.request_ids.next();
+
+        let msg: Box<dyn Message> =
+            Box::new(GetBlockHashesByEpoch { request_id, epochs });
+
+        msg.send(io, peer)?;
+        Ok(Some(request_id))
+    }
+
+    pub fn sync(&self, io: &dyn NetworkContext) {
+        info!("epoch sync statistics: {:?}", self.get_statistics());
+
+        if self.headers.num_waiting() >= NUM_WAITING_HEADERS_THRESHOLD {
+            return;
+        }
+
+        // choose set of epochs to request
+        let epochs = self.collect_epochs_to_request();
+
+        // request epochs in batches from random peers
+        for batch in epochs.chunks(EPOCH_REQUEST_BATCH_SIZE) {
+            // find maximal epoch number in this chunk
+            let max = max_of_collection(batch.iter()).expect("chunk not empty");
+
+            // choose random peer that has the epochs we need
+            let predicate = |s: &FullPeerState| s.best_epoch >= *max;
+            let peer = match self.peers.random_peer_satisfying(predicate) {
+                Some(peer) => peer,
+                None => {
+                    warn!("No peers available; aborting sync");
+                    break;
+                }
+            };
+
+            // request epoch batch
+            match self.request_epochs(io, peer, batch.to_vec()) {
+                Ok(None) => {}
+                Ok(Some(id)) => {
+                    self.insert_in_flight(id, batch.to_vec());
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to request epochs {:?} from peer {:?}: {:?}",
+                        batch, peer, e
+                    );
+                }
+            }
         }
     }
 }

--- a/core/src/light_protocol/handler/sync/headers.rs
+++ b/core/src/light_protocol/handler/sync/headers.rs
@@ -101,7 +101,7 @@ pub(super) struct Headers {
     graph: Arc<SynchronizationGraph>,
 
     // series of unique request ids
-    request_ids: Arc<UniqueId>,
+    request_id_allocator: Arc<UniqueId>,
 
     // sync and request manager
     sync_manager: SyncManager<H256, MissingHeader>,
@@ -110,7 +110,7 @@ pub(super) struct Headers {
 impl Headers {
     pub fn new(
         graph: Arc<SynchronizationGraph>, peers: Arc<Peers<FullPeerState>>,
-        request_ids: Arc<UniqueId>,
+        request_id_allocator: Arc<UniqueId>,
     ) -> Self
     {
         let duplicate_count = AtomicU64::new(0);
@@ -120,7 +120,7 @@ impl Headers {
             duplicate_count,
             graph,
             sync_manager,
-            request_ids,
+            request_id_allocator,
         }
     }
 
@@ -206,7 +206,7 @@ impl Headers {
         }
 
         let msg: Box<dyn Message> = Box::new(GetBlockHeaders {
-            request_id: self.request_ids.next(),
+            request_id: self.request_id_allocator.next(),
             hashes,
         });
 

--- a/core/src/light_protocol/handler/sync/headers.rs
+++ b/core/src/light_protocol/handler/sync/headers.rs
@@ -2,19 +2,42 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use parking_lot::RwLock;
 use std::{
     cmp,
-    collections::{BinaryHeap, HashMap},
-    sync::Arc,
+    collections::HashSet,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
     time::{Duration, Instant},
 };
 
 use crate::{
-    parameters::light::{HEADER_REQUEST_TIMEOUT_MS, MAX_HEADERS_IN_FLIGHT},
+    light_protocol::{
+        common::{Peers, UniqueId},
+        handler::FullPeerState,
+        message::GetBlockHeaders,
+        Error,
+    },
+    message::Message,
+    network::{NetworkContext, PeerId},
+    parameters::light::{
+        HEADER_REQUEST_BATCH_SIZE, HEADER_REQUEST_TIMEOUT_MS,
+        MAX_HEADERS_IN_FLIGHT,
+    },
     sync::SynchronizationGraph,
 };
+
+use super::sync_manager::{HasKey, SyncManager};
 use cfx_types::H256;
+use primitives::BlockHeader;
+
+#[derive(Debug)]
+struct Statistics {
+    duplicate_count: u64,
+    in_flight: usize,
+    waiting: usize,
+}
 
 // NOTE: order defines priority: Epoch < Reference < NewHash
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -66,126 +89,140 @@ impl PartialOrd for MissingHeader {
     }
 }
 
-#[derive(Debug)]
-struct HeaderRequest {
-    pub header: MissingHeader,
-    pub sent_at: Instant,
-}
-
-impl HeaderRequest {
-    pub fn new(header: MissingHeader) -> Self {
-        HeaderRequest {
-            header,
-            sent_at: Instant::now(),
-        }
-    }
+impl HasKey<H256> for MissingHeader {
+    fn key(&self) -> H256 { self.hash }
 }
 
 pub(super) struct Headers {
+    // number of headers received multiple times
+    duplicate_count: AtomicU64,
+
     // shared synchronization graph
     graph: Arc<SynchronizationGraph>,
 
-    // headers requested but not received yet
-    in_flight: RwLock<HashMap<H256, HeaderRequest>>,
+    // series of unique request ids
+    request_ids: Arc<UniqueId>,
 
-    // priority queue of headers we need excluding the ones in `in_flight`
-    waiting: RwLock<BinaryHeap<MissingHeader>>,
+    // sync and request manager
+    sync_manager: SyncManager<H256, MissingHeader>,
 }
 
 impl Headers {
-    pub fn new(graph: Arc<SynchronizationGraph>) -> Self {
+    pub fn new(
+        graph: Arc<SynchronizationGraph>, peers: Arc<Peers<FullPeerState>>,
+        request_ids: Arc<UniqueId>,
+    ) -> Self
+    {
+        let duplicate_count = AtomicU64::new(0);
+        let sync_manager = SyncManager::new(peers.clone());
+
         Headers {
+            duplicate_count,
             graph,
-            in_flight: RwLock::new(HashMap::new()),
-            waiting: RwLock::new(BinaryHeap::new()),
+            sync_manager,
+            request_ids,
         }
     }
 
-    pub fn num_waiting(&self) -> usize { self.waiting.read().len() }
+    #[inline]
+    pub fn num_waiting(&self) -> usize { self.sync_manager.num_waiting() }
 
-    pub fn num_in_flight(&self) -> usize { self.in_flight.read().len() }
-
-    pub fn insert_in_flight<I>(&self, missing: I)
-    where I: Iterator<Item = MissingHeader> {
-        let new = missing.map(|h| (h.hash.clone(), HeaderRequest::new(h)));
-        self.in_flight.write().extend(new);
+    #[inline]
+    fn get_statistics(&self) -> Statistics {
+        Statistics {
+            duplicate_count: self.duplicate_count.load(Ordering::Relaxed),
+            in_flight: self.sync_manager.num_in_flight(),
+            waiting: self.sync_manager.num_waiting(),
+        }
     }
 
-    pub fn remove_in_flight(&self, hash: &H256) {
-        self.in_flight.write().remove(&hash);
-    }
-
-    pub fn insert_waiting<I>(&self, hashes: I, source: HashSource)
+    #[inline]
+    pub fn request<I>(&self, hashes: I, source: HashSource)
     where I: Iterator<Item = H256> {
-        let headers = hashes.map(|h| MissingHeader::new(h, source.clone()));
-        self.reinsert_waiting(headers);
+        let headers = hashes
+            .filter(|h| !self.graph.contains_block_header(&h))
+            .map(|h| MissingHeader::new(h, source.clone()));
+
+        self.sync_manager.insert_waiting(headers);
     }
 
-    pub fn reinsert_waiting<I>(&self, headers: I)
-    where I: Iterator<Item = MissingHeader> {
-        let in_flight = self.in_flight.read();
-        let mut waiting = self.waiting.write();
+    pub fn receive<I>(&self, headers: I)
+    where I: Iterator<Item = BlockHeader> {
+        let mut missing = HashSet::new();
 
-        let missing = headers
-            .filter(|h| !in_flight.contains_key(&h.hash))
-            .filter(|h| !self.graph.contains_block_header(&h.hash));
+        // TODO(thegaram): validate header timestamps
+        for header in headers {
+            let hash = header.hash();
 
-        waiting.extend(missing);
-    }
+            // signal receipt
+            self.sync_manager.remove_in_flight(&hash);
 
-    pub fn collect_headers_to_request(&self) -> Vec<MissingHeader> {
-        let in_flight = self.in_flight.read();
-        let mut waiting = self.waiting.write();
-
-        let num_to_request = MAX_HEADERS_IN_FLIGHT - in_flight.len();
-
-        if num_to_request == 0 {
-            return vec![];
-        }
-
-        let mut headers = vec![];
-
-        // NOTE: cannot use iterator on BinaryHeap as
-        // it returns elements in arbitrary order!
-        while let Some(h) = waiting.pop() {
-            if !in_flight.contains_key(&h.hash)
-                && !self.graph.contains_block_header(&h.hash)
-            {
-                headers.push(h);
+            // check duplicates
+            if self.graph.contains_block_header(&hash) {
+                self.duplicate_count.fetch_add(1, Ordering::Relaxed);
+                continue;
             }
 
-            if headers.len() == num_to_request {
-                break;
+            // insert into graph
+            let (valid, _) = self.graph.insert_block_header(
+                &mut header.clone(),
+                true,  /* need_to_verify */
+                false, /* bench_mode */
+                true,  /* insert_to_consensus */
+                true,  /* persistent */
+            );
+
+            if !valid {
+                continue;
+            }
+
+            // store missing dependencies
+            missing.insert(*header.parent_hash());
+
+            for referee in header.referee_hashes() {
+                missing.insert(*referee);
             }
         }
 
-        headers
+        let missing = missing.into_iter();
+        self.request(missing, HashSource::Reference);
     }
 
-    fn remove_timeout_requests(&self) -> Vec<MissingHeader> {
-        let mut in_flight = self.in_flight.write();
-        let timeout = Duration::from_millis(HEADER_REQUEST_TIMEOUT_MS);
-
-        // collect timed-out requests
-        let headers: Vec<_> = in_flight
-            .iter()
-            .filter_map(|(_hash, req)| match req.sent_at {
-                t if t.elapsed() < timeout => None,
-                _ => Some(req.header.clone()),
-            })
-            .collect();
-
-        // remove requests from `in_flight`
-        for h in &headers {
-            in_flight.remove(&h.hash);
-        }
-
-        headers
-    }
-
+    #[inline]
     pub fn clean_up(&self) {
-        let headers = self.remove_timeout_requests();
-        self.reinsert_waiting(headers.into_iter());
+        let timeout = Duration::from_millis(HEADER_REQUEST_TIMEOUT_MS);
+        let headers = self.sync_manager.remove_timeout_requests(timeout);
+        self.sync_manager.insert_waiting(headers.into_iter());
+    }
+
+    #[inline]
+    fn send_request(
+        &self, io: &dyn NetworkContext, peer: PeerId, hashes: Vec<H256>,
+    ) -> Result<(), Error> {
+        info!("send_request peer={:?} hashes={:?}", peer, hashes);
+
+        if hashes.is_empty() {
+            return Ok(());
+        }
+
+        let msg: Box<dyn Message> = Box::new(GetBlockHeaders {
+            request_id: self.request_ids.next(),
+            hashes,
+        });
+
+        msg.send(io, peer)?;
+        Ok(())
+    }
+
+    #[inline]
+    pub fn sync(&self, io: &dyn NetworkContext) {
+        info!("header sync statistics: {:?}", self.get_statistics());
+
+        self.sync_manager.sync(
+            MAX_HEADERS_IN_FLIGHT,
+            HEADER_REQUEST_BATCH_SIZE,
+            |peer, hashes| self.send_request(io, peer, hashes),
+        );
     }
 }
 

--- a/core/src/light_protocol/handler/sync/headers.rs
+++ b/core/src/light_protocol/handler/sync/headers.rs
@@ -42,9 +42,9 @@ struct Statistics {
 // NOTE: order defines priority: Epoch < Reference < NewHash
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub(super) enum HashSource {
-    Epoch,     // hash received through an epoch request
-    Reference, // hash referenced by a header we received
-    NewHash,   // hash received through a new hashes announcement
+    Epoch,      // hash received through an epoch request
+    Dependency, // hash referenced by a header we received
+    NewHash,    // hash received through a new hashes announcement
 }
 
 #[derive(Clone, Debug, Eq)]
@@ -185,7 +185,7 @@ impl Headers {
         }
 
         let missing = missing.into_iter();
-        self.request(missing, HashSource::Reference);
+        self.request(missing, HashSource::Dependency);
     }
 
     #[inline]
@@ -238,8 +238,8 @@ mod tests {
 
     #[test]
     fn test_ordering() {
-        assert!(HashSource::Epoch < HashSource::Reference);
-        assert!(HashSource::Reference < HashSource::NewHash);
+        assert!(HashSource::Epoch < HashSource::Dependency);
+        assert!(HashSource::Dependency < HashSource::NewHash);
 
         let now = Instant::now();
         let one_ms_ago = now.sub(Duration::from_millis(1));
@@ -261,7 +261,7 @@ mod tests {
         let h2 = MissingHeader {
             hash: 2.into(),
             since: now,
-            source: HashSource::Reference,
+            source: HashSource::Dependency,
         };
 
         assert!(h1 < h2); // higher source priority
@@ -269,7 +269,7 @@ mod tests {
         let h3 = MissingHeader {
             hash: 3.into(),
             since: one_ms_ago,
-            source: HashSource::Reference,
+            source: HashSource::Dependency,
         };
 
         assert!(h2 < h3); // longer waiting time
@@ -334,13 +334,13 @@ mod tests {
         let h2 = MissingHeader {
             hash: 2.into(),
             since: now,
-            source: HashSource::Reference,
+            source: HashSource::Dependency,
         };
 
         let h3 = MissingHeader {
             hash: 3.into(),
             since: one_ms_ago,
-            source: HashSource::Reference,
+            source: HashSource::Dependency,
         };
 
         let h4 = MissingHeader {

--- a/core/src/light_protocol/handler/sync/mod.rs
+++ b/core/src/light_protocol/handler/sync/mod.rs
@@ -2,92 +2,68 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
+mod blooms;
 mod epochs;
 mod headers;
+mod sync_manager;
+mod witnesses;
 
 use rlp::Rlp;
-use std::{
-    cmp,
-    collections::HashSet,
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
-};
-
-use cfx_types::H256;
+use std::sync::Arc;
 
 use crate::{
     consensus::ConsensusGraph,
     light_protocol::{
-        common::Peers,
+        common::{Peers, UniqueId},
+        handler::FullPeerState,
         message::{
             BlockHashes as GetBlockHashesResponse,
-            BlockHeaders as GetBlockHeadersResponse, GetBlockHashesByEpoch,
-            GetBlockHeaders, NewBlockHashes,
+            BlockHeaders as GetBlockHeadersResponse,
+            Blooms as GetBloomsResponse, NewBlockHashes,
+            WitnessInfo as GetWitnessInfoResponse,
         },
         Error,
     },
-    message::{Message, RequestId},
     network::{NetworkContext, PeerId},
-    parameters::light::{
-        CATCH_UP_EPOCH_LAG_THRESHOLD, EPOCH_REQUEST_BATCH_SIZE,
-        HEADER_REQUEST_BATCH_SIZE, NUM_WAITING_HEADERS_THRESHOLD,
-    },
-    primitives::BlockHeader,
+    parameters::light::CATCH_UP_EPOCH_LAG_THRESHOLD,
     sync::SynchronizationGraph,
 };
 
-use super::FullPeerState;
-
+use blooms::Blooms;
 use epochs::Epochs;
 use headers::{HashSource, Headers};
-
-fn max_of_collection<I, T: Ord>(collection: I) -> Option<T>
-where I: Iterator<Item = T> {
-    collection.fold(None, |max_so_far, x| match max_so_far {
-        None => Some(x),
-        Some(max_so_far) => Some(cmp::max(max_so_far, x)),
-    })
-}
+use witnesses::Witnesses;
 
 #[derive(Debug)]
 struct Statistics {
     catch_up_mode: bool,
-    duplicate_count: u64,
-    epochs_in_flight: usize,
-    headers_in_flight: usize,
-    headers_waiting: usize,
     latest_epoch: u64,
 }
 
 pub(super) struct SyncHandler {
+    // bloom sync manager
+    blooms: Arc<Blooms>,
+
     // shared consensus graph
     consensus: Arc<ConsensusGraph>,
 
-    // number of headers received multiple times
-    duplicate_count: AtomicU64,
-
-    // epoch request manager
+    // epoch sync manager
     epochs: Epochs,
 
-    // shared synchronization graph
-    graph: Arc<SynchronizationGraph>,
-
-    // header request manager
-    headers: Headers,
-
-    // the next request id to be used when sending messages
-    next_request_id: Arc<AtomicU64>,
+    // header sync manager
+    headers: Arc<Headers>,
 
     // collection of all peers available
     peers: Arc<Peers<FullPeerState>>,
+
+    // witness sync manager
+    witnesses: Witnesses,
 }
 
 impl SyncHandler {
     pub(super) fn new(
         consensus: Arc<ConsensusGraph>, graph: Arc<SynchronizationGraph>,
-        next_request_id: Arc<AtomicU64>, peers: Arc<Peers<FullPeerState>>,
+        request_ids: Arc<UniqueId>, peers: Arc<Peers<FullPeerState>>,
     ) -> Self
     {
         // TODO(thegaram): At this point the light node does not persist
@@ -95,24 +71,40 @@ impl SyncHandler {
         // along with a Merkle-root for headers in each era.
         graph.recover_graph_from_db(true /* header_only */);
 
-        let duplicate_count = AtomicU64::new(0);
-        let epochs = Epochs::new(consensus.clone(), peers.clone());
-        let headers = Headers::new(graph.clone());
+        let headers = Arc::new(Headers::new(
+            graph.clone(),
+            peers.clone(),
+            request_ids.clone(),
+        ));
+
+        let epochs = Epochs::new(
+            consensus.clone(),
+            headers.clone(),
+            peers.clone(),
+            request_ids.clone(),
+        );
+
+        let blooms = Arc::new(Blooms::new(
+            consensus.clone(),
+            peers.clone(),
+            request_ids.clone(),
+        ));
+
+        let witnesses = Witnesses::new(
+            blooms.clone(),
+            consensus.clone(),
+            peers.clone(),
+            request_ids.clone(),
+        );
 
         SyncHandler {
+            blooms,
             consensus,
-            duplicate_count,
             epochs,
-            graph,
             headers,
-            next_request_id,
             peers,
+            witnesses,
         }
-    }
-
-    #[inline]
-    fn next_request_id(&self) -> RequestId {
-        self.next_request_id.fetch_add(1, Ordering::Relaxed).into()
     }
 
     #[inline]
@@ -145,10 +137,6 @@ impl SyncHandler {
     fn get_statistics(&self) -> Statistics {
         Statistics {
             catch_up_mode: self.catch_up_mode(),
-            duplicate_count: self.duplicate_count.load(Ordering::Relaxed),
-            epochs_in_flight: self.epochs.num_requests_in_flight(),
-            headers_in_flight: self.headers.num_in_flight(),
-            headers_waiting: self.headers.num_waiting(),
             latest_epoch: self.consensus.best_epoch_number(),
         }
     }
@@ -163,172 +151,7 @@ impl SyncHandler {
         });
 
         let terminals = terminals.into_iter();
-        self.headers.insert_waiting(terminals, HashSource::NewHash);
-    }
-
-    #[inline]
-    fn request_epochs(
-        &self, io: &dyn NetworkContext, peer: PeerId, epochs: Vec<u64>,
-    ) -> Result<Option<RequestId>, Error> {
-        info!("request_epochs peer={:?} epochs={:?}", peer, epochs);
-
-        if epochs.is_empty() {
-            return Ok(None);
-        }
-
-        let request_id = self.next_request_id();
-
-        let msg: Box<dyn Message> =
-            Box::new(GetBlockHashesByEpoch { request_id, epochs });
-
-        msg.send(io, peer)?;
-        Ok(Some(request_id))
-    }
-
-    #[inline]
-    fn request_headers(
-        &self, io: &dyn NetworkContext, peer: PeerId, hashes: Vec<H256>,
-    ) -> Result<(), Error> {
-        info!("request_headers peer={:?} hashes={:?}", peer, hashes);
-
-        if hashes.is_empty() {
-            return Ok(());
-        }
-
-        let msg: Box<dyn Message> = Box::new(GetBlockHeaders {
-            request_id: self.next_request_id(),
-            hashes,
-        });
-
-        msg.send(io, peer)?;
-        Ok(())
-    }
-
-    fn handle_headers(&self, headers: Vec<BlockHeader>) {
-        let mut missing = HashSet::new();
-
-        // TODO(thegaram): validate header timestamps
-        for header in headers {
-            let hash = header.hash();
-
-            // signal receipt
-            self.headers.remove_in_flight(&hash);
-
-            // check duplicates
-            if self.graph.contains_block_header(&hash) {
-                self.duplicate_count.fetch_add(1, Ordering::Relaxed);
-                continue;
-            }
-
-            // insert into graph
-            let (valid, _) = self.graph.insert_block_header(
-                &mut header.clone(),
-                true,  /* need_to_verify */
-                false, /* bench_mode */
-                true,  /* insert_to_consensus */
-                true,  /* persistent */
-            );
-
-            if !valid {
-                continue;
-            }
-
-            // store missing dependencies
-            missing.insert(*header.parent_hash());
-
-            for referee in header.referee_hashes() {
-                missing.insert(*referee);
-            }
-        }
-
-        let missing = missing.into_iter();
-        self.headers.insert_waiting(missing, HashSource::Reference);
-    }
-
-    fn sync_headers(&self, io: &dyn NetworkContext) {
-        info!("sync_headers; statistics: {:?}", self.get_statistics());
-
-        // check if there are any peers available
-        if self.peers.is_empty() {
-            warn!("No peers available; aborting sync");
-            return;
-        }
-
-        // choose set of hashes to request
-        let headers = self.headers.collect_headers_to_request();
-
-        // request headers in batches from random peers
-        for batch in headers.chunks(HEADER_REQUEST_BATCH_SIZE) {
-            let peer = match self.peers.random_peer() {
-                Some(peer) => peer,
-                None => {
-                    warn!("No peers available");
-                    self.headers.reinsert_waiting(batch.to_owned().into_iter());
-
-                    // NOTE: cannot do early return as that way headers
-                    // in subsequent batches would be lost
-                    continue;
-                }
-            };
-
-            let hashes = batch.iter().map(|h| h.hash.clone()).collect();
-
-            match self.request_headers(io, peer, hashes) {
-                Ok(_) => {
-                    self.headers.insert_in_flight(batch.to_owned().into_iter());
-                }
-                Err(e) => {
-                    warn!(
-                        "Failed to request headers {:?} from peer {:?}: {:?}",
-                        batch, peer, e
-                    );
-
-                    self.headers.reinsert_waiting(batch.to_owned().into_iter());
-                }
-            }
-        }
-    }
-
-    fn sync_epochs(&self, io: &dyn NetworkContext) {
-        info!("sync_epochs; statistics: {:?}", self.get_statistics());
-
-        // return if we already have enough hashes in the pipeline
-        if self.headers.num_waiting() >= NUM_WAITING_HEADERS_THRESHOLD {
-            return;
-        }
-
-        // choose set of epochs to request
-        let epochs = self.epochs.collect_epochs_to_request();
-
-        // request epochs in batches from random peers
-        for batch in epochs.chunks(EPOCH_REQUEST_BATCH_SIZE) {
-            // find maximal epoch number in this chunk
-            let max = max_of_collection(batch.iter()).expect("chunk not empty");
-
-            // choose random peer that has the epochs we need
-            let predicate = |s: &FullPeerState| s.best_epoch >= *max;
-            let peer = match self.peers.random_peer_satisfying(predicate) {
-                Some(peer) => peer,
-                None => {
-                    warn!("No peers available; aborting sync");
-                    break;
-                }
-            };
-
-            // request epoch batch
-            match self.request_epochs(io, peer, batch.to_vec()) {
-                Ok(None) => {}
-                Ok(Some(id)) => {
-                    self.epochs.insert_in_flight(id, batch.to_vec());
-                }
-                Err(e) => {
-                    warn!(
-                        "Failed to request epochs {:?} from peer {:?}: {:?}",
-                        batch, peer, e
-                    );
-                }
-            }
-        }
+        self.headers.request(terminals, HashSource::NewHash);
     }
 
     pub(super) fn on_block_hashes(
@@ -337,10 +160,10 @@ impl SyncHandler {
         let resp: GetBlockHashesResponse = rlp.as_val()?;
         info!("on_block_hashes resp={:?}", resp);
 
-        self.epochs.remove_in_flight(&resp.request_id);
+        self.epochs.receive(&resp.request_id);
 
         let hashes = resp.hashes.into_iter();
-        self.headers.insert_waiting(hashes, HashSource::Epoch);
+        self.headers.request(hashes, HashSource::Epoch);
 
         self.start_sync(io);
         Ok(())
@@ -352,7 +175,7 @@ impl SyncHandler {
         let resp: GetBlockHeadersResponse = rlp.as_val()?;
         info!("on_block_headers resp={:?}", resp);
 
-        self.handle_headers(resp.headers);
+        self.headers.receive(resp.headers.into_iter());
 
         self.start_sync(io);
         Ok(())
@@ -373,30 +196,60 @@ impl SyncHandler {
         }
 
         let hashes = msg.hashes.into_iter();
-        self.headers.insert_waiting(hashes, HashSource::NewHash);
+        self.headers.request(hashes, HashSource::NewHash);
+
+        self.start_sync(io);
+        Ok(())
+    }
+
+    pub(super) fn on_witness_info(
+        &self, io: &dyn NetworkContext, _peer: PeerId, rlp: &Rlp,
+    ) -> Result<(), Error> {
+        let resp: GetWitnessInfoResponse = rlp.as_val()?;
+        info!("on_witness_info resp={:?}", resp);
+
+        self.witnesses.receive(resp.infos.into_iter())?;
+
+        self.start_sync(io);
+        Ok(())
+    }
+
+    pub(super) fn on_blooms(
+        &self, io: &dyn NetworkContext, _peer: PeerId, rlp: &Rlp,
+    ) -> Result<(), Error> {
+        let resp: GetBloomsResponse = rlp.as_val()?;
+        info!("on_blooms resp={:?}", resp);
+
+        self.blooms.receive(resp.blooms.into_iter())?;
 
         self.start_sync(io);
         Ok(())
     }
 
     pub(super) fn start_sync(&self, io: &dyn NetworkContext) {
-        info!("start_sync; statistics: {:?}", self.get_statistics());
+        info!("general sync statistics: {:?}", self.get_statistics());
 
         match self.catch_up_mode() {
             true => {
-                self.sync_headers(io);
-                self.sync_epochs(io);
+                self.headers.sync(io);
+                self.epochs.sync(io);
+                self.witnesses.sync(io);
+                self.blooms.sync(io);
             }
             false => {
                 self.collect_terminals();
-                self.sync_headers(io);
+                self.headers.sync(io);
+                self.witnesses.sync(io);
+                self.blooms.sync(io);
             }
         };
     }
 
     pub(super) fn clean_up_requests(&self) {
         info!("clean_up_requests");
+        self.blooms.clean_up();
         self.epochs.clean_up();
         self.headers.clean_up();
+        self.witnesses.clean_up();
     }
 }

--- a/core/src/light_protocol/handler/sync/mod.rs
+++ b/core/src/light_protocol/handler/sync/mod.rs
@@ -63,7 +63,7 @@ pub(super) struct SyncHandler {
 impl SyncHandler {
     pub(super) fn new(
         consensus: Arc<ConsensusGraph>, graph: Arc<SynchronizationGraph>,
-        request_ids: Arc<UniqueId>, peers: Arc<Peers<FullPeerState>>,
+        request_id_allocator: Arc<UniqueId>, peers: Arc<Peers<FullPeerState>>,
     ) -> Self
     {
         // TODO(thegaram): At this point the light node does not persist
@@ -74,27 +74,27 @@ impl SyncHandler {
         let headers = Arc::new(Headers::new(
             graph.clone(),
             peers.clone(),
-            request_ids.clone(),
+            request_id_allocator.clone(),
         ));
 
         let epochs = Epochs::new(
             consensus.clone(),
             headers.clone(),
             peers.clone(),
-            request_ids.clone(),
+            request_id_allocator.clone(),
         );
 
         let blooms = Arc::new(Blooms::new(
             consensus.clone(),
             peers.clone(),
-            request_ids.clone(),
+            request_id_allocator.clone(),
         ));
 
         let witnesses = Witnesses::new(
             blooms.clone(),
             consensus.clone(),
             peers.clone(),
-            request_ids.clone(),
+            request_id_allocator.clone(),
         );
 
         SyncHandler {

--- a/core/src/light_protocol/handler/sync/sync_manager.rs
+++ b/core/src/light_protocol/handler/sync/sync_manager.rs
@@ -1,0 +1,192 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use parking_lot::RwLock;
+use std::{
+    collections::{BinaryHeap, HashMap},
+    time::{Duration, Instant},
+};
+
+#[derive(Debug)]
+struct InFlightRequest<T> {
+    pub item: T,
+    pub sent_at: Instant,
+}
+
+impl<T> InFlightRequest<T> {
+    pub fn new(item: T) -> Self {
+        InFlightRequest {
+            item,
+            sent_at: Instant::now(),
+        }
+    }
+}
+
+pub trait HasKey<Key>
+where Key: Clone
+{
+    fn key(&self) -> Key;
+}
+
+use super::super::FullPeerState;
+use crate::{
+    light_protocol::{common::Peers, Error},
+    network::PeerId,
+};
+use std::sync::Arc;
+
+use std::{cmp::Ord, fmt::Debug, hash::Hash};
+
+pub(super) struct SyncManager<Key, Item> {
+    // headers requested but not received yet
+    in_flight: RwLock<HashMap<Key, InFlightRequest<Item>>>,
+
+    // priority queue of headers we need excluding the ones in `in_flight`
+    waiting: RwLock<BinaryHeap<Item>>,
+
+    // collection of all peers available
+    peers: Arc<Peers<FullPeerState>>,
+}
+
+impl<Key, Item> SyncManager<Key, Item>
+where
+    Key: Copy + Eq + Hash,
+    Item: Debug + Clone + HasKey<Key> + Ord,
+{
+    pub fn new(peers: Arc<Peers<FullPeerState>>) -> Self {
+        let in_flight = RwLock::new(HashMap::new());
+        let waiting = RwLock::new(BinaryHeap::new());
+
+        SyncManager {
+            in_flight,
+            waiting,
+            peers,
+        }
+    }
+
+    #[inline]
+    pub fn num_waiting(&self) -> usize { self.waiting.read().len() }
+
+    #[inline]
+    pub fn num_in_flight(&self) -> usize { self.in_flight.read().len() }
+
+    #[inline]
+    pub fn insert_in_flight<I>(&self, missing: I)
+    where I: Iterator<Item = Item> {
+        let new = missing.map(|item| (item.key(), InFlightRequest::new(item)));
+        self.in_flight.write().extend(new);
+    }
+
+    #[inline]
+    pub fn remove_in_flight(&self, key: &Key) {
+        self.in_flight.write().remove(&key);
+    }
+
+    #[inline]
+    pub fn insert_waiting<I>(&self, items: I)
+    where I: Iterator<Item = Item> {
+        let in_flight = self.in_flight.read();
+        let mut waiting = self.waiting.write();
+        let missing = items.filter(|item| !in_flight.contains_key(&item.key()));
+        waiting.extend(missing);
+    }
+
+    #[inline]
+    pub fn collect_to_request(&self, num_to_request: usize) -> Vec<Item> {
+        if num_to_request == 0 {
+            return vec![];
+        }
+
+        let in_flight = self.in_flight.read();
+        let mut waiting = self.waiting.write();
+
+        let mut items = vec![];
+
+        // NOTE: cannot use iterator on BinaryHeap as
+        // it returns elements in arbitrary order!
+        while let Some(item) = waiting.pop() {
+            if !in_flight.contains_key(&item.key()) {
+                items.push(item);
+            }
+
+            if items.len() == num_to_request {
+                break;
+            }
+        }
+
+        items
+    }
+
+    pub fn sync(
+        &self, max_in_flight: usize, batch_size: usize,
+        request: impl Fn(PeerId, Vec<Key>) -> Result<(), Error>,
+    )
+    {
+        // check if there are any peers available
+        if self.peers.is_empty() {
+            warn!("No peers available; aborting sync");
+            return;
+        }
+
+        // choose set of hashes to request
+        let num_to_request = max_in_flight - self.num_in_flight();
+
+        let items = match self.collect_to_request(num_to_request) {
+            ref hs if hs.is_empty() => return,
+            hs => hs,
+        };
+
+        // request items in batches from random peers
+        for batch in items.chunks(batch_size) {
+            let peer = match self.peers.random_peer() {
+                Some(peer) => peer,
+                None => {
+                    warn!("No peers available");
+                    self.insert_waiting(batch.to_owned().into_iter());
+
+                    // NOTE: cannot do early return as that way items
+                    // in subsequent batches would be lost
+                    continue;
+                }
+            };
+
+            let keys = batch.iter().map(|h| h.key()).collect();
+
+            match request(peer, keys) {
+                Ok(_) => {
+                    self.insert_in_flight(batch.to_owned().into_iter());
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to request items {:?} from peer {:?}: {:?}",
+                        batch, peer, e
+                    );
+
+                    self.insert_waiting(batch.to_owned().into_iter());
+                }
+            }
+        }
+    }
+
+    #[inline]
+    pub fn remove_timeout_requests(&self, timeout: Duration) -> Vec<Item> {
+        let mut in_flight = self.in_flight.write();
+
+        // collect timed-out requests
+        let items: Vec<_> = in_flight
+            .iter()
+            .filter_map(|(_hash, req)| match req.sent_at {
+                t if t.elapsed() < timeout => None,
+                _ => Some(req.item.clone()),
+            })
+            .collect();
+
+        // remove requests from `in_flight`
+        for item in &items {
+            in_flight.remove(&item.key());
+        }
+
+        items
+    }
+}

--- a/core/src/light_protocol/handler/sync/witnesses.rs
+++ b/core/src/light_protocol/handler/sync/witnesses.rs
@@ -1,0 +1,315 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use std::{
+    cmp,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use parking_lot::RwLock;
+
+use crate::{
+    consensus::ConsensusGraph,
+    light_protocol::{
+        common::{LedgerInfo, LedgerProof, Peers, UniqueId},
+        handler::FullPeerState,
+        message::{GetWitnessInfo, WitnessInfoWithHeight},
+        Error, ErrorKind,
+    },
+    message::Message,
+    network::{NetworkContext, PeerId},
+    parameters::{
+        consensus::DEFERRED_STATE_EPOCH_COUNT,
+        light::{
+            BLAME_CHECK_OFFSET, MAX_WITNESSES_IN_FLIGHT,
+            NUM_WAITING_WITNESSES_THRESHOLD, WITNESS_REQUEST_BATCH_SIZE,
+            WITNESS_REQUEST_TIMEOUT_MS,
+        },
+    },
+};
+
+use super::{
+    blooms::Blooms,
+    sync_manager::{HasKey, SyncManager},
+};
+
+#[derive(Debug)]
+struct Statistics {
+    in_flight: usize,
+    verified: u64,
+    waiting: usize,
+}
+
+#[derive(Clone, Debug, Eq)]
+pub(super) struct MissingWitness {
+    pub height: u64,
+    pub since: Instant,
+}
+
+impl MissingWitness {
+    pub fn new(height: u64) -> Self {
+        MissingWitness {
+            height,
+            since: Instant::now(),
+        }
+    }
+}
+
+impl PartialEq for MissingWitness {
+    fn eq(&self, other: &Self) -> bool { self.height == other.height }
+}
+
+// MissingWitness::cmp is used for prioritizing header requests
+impl Ord for MissingWitness {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        if self.eq(other) {
+            return cmp::Ordering::Equal;
+        }
+
+        let cmp_since = self.since.cmp(&other.since).reverse();
+        let cmp_height = self.height.cmp(&other.height);
+
+        cmp_since.then(cmp_height)
+    }
+}
+
+impl PartialOrd for MissingWitness {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl HasKey<u64> for MissingWitness {
+    fn key(&self) -> u64 { self.height }
+}
+
+pub(super) struct Witnesses {
+    // bloom sync manager
+    blooms: Arc<Blooms>,
+
+    // shared consensus graph
+    consensus: Arc<ConsensusGraph>,
+
+    // latest header for which we have trusted information
+    latest_verified_header: RwLock<u64>,
+
+    // helper API for retrieving ledger information
+    ledger: LedgerInfo,
+
+    // series of unique request ids
+    request_ids: Arc<UniqueId>,
+
+    // sync and request manager
+    sync_manager: SyncManager<u64, MissingWitness>,
+}
+
+impl Witnesses {
+    pub fn new(
+        blooms: Arc<Blooms>, consensus: Arc<ConsensusGraph>,
+        peers: Arc<Peers<FullPeerState>>, request_ids: Arc<UniqueId>,
+    ) -> Self
+    {
+        let latest_verified_header = RwLock::new(0);
+        let ledger = LedgerInfo::new(consensus.clone());
+        let sync_manager = SyncManager::new(peers.clone());
+
+        Witnesses {
+            blooms,
+            consensus,
+            latest_verified_header,
+            ledger,
+            request_ids,
+            sync_manager,
+        }
+    }
+
+    #[inline]
+    fn get_statistics(&self) -> Statistics {
+        Statistics {
+            in_flight: self.sync_manager.num_in_flight(),
+            verified: *self.latest_verified_header.read(),
+            waiting: self.sync_manager.num_waiting(),
+        }
+    }
+
+    #[inline]
+    pub fn request<I>(&self, witnesses: I)
+    where I: Iterator<Item = u64> {
+        let witnesses = witnesses.map(|h| MissingWitness::new(h));
+        self.sync_manager.insert_waiting(witnesses);
+    }
+
+    pub fn receive<I>(&self, witnesses: I) -> Result<(), Error>
+    where I: Iterator<Item = WitnessInfoWithHeight> {
+        for item in witnesses {
+            let witness = item.height;
+            let receipts = item.receipt_hashes;
+            let blooms = item.bloom_hashes;
+
+            // validate hashes
+            let header = self.ledger.pivot_header_of(witness)?;
+            LedgerProof::ReceiptsRoot(receipts.clone()).validate(&header)?;
+            LedgerProof::LogsBloomHash(blooms.clone()).validate(&header)?;
+
+            // the previous validation should not pass if this is not true
+            assert!(receipts.len() == blooms.len());
+
+            // handle valid hashes
+            for ii in 0..blooms.len() as u64 {
+                // find corresponding epoch
+                let height = witness - ii;
+                let epoch = height.saturating_sub(DEFERRED_STATE_EPOCH_COUNT);
+
+                // store receipts root and logs bloom hash
+                self.consensus.data_man.insert_epoch_execution_commitments(
+                    self.ledger.pivot_hash_of(epoch)?,
+                    receipts[ii as usize],
+                    blooms[ii as usize],
+                );
+
+                // request bloom for this epoch
+                self.blooms.request(epoch);
+            }
+
+            // signal receipt
+            self.sync_manager.remove_in_flight(&witness);
+        }
+
+        Ok(())
+    }
+
+    #[inline]
+    pub fn clean_up(&self) {
+        let timeout = Duration::from_millis(WITNESS_REQUEST_TIMEOUT_MS);
+        let witnesses = self.sync_manager.remove_timeout_requests(timeout);
+        self.sync_manager.insert_waiting(witnesses.into_iter());
+    }
+
+    #[inline]
+    fn send_request(
+        &self, io: &dyn NetworkContext, peer: PeerId, witnesses: Vec<u64>,
+    ) -> Result<(), Error> {
+        info!("send_request peer={:?} witnesses={:?}", peer, witnesses);
+
+        if witnesses.is_empty() {
+            return Ok(());
+        }
+
+        let msg: Box<dyn Message> = Box::new(GetWitnessInfo {
+            request_id: self.request_ids.next(),
+            witnesses,
+        });
+
+        msg.send(io, peer)?;
+        Ok(())
+    }
+
+    #[inline]
+    pub fn sync(&self, io: &dyn NetworkContext) {
+        info!("witness sync statistics: {:?}", self.get_statistics());
+
+        if let Err(e) = self.verify_pivot_chain() {
+            warn!("Failed to verify pivot chain: {:?}", e);
+            return;
+        }
+
+        if let Err(e) = self.collect_witnesses() {
+            warn!("Failed to collect witnesses: {:?}", e);
+            return;
+        }
+
+        self.sync_manager.sync(
+            MAX_WITNESSES_IN_FLIGHT,
+            WITNESS_REQUEST_BATCH_SIZE,
+            |peer, witnesses| self.send_request(io, peer, witnesses),
+        );
+    }
+
+    #[inline]
+    fn is_blamed(&self, height: u64) -> bool {
+        self.ledger.witness_of_header_at(height) != Some(height)
+    }
+
+    // a header is trusted if
+    //     a) it is not blamed (i.e. it is its own witness)
+    //     b) we have received and validated the corresponding root
+    #[inline]
+    fn is_header_trusted(&self, height: u64) -> Result<bool, Error> {
+        let epoch = height.saturating_sub(DEFERRED_STATE_EPOCH_COUNT);
+        let pivot = self.ledger.pivot_hash_of(epoch)?;
+
+        Ok(!self.is_blamed(height)
+            || self
+                .consensus
+                .data_man
+                .get_epoch_execution_commitments(&pivot)
+                .is_some())
+    }
+
+    fn verify_pivot_chain(&self) -> Result<(), Error> {
+        let best = self.consensus.best_epoch_number() - BLAME_CHECK_OFFSET;
+        let mut latest = self.latest_verified_header.write();
+
+        let mut height = *latest + 1;
+
+        // iterate through all trusted pivot headers
+        // TODO(thegaram): consider chain-reorg
+        while height < best && self.is_header_trusted(height)? {
+            debug!("header {} is valid", height);
+
+            let header = self.ledger.pivot_header_of(height)?;
+            let epoch = height.saturating_sub(DEFERRED_STATE_EPOCH_COUNT);
+
+            // for blamed and blaming blocks, we've stored the correct roots in
+            // the `on_witness_info` response handler
+            if !self.is_blamed(height) && header.blame() == 0 {
+                self.consensus.data_man.insert_epoch_execution_commitments(
+                    self.ledger.pivot_hash_of(epoch)?,
+                    *header.deferred_receipts_root(),
+                    *header.deferred_logs_bloom_hash(),
+                );
+            }
+
+            // request corresponding bloom
+            self.blooms.request(epoch);
+
+            *latest = height;
+            height += 1;
+        }
+
+        Ok(())
+    }
+
+    fn collect_witnesses(&self) -> Result<(), Error> {
+        let best = self.consensus.best_epoch_number() - BLAME_CHECK_OFFSET;
+        let mut height = *self.latest_verified_header.read() + 1;
+
+        while height <= best
+            && self.sync_manager.num_waiting() < NUM_WAITING_WITNESSES_THRESHOLD
+        {
+            // header trusted
+            if !self.is_blamed(height) {
+                height += 1;
+                continue;
+            }
+
+            // header not trusted
+            let witness = match self.ledger.witness_of_header_at(height) {
+                Some(w) => w,
+                None => {
+                    warn!("Unable to get witness!");
+                    return Err(ErrorKind::InternalError.into());
+                }
+            };
+
+            debug!("header {} is NOT valid, witness: {}", height, witness);
+            self.request(std::iter::once(witness));
+
+            height = witness + 1;
+        }
+
+        Ok(())
+    }
+}

--- a/core/src/light_protocol/handler/sync/witnesses.rs
+++ b/core/src/light_protocol/handler/sync/witnesses.rs
@@ -99,7 +99,7 @@ pub(super) struct Witnesses {
     ledger: LedgerInfo,
 
     // series of unique request ids
-    request_ids: Arc<UniqueId>,
+    request_id_allocator: Arc<UniqueId>,
 
     // sync and request manager
     sync_manager: SyncManager<u64, MissingWitness>,
@@ -108,7 +108,7 @@ pub(super) struct Witnesses {
 impl Witnesses {
     pub fn new(
         blooms: Arc<Blooms>, consensus: Arc<ConsensusGraph>,
-        peers: Arc<Peers<FullPeerState>>, request_ids: Arc<UniqueId>,
+        peers: Arc<Peers<FullPeerState>>, request_id_allocator: Arc<UniqueId>,
     ) -> Self
     {
         let latest_verified_header = RwLock::new(0);
@@ -120,7 +120,7 @@ impl Witnesses {
             consensus,
             latest_verified_header,
             ledger,
-            request_ids,
+            request_id_allocator,
             sync_manager,
         }
     }
@@ -198,7 +198,7 @@ impl Witnesses {
         }
 
         let msg: Box<dyn Message> = Box::new(GetWitnessInfo {
-            request_id: self.request_ids.next(),
+            request_id: self.request_id_allocator.next(),
             witnesses,
         });
 

--- a/core/src/light_protocol/message/message.rs
+++ b/core/src/light_protocol/message/message.rs
@@ -25,6 +25,10 @@ build_msgid! {
     RECEIPTS = 0x0d
     GET_TXS = 0x0e
     TXS = 0x0f
+    GET_WITNESS_INFO = 0x10
+    WITNESS_INFO = 0x11
+    GET_BLOOMS = 0x12
+    BLOOMS = 0x13
 
     INVALID = 0xff
 }
@@ -46,6 +50,10 @@ build_msg_impl! { GetReceipts, msgid::GET_RECEIPTS, "GetReceipts" }
 build_msg_impl! { Receipts, msgid::RECEIPTS, "Receipts" }
 build_msg_impl! { GetTxs, msgid::GET_TXS, "GetTxs" }
 build_msg_impl! { Txs, msgid::TXS, "Txs" }
+build_msg_impl! { GetWitnessInfo, msgid::GET_WITNESS_INFO, "GetWitnessInfo" }
+build_msg_impl! { WitnessInfo, msgid::WITNESS_INFO, "WitnessInfo" }
+build_msg_impl! { GetBlooms, msgid::GET_BLOOMS, "GetBlooms" }
+build_msg_impl! { Blooms, msgid::BLOOMS, "Blooms" }
 
 // generate `impl HasRequestId for _` for each request type
 build_has_request_id_impl! { GetStateRoot }

--- a/core/src/light_protocol/message/mod.rs
+++ b/core/src/light_protocol/message/mod.rs
@@ -9,8 +9,9 @@ mod protocol;
 pub use message::msgid;
 pub use node_type::NodeType;
 pub use protocol::{
-    BlockHashes, BlockHeaders, GetBlockHashesByEpoch, GetBlockHeaders,
-    GetReceipts, GetStateEntry, GetStateRoot, GetTxs, NewBlockHashes, Receipts,
-    ReceiptsWithProof, SendRawTx, StateEntry, StateRoot, StateRootWithProof,
-    StatusPing, StatusPong, Txs,
+    BlockHashes, BlockHeaders, BloomWithEpoch, Blooms, GetBlockHashesByEpoch,
+    GetBlockHeaders, GetBlooms, GetReceipts, GetStateEntry, GetStateRoot,
+    GetTxs, GetWitnessInfo, NewBlockHashes, Receipts, ReceiptsWithProof,
+    SendRawTx, StateEntry, StateRoot, StateRootWithProof, StatusPing,
+    StatusPong, Txs, WitnessInfo, WitnessInfoWithHeight,
 };

--- a/core/src/light_protocol/message/protocol.rs
+++ b/core/src/light_protocol/message/protocol.rs
@@ -2,7 +2,7 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use cfx_types::H256;
+use cfx_types::{Bloom, H256};
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 use rlp_derive::{RlpDecodable, RlpEncodable};
 
@@ -146,6 +146,7 @@ pub struct Receipts {
     pub pivot_hash: H256,
     pub receipts: ReceiptsWithProof,
 }
+
 #[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
 pub struct GetTxs {
     pub request_id: RequestId,
@@ -156,4 +157,42 @@ pub struct GetTxs {
 pub struct Txs {
     pub request_id: RequestId,
     pub txs: Vec<SignedTransaction>,
+}
+
+#[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
+pub struct GetWitnessInfo {
+    pub request_id: RequestId,
+    pub witnesses: Vec<u64>,
+}
+
+#[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
+pub struct WitnessInfoWithHeight {
+    pub height: u64,
+    pub receipt_hashes: Vec<H256>,
+    pub bloom_hashes: Vec<H256>,
+    // TODO(thegaram): send state roots as well
+}
+
+#[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
+pub struct WitnessInfo {
+    pub request_id: RequestId,
+    pub infos: Vec<WitnessInfoWithHeight>,
+}
+
+#[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
+pub struct GetBlooms {
+    pub request_id: RequestId,
+    pub epochs: Vec<u64>,
+}
+
+#[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
+pub struct BloomWithEpoch {
+    pub epoch: u64,
+    pub bloom: Bloom,
+}
+
+#[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
+pub struct Blooms {
+    pub request_id: RequestId,
+    pub blooms: Vec<BloomWithEpoch>,
 }

--- a/core/src/parameters.rs
+++ b/core/src/parameters.rs
@@ -125,9 +125,11 @@ pub mod light {
     /// Frequency of re-triggering sync.
     pub const SYNC_PERIOD_MS: u64 = 5000;
 
-    /// Timeout for `GetBlockHashesByEpoch` and `GetBlockHeaders` requests.
+    /// Request timeouts.
     pub const EPOCH_REQUEST_TIMEOUT_MS: u64 = 2000;
     pub const HEADER_REQUEST_TIMEOUT_MS: u64 = 2000;
+    pub const WITNESS_REQUEST_TIMEOUT_MS: u64 = 2000;
+    pub const BLOOM_REQUEST_TIMEOUT_MS: u64 = 2000;
 
     /// Maximum time period we wait for a response for an on-demand query.
     /// After this timeout has been reached, we try another peer or give up.
@@ -136,13 +138,17 @@ pub mod light {
     /// Period of time to sleep between subsequent polls for on-demand queries.
     pub const POLL_PERIOD_MS: u64 = 100;
 
-    /// (Maximum) number of epochs/headers requested in a single request.
+    /// (Maximum) number of items requested in a single request.
     pub const EPOCH_REQUEST_BATCH_SIZE: usize = 30;
     pub const HEADER_REQUEST_BATCH_SIZE: usize = 30;
+    pub const BLOOM_REQUEST_BATCH_SIZE: usize = 30;
+    pub const WITNESS_REQUEST_BATCH_SIZE: usize = 10;
 
-    /// Maximum number of in-flight headers at any given time.
-    /// If we reach this limit, we will not request any more headers.
+    /// Maximum number of in-flight items at any given time.
+    /// If we reach this limit, we will not request any more.
     pub const MAX_HEADERS_IN_FLIGHT: usize = 500;
+    pub const MAX_WITNESSES_IN_FLIGHT: usize = 30;
+    pub const MAX_BLOOMS_IN_FLIGHT: usize = 500;
 
     /// Maximum number of in-flight epoch requests at any given time.
     /// Similar to `MAX_HEADERS_IN_FLIGHT`. However, it is hard to match
@@ -152,15 +158,20 @@ pub mod light {
     /// Number of epochs to request in one round (in possibly multiple batches).
     pub const NUM_EPOCHS_TO_REQUEST: usize = 200;
 
-    /// Minimum number of missing headers during catch-up mode.
-    /// If we have fewer, we will try to request some more using a
-    /// `GetBlockHashesByEpoch` request.
+    /// Minimum number of missing items in the sync pipeline.
+    /// If we have fewer, we will try to request some more.
     pub const NUM_WAITING_HEADERS_THRESHOLD: usize = 1000;
+    pub const NUM_WAITING_WITNESSES_THRESHOLD: usize = 30;
 
     /// Max number of epochs/headers/txs to send to a light peer in a response.
     pub const MAX_EPOCHS_TO_SEND: usize = 128;
     pub const MAX_HEADERS_TO_SEND: usize = 512;
     pub const MAX_TXS_TO_SEND: usize = 1024;
+
+    /// During syncing, we might transiently have enough malicious blaming
+    /// blocks to consider a correct header incorrect. For this reason, we
+    /// first wait for enough header to accumulate before checking blaming.
+    pub const BLAME_CHECK_OFFSET: u64 = 20;
 }
 
 pub const WORKER_COMPUTATION_PARALLELISM: usize = 8;

--- a/primitives/src/block_header.rs
+++ b/primitives/src/block_header.rs
@@ -453,6 +453,13 @@ impl BlockHeaderBuilder {
         keccak(bloom)
     }
 
+    pub fn compute_aggregated_bloom(blooms: Vec<Bloom>) -> Bloom {
+        blooms.into_iter().fold(Bloom::zero(), |mut res, bloom| {
+            res.accrue_bloom(&bloom);
+            res
+        })
+    }
+
     pub fn compute_blame_state_root_vec_root(roots: Vec<H256>) -> H256 {
         let mut rlp_stream = RlpStream::new_list(roots.len());
         for root in roots {

--- a/tests/light/tx_relay_test.py
+++ b/tests/light/tx_relay_test.py
@@ -109,13 +109,12 @@ class TxRelayTest(ConfluxTestFramework):
         epoch_before_blamed_blocks = self.rpc[FULLNODE0].epoch_number()
 
         # generate some incorrect blocks
+        # NOTE: we avoid 51% attacks as it could cause some inconsistency during syncing
         for _ in range(num_blocks):
-            self.generate_incorrect_block(FULLNODE0)
-
-        # generate one correct block and check blame info
-        hash = self.generate_correct_block(FULLNODE0)
-        block = self.rpc[FULLNODE0].block_by_hash(hash)
-        assert_equal(block["blame"], num_blocks)
+            if random.random() < 0.66:
+                self.generate_correct_block(FULLNODE0)
+            else:
+                self.generate_incorrect_block(FULLNODE0)
 
         # generate some correct blocks to make sure we are confident about the previous one
         sync_blocks(self.nodes[FULLNODE0:FULLNODE1])


### PR DESCRIPTION
**Overview**

In Conflux, the block header contains no bloom filter -- only a commitment to the epoch bloom (`logs_bloom_hash`). This is computed by taking the keccak hash of the aggregated bloom of all receipts in the epoch.

Light nodes, however, need the bloom filters locally, in order to decide which epochs might contain a corresponding log. These bloom filters need to be requested from (full node) peers.

To be able to verify a bloom filter received from a peer, we also need to retrieve and verify the correct roots (`logs_bloom_hash` in particular) for each header.

**Sync overview**

This PR adds witness and bloom syncing to light nodes. The sync process goes as follows:

1. We sync epochs and headers normally as before.
2. We periodically check the pivot chain in our local consensus graph (`sync::witnesses::verify_pivot_chain`).
3. Upon encountering a blamed block, we request the corresponding witness information (`GetWitnessInfo` message).
4. Upon receiving the witness hashes, we validate and store them locally (`sync::witnesses::receive`).
5. Then, we proceed to request the corresponding bloom filters (`GetBlooms` message).
6. Upon receiving the bloom filters, we validate and store them locally (`sync::blooms::receive`).

The process is managed by 4 sync handlers (`blooms`, `epochs`, `headers`, `witnesses`), that share some of their implementation in `SyncManager`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/583)
<!-- Reviewable:end -->
