### PR TITLE
Light node log filtering

### DIFF
--- a/client/src/rpc/impls/light.rs
+++ b/client/src/rpc/impls/light.rs
@@ -105,8 +105,12 @@ impl RpcImpl {
 
     #[allow(unused_variables)]
     fn get_logs(&self, filter: RpcFilter) -> RpcResult<Vec<RpcLog>> {
-        // TODO
-        unimplemented!()
+        info!("RPC Request: cfx_getLogs({:?})", filter);
+        self.light
+            .get_logs(filter.into())
+            .map(|logs| logs.iter().cloned().map(RpcLog::from).collect())
+            .map_err(|e| format!("Log filtering failed: {:?}", e))
+            .map_err(RpcError::invalid_params)
     }
 
     fn send_raw_transaction(&self, raw: Bytes) -> RpcResult<RpcH256> {

--- a/core/src/light_protocol/common/ledger_info.rs
+++ b/core/src/light_protocol/common/ledger_info.rs
@@ -6,15 +6,13 @@ use std::sync::Arc;
 
 use cfx_types::{Bloom, H256};
 use primitives::{
-    BlockHeader, BlockHeaderBuilder, EpochNumber, Receipt, StateRoot,
+    Block, BlockHeader, BlockHeaderBuilder, EpochNumber, Receipt, StateRoot,
 };
 
 use crate::{
     consensus::ConsensusGraph,
     light_protocol::{
-        message::{
-            ReceiptsWithProof, StateRootWithProof, WitnessInfoWithHeight,
-        },
+        message::{StateRootWithProof, WitnessInfoWithHeight},
         Error, ErrorKind,
     },
     parameters::consensus::DEFERRED_STATE_EPOCH_COUNT,
@@ -41,6 +39,26 @@ impl LedgerInfo {
         LedgerInfo { consensus }
     }
 
+    /// Get block `hash`, if it exists.
+    #[inline]
+    pub fn block(&self, hash: H256) -> Result<Block, Error> {
+        self.consensus
+            .data_man
+            .block_by_hash(&hash, false)
+            .map(|b| (*b).clone())
+            .ok_or(ErrorKind::InternalError.into())
+    }
+
+    /// Get header `hash`, if it exists.
+    #[inline]
+    pub fn header(&self, hash: H256) -> Result<BlockHeader, Error> {
+        self.consensus
+            .data_man
+            .block_header_by_hash(&hash)
+            .map(|h| (*h).clone())
+            .ok_or(ErrorKind::InternalError.into())
+    }
+
     /// Get hash of block at `height` on the pivot chain, if it exists.
     #[inline]
     pub fn pivot_hash_of(&self, height: u64) -> Result<H256, Error> {
@@ -52,10 +70,7 @@ impl LedgerInfo {
     #[inline]
     pub fn pivot_header_of(&self, height: u64) -> Result<BlockHeader, Error> {
         let pivot = self.pivot_hash_of(height)?;
-        let header = self.consensus.data_man.block_header_by_hash(&pivot);
-        header
-            .map(|h| (*h).clone())
-            .ok_or(ErrorKind::InternalError.into())
+        self.header(pivot)
     }
 
     /// Get all block hashes corresponding to the pivot block at `height`.
@@ -170,9 +185,7 @@ impl LedgerInfo {
     /// Get the epoch receipts corresponding to the execution of `epoch`.
     /// Returns a vector of receipts for each block in `epoch`.
     #[inline]
-    pub fn epoch_receipts_of(
-        &self, epoch: u64,
-    ) -> Result<Vec<Vec<Receipt>>, Error> {
+    pub fn receipts_of(&self, epoch: u64) -> Result<Vec<Vec<Receipt>>, Error> {
         let pivot = self.pivot_hash_of(epoch)?;
         let hashes = self.block_hashes_in(epoch)?;
 
@@ -186,23 +199,6 @@ impl LedgerInfo {
                     .ok_or(ErrorKind::InternalError.into())
             })
             .collect()
-    }
-
-    /// Get the epoch receipts corresponding to the execution of `epoch`.
-    /// Returns a ledger proof along with the receipts.
-    #[inline]
-    pub fn receipts_with_proof_of(
-        &self, epoch: u64,
-    ) -> Result<ReceiptsWithProof, Error> {
-        let receipts = self.epoch_receipts_of(epoch)?;
-
-        let proof = self
-            .headers_needed_to_verify(epoch)?
-            .into_iter()
-            .map(|h| self.correct_deferred_receipts_root_hash_of(h))
-            .collect::<Result<Vec<H256>, Error>>()?;
-
-        Ok(ReceiptsWithProof { receipts, proof })
     }
 
     /// Get the aggregated bloom corresponding to the execution of `epoch`.

--- a/core/src/light_protocol/common/ledger_info.rs
+++ b/core/src/light_protocol/common/ledger_info.rs
@@ -44,7 +44,7 @@ impl LedgerInfo {
     pub fn block(&self, hash: H256) -> Result<Block, Error> {
         self.consensus
             .data_man
-            .block_by_hash(&hash, false)
+            .block_by_hash(&hash, false /* update_cache */)
             .map(|b| (*b).clone())
             .ok_or(ErrorKind::InternalError.into())
     }
@@ -194,7 +194,9 @@ impl LedgerInfo {
             .map(|h| {
                 self.consensus
                     .data_man
-                    .block_results_by_hash_with_epoch(&h, &pivot, false)
+                    .block_results_by_hash_with_epoch(
+                        &h, &pivot, false, /* update_cache */
+                    )
                     .map(|res| (*res.receipts).clone())
                     .ok_or(ErrorKind::InternalError.into())
             })
@@ -212,7 +214,9 @@ impl LedgerInfo {
             .map(|h| {
                 self.consensus
                     .data_man
-                    .block_results_by_hash_with_epoch(&h, &pivot, false)
+                    .block_results_by_hash_with_epoch(
+                        &h, &pivot, false, /* update_cache */
+                    )
                     .map(|res| res.bloom)
                     .ok_or(ErrorKind::InternalError.into())
             })

--- a/core/src/light_protocol/common/validate.rs
+++ b/core/src/light_protocol/common/validate.rs
@@ -5,15 +5,12 @@
 use std::sync::Arc;
 
 use cfx_types::{Bloom, H256};
-use primitives::{BlockHeaderBuilder, SignedTransaction};
+use primitives::{Block, BlockHeaderBuilder, Receipt, SignedTransaction};
 
 use crate::{
     consensus::ConsensusGraph,
     hash::keccak,
-    light_protocol::{
-        message::{ReceiptsWithProof, StateRootWithProof},
-        Error, ErrorKind,
-    },
+    light_protocol::{message::StateRootWithProof, Error, ErrorKind},
     parameters::consensus::DEFERRED_STATE_EPOCH_COUNT,
 };
 
@@ -63,6 +60,49 @@ impl Validate {
                 received, local
             );
             return Err(ErrorKind::InvalidBloom.into());
+        }
+
+        Ok(())
+    }
+
+    #[inline]
+    pub fn receipts_with_local_info(
+        &self, epoch: u64, receipts: &Vec<Vec<Receipt>>,
+    ) -> Result<(), Error> {
+        let pivot = self.ledger.pivot_hash_of(epoch)?;
+
+        let local = self
+            .consensus
+            .data_man
+            .get_epoch_execution_commitments(&pivot);
+
+        let local = match local {
+            Some(res) => res.receipts_root,
+            None => {
+                warn!(
+                    "Receipts root not found, epoch={}, receipts={:?}",
+                    epoch, receipts
+                );
+                return Err(ErrorKind::InternalError.into());
+            }
+        };
+
+        // convert Vec<Vec<Receipt>> -> Vec<Arc<Vec<Receipt>>>
+        // for API compatibility
+        let rs = receipts
+            .clone()
+            .into_iter()
+            .map(|rs| Arc::new(rs))
+            .collect();
+
+        let received = BlockHeaderBuilder::compute_block_receipts_root(&rs);
+
+        if received != local {
+            warn!(
+                "Receipt validation failed, received={:?}, local={:?}",
+                received, local
+            );
+            return Err(ErrorKind::InvalidReceipts.into());
         }
 
         Ok(())
@@ -137,30 +177,6 @@ impl Validate {
     }
 
     #[inline]
-    pub fn receipts(
-        &self, epoch: u64, rwp: &ReceiptsWithProof,
-    ) -> Result<(), Error> {
-        let ReceiptsWithProof { receipts, proof } = rwp;
-        let proof = LedgerProof::ReceiptsRoot(proof.to_vec());
-
-        // convert Vec<Vec<_>> to Vec<Arc<Vec<_>>>
-        let rs = receipts.into_iter().cloned().map(Arc::new).collect();
-
-        let received = self.ledger_proof(epoch, proof)?;
-        let computed = BlockHeaderBuilder::compute_block_receipts_root(&rs);
-
-        if received != computed {
-            info!(
-                "Receipts root hash mismatch: received={}, computed={}",
-                received, computed
-            );
-            return Err(ErrorKind::InvalidReceipts.into());
-        }
-
-        Ok(())
-    }
-
-    #[inline]
     pub fn state_root(
         &self, epoch: u64, srwp: &StateRootWithProof,
     ) -> Result<(), Error> {
@@ -182,7 +198,9 @@ impl Validate {
     }
 
     #[inline]
-    pub fn txs(&self, txs: &Vec<SignedTransaction>) -> Result<(), Error> {
+    pub fn tx_signatures(
+        &self, txs: &Vec<SignedTransaction>,
+    ) -> Result<(), Error> {
         for tx in txs {
             match tx.verify_public(false) {
                 Ok(true) => continue,
@@ -191,6 +209,30 @@ impl Validate {
                     return Err(ErrorKind::InvalidTxSignature.into());
                 }
             }
+        }
+
+        Ok(())
+    }
+
+    #[inline]
+    pub fn block_txs(
+        &self, hash: H256, txs: &Vec<SignedTransaction>,
+    ) -> Result<(), Error> {
+        // first, validate signatures for each tx
+        self.tx_signatures(txs)?;
+
+        // then, compute tx root and match against header info
+        let local = *self.ledger.header(hash)?.transactions_root();
+
+        let txs: Vec<_> = txs.iter().map(|tx| Arc::new(tx.clone())).collect();
+        let received = Block::compute_transaction_root(&txs);
+
+        if received != local {
+            warn!(
+                "Tx root validation failed, received={:?}, local={:?}",
+                received, local
+            );
+            return Err(ErrorKind::InvalidTxRoot.into());
         }
 
         Ok(())

--- a/core/src/light_protocol/error.rs
+++ b/core/src/light_protocol/error.rs
@@ -23,6 +23,7 @@ error_chain! {
             description("Genesis mismatch"),
             display("Genesis mismatch"),
         }
+
         NoResponse {
             description("NoResponse"),
             display("NoResponse"),
@@ -61,6 +62,11 @@ error_chain! {
         InvalidStateRoot {
             description("Invalid state root"),
             display("Invalid state root"),
+        }
+
+        InvalidTxRoot {
+            description("Invalid tx root"),
+            display("Invalid tx root"),
         }
 
         InvalidTxSignature {
@@ -171,6 +177,7 @@ pub fn handle(io: &dyn NetworkContext, peer: PeerId, msg_id: MsgId, e: Error) {
         | ErrorKind::InvalidReceipts
         | ErrorKind::InvalidStateProof
         | ErrorKind::InvalidStateRoot
+        | ErrorKind::InvalidTxRoot
         | ErrorKind::InvalidTxSignature
         | ErrorKind::ValidationFailed
         | ErrorKind::Decoder(_) => op = Some(UpdateNodeOperation::Remove),

--- a/core/src/light_protocol/handler/mod.rs
+++ b/core/src/light_protocol/handler/mod.rs
@@ -54,7 +54,7 @@ pub struct Handler {
     pub query: QueryHandler,
 
     // sub-handler serving epoch and headers for syncing
-    sync: SyncHandler,
+    pub sync: SyncHandler,
 
     // helper API for validating ledger and state information
     validate: Validate,
@@ -138,12 +138,13 @@ impl Handler {
             // messages related to sync
             msgid::BLOCK_HASHES => self.sync.on_block_hashes(io, peer, &rlp),
             msgid::BLOCK_HEADERS => self.sync.on_block_headers(io, peer, &rlp),
+            msgid::BLOCK_TXS => self.sync.on_block_txs(io, peer, &rlp),
             msgid::BLOOMS => self.sync.on_blooms(io, peer, &rlp),
             msgid::NEW_BLOCK_HASHES => self.sync.on_new_block_hashes(io, peer, &rlp),
+            msgid::RECEIPTS => self.sync.on_receipts(io, peer, &rlp),
             msgid::WITNESS_INFO => self.sync.on_witness_info(io, peer, &rlp),
 
             // messages related to queries
-            msgid::RECEIPTS => self.query.on_receipts(io, peer, &rlp),
             msgid::STATE_ENTRY => self.query.on_state_entry(io, peer, &rlp),
             msgid::STATE_ROOT => self.query.on_state_root(io, peer, &rlp),
             msgid::TXS => self.query.on_txs(io, peer, &rlp),

--- a/core/src/light_protocol/handler/sync/block_txs.rs
+++ b/core/src/light_protocol/handler/sync/block_txs.rs
@@ -9,8 +9,9 @@ use std::{
     time::{Duration, Instant},
 };
 
-use cfx_types::Bloom;
+use cfx_types::H256;
 use parking_lot::RwLock;
+use primitives::SignedTransaction;
 
 extern crate futures;
 use futures::{Async, Future, Poll};
@@ -20,14 +21,14 @@ use crate::{
     light_protocol::{
         common::{Peers, UniqueId, Validate},
         handler::FullPeerState,
-        message::{BloomWithEpoch, GetBlooms},
+        message::{BlockTxsWithHash, GetBlockTxs},
         Error,
     },
     message::Message,
     network::{NetworkContext, PeerId},
     parameters::light::{
-        BLOOM_REQUEST_BATCH_SIZE, BLOOM_REQUEST_TIMEOUT_MS,
-        MAX_BLOOMS_IN_FLIGHT,
+        BLOCK_TX_REQUEST_BATCH_SIZE, BLOCK_TX_REQUEST_TIMEOUT_MS,
+        MAX_BLOCK_TXS_IN_FLIGHT,
     },
 };
 
@@ -41,88 +42,90 @@ struct Statistics {
 }
 
 #[derive(Clone, Debug, Eq)]
-pub(super) struct MissingBloom {
-    pub epoch: u64,
+pub(super) struct MissingBlockTxs {
+    pub hash: H256,
     pub since: Instant,
 }
 
-impl MissingBloom {
-    pub fn new(epoch: u64) -> Self {
-        MissingBloom {
-            epoch,
+impl MissingBlockTxs {
+    pub fn new(hash: H256) -> Self {
+        MissingBlockTxs {
+            hash,
             since: Instant::now(),
         }
     }
 }
 
-impl PartialEq for MissingBloom {
-    fn eq(&self, other: &Self) -> bool { self.epoch == other.epoch }
+impl PartialEq for MissingBlockTxs {
+    fn eq(&self, other: &Self) -> bool { self.hash == other.hash }
 }
 
-// MissingBloom::cmp is used for prioritizing bloom requests
-impl Ord for MissingBloom {
+// MissingBlockTxs::cmp is used for prioritizing bloom requests
+impl Ord for MissingBlockTxs {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
         if self.eq(other) {
             return cmp::Ordering::Equal;
         }
 
         let cmp_since = self.since.cmp(&other.since).reverse();
-        let cmp_epoch = self.epoch.cmp(&other.epoch).reverse();
+        let cmp_hash = self.hash.cmp(&other.hash).reverse();
 
-        cmp_since.then(cmp_epoch)
+        cmp_since.then(cmp_hash)
     }
 }
 
-impl PartialOrd for MissingBloom {
+impl PartialOrd for MissingBlockTxs {
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl HasKey<u64> for MissingBloom {
-    fn key(&self) -> u64 { self.epoch }
+impl HasKey<H256> for MissingBlockTxs {
+    fn key(&self) -> H256 { self.hash }
 }
 
-pub struct BloomFuture {
-    epoch: u64,
-    verified: Arc<RwLock<HashMap<u64, Bloom>>>,
+pub struct BlockTxsFuture {
+    hash: H256,
+    verified: Arc<RwLock<HashMap<H256, Vec<SignedTransaction>>>>,
 }
 
-impl BloomFuture {
+impl BlockTxsFuture {
     pub fn new(
-        epoch: u64, verified: Arc<RwLock<HashMap<u64, Bloom>>>,
-    ) -> BloomFuture {
-        BloomFuture { epoch, verified }
+        hash: H256,
+        verified: Arc<RwLock<HashMap<H256, Vec<SignedTransaction>>>>,
+    ) -> BlockTxsFuture
+    {
+        BlockTxsFuture { hash, verified }
     }
 }
 
-impl Future for BloomFuture {
+impl Future for BlockTxsFuture {
     type Error = Error;
-    type Item = Bloom;
+    type Item = Vec<SignedTransaction>;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        match self.verified.read().get(&self.epoch) {
+        match self.verified.read().get(&self.hash) {
             None => Ok(Async::NotReady),
-            Some(bloom) => Ok(Async::Ready(*bloom)),
+            Some(txs) => Ok(Async::Ready(txs.clone())),
         }
     }
 }
 
-pub struct Blooms {
+pub struct BlockTxs {
     // series of unique request ids
     request_id_allocator: Arc<UniqueId>,
 
     // sync and request manager
-    sync_manager: SyncManager<u64, MissingBloom>,
+    sync_manager: SyncManager<H256, MissingBlockTxs>,
 
     // helper API for validating ledger and state information
     validate: Validate,
 
-    // bloom filters received from full node
-    verified: Arc<RwLock<HashMap<u64, Bloom>>>,
+    // block txs received from full node
+    verified: Arc<RwLock<HashMap<H256, Vec<SignedTransaction>>>>,
 }
 
-impl Blooms {
+impl BlockTxs {
     pub(super) fn new(
         consensus: Arc<ConsensusGraph>, peers: Arc<Peers<FullPeerState>>,
         request_id_allocator: Arc<UniqueId>,
@@ -132,9 +135,7 @@ impl Blooms {
         let validate = Validate::new(consensus.clone());
         let verified = Arc::new(RwLock::new(HashMap::new()));
 
-        verified.write().insert(0, Bloom::zero());
-
-        Blooms {
+        BlockTxs {
             request_id_allocator,
             sync_manager,
             validate,
@@ -153,26 +154,26 @@ impl Blooms {
 
     #[inline]
     pub fn request(
-        &self, epoch: u64,
-    ) -> impl Future<Item = Bloom, Error = Error> {
-        if !self.verified.read().contains_key(&epoch) {
-            let missing = MissingBloom::new(epoch);
+        &self, hash: H256,
+    ) -> impl Future<Item = Vec<SignedTransaction>, Error = Error> {
+        if !self.verified.read().contains_key(&hash) {
+            let missing = MissingBlockTxs::new(hash);
             self.sync_manager.insert_waiting(std::iter::once(missing));
         }
 
-        BloomFuture::new(epoch, self.verified.clone())
+        BlockTxsFuture::new(hash, self.verified.clone())
     }
 
     #[inline]
     pub(super) fn receive(
-        &self, blooms: impl Iterator<Item = BloomWithEpoch>,
+        &self, block_txs: impl Iterator<Item = BlockTxsWithHash>,
     ) -> Result<(), Error> {
-        for BloomWithEpoch { epoch, bloom } in blooms {
-            info!("Validating bloom {:?} with epoch {}", bloom, epoch);
-            self.validate.bloom_with_local_info(epoch, bloom)?;
+        for BlockTxsWithHash { hash, block_txs } in block_txs {
+            info!("Validating block_txs {:?} with hash {}", block_txs, hash);
+            self.validate.block_txs(hash, &block_txs)?;
 
-            self.verified.write().insert(epoch, bloom);
-            self.sync_manager.remove_in_flight(&epoch);
+            self.verified.write().insert(hash, block_txs);
+            self.sync_manager.remove_in_flight(&hash);
         }
 
         Ok(())
@@ -180,24 +181,24 @@ impl Blooms {
 
     #[inline]
     pub(super) fn clean_up(&self) {
-        let timeout = Duration::from_millis(BLOOM_REQUEST_TIMEOUT_MS);
-        let blooms = self.sync_manager.remove_timeout_requests(timeout);
-        self.sync_manager.insert_waiting(blooms.into_iter());
+        let timeout = Duration::from_millis(BLOCK_TX_REQUEST_TIMEOUT_MS);
+        let block_txs = self.sync_manager.remove_timeout_requests(timeout);
+        self.sync_manager.insert_waiting(block_txs.into_iter());
     }
 
     #[inline]
     fn send_request(
-        &self, io: &dyn NetworkContext, peer: PeerId, epochs: Vec<u64>,
+        &self, io: &dyn NetworkContext, peer: PeerId, hashes: Vec<H256>,
     ) -> Result<(), Error> {
-        info!("send_request peer={:?} epochs={:?}", peer, epochs);
+        info!("send_request peer={:?} hashes={:?}", peer, hashes);
 
-        if epochs.is_empty() {
+        if hashes.is_empty() {
             return Ok(());
         }
 
-        let msg: Box<dyn Message> = Box::new(GetBlooms {
+        let msg: Box<dyn Message> = Box::new(GetBlockTxs {
             request_id: self.request_id_allocator.next(),
-            epochs,
+            hashes,
         });
 
         msg.send(io, peer)?;
@@ -206,11 +207,11 @@ impl Blooms {
 
     #[inline]
     pub(super) fn sync(&self, io: &dyn NetworkContext) {
-        info!("bloom sync statistics: {:?}", self.get_statistics());
+        info!("block tx sync statistics: {:?}", self.get_statistics());
 
         self.sync_manager.sync(
-            MAX_BLOOMS_IN_FLIGHT,
-            BLOOM_REQUEST_BATCH_SIZE,
+            MAX_BLOCK_TXS_IN_FLIGHT,
+            BLOCK_TX_REQUEST_BATCH_SIZE,
             |peer, epochs| self.send_request(io, peer, epochs),
         );
     }

--- a/core/src/light_protocol/handler/sync/future_item.rs
+++ b/core/src/light_protocol/handler/sync/future_item.rs
@@ -1,0 +1,40 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+extern crate futures;
+
+use futures::{Async, Future, Poll};
+use parking_lot::RwLock;
+use std::{collections::HashMap, hash::Hash, sync::Arc};
+
+use crate::light_protocol::Error;
+
+pub struct FutureItem<K, V> {
+    key: K,
+    verified: Arc<RwLock<HashMap<K, V>>>,
+}
+
+impl<K, V> FutureItem<K, V> {
+    pub fn new(
+        key: K, verified: Arc<RwLock<HashMap<K, V>>>,
+    ) -> FutureItem<K, V> {
+        FutureItem { key, verified }
+    }
+}
+
+impl<K, V> Future for FutureItem<K, V>
+where
+    K: Eq + Hash,
+    V: Clone,
+{
+    type Error = Error;
+    type Item = V;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        match self.verified.read().get(&self.key) {
+            None => Ok(Async::NotReady),
+            Some(item) => Ok(Async::Ready(item.clone())),
+        }
+    }
+}

--- a/core/src/light_protocol/handler/sync/mod.rs
+++ b/core/src/light_protocol/handler/sync/mod.rs
@@ -2,9 +2,11 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
+mod block_txs;
 mod blooms;
 mod epochs;
 mod headers;
+mod receipts;
 mod sync_manager;
 mod witnesses;
 
@@ -19,7 +21,8 @@ use crate::{
         message::{
             BlockHashes as GetBlockHashesResponse,
             BlockHeaders as GetBlockHeadersResponse,
-            Blooms as GetBloomsResponse, NewBlockHashes,
+            BlockTxs as GetBlockTxsResponse, Blooms as GetBloomsResponse,
+            NewBlockHashes, Receipts as GetReceiptsResponse,
             WitnessInfo as GetWitnessInfoResponse,
         },
         Error,
@@ -29,9 +32,11 @@ use crate::{
     sync::SynchronizationGraph,
 };
 
+use block_txs::BlockTxs;
 use blooms::Blooms;
 use epochs::Epochs;
 use headers::{HashSource, Headers};
+use receipts::Receipts;
 use witnesses::Witnesses;
 
 #[derive(Debug)]
@@ -40,9 +45,12 @@ struct Statistics {
     latest_epoch: u64,
 }
 
-pub(super) struct SyncHandler {
+pub struct SyncHandler {
+    // block tx sync manager
+    pub block_txs: BlockTxs,
+
     // bloom sync manager
-    blooms: Arc<Blooms>,
+    pub blooms: Blooms,
 
     // shared consensus graph
     consensus: Arc<ConsensusGraph>,
@@ -56,8 +64,11 @@ pub(super) struct SyncHandler {
     // collection of all peers available
     peers: Arc<Peers<FullPeerState>>,
 
+    // receipt sync manager
+    pub receipts: Receipts,
+
     // witness sync manager
-    witnesses: Witnesses,
+    pub witnesses: Witnesses,
 }
 
 impl SyncHandler {
@@ -70,6 +81,12 @@ impl SyncHandler {
         // anything. Need to make sure we persist the checkpoint hashes,
         // along with a Merkle-root for headers in each era.
         graph.recover_graph_from_db(true /* header_only */);
+
+        let block_txs = BlockTxs::new(
+            consensus.clone(),
+            peers.clone(),
+            request_id_allocator.clone(),
+        );
 
         let headers = Arc::new(Headers::new(
             graph.clone(),
@@ -84,25 +101,32 @@ impl SyncHandler {
             request_id_allocator.clone(),
         );
 
-        let blooms = Arc::new(Blooms::new(
+        let blooms = Blooms::new(
             consensus.clone(),
             peers.clone(),
             request_id_allocator.clone(),
-        ));
+        );
 
         let witnesses = Witnesses::new(
-            blooms.clone(),
+            consensus.clone(),
+            peers.clone(),
+            request_id_allocator.clone(),
+        );
+
+        let receipts = Receipts::new(
             consensus.clone(),
             peers.clone(),
             request_id_allocator.clone(),
         );
 
         SyncHandler {
+            block_txs,
             blooms,
             consensus,
             epochs,
             headers,
             peers,
+            receipts,
             witnesses,
         }
     }
@@ -226,6 +250,30 @@ impl SyncHandler {
         Ok(())
     }
 
+    pub(super) fn on_receipts(
+        &self, io: &dyn NetworkContext, _peer: PeerId, rlp: &Rlp,
+    ) -> Result<(), Error> {
+        let resp: GetReceiptsResponse = rlp.as_val()?;
+        info!("on_receipts resp={:?}", resp);
+
+        self.receipts.receive(resp.receipts.into_iter())?;
+
+        self.start_sync(io);
+        Ok(())
+    }
+
+    pub(super) fn on_block_txs(
+        &self, io: &dyn NetworkContext, _peer: PeerId, rlp: &Rlp,
+    ) -> Result<(), Error> {
+        let resp: GetBlockTxsResponse = rlp.as_val()?;
+        info!("on_block_txs resp={:?}", resp);
+
+        self.block_txs.receive(resp.block_txs.into_iter())?;
+
+        self.start_sync(io);
+        Ok(())
+    }
+
     pub(super) fn start_sync(&self, io: &dyn NetworkContext) {
         info!("general sync statistics: {:?}", self.get_statistics());
 
@@ -235,12 +283,16 @@ impl SyncHandler {
                 self.epochs.sync(io);
                 self.witnesses.sync(io);
                 self.blooms.sync(io);
+                self.receipts.sync(io);
+                self.block_txs.sync(io);
             }
             false => {
                 self.collect_terminals();
                 self.headers.sync(io);
                 self.witnesses.sync(io);
                 self.blooms.sync(io);
+                self.receipts.sync(io);
+                self.block_txs.sync(io);
             }
         };
     }
@@ -251,5 +303,7 @@ impl SyncHandler {
         self.epochs.clean_up();
         self.headers.clean_up();
         self.witnesses.clean_up();
+        self.receipts.clean_up();
+        self.block_txs.clean_up();
     }
 }

--- a/core/src/light_protocol/handler/sync/mod.rs
+++ b/core/src/light_protocol/handler/sync/mod.rs
@@ -5,6 +5,7 @@
 mod block_txs;
 mod blooms;
 mod epochs;
+mod future_item;
 mod headers;
 mod receipts;
 mod sync_manager;

--- a/core/src/light_protocol/handler/sync/receipts.rs
+++ b/core/src/light_protocol/handler/sync/receipts.rs
@@ -26,8 +26,8 @@ use crate::{
     message::Message,
     network::{NetworkContext, PeerId},
     parameters::light::{
-        RECEIPT_REQUEST_TIMEOUT_MS, MAX_RECEIPTS_IN_FLIGHT,
-        RECEIPT_REQUEST_BATCH_SIZE,
+        MAX_RECEIPTS_IN_FLIGHT, RECEIPT_REQUEST_BATCH_SIZE,
+        RECEIPT_REQUEST_TIMEOUT_MS,
     },
 };
 

--- a/core/src/light_protocol/message/message.rs
+++ b/core/src/light_protocol/message/message.rs
@@ -29,6 +29,8 @@ build_msgid! {
     WITNESS_INFO = 0x11
     GET_BLOOMS = 0x12
     BLOOMS = 0x13
+    GET_BLOCK_TXS = 0x014
+    BLOCK_TXS = 0x015
 
     INVALID = 0xff
 }
@@ -54,6 +56,8 @@ build_msg_impl! { GetWitnessInfo, msgid::GET_WITNESS_INFO, "GetWitnessInfo" }
 build_msg_impl! { WitnessInfo, msgid::WITNESS_INFO, "WitnessInfo" }
 build_msg_impl! { GetBlooms, msgid::GET_BLOOMS, "GetBlooms" }
 build_msg_impl! { Blooms, msgid::BLOOMS, "Blooms" }
+build_msg_impl! { GetBlockTxs, msgid::GET_BLOCK_TXS, "GetBlockTxs" }
+build_msg_impl! { BlockTxs, msgid::BLOCK_TXS, "BlockTxs" }
 
 // generate `impl HasRequestId for _` for each request type
 build_has_request_id_impl! { GetStateRoot }

--- a/core/src/light_protocol/message/mod.rs
+++ b/core/src/light_protocol/message/mod.rs
@@ -9,9 +9,10 @@ mod protocol;
 pub use message::msgid;
 pub use node_type::NodeType;
 pub use protocol::{
-    BlockHashes, BlockHeaders, BloomWithEpoch, Blooms, GetBlockHashesByEpoch,
-    GetBlockHeaders, GetBlooms, GetReceipts, GetStateEntry, GetStateRoot,
-    GetTxs, GetWitnessInfo, NewBlockHashes, Receipts, ReceiptsWithProof,
-    SendRawTx, StateEntry, StateRoot, StateRootWithProof, StatusPing,
-    StatusPong, Txs, WitnessInfo, WitnessInfoWithHeight,
+    BlockHashes, BlockHeaders, BlockTxs, BlockTxsWithHash, BloomWithEpoch,
+    Blooms, GetBlockHashesByEpoch, GetBlockHeaders, GetBlockTxs, GetBlooms,
+    GetReceipts, GetStateEntry, GetStateRoot, GetTxs, GetWitnessInfo,
+    NewBlockHashes, Receipts, ReceiptsWithEpoch, SendRawTx, StateEntry,
+    StateRoot, StateRootWithProof, StatusPing, StatusPong, Txs, WitnessInfo,
+    WitnessInfoWithHeight,
 };

--- a/core/src/parameters.rs
+++ b/core/src/parameters.rs
@@ -123,17 +123,19 @@ pub mod light {
     pub const CLEANUP_PERIOD_MS: u64 = 1000;
 
     /// Frequency of re-triggering sync.
-    pub const SYNC_PERIOD_MS: u64 = 5000;
+    pub const SYNC_PERIOD_MS: u64 = 1000;
 
     /// Request timeouts.
     pub const EPOCH_REQUEST_TIMEOUT_MS: u64 = 2000;
     pub const HEADER_REQUEST_TIMEOUT_MS: u64 = 2000;
     pub const WITNESS_REQUEST_TIMEOUT_MS: u64 = 2000;
     pub const BLOOM_REQUEST_TIMEOUT_MS: u64 = 2000;
+    pub const RECEIPT_REQUEST_TIMEOUT_MS: u64 = 2000;
+    pub const BLOCK_TX_REQUEST_TIMEOUT_MS: u64 = 2000;
 
     /// Maximum time period we wait for a response for an on-demand query.
     /// After this timeout has been reached, we try another peer or give up.
-    pub const MAX_POLL_TIME_MS: u64 = 1000;
+    pub const MAX_POLL_TIME_MS: u64 = 4000;
 
     /// Period of time to sleep between subsequent polls for on-demand queries.
     pub const POLL_PERIOD_MS: u64 = 100;
@@ -143,12 +145,16 @@ pub mod light {
     pub const HEADER_REQUEST_BATCH_SIZE: usize = 30;
     pub const BLOOM_REQUEST_BATCH_SIZE: usize = 30;
     pub const WITNESS_REQUEST_BATCH_SIZE: usize = 10;
+    pub const RECEIPT_REQUEST_BATCH_SIZE: usize = 30;
+    pub const BLOCK_TX_REQUEST_BATCH_SIZE: usize = 30;
 
     /// Maximum number of in-flight items at any given time.
     /// If we reach this limit, we will not request any more.
     pub const MAX_HEADERS_IN_FLIGHT: usize = 500;
     pub const MAX_WITNESSES_IN_FLIGHT: usize = 30;
     pub const MAX_BLOOMS_IN_FLIGHT: usize = 500;
+    pub const MAX_RECEIPTS_IN_FLIGHT: usize = 100;
+    pub const MAX_BLOCK_TXS_IN_FLIGHT: usize = 100;
 
     /// Maximum number of in-flight epoch requests at any given time.
     /// Similar to `MAX_HEADERS_IN_FLIGHT`. However, it is hard to match
@@ -172,6 +178,12 @@ pub mod light {
     /// blocks to consider a correct header incorrect. For this reason, we
     /// first wait for enough header to accumulate before checking blaming.
     pub const BLAME_CHECK_OFFSET: u64 = 20;
+
+    /// During log filtering, we stream a set of items (blooms, receipts, txs)
+    /// to match against. To make the process faster, we need to make sure that
+    /// there's always plenty of items in flight. This way, we can reduce idle
+    /// time when we're waiting to recveive an item.
+    pub const LOG_FILTERING_LOOKAHEAD: usize = 100;
 }
 
 pub const WORKER_COMPUTATION_PARALLELISM: usize = 8;

--- a/tests/light/log_filtering_test.py
+++ b/tests/light/log_filtering_test.py
@@ -46,10 +46,6 @@ class LogFilteringTest(ConfluxTestFramework):
         # connect archive nodes
         connect_nodes(self.nodes, FULLNODE0, FULLNODE1)
 
-        # connect light node to archive nodes
-        connect_nodes(self.nodes, LIGHTNODE, FULLNODE0)
-        connect_nodes(self.nodes, LIGHTNODE, FULLNODE1)
-
         # wait for phase changes to complete
         self.nodes[FULLNODE0].wait_for_phase(["NormalSyncPhase"])
         self.nodes[FULLNODE1].wait_for_phase(["NormalSyncPhase"])
@@ -87,8 +83,15 @@ class LogFilteringTest(ConfluxTestFramework):
         for _ in range(50):
             self.generate_correct_block(FULLNODE0)
 
+        self.log.info("syncing full nodes...")
+        sync_blocks(self.nodes[FULLNODE0:FULLNODE1])
+
+        # connect light node to full nodes
+        connect_nodes(self.nodes, LIGHTNODE, FULLNODE0)
+        connect_nodes(self.nodes, LIGHTNODE, FULLNODE1)
+
         # make sure we all nodes are in sync
-        self.log.info("syncing...")
+        self.log.info("syncing light node...")
         sync_blocks(self.nodes[:])
 
         # apply filter, we expect a single log with 2 topics

--- a/tests/light/log_filtering_test.py
+++ b/tests/light/log_filtering_test.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+
+# allow imports from parent directory
+# source: https://stackoverflow.com/a/11158224
+import os, sys
+sys.path.insert(1, os.path.join(sys.path[0], '..'))
+
+import eth_utils
+
+from conflux.config import default_config
+from conflux.filter import Filter
+from conflux.rpc import RpcClient
+from conflux.utils import sha3 as keccak, privtoaddr
+from test_framework.blocktools import create_transaction, encode_hex_0x
+from test_framework.test_framework import ConfluxTestFramework
+from test_framework.util import assert_equal, assert_is_hex_string, assert_is_hash_string
+from test_framework.util import *
+
+CONTRACT_PATH = "../contracts/EventsTestContract_bytecode.dat"
+CONSTRUCTED_TOPIC = encode_hex_0x(keccak(b"Constructed(address)"))
+CALLED_TOPIC = encode_hex_0x(keccak(b"Called(address,uint32)"))
+NUM_CALLS = 20
+
+FULLNODE0 = 0
+FULLNODE1 = 1
+LIGHTNODE = 2
+
+class LogFilteringTest(ConfluxTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 3
+
+    def setup_network(self):
+        self.add_nodes(self.num_nodes)
+
+        self.start_node(FULLNODE0, ["--archive"])
+        self.start_node(FULLNODE1, ["--archive"])
+        self.start_node(LIGHTNODE, ["--light"], phase_to_wait=None)
+
+        # set up RPC clients
+        self.rpc = [None] * self.num_nodes
+        self.rpc[FULLNODE0] = RpcClient(self.nodes[FULLNODE0])
+        self.rpc[FULLNODE1] = RpcClient(self.nodes[FULLNODE1])
+        self.rpc[LIGHTNODE] = RpcClient(self.nodes[LIGHTNODE])
+
+        # connect archive nodes
+        connect_nodes(self.nodes, FULLNODE0, FULLNODE1)
+
+        # connect light node to archive nodes
+        connect_nodes(self.nodes, LIGHTNODE, FULLNODE0)
+        connect_nodes(self.nodes, LIGHTNODE, FULLNODE1)
+
+        # wait for phase changes to complete
+        self.nodes[FULLNODE0].wait_for_phase(["NormalSyncPhase"])
+        self.nodes[FULLNODE1].wait_for_phase(["NormalSyncPhase"])
+
+    def generate_correct_block(self, node=None):
+        if node is None: node = self.random_full_node()
+        return self.rpc[node].generate_block()
+
+    def run_test(self):
+        priv_key = default_config["GENESIS_PRI_KEY"]
+        sender = eth_utils.encode_hex(privtoaddr(priv_key))
+
+        # deploy contract
+        bytecode_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), CONTRACT_PATH)
+        assert(os.path.isfile(bytecode_file))
+        bytecode = open(bytecode_file).read()
+        _, contractAddr = self.deploy_contract(sender, priv_key, bytecode)
+        self.log.info("contract deployed")
+
+        contract_epoch = hex(self.rpc[FULLNODE0].epoch_number())
+
+        # call method once
+        receipt = self.call_contract(sender, priv_key, contractAddr, encode_hex_0x(keccak(b"foo()")))
+        call_epoch = hex(self.rpc[FULLNODE0].epoch_number())
+
+        # deploy another instance of the contract
+        _, contractAddr2 = self.deploy_contract(sender, priv_key, bytecode)
+
+        # call method multiple times
+        for ii in range(0, NUM_CALLS - 3):
+            self.call_contract(sender, priv_key, contractAddr, encode_hex_0x(keccak(b"foo()")))
+
+        # make sure we have enough blocks to be certain about the validity of previous blocks
+        self.log.info("generating blocks...")
+        for _ in range(50):
+            self.generate_correct_block(FULLNODE0)
+
+        # make sure we all nodes are in sync
+        self.log.info("syncing...")
+        sync_blocks(self.nodes[:])
+
+        # apply filter, we expect a single log with 2 topics
+        self.log.info("testing filter range...")
+        self.check_filter(Filter(from_epoch="earliest", to_epoch=contract_epoch))
+        self.check_filter(Filter(from_epoch="earliest", to_epoch=call_epoch))
+        self.check_filter(Filter())
+        self.check_filter(Filter(from_epoch="0x0", to_epoch="0x0"))
+
+        # TODO(thegaram): support this
+        # apply filter for specific block, we expect a single log with 3 topics
+        # self.check_filter(Filter(block_hashes=[receipt["blockHash"]]))
+
+        # apply filter for specific topics
+        self.log.info("testing filter topics...")
+        self.check_filter(Filter(topics=[CONSTRUCTED_TOPIC]))
+        self.check_filter(Filter(topics=[CALLED_TOPIC]))
+        self.check_filter(Filter(topics=[None, self.address_to_topic(sender)]))
+        self.check_filter(Filter(topics=[CALLED_TOPIC, None, [self.number_to_topic(3), self.number_to_topic(4)]]))
+
+        # apply filter with limit
+        self.log.info("testing filter limit...")
+        self.check_filter(Filter(limit=("0x%x" % (NUM_CALLS // 2))))
+
+        # apply filter for specific contract address
+        self.log.info("testing address filtering...")
+        self.check_filter(Filter(address=[contractAddr]))
+        self.check_filter(Filter(address=[contractAddr2]))
+
+        self.log.info("Pass")
+
+    def check_filter(self, filter):
+        assert_equal(self.rpc[LIGHTNODE].get_logs(filter), self.rpc[FULLNODE0].get_logs(filter))
+
+    def address_to_topic(self, address):
+        return "0x" + address[2:].zfill(64)
+
+    def number_to_topic(self, number):
+        return "0x" + ("%x" % number).zfill(64)
+
+    def deploy_contract(self, sender, priv_key, data_hex):
+        tx = self.rpc[FULLNODE0].new_contract_tx(receiver="", data_hex=data_hex, sender=sender, priv_key=priv_key)
+        assert_equal(self.rpc[FULLNODE0].send_tx(tx, True), tx.hash_hex())
+        receipt = self.rpc[FULLNODE0].get_receipt(tx.hash_hex())
+        address = receipt["contractCreated"]
+        assert_is_hex_string(address)
+        return receipt, address
+
+    def call_contract(self, sender, priv_key, contract, data_hex):
+        tx = self.rpc[FULLNODE0].new_contract_tx(receiver=contract, data_hex=data_hex, sender=sender, priv_key=priv_key)
+        assert_equal(self.rpc[FULLNODE0].send_tx(tx, True), tx.hash_hex())
+        receipt = self.rpc[FULLNODE0].get_receipt(tx.hash_hex())
+        return receipt
+
+if __name__ == "__main__":
+    LogFilteringTest().main()


### PR DESCRIPTION
**Overview**

This PR adds log filtering functionality to light nodes. It is conceptually divided into 3 commits.

---

**2f98408:  add new future-based sync API for retrieving block txs, blooms, and receipts**

Add `sync::{block_txs, blooms, receitps}`, providing an API for verifiable retrieval of transactions, bloom filters, and receipts.

Items can be requested using the `::request` method and a key (epoch number or block hash). This method puts the key into a request queue and returns a `Future`. During syncing, these keys are grouped together and requested from peers. The caller can eventually retrieve the value by polling the returned `Future`.

Upon receiving a response from a peer, the node verifies it using `header.transaction_root` or the previously verified `header.deferred_receipts_root` or `header.deferred_logs_bloom_hash`. Verified items are stored in-memory in the `::verified` field of each of these sync handlers. This serves as a cache: subsequent queries to the same item can be retrieved from memory directly. (TODO: add gc to cache, maybe use `TransientHashMap`?)

---

**1a1eb79: add block tx, bloom, and receipts sync to light protocol**

Wire up the sync handlers described above to the network protocol. Add corresponding message types and handler methods.

---

**ea8ec8f: add light node log filtering**

Add light node log filtering (`core::light_protocol::query_service::get_logs`) and expose it on the light node rpc (`client::rpc::impl::light`). Add corresponding integration tests `tests/light/log_filtering_test.py`.

Log filtering on light nodes is done according the following process:
1. Given a set of epochs, retrieve and verify the corresponding log blooms filters.
2. For matching epochs, retrieve and verify the corresponding receipts.
3. For matching receipt logs, retrieve and verify the corresponding transaction, so that we can attach the corresponding transaction hash.

That is, for each matching log, we have 3 round trips. This is alleviated by the facts that
- Items retrieved and verified previously can be retrieved from local memory directly.
- Multiple items might be requested in a single request.

Subtleties include:
- Given `filter.limit`, we do not actually want to retrieve all epochs before processing the logs. For instance, if the last 10 epochs already provide enough logs, we can cut the operation short.
- We want to make sure that there are always multiple items in flight so that we can have a *request pipeline*, i.e. we should be able to filter epochs while subsequent epochs are already in flight.

To abstract out the complexity, `get_logs` makes heavy use of `futures::Stream`. The main log filtering logic follows the full node implementation (`consensus::logs`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/594)
<!-- Reviewable:end -->
