### PR TITLE
Fix recovery problems for full/archive node.

### DIFF
--- a/core/src/block_data_manager.rs
+++ b/core/src/block_data_manager.rs
@@ -59,23 +59,11 @@ pub struct EpochExecutionCommitments {
     pub logs_bloom_hash: H256,
 }
 
-#[derive(Clone, RlpEncodable, RlpDecodable)]
+#[derive(Clone, RlpEncodable, RlpDecodable, Default)]
 pub struct ConsensusGraphExecutionInfo {
-    pub state_valid: bool,
     pub original_deferred_state_root: H256,
     pub original_deferred_receipt_root: H256,
     pub original_deferred_logs_bloom_hash: H256,
-}
-
-impl Default for ConsensusGraphExecutionInfo {
-    fn default() -> Self {
-        ConsensusGraphExecutionInfo {
-            state_valid: true,
-            original_deferred_state_root: Default::default(),
-            original_deferred_receipt_root: Default::default(),
-            original_deferred_logs_bloom_hash: Default::default(),
-        }
-    }
 }
 
 pub struct BlockDataManager {

--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -240,11 +240,13 @@ impl ConsensusExecutor {
                 KECCAK_EMPTY_BLOOM,
             )
         } else {
-            if let Some(result) = self.handler.get_execution_result(&epoch_hash)
-            {
+            if self.handler.data_man.epoch_executed(&epoch_hash) {
                 // The epoch already executed, so we do not need wait for the
                 // queue to be empty
-                return result;
+                return self
+                    .handler
+                    .get_execution_result(&epoch_hash)
+                    .expect("it should success");
             }
             let (sender, receiver) = channel();
             debug!("Wait for execution result of epoch {:?}", epoch_hash);

--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -340,10 +340,8 @@ impl ConsensusExecutor {
                         if *index == pivot_arena_index {
                             no_reward =
                                 block_consensus_node.data.partial_invalid
-                                    || !inner
-                                        .execution_info_cache
-                                        .get(&pivot_arena_index)
-                                        .unwrap()
+                                    || !inner.arena[pivot_arena_index]
+                                        .data
                                         .state_valid;
                         } else {
                             no_reward = block_consensus_node

--- a/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
+++ b/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
@@ -1386,7 +1386,6 @@ impl ConsensusNewBlockHandler {
     /// recover receipts_root and logs_bloom_hash in pivot chain
     pub fn construct_pivot_state(&self, inner: &mut ConsensusGraphInner) {
         if inner.pivot_chain.len() < DEFERRED_STATE_EPOCH_COUNT as usize {
-            // full node will leave this function here
             return;
         }
         // recover `EpochExecutionCommitments` from

--- a/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
+++ b/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
@@ -1386,92 +1386,99 @@ impl ConsensusNewBlockHandler {
     /// recover receipts_root and logs_bloom_hash in pivot chain
     pub fn construct_pivot_state(&self, inner: &mut ConsensusGraphInner) {
         if inner.pivot_chain.len() < DEFERRED_STATE_EPOCH_COUNT as usize {
+            // full node will leave this function here
             return;
         }
-        // recover receipts_root and logs_bloom_hash from block header
+        // recover `EpochExecutionCommitments` from
+        // `execution_info_cache` or recompute the state if it is not exist in
+        // `execution_info_cache`
         for pivot_index in
-            DEFERRED_STATE_EPOCH_COUNT as usize..inner.pivot_chain.len()
+            0..inner.pivot_chain.len() - DEFERRED_STATE_EPOCH_COUNT as usize + 1
         {
             let arena_index = inner.pivot_chain[pivot_index];
-            let deffered_arena_index = inner.pivot_chain
-                [pivot_index - DEFERRED_STATE_EPOCH_COUNT as usize];
-            // block header must exist in db
-            let block_header = self
-                .data_man
-                .block_header_by_hash(&inner.arena[arena_index].hash)
-                .unwrap();
-            if inner.arena[deffered_arena_index].hash
-                != self.data_man.true_genesis_block.hash()
+            let exec_pivot_index =
+                pivot_index + DEFERRED_STATE_EPOCH_COUNT as usize;
+            if exec_pivot_index < inner.pivot_chain.len()
+                && inner
+                    .execution_info_cache
+                    .contains_key(&inner.pivot_chain[exec_pivot_index])
             {
-                self.data_man.insert_epoch_execution_commitments(
-                    inner.arena[deffered_arena_index].hash,
-                    *block_header.deferred_receipts_root(),
-                    *block_header.deferred_logs_bloom_hash(),
-                );
-            }
-        }
-        // Compute state for the deferred block of the mining block,
-        // which is may not in the db
-        let pivot_arena_index = inner.pivot_chain
-            [inner.pivot_chain.len() - DEFERRED_STATE_EPOCH_COUNT as usize];
-        let pivot_hash = inner.arena[pivot_arena_index].hash.clone();
-        if pivot_hash == inner.data_man.true_genesis_block.hash() {
-            return;
-        }
-        let epoch_arena_indices = &inner.arena[pivot_arena_index]
-            .data
-            .ordered_executable_epoch_blocks;
-        let mut epoch_receipts = Vec::with_capacity(epoch_arena_indices.len());
-
-        let mut receipts_correct = true;
-        for i in epoch_arena_indices {
-            if let Some(r) = self.data_man.block_results_by_hash_with_epoch(
-                &inner.arena[*i].hash,
-                &pivot_hash,
-                true,
-            ) {
-                epoch_receipts.push(r.receipts);
+                let exec_arena_index = inner.pivot_chain[exec_pivot_index];
+                let exec_info =
+                    inner.execution_info_cache.get(&exec_arena_index).unwrap();
+                if inner.arena[arena_index].hash
+                    != self.data_man.true_genesis_block.hash()
+                {
+                    self.data_man.insert_epoch_execution_commitments(
+                        inner.arena[arena_index].hash,
+                        exec_info.original_deferred_receipt_root,
+                        exec_info.original_deferred_logs_bloom_hash,
+                    );
+                }
             } else {
-                // Constructed pivot chain does not match receipts in
-                // db, so we have to recompute
-                // the receipts of this epoch
-                receipts_correct = false;
-                break;
+                let pivot_hash = inner.arena[arena_index].hash.clone();
+                if pivot_hash == inner.data_man.true_genesis_block.hash() {
+                    return;
+                }
+                let epoch_arena_indices = &inner.arena[arena_index]
+                    .data
+                    .ordered_executable_epoch_blocks;
+                let mut epoch_receipts =
+                    Vec::with_capacity(epoch_arena_indices.len());
+
+                let mut receipts_correct = true;
+                for i in epoch_arena_indices {
+                    if let Some(r) =
+                        self.data_man.block_results_by_hash_with_epoch(
+                            &inner.arena[*i].hash,
+                            &pivot_hash,
+                            true,
+                        )
+                    {
+                        epoch_receipts.push(r.receipts);
+                    } else {
+                        // Constructed pivot chain does not match receipts in
+                        // db, so we have to recompute
+                        // the receipts of this epoch
+                        receipts_correct = false;
+                        break;
+                    }
+                }
+                if receipts_correct {
+                    let pivot_receipts_root =
+                        BlockHeaderBuilder::compute_block_receipts_root(
+                            &epoch_receipts,
+                        );
+                    let pivot_logs_bloom_hash =
+                        BlockHeaderBuilder::compute_block_logs_bloom_hash(
+                            &epoch_receipts,
+                        );
+                    self.data_man.insert_epoch_execution_commitments(
+                        pivot_hash,
+                        pivot_receipts_root,
+                        pivot_logs_bloom_hash,
+                    );
+                } else {
+                    let reward_execution_info =
+                        self.executor.get_reward_execution_info(
+                            &self.data_man,
+                            inner,
+                            arena_index,
+                        );
+                    let epoch_block_hashes =
+                        inner.get_epoch_block_hashes(arena_index);
+                    let start_block_number =
+                        inner.get_epoch_start_block_number(arena_index);
+                    self.executor.compute_epoch(EpochExecutionTask::new(
+                        pivot_hash,
+                        epoch_block_hashes,
+                        start_block_number,
+                        reward_execution_info,
+                        true,
+                        false,
+                    ));
+                }
             }
-        }
-        if receipts_correct {
-            let pivot_receipts_root =
-                BlockHeaderBuilder::compute_block_receipts_root(
-                    &epoch_receipts,
-                );
-            let pivot_logs_bloom_hash =
-                BlockHeaderBuilder::compute_block_logs_bloom_hash(
-                    &epoch_receipts,
-                );
-            self.data_man.insert_epoch_execution_commitments(
-                pivot_hash,
-                pivot_receipts_root,
-                pivot_logs_bloom_hash,
-            );
-        } else {
-            let reward_execution_info =
-                self.executor.get_reward_execution_info(
-                    &self.data_man,
-                    inner,
-                    pivot_arena_index,
-                );
-            let epoch_block_hashes =
-                inner.get_epoch_block_hashes(pivot_arena_index);
-            let start_block_number =
-                inner.get_epoch_start_block_number(pivot_arena_index);
-            self.executor.compute_epoch(EpochExecutionTask::new(
-                pivot_hash,
-                epoch_block_hashes,
-                start_block_number,
-                reward_execution_info,
-                true,
-                false,
-            ));
         }
     }
 }

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -26,7 +26,7 @@ use crate::parameters::{
     block::REFEREE_BOUND, consensus::*, consensus_internal::*,
 };
 use metrics::{register_meter_with_group, Meter, MeterTimer};
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use primitives::{
     filter::{Filter, FilterError},
     log_entry::{LocalizedLogEntry, LogEntry},
@@ -35,7 +35,10 @@ use primitives::{
 };
 use rayon::prelude::*;
 use std::{
-    cmp::Reverse, collections::HashSet, sync::Arc, thread::sleep,
+    cmp::Reverse,
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    thread::sleep,
     time::Duration,
 };
 
@@ -110,6 +113,15 @@ pub struct ConsensusGraph {
     /// Make sure that it is only modified when holding inner lock to prevent
     /// any inconsistency
     best_info: RwLock<Arc<BestInformation>>,
+    /// This is the hash of latest block inserted into consensus graph.
+    /// Since the critical section is very short, a `Mutex` is enough.
+    pub latest_inserted_block: Mutex<H256>,
+    /// This HashMap stores whether the state in header is correct or not for
+    /// pivot blocks from current era genesis to first trusted blame block
+    /// after current era stable genesis.
+    /// We use `Mutex` here because other thread will only modify it once and
+    /// after that only current thread will operate this map.
+    pub pivot_block_state_valid_map: Mutex<HashMap<H256, bool>>,
 }
 
 pub type SharedConsensusGraph = Arc<ConsensusGraph>;
@@ -130,6 +142,7 @@ impl ConsensusGraph {
                 data_man.clone(),
                 conf.inner_conf.clone(),
                 era_genesis_block_hash,
+                None,
             )));
         let executor = ConsensusExecutor::start(
             txpool.clone(),
@@ -151,6 +164,8 @@ impl ConsensusGraph {
             ),
             confirmation_meter,
             best_info: RwLock::new(Arc::new(Default::default())),
+            latest_inserted_block: Mutex::new(*era_genesis_block_hash),
+            pivot_block_state_valid_map: Mutex::new(Default::default()),
         };
         graph.update_best_info(&*graph.inner.read());
         graph
@@ -401,17 +416,28 @@ impl ConsensusGraph {
             MeterTimer::time_func(CONSENSIS_ON_NEW_BLOCK_TIMER.as_ref());
         self.statistics.inc_consensus_graph_processed_block_count();
 
-        if !ignore_body {
-            let block = self.data_man.block_by_hash(hash, true).unwrap();
-            debug!(
-                "insert new block into consensus: block_header={:?} tx_count={}, block_size={}",
-                block.block_header,
-                block.transactions.len(),
-                block.size(),
-            );
+        let block_opt = if ignore_body {
+            None
+        } else {
+            self.data_man.block_by_hash(hash, true)
+        };
 
-            {
-                let inner = &mut *self.inner.write();
+        let header_opt = if ignore_body {
+            self.data_man.block_header_by_hash(hash)
+        } else {
+            None
+        };
+
+        {
+            let inner = &mut *self.inner.write();
+            if !ignore_body {
+                let block = block_opt.unwrap();
+                debug!(
+                    "insert new block into consensus: block_header={:?} tx_count={}, block_size={}",
+                    block.block_header,
+                    block.transactions.len(),
+                    block.size(),
+                );
                 self.new_block_handler.on_new_block(
                     inner,
                     &self.confirmation_meter,
@@ -419,20 +445,12 @@ impl ConsensusGraph {
                     &block.block_header,
                     Some(&block.transactions),
                 );
-                self.update_best_info(inner);
-            }
-            self.txpool
-                .notify_new_best_info(self.best_info.read().clone());
-        } else {
-            // This `ignore_body` case will only be used during recovery from
-            // checkpoint, either from db or from remote peers
-            let header = self.data_man.block_header_by_hash(hash).unwrap();
-            debug!(
-                "insert new block_header into consensus: block_header={:?}",
-                header
-            );
-            {
-                let inner = &mut *self.inner.write();
+            } else {
+                let header = header_opt.unwrap();
+                debug!(
+                    "insert new block_header into consensus: block_header={:?}",
+                    header
+                );
                 self.new_block_handler.on_new_block(
                     inner,
                     &self.confirmation_meter,
@@ -440,6 +458,7 @@ impl ConsensusGraph {
                     header.as_ref(),
                     None,
                 );
+                // for archive node, we should recover exec_info from db
                 if let Some(arena_index) = inner.hash_to_arena_indices.get(hash)
                 {
                     if let Some(exe_info) = self
@@ -451,18 +470,28 @@ impl ConsensusGraph {
                             .insert(*arena_index, exe_info);
                     }
                 }
-
-                // If we have recovered all blocks in the past of stable block,
-                // we should reset the pivot chain. And later
-                // processed blocks may not be pending.
-                if *hash == self.data_man.get_cur_consensus_era_stable_hash() {
-                    inner.set_pivot_to_stable(hash);
-                }
-                self.update_best_info(inner);
             }
-            self.txpool
-                .notify_new_best_info(self.best_info.read().clone());
+
+            // for full node, we should recover state_valid for pivot block
+            let mut pivot_block_state_valid_map =
+                self.pivot_block_state_valid_map.lock();
+            if !pivot_block_state_valid_map.is_empty()
+                && pivot_block_state_valid_map.contains_key(&hash)
+            {
+                let arena_index =
+                    *inner.hash_to_arena_indices.get(&hash).unwrap();
+                inner.arena[arena_index].data.state_valid =
+                    pivot_block_state_valid_map.remove(&hash).unwrap();
+            }
+
+            self.update_best_info(inner);
+            if *hash == self.data_man.get_cur_consensus_era_stable_hash() {
+                inner.set_pivot_to_stable(hash);
+            }
         }
+        self.txpool
+            .notify_new_best_info(self.best_info.read().clone());
+        *self.latest_inserted_block.lock() = *hash;
     }
 
     pub fn best_block_hash(&self) -> H256 {
@@ -734,11 +763,10 @@ impl ConsensusGraph {
         self.inner.read().old_era_block_set.lock().pop_front()
     }
 
-    pub fn get_trusted_blame_block(&self) -> Option<H256> {
+    /// Find a trusted blame block for checkpoint
+    pub fn get_trusted_blame_block(&self, stable_hash: &H256) -> Option<H256> {
         let inner = self.inner.read();
-        inner
-            .find_first_index_with_correct_state_of(0)
-            .and_then(|index| Some(inner.arena[inner.pivot_chain[index]].hash))
+        inner.get_trusted_blame_block(stable_hash)
     }
 
     pub fn first_trusted_header_starting_from(

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -462,18 +462,6 @@ impl ConsensusGraph {
                     header.as_ref(),
                     None,
                 );
-                // for archive node, we should recover exec_info from db
-                if let Some(arena_index) = inner.hash_to_arena_indices.get(hash)
-                {
-                    if let Some(exe_info) = self
-                        .data_man
-                        .consensus_graph_execution_info_from_db(hash)
-                    {
-                        inner
-                            .execution_info_cache
-                            .insert(*arena_index, exe_info);
-                    }
-                }
             }
 
             // for full node, we should recover state_valid for pivot block
@@ -486,6 +474,15 @@ impl ConsensusGraph {
                     *inner.hash_to_arena_indices.get(&hash).unwrap();
                 inner.arena[arena_index].data.state_valid =
                     pivot_block_state_valid_map.remove(&hash).unwrap();
+            }
+
+            // we should recover exec_info from db
+            if let Some(arena_index) = inner.hash_to_arena_indices.get(hash) {
+                if let Some(exe_info) =
+                    self.data_man.consensus_graph_execution_info_from_db(hash)
+                {
+                    inner.execution_info_cache.insert(*arena_index, exe_info);
+                }
             }
 
             self.update_best_info(inner);

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -446,6 +446,10 @@ impl ConsensusGraph {
                     Some(&block.transactions),
                 );
             } else {
+                // This `ignore_body` case will only be used when
+                // 1. archive node is in `CatchUpRecoverBlockFromDB` phase
+                // 2. full node is in `CatchUpRecoverBlockHeaderFromDB`,
+                // `CatchUpSyncBlockHeader` or `CatchUpRecoverBlockFromDB` phase
                 let header = header_opt.unwrap();
                 debug!(
                     "insert new block_header into consensus: block_header={:?}",

--- a/core/src/parameters.rs
+++ b/core/src/parameters.rs
@@ -16,6 +16,9 @@ pub mod consensus {
     pub const ERA_DEFAULT_EPOCH_COUNT: u64 = 50000;
     // FIXME: We should use finality to determine the checkpoint moment instead.
     pub const ERA_DEFAULT_CHECKPOINT_GAP: u64 = 50000;
+
+    pub const NULL: usize = !0;
+    pub const NULLU64: u64 = !0;
 }
 
 pub mod consensus_internal {

--- a/core/src/sync/state/snapshot_chunk_sync.rs
+++ b/core/src/sync/state/snapshot_chunk_sync.rs
@@ -470,8 +470,8 @@ impl SnapshotChunkSync {
             return None;
         }
         // check checkpoint position in `state_blame_vec`
-        let offset = trusted_blame_block.height() - checkpoint.height()
-            + DEFERRED_STATE_EPOCH_COUNT;
+        let offset = trusted_blame_block.height()
+            - (checkpoint.height() + DEFERRED_STATE_EPOCH_COUNT);
         if offset as usize >= state_blame_vec.len() {
             return None;
         }

--- a/core/src/sync/state/snapshot_manifest_request.rs
+++ b/core/src/sync/state/snapshot_manifest_request.rs
@@ -37,11 +37,15 @@ impl Handleable for SnapshotManifestRequest {
                 _ => RangedManifest::default(),
             };
 
+        let (state_blame_vec, receipt_blame_vec, bloom_blame_vec) =
+            self.get_blame_states(ctx).unwrap_or_default();
         ctx.send_response(&SnapshotManifestResponse {
             request_id: self.request_id,
             checkpoint: self.checkpoint.clone(),
             manifest,
-            state_blame_vec: self.get_blame_states(ctx).unwrap_or_default(),
+            state_blame_vec,
+            receipt_blame_vec,
+            bloom_blame_vec,
         })
     }
 }
@@ -70,7 +74,9 @@ impl SnapshotManifestRequest {
     /// return an empty vec if some information not exist in db, caller may find
     /// another peer to send the request; otherwise return a state_blame_vec
     /// of the requested block
-    fn get_blame_states(self, ctx: &Context) -> Option<Vec<H256>> {
+    fn get_blame_states(
+        &self, ctx: &Context,
+    ) -> Option<(Vec<H256>, Vec<H256>, Vec<H256>)> {
         let trusted_block = ctx
             .manager
             .graph
@@ -78,6 +84,8 @@ impl SnapshotManifestRequest {
             .block_header_by_hash(&self.trusted_blame_block?)?;
 
         let mut state_blame_vec = Vec::new();
+        let mut receipt_blame_vec = Vec::new();
+        let mut bloom_blame_vec = Vec::new();
         let mut block_hash = trusted_block.hash();
         let mut request_invalid = false;
         loop {
@@ -88,6 +96,10 @@ impl SnapshotManifestRequest {
                 .consensus_graph_execution_info_from_db(&block_hash)
             {
                 state_blame_vec.push(exec_info.original_deferred_state_root);
+                receipt_blame_vec
+                    .push(exec_info.original_deferred_receipt_root);
+                bloom_blame_vec
+                    .push(exec_info.original_deferred_logs_bloom_hash);
                 if state_blame_vec.len() == trusted_block.blame() as usize + 1 {
                     break;
                 }
@@ -113,7 +125,7 @@ impl SnapshotManifestRequest {
         if request_invalid {
             None
         } else {
-            Some(state_blame_vec)
+            Some((state_blame_vec, receipt_blame_vec, bloom_blame_vec))
         }
     }
 }

--- a/core/src/sync/state/snapshot_manifest_response.rs
+++ b/core/src/sync/state/snapshot_manifest_response.rs
@@ -21,6 +21,8 @@ pub struct SnapshotManifestResponse {
     pub checkpoint: H256,
     pub manifest: RangedManifest,
     pub state_blame_vec: Vec<H256>,
+    pub receipt_blame_vec: Vec<H256>,
+    pub bloom_blame_vec: Vec<H256>,
 }
 
 build_msg_impl! { SnapshotManifestResponse, msgid::GET_SNAPSHOT_MANIFEST_RESPONSE, "SnapshotManifestResponse" }
@@ -77,6 +79,13 @@ impl SnapshotManifestResponse {
             && self.state_blame_vec.is_empty()
         {
             debug!("Responded snapshot manifest has empty blame states");
+            bail!(ErrorKind::Invalid);
+        }
+
+        if self.state_blame_vec.len() != self.receipt_blame_vec.len()
+            || self.state_blame_vec.len() != self.bloom_blame_vec.len()
+        {
+            debug!("Responded snapshot manifest has mismatch blame states/receipts/blooms");
             bail!(ErrorKind::Invalid);
         }
 

--- a/core/src/sync/synchronization_phases.rs
+++ b/core/src/sync/synchronization_phases.rs
@@ -318,6 +318,7 @@ impl SynchronizationPhaseTrait for CatchUpCheckpointPhase {
             if self.state_sync.status() == Status::Completed {
                 DynamicCapability::ServeCheckpoint(Some(checkpoint))
                     .broadcast(io, &sync_handler.syn);
+                self.state_sync.restore_execution_state(sync_handler);
                 return SyncPhaseType::CatchUpRecoverBlockFromDB;
             }
         } else {

--- a/core/src/sync/synchronization_phases.rs
+++ b/core/src/sync/synchronization_phases.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     consensus::ConsensusGraphInner,
-    parameters::sync::CATCH_UP_EPOCH_LAG_THRESHOLD,
+    parameters::{consensus::NULL, sync::CATCH_UP_EPOCH_LAG_THRESHOLD},
     sync::{
         message::DynamicCapability,
         state::{SnapshotChunkSync, Status},
@@ -21,6 +21,7 @@ use std::{
         atomic::{AtomicBool, Ordering as AtomicOrdering},
         Arc,
     },
+    thread, time,
 };
 
 ///
@@ -307,7 +308,7 @@ impl SynchronizationPhaseTrait for CatchUpCheckpointPhase {
         let checkpoint = sync_handler
             .graph
             .data_man
-            .get_cur_consensus_era_genesis_hash();
+            .get_cur_consensus_era_stable_hash();
 
         if self.state_sync.checkpoint() == checkpoint {
             if let Status::Restoring(_) = self.state_sync.status() {
@@ -321,7 +322,11 @@ impl SynchronizationPhaseTrait for CatchUpCheckpointPhase {
             }
         } else {
             // start to sync new checkpoint if new era started,
-            match sync_handler.graph.consensus.get_trusted_blame_block() {
+            match sync_handler
+                .graph
+                .consensus
+                .get_trusted_blame_block(&checkpoint)
+            {
                 Some(block) => {
                     self.state_sync.start(checkpoint, block, io, sync_handler)
                 }
@@ -345,12 +350,12 @@ impl SynchronizationPhaseTrait for CatchUpCheckpointPhase {
         let checkpoint = sync_handler
             .graph
             .data_man
-            .get_cur_consensus_era_genesis_hash();
+            .get_cur_consensus_era_stable_hash();
 
         let trusted_blame_block = match sync_handler
             .graph
             .consensus
-            .get_trusted_blame_block()
+            .get_trusted_blame_block(&checkpoint)
         {
             Some(block) => block,
             None => {
@@ -410,17 +415,72 @@ impl SynchronizationPhaseTrait for CatchUpRecoverBlockFromDbPhase {
     {
         info!("start phase {:?}", self.name());
         {
-            let (cur_era_genesis_hash, _) =
-                self.graph.get_genesis_hash_and_height_in_current_era();
-            // Acquire both lock first to ensure consistency
-            let old_consensus_inner = &mut *self.graph.consensus.inner.write();
+            // Acquire the lock of synchronization graph first to make sure no
+            // more blocks will be inserted into synchronization graph.
             let old_sync_inner = &mut *self.graph.inner.write();
+            // Wait until all the graph ready blocks in queue are inserted into
+            // consensus graph.
+            while *self.graph.latest_graph_ready_block.lock()
+                != *self.graph.consensus.latest_inserted_block.lock()
+            {
+                thread::sleep(time::Duration::from_millis(100));
+            }
+            // Now, we can safely acquire the lock of consensus graph
+            let old_consensus_inner = &mut *self.graph.consensus.inner.write();
+
+            let (cur_era_genesis_hash, _) =
+                old_sync_inner.get_genesis_hash_and_height_in_current_era();
+
+            // TODO: Make sure that the checkpoint will not change between the
+            // end of CatchUpCheckpointPhase and the start of
+            // CatchUpRecoverBlockFromDbPhase.
+            let checkpoint =
+                self.graph.data_man.get_cur_consensus_era_stable_hash();
+            // For archive node, this will be `None` or `checkpoint` if
+            // `checkpoint` is true genesis.
+            // For full node, this will never be `None` and we will get first
+            // pivot block whose `state_valid` is `true` after `checkpoint`
+            // (include `checkpoint` itself).
+            let trusted_blame_block =
+                old_consensus_inner.get_trusted_blame_block(&checkpoint);
+            // This map will be used to recover `state_valid` info for each
+            // pivot block before `trusted_blame_block`.
+            let mut pivot_block_state_valid_map =
+                self.graph.consensus.pivot_block_state_valid_map.lock();
+            if trusted_blame_block.is_some() {
+                let mut cur = *old_consensus_inner
+                    .hash_to_arena_indices
+                    .get(trusted_blame_block.as_ref().unwrap())
+                    .unwrap();
+                while cur != NULL {
+                    let blame = self
+                        .graph
+                        .data_man
+                        .block_header_by_hash(
+                            &old_consensus_inner.arena[cur].hash,
+                        )
+                        .unwrap()
+                        .blame();
+                    for i in 0..blame + 1 {
+                        pivot_block_state_valid_map.insert(
+                            old_consensus_inner.arena[cur].hash,
+                            i == 0,
+                        );
+                        cur = old_consensus_inner.arena[cur].parent;
+                        if cur == NULL {
+                            break;
+                        }
+                    }
+                }
+            }
+
             let new_consensus_inner =
                 ConsensusGraphInner::with_era_genesis_block(
                     old_consensus_inner.pow_config.clone(),
                     self.graph.data_man.clone(),
                     old_consensus_inner.inner_conf.clone(),
                     &cur_era_genesis_hash,
+                    trusted_blame_block,
                 );
             self.graph.consensus.update_best_info(&new_consensus_inner);
             *old_consensus_inner = new_consensus_inner;
@@ -433,6 +493,15 @@ impl SynchronizationPhaseTrait for CatchUpRecoverBlockFromDbPhase {
                 old_sync_inner.data_man.clone(),
             );
             *old_sync_inner = new_sync_inner;
+
+            // If `checkpoint` is true genesis, `state_valid` must be true.
+            if checkpoint == self.graph.data_man.true_genesis_block.hash()
+                && pivot_block_state_valid_map.contains_key(&checkpoint)
+            {
+                assert!(pivot_block_state_valid_map
+                    .remove(&checkpoint)
+                    .unwrap());
+            }
 
             self.graph
                 .statistics


### PR DESCRIPTION
#### Archive Node:

We need restore `ConsensusGraphExecutionInfo` and `EpochExecutionCommitments` for blocks in pivot chain from db. We can directly load `ConsensusGraphExecutionInfo` from db. The `EpochExecutionCommitments` comes from two parts. For those blocks having `ConsensusGraphExecutionInfo`, we can restore `EpochExecutionCommitments` for the corresponding deferred blocks. For other blocks, a re-execution is needed.

#### Full Node

1. We should synchronize the snapshot for stable genesis instead of current genesis.
2. After the synchronization and validation of checkpoint, we can know whether the states stored in header are correct based on the blame info of the `first_trusted_blame_block` after  stable  genesis. Also, we can recover the `EpochExecutionCommitments` and `StateRoot` of stable genesis. So we can safely begin execution process after stable genesis. However, the state of blocks between stable genesis and `first_trusted_blame_block` can't be verified since we don't have the `ConsensusGraphExecutionInfo` before stable genesis.
3. As a result, we will not verified the state of blocks until the `first_trusted_blame_block` appears in pivot chain (i.e. If the lowest common ancestor of current block's parent and `first_trusted_blame_block` is before `first_trusted_blame_block`, we will not verify the state for current block).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/588)
<!-- Reviewable:end -->
