### PR TITLE
Integrate the new added storage API to sync checkpoint

### DIFF
--- a/core/src/storage/impls/storage_db/snapshot_sync.rs
+++ b/core/src/storage/impls/storage_db/snapshot_sync.rs
@@ -6,7 +6,6 @@ use crate::storage::impls::errors::Error;
 use cfx_types::H256;
 use primitives::{MerkleHash, StateRoot};
 use rlp_derive::{RlpDecodable, RlpEncodable};
-use std::sync::mpsc::Sender;
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, RlpDecodable, RlpEncodable)]
 pub struct ChunkKey {}
@@ -62,16 +61,15 @@ impl Restorer {
         unimplemented!()
     }
 
-    /// Start to restore chunks asynchronously and notify the restoration
-    /// progress with specified sender.
-    pub fn start_to_restore(&self, _progress_sender: Sender<RestoreProgress>) {
-        unimplemented!()
-    }
+    /// Start to restore chunks asynchronously.
+    pub fn start_to_restore(&self) { unimplemented!() }
 
     /// Check if the restored snapshot match with the specified snapshot root.
     pub fn is_valid(&self, _snapshot_root: &MerkleHash) -> bool {
         unimplemented!()
     }
+
+    pub fn progress(&self) -> RestoreProgress { unimplemented!() }
 
     pub fn restored_state_root(&self) -> StateRoot { unimplemented!() }
 }

--- a/core/src/storage/impls/storage_db/snapshot_sync.rs
+++ b/core/src/storage/impls/storage_db/snapshot_sync.rs
@@ -2,12 +2,16 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use crate::storage::impls::errors::*;
-use primitives::MerkleHash;
+use crate::storage::impls::errors::Error;
+use cfx_types::H256;
+use primitives::{MerkleHash, StateRoot};
+use rlp_derive::{RlpDecodable, RlpEncodable};
 use std::sync::mpsc::Sender;
 
+#[derive(Clone, Debug, Eq, PartialEq, Hash, RlpDecodable, RlpEncodable)]
 pub struct ChunkKey {}
 
+#[derive(Default, RlpDecodable, RlpEncodable)]
 pub struct RangedManifest {}
 
 impl RangedManifest {
@@ -15,8 +19,8 @@ impl RangedManifest {
     /// requested start chunk key. Basically, the retrieved chunks should
     /// not be empty, and the proofs of all chunk keys are valid.
     pub fn validate(
-        &self, _snapshot_root: &MerkleHash, _start_chunk: &ChunkKey,
-    ) -> Result<()> {
+        &self, _snapshot_root: &MerkleHash, _start_chunk: &Option<ChunkKey>,
+    ) -> Result<(), Error> {
         unimplemented!()
     }
 
@@ -25,19 +29,31 @@ impl RangedManifest {
     pub fn chunks(&self) -> Vec<ChunkKey> { unimplemented!() }
 
     // todo validate the integrity of all manifest, e.g. no chunk missed
+
+    pub fn load(
+        _checkpoint: &H256, _start_chunk: &Option<ChunkKey>,
+    ) -> Result<Option<RangedManifest>, Error> {
+        unimplemented!()
+    }
 }
 
+#[derive(Default, RlpDecodable, RlpEncodable)]
 pub struct Chunk {}
 
 impl Chunk {
     /// Validate the chunk with specified key and snapshot merkle root.
     pub fn validate(
         &self, _key: &ChunkKey, _snapshot_root: &MerkleHash,
-    ) -> Result<()> {
+    ) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    pub fn load(_chunk_key: &ChunkKey) -> Result<Option<Chunk>, Error> {
         unimplemented!()
     }
 }
 
+#[derive(Default)]
 pub struct Restorer {}
 
 impl Restorer {
@@ -48,9 +64,7 @@ impl Restorer {
 
     /// Start to restore chunks asynchronously and notify the restoration
     /// progress with specified sender.
-    /// The progress is (num_pending_chunks, num_restored_chunks),
-    /// and snapshot restoration completed when num_pending_chunks is 0.
-    pub fn start_to_restore(&self, _progress_sender: Sender<(usize, usize)>) {
+    pub fn start_to_restore(&self, _progress_sender: Sender<RestoreProgress>) {
         unimplemented!()
     }
 
@@ -58,4 +72,13 @@ impl Restorer {
     pub fn is_valid(&self, _snapshot_root: &MerkleHash) -> bool {
         unimplemented!()
     }
+
+    pub fn restored_state_root(&self) -> StateRoot { unimplemented!() }
+}
+
+#[derive(Default, Debug)]
+pub struct RestoreProgress {}
+
+impl RestoreProgress {
+    pub fn is_completed(&self) -> bool { unimplemented!() }
 }

--- a/core/src/storage/mod.rs
+++ b/core/src/storage/mod.rs
@@ -21,7 +21,7 @@ pub use self::{
             guarded_value::GuardedValue, MultiVersionMerklePatriciaTrie,
         },
         storage_db::snapshot_sync::{
-            Chunk, ChunkKey, RangedManifest, Restorer,
+            Chunk, ChunkKey, RangedManifest, RestoreProgress, Restorer,
         },
     },
     state::{State as Storage, StateTrait as StorageTrait},

--- a/core/src/sync/state/mod.rs
+++ b/core/src/sync/state/mod.rs
@@ -8,28 +8,6 @@ mod snapshot_chunk_sync;
 mod snapshot_manifest_request;
 mod snapshot_manifest_response;
 
-use crate::sync::SynchronizationProtocolHandler;
-use cfx_types::H256;
-use network::NetworkContext;
-
-/// Trait of sync state with given checkpoint. Generally, there're 2 ways
-/// to sync state:
-/// 1. Recursively sync the state MPT from root node to leaf node without
-/// accurate progress.
-/// 2. Divide the state MPT into different chunks, and sync up all chunks
-/// with accurate progress.
-pub trait StateSync {
-    /// Start to sync state for the specified checkpoint.
-    /// - If sync is inactive, then start to sync state.
-    /// - Otherwise if checkpoint not changed, then no-op happen.
-    /// - Otherwise, cleanup the previous sync and start new sync.
-    fn start(
-        &self, _checkpoint: H256, _trusted_blame_block: H256,
-        _io: &dyn NetworkContext,
-        _sync_handler: &SynchronizationProtocolHandler,
-    );
-}
-
 pub use self::{
     snapshot_chunk_request::SnapshotChunkRequest,
     snapshot_chunk_response::SnapshotChunkResponse,

--- a/core/src/sync/state/snapshot_chunk_sync.rs
+++ b/core/src/sync/state/snapshot_chunk_sync.rs
@@ -350,6 +350,10 @@ impl SnapshotChunkSync {
         };
 
         inner.restore_progress = inner.restorer.progress();
+        trace!(
+            "Snapshot chunk restoration progress: {:?}",
+            inner.restore_progress
+        );
         if !inner.restore_progress.is_completed() {
             return;
         }

--- a/core/src/sync/state/snapshot_chunk_sync.rs
+++ b/core/src/sync/state/snapshot_chunk_sync.rs
@@ -341,6 +341,7 @@ impl SnapshotChunkSync {
         debug!("sync state progress: {:?}", *inner);
     }
 
+    /// Update the progress of snapshot restoration.
     pub fn update_restore_progress(&self) {
         let mut inner = self.inner.write();
 

--- a/core/src/sync/state/snapshot_chunk_sync.rs
+++ b/core/src/sync/state/snapshot_chunk_sync.rs
@@ -2,23 +2,26 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use crate::sync::{
-    message::{Context, DynamicCapability},
-    state::{
-        snapshot_chunk_request::SnapshotChunkRequest,
-        snapshot_manifest_request::SnapshotManifestRequest,
-        snapshot_manifest_response::SnapshotManifestResponse, StateSync,
+use crate::{
+    storage::{Chunk, ChunkKey, RestoreProgress, Restorer},
+    sync::{
+        message::{Context, DynamicCapability},
+        state::{
+            snapshot_chunk_request::SnapshotChunkRequest,
+            snapshot_manifest_request::SnapshotManifestRequest,
+            snapshot_manifest_response::SnapshotManifestResponse, StateSync,
+        },
+        SynchronizationProtocolHandler,
     },
-    SynchronizationProtocolHandler,
 };
-use cfx_bytes::Bytes;
 use cfx_types::H256;
 use network::{NetworkContext, PeerId};
 use parking_lot::RwLock;
 use primitives::BlockHeaderBuilder;
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{HashSet, VecDeque},
     fmt::{Debug, Formatter, Result},
+    sync::{mpsc::channel, Arc},
     time::Instant,
 };
 
@@ -27,6 +30,7 @@ pub enum Status {
     Inactive,
     DownloadingManifest(Instant),
     DownloadingChunks(Instant),
+    Restoring(Instant),
     Completed,
     Invalid,
 }
@@ -45,6 +49,9 @@ impl Debug for Status {
             Status::DownloadingChunks(t) => {
                 format!("downloading chunks ({:?})", t.elapsed())
             }
+            Status::Restoring(t) => {
+                format!("restoring chunks ({:?})", t.elapsed())
+            }
             Status::Completed => "completed".into(),
             Status::Invalid => "invalid".into(),
         };
@@ -58,11 +65,18 @@ struct Inner {
     checkpoint: H256,
     trusted_blame_block: H256,
     status: Status,
-    state_blame_vec: Vec<H256>,
-    pending_chunks: VecDeque<H256>,
-    downloading_chunks: HashSet<H256>,
-    restoring_chunks: HashSet<H256>,
-    restored_chunks: HashSet<H256>,
+
+    // blame state that used to verify restored state root
+    blame_state: H256,
+
+    // download
+    pending_chunks: VecDeque<ChunkKey>,
+    downloading_chunks: HashSet<ChunkKey>,
+    num_downloaded: usize,
+
+    // restore
+    restorer: Restorer,
+    restore_progress: RestoreProgress,
 }
 
 impl Inner {
@@ -70,11 +84,12 @@ impl Inner {
         self.checkpoint = checkpoint;
         self.trusted_blame_block = trusted_blame_block;
         self.status = Status::DownloadingManifest(Instant::now());
-        self.state_blame_vec.clear();
+        self.blame_state = H256::new();
         self.pending_chunks.clear();
         self.downloading_chunks.clear();
-        self.restoring_chunks.clear();
-        self.restored_chunks.clear();
+        self.num_downloaded = 0;
+        self.restorer = Restorer::default();
+        self.restore_progress = RestoreProgress::default();
     }
 }
 
@@ -82,18 +97,18 @@ impl Debug for Inner {
     fn fmt(&self, f: &mut Formatter) -> Result {
         write!(
             f,
-            "(status = {:?}, pending = {}, downloading = {}, restoring = {}, restored = {})",
+            "(status = {:?}, download = {}/{}/{}, restore progress = {:?})",
             self.status,
             self.pending_chunks.len(),
             self.downloading_chunks.len(),
-            self.restoring_chunks.len(),
-            self.restored_chunks.len(),
+            self.num_downloaded,
+            self.restore_progress,
         )
     }
 }
 
 pub struct SnapshotChunkSync {
-    inner: RwLock<Inner>,
+    inner: Arc<RwLock<Inner>>,
     max_download_peers: usize,
 }
 
@@ -115,21 +130,9 @@ impl StateSync for SnapshotChunkSync {
 
         self.abort();
 
-        inner.reset(checkpoint.clone(), trusted_blame_block.clone());
+        inner.reset(checkpoint, trusted_blame_block);
 
-        // start to request manifest with specified checkpoint
-        let request =
-            SnapshotManifestRequest::new(checkpoint, trusted_blame_block);
-        let peer = sync_handler.syn.get_random_peer_with_cap(Some(
-            DynamicCapability::ServeCheckpoint(Some(inner.checkpoint.clone())),
-        ));
-
-        sync_handler.request_manager.request_with_delay(
-            io,
-            Box::new(request),
-            peer,
-            None,
-        );
+        self.request_manifest(&inner, io, sync_handler);
     }
 }
 
@@ -153,6 +156,29 @@ impl SnapshotChunkSync {
 
     pub fn checkpoint(&self) -> H256 { self.inner.read().checkpoint.clone() }
 
+    /// request manifest from random peer
+    fn request_manifest(
+        &self, inner: &Inner, io: &dyn NetworkContext,
+        sync_handler: &SynchronizationProtocolHandler,
+    )
+    {
+        let request = SnapshotManifestRequest::new(
+            inner.checkpoint.clone(),
+            inner.trusted_blame_block.clone(),
+        );
+
+        let peer = sync_handler.syn.get_random_peer_with_cap(Some(
+            DynamicCapability::ServeCheckpoint(Some(inner.checkpoint.clone())),
+        ));
+
+        sync_handler.request_manager.request_with_delay(
+            io,
+            Box::new(request),
+            peer,
+            None,
+        );
+    }
+
     pub fn handle_snapshot_manifest_response(
         &self, ctx: &Context, response: SnapshotManifestResponse,
     ) {
@@ -168,27 +194,59 @@ impl SnapshotChunkSync {
         }
 
         // status mismatch
-        match inner.status {
-            Status::DownloadingManifest(start_time) => {
-                info!(
-                    "Snapshot manifest received, checkpoint = {:?}, elapsed = {:?}, chunks = {}",
-                    inner.checkpoint,
-                    start_time.elapsed(),
-                    response.chunk_hashes.len(),
-                );
-            }
+        let start_time = match inner.status {
+            Status::DownloadingManifest(start_time) => start_time,
             _ => {
                 info!("Snapshot manifest received, but mismatch with current status {:?}", inner.status);
                 return;
             }
+        };
+
+        // validate blame state if requested
+        if !response.state_blame_vec.is_empty() {
+            match Self::validate_blame_states(
+                ctx,
+                &inner.checkpoint,
+                &inner.trusted_blame_block,
+                response.state_blame_vec,
+            ) {
+                Some(state) => inner.blame_state = state,
+                None => {
+                    warn!("failed to validate the blame state, re-sync manifest from other peer");
+                    self.resync_manifest(ctx, &mut inner);
+                    return;
+                }
+            }
         }
 
+        inner.pending_chunks.extend(response.manifest.chunks());
+
+        // continue to request remaining manifest if any
+        if let Some(next_chunk) = response.manifest.next_chunk() {
+            let request = SnapshotManifestRequest::new_with_start_chunk(
+                inner.checkpoint.clone(),
+                next_chunk,
+            );
+            ctx.manager.request_manager.request_with_delay(
+                ctx.io,
+                Box::new(request),
+                Some(ctx.peer),
+                None,
+            );
+            return;
+        }
+
+        // todo validate the integrity of manifest, and re-sync it if failed
+
+        info!(
+            "Snapshot manifest received, checkpoint = {:?}, elapsed = {:?}, chunks = {}",
+            inner.checkpoint,
+            start_time.elapsed(),
+            inner.pending_chunks.len(),
+        );
+
         // update status
-        inner
-            .pending_chunks
-            .extend(response.chunk_hashes.into_iter());
         inner.status = Status::DownloadingChunks(Instant::now());
-        inner.state_blame_vec = response.state_blame_vec;
 
         // request snapshot chunks from peers concurrently
         let peers = ctx.manager.syn.get_random_peers_satisfying(
@@ -210,15 +268,22 @@ impl SnapshotChunkSync {
         debug!("sync state progress: {:?}", *inner);
     }
 
+    fn resync_manifest(&self, ctx: &Context, inner: &mut Inner) {
+        let checkpoint = inner.checkpoint.clone();
+        let trusted_blame_block = inner.trusted_blame_block.clone();
+        inner.reset(checkpoint, trusted_blame_block);
+        self.request_manifest(&inner, ctx.io, ctx.manager);
+    }
+
     fn request_chunk(
         &self, ctx: &Context, inner: &mut Inner, peer: PeerId,
-    ) -> Option<H256> {
-        let chunk_hash = inner.pending_chunks.pop_front()?;
-        assert!(inner.downloading_chunks.insert(chunk_hash));
+    ) -> Option<ChunkKey> {
+        let chunk_key = inner.pending_chunks.pop_front()?;
+        assert!(inner.downloading_chunks.insert(chunk_key.clone()));
 
         let request = SnapshotChunkRequest::new(
             inner.checkpoint.clone(),
-            chunk_hash.clone(),
+            chunk_key.clone(),
         );
 
         ctx.manager.request_manager.request_with_delay(
@@ -228,55 +293,97 @@ impl SnapshotChunkSync {
             None,
         );
 
-        Some(chunk_hash)
+        Some(chunk_key)
     }
 
     pub fn handle_snapshot_chunk_response(
-        &self, ctx: &Context, chunk: H256, _kvs: HashMap<H256, Bytes>,
+        &self, ctx: &Context, chunk_key: ChunkKey, chunk: Chunk,
     ) {
         let mut inner = self.inner.write();
 
         // status mismatch
-        let download_start_time: Instant;
-        match inner.status {
+        let download_start_time = match inner.status {
             Status::DownloadingChunks(t) => {
-                download_start_time = t;
                 debug!(
                     "Snapshot chunk received, checkpoint = {:?}, chunk = {:?}",
-                    inner.checkpoint, chunk
+                    inner.checkpoint, chunk_key
                 );
+                t
             }
             _ => {
                 debug!("Snapshot chunk received, but mismatch with current status {:?}", inner.status);
                 return;
             }
-        }
+        };
 
         // maybe received a out-of-date snapshot chunk, e.g. new era started
-        if !inner.downloading_chunks.remove(&chunk) {
-            debug!("Snapshot chunk received, but not in downloading queue");
+        if !inner.downloading_chunks.remove(&chunk_key) {
+            info!("Snapshot chunk received, but not in downloading queue");
             return;
         }
 
-        assert_eq!(inner.restoring_chunks.contains(&chunk), false);
-        assert_eq!(inner.restored_chunks.contains(&chunk), false);
-
-        // todo restore the snapshot in storage
-        // 1. restore async (e.g. via channel, write to disk first)
-        // 2. when restore completed, verify the restored state root
-        inner.restoring_chunks.insert(chunk);
+        inner.num_downloaded += 1;
+        inner.restorer.append(&chunk_key, chunk);
 
         // continue to request remaining chunks
         self.request_chunk(ctx, &mut inner, ctx.peer);
 
+        // begin to restore if all chunks downloaded
         if inner.downloading_chunks.is_empty() {
             debug!(
                 "Snapshot chunks are all downloaded in {:?}",
                 download_start_time.elapsed()
             );
+
+            self.start_to_restore(&mut inner);
         }
 
         debug!("sync state progress: {:?}", *inner);
+    }
+
+    fn start_to_restore(&self, inner: &mut Inner) {
+        let (sender, receiver) = channel::<RestoreProgress>();
+
+        let inner_cloned = self.inner.clone();
+        std::thread::Builder::new()
+            .name("SnapshotRestoreMonitor".into())
+            .spawn(move || {
+                // monitor the restoration progress
+                while let Ok(rp) = receiver.recv() {
+                    let completed = rp.is_completed();
+                    trace!("Snapshot chunk restoration progress: {:?}", rp);
+                    inner_cloned.write().restore_progress = rp;
+                    if completed {
+                        break;
+                    }
+                }
+
+                let mut inner = inner_cloned.write();
+                match inner.status {
+                    Status::Restoring(t) => {
+                        info!("Snapshot chunks restoration completed in {:?}", t.elapsed());
+                    }
+                    _ => {
+                        info!("Snapshot chunks restoration completed, but mismatch with current status {:?}", inner.status);
+                        return;
+                    }
+                };
+
+                // verify the blame state
+                let root = inner.restorer.restored_state_root();
+                if root.compute_state_root_hash() == inner.blame_state {
+                    info!("Snapshot chunks restored successfully");
+                    inner.status = Status::Completed;
+                } else {
+                    warn!("Failed to restore snapshot chunks, blame state mismatch");
+                    inner.status = Status::Invalid;
+                }
+            })
+            .expect("should create thread to monitor snapshot restoration");
+
+        // start to restore and update status
+        inner.restorer.start_to_restore(sender);
+        inner.status = Status::Restoring(Instant::now());
     }
 
     pub fn on_checkpoint_served(&self, ctx: &Context, checkpoint: &H256) {
@@ -290,50 +397,46 @@ impl SnapshotChunkSync {
         }
     }
 
-    // todo call this method to validate the state root after chunks restored
-    #[allow(dead_code)]
-    fn validate_blame_states(&self, ctx: &Context, inner: &mut Inner) {
+    fn validate_blame_states(
+        ctx: &Context, checkpoint: &H256, trusted_blame_block: &H256,
+        state_blame_vec: Vec<H256>,
+    ) -> Option<H256>
+    {
         // these two header must exist in disk, it's safe to unwrap
         let checkpoint = ctx
             .manager
             .graph
             .data_man
-            .block_header_by_hash(&inner.checkpoint)
+            .block_header_by_hash(checkpoint)
             .unwrap();
         let trusted_blame_block = ctx
             .manager
             .graph
             .data_man
-            .block_header_by_hash(&inner.trusted_blame_block)
+            .block_header_by_hash(trusted_blame_block)
             .unwrap();
 
         // check blame count correct
-        if trusted_blame_block.blame() as usize + 1
-            != inner.state_blame_vec.len()
-        {
-            inner.status = Status::Invalid;
-            return;
+        if trusted_blame_block.blame() as usize + 1 != state_blame_vec.len() {
+            return None;
         }
         // check checkpoint position in `state_blame_vec`
         let offset = trusted_blame_block.height() - checkpoint.height();
-        if offset as usize >= inner.state_blame_vec.len() {
-            inner.status = Status::Invalid;
-            return;
+        if offset as usize >= state_blame_vec.len() {
+            return None;
         }
         let deferred_state_root = if trusted_blame_block.blame() == 0 {
-            inner.state_blame_vec[0].clone()
+            state_blame_vec[0].clone()
         } else {
             BlockHeaderBuilder::compute_blame_state_root_vec_root(
-                inner.state_blame_vec.to_vec(),
+                state_blame_vec.to_vec(),
             )
         };
         // check `deferred_state_root` is correct
         if deferred_state_root != *trusted_blame_block.deferred_state_root() {
-            inner.status = Status::Invalid;
-            return;
+            return None;
         }
-        // TODO: check state_blame_vec[offset] equals to recovered checkpoint
-        // state_root
-        inner.status = Status::Completed;
+
+        Some(state_blame_vec[offset as usize].clone())
     }
 }

--- a/core/src/sync/state/snapshot_manifest_response.rs
+++ b/core/src/sync/state/snapshot_manifest_response.rs
@@ -4,6 +4,7 @@
 
 use crate::{
     message::{Message, MsgId},
+    storage::RangedManifest,
     sync::{
         message::{msgid, Context, Handleable},
         state::SnapshotManifestRequest,
@@ -12,13 +13,13 @@ use crate::{
 };
 use cfx_types::H256;
 use rlp_derive::{RlpDecodable, RlpEncodable};
-use std::{any::Any, collections::HashSet};
+use std::any::Any;
 
-#[derive(Debug, RlpDecodable, RlpEncodable)]
+#[derive(RlpDecodable, RlpEncodable)]
 pub struct SnapshotManifestResponse {
     pub request_id: u64,
     pub checkpoint: H256,
-    pub chunk_hashes: Vec<H256>,
+    pub manifest: RangedManifest,
     pub state_blame_vec: Vec<H256>,
 }
 
@@ -34,7 +35,7 @@ impl Handleable for SnapshotManifestResponse {
             true,
         )?;
 
-        if let Err(e) = self.validate(request) {
+        if let Err(e) = self.validate(ctx, request) {
             ctx.manager
                 .request_manager
                 .remove_mismatch_request(ctx.io, &message);
@@ -50,7 +51,9 @@ impl Handleable for SnapshotManifestResponse {
 }
 
 impl SnapshotManifestResponse {
-    fn validate(&self, request: &SnapshotManifestRequest) -> Result<(), Error> {
+    fn validate(
+        &self, ctx: &Context, request: &SnapshotManifestRequest,
+    ) -> Result<(), Error> {
         if self.checkpoint != request.checkpoint {
             debug!(
                 "Responded snapshot manifest checkpoint mismatch, requested = {:?}, responded = {:?}",
@@ -60,19 +63,19 @@ impl SnapshotManifestResponse {
             bail!(ErrorKind::Invalid);
         }
 
-        if self.chunk_hashes.is_empty() {
-            debug!("Responded snapshot manifest has empty chunks");
+        let root = ctx.must_get_state_root(&self.checkpoint);
+
+        if let Err(e) = self
+            .manifest
+            .validate(&root.snapshot_root, &request.start_chunk)
+        {
+            debug!("failed to validate snapshot manifest, error = {:?}", e);
             bail!(ErrorKind::Invalid);
         }
 
-        let distinct_chunks: HashSet<H256> =
-            self.chunk_hashes.iter().cloned().collect();
-        if distinct_chunks.len() != self.chunk_hashes.len() {
-            debug!("Responded snapshot manifest has duplicated chunks");
-            bail!(ErrorKind::Invalid);
-        }
-
-        if self.state_blame_vec.is_empty() {
+        if request.trusted_blame_block.is_some()
+            && self.state_blame_vec.is_empty()
+        {
             debug!("Responded snapshot manifest has empty blame states");
             bail!(ErrorKind::Invalid);
         }


### PR DESCRIPTION
- Add more necessary storage API for checkpoint sync.
- Use storage data structures in snapshot requests/responses.
- Implement the "handle" trait of snapshot requests/responses with storage APIs.
- Add implementation for snapshot chunks restoration.
- Validate blame state in 2 phases: 1) get the manifest; 2) state restored;

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/589)
<!-- Reviewable:end -->
