### PR TITLE
Refactor network code

### DIFF
--- a/network/src/connection.rs
+++ b/network/src/connection.rs
@@ -443,7 +443,11 @@ pub struct PacketWithLenAssembler {
 
 impl PacketWithLenAssembler {
     fn new(data_len_bytes: usize, mut max_packet_len: usize) -> Self {
-        assert!(data_len_bytes > 0 && data_len_bytes <= 8);
+        assert!(
+            data_len_bytes > 0
+                && data_len_bytes <= 4
+                && data_len_bytes < max_packet_len
+        );
 
         let max = usize::max_value() >> (64 - 8 * data_len_bytes);
         assert!(max_packet_len <= max);

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -32,7 +32,8 @@ extern crate strum;
 extern crate strum_macros;
 extern crate keccak_hash;
 
-pub type ProtocolId = [u8; 3];
+pub const PROTOCOL_ID_SIZE: usize = 3;
+pub type ProtocolId = [u8; PROTOCOL_ID_SIZE];
 pub type HandlerWorkType = u8;
 pub type PeerId = usize;
 

--- a/network/src/session.rs
+++ b/network/src/session.rs
@@ -3,17 +3,14 @@
 // See http://www.gnu.org/licenses/
 
 use crate::{
-    connection::{
-        Connection as TcpConnection, ConnectionDetails, PacketSizer,
-        SendQueueStatus, WriteStatus, MAX_PAYLOAD_SIZE,
-    },
+    connection::{Connection, ConnectionDetails, SendQueueStatus, WriteStatus},
     handshake::Handshake,
     node_table::{NodeEndpoint, NodeEntry, NodeId},
     service::NetworkServiceInner,
     Capability, DisconnectReason, Error, ErrorKind, ProtocolId,
     SessionMetadata, UpdateNodeOperation,
 };
-use bytes::{Buf, BufMut, Bytes, BytesMut, IntoBuf};
+use bytes::{BufMut, Bytes, BytesMut};
 use io::*;
 use mio::{deprecated::*, tcp::*, *};
 use priority_send_queue::SendQueuePriority;
@@ -25,8 +22,6 @@ use std::{
     str,
     time::{Duration, Instant},
 };
-
-pub type Connection = TcpConnection<SessionPacket>;
 
 pub struct Session {
     pub metadata: SessionMetadata,
@@ -392,7 +387,7 @@ impl Session {
             return Err(ErrorKind::Expired.into());
         }
 
-        SessionPacket::assemble(packet_id, protocol, data)
+        Ok(SessionPacket::assemble(packet_id, protocol, data))
     }
 
     pub fn send_packet<Message: Send + Sync + Clone>(
@@ -554,43 +549,33 @@ impl<T> MovableWrapper<T> {
     }
 }
 
-pub struct SessionPacket {
+struct SessionPacket {
     pub id: u8,
     pub protocol: Option<ProtocolId>,
     pub data: Bytes,
 }
 
 impl SessionPacket {
-    pub fn assemble(
-        id: u8, protocol: Option<ProtocolId>, data: &[u8],
-    ) -> Result<BytesMut, Error> {
+    fn assemble(id: u8, protocol: Option<ProtocolId>, data: &[u8]) -> BytesMut {
         let packet_size = 1 + protocol.map_or(0, |p| p.len()) + data.len();
 
-        if packet_size > MAX_PAYLOAD_SIZE {
-            error!(
-                "Packet is too big, size = {}, max = {}",
-                packet_size, MAX_PAYLOAD_SIZE
-            );
-            bail!(ErrorKind::OversizedPacket);
-        }
-
-        let mut packet = BytesMut::with_capacity(3 + packet_size);
-        packet.put_uint_le(packet_size as u64, 3);
+        let mut packet = BytesMut::with_capacity(packet_size);
         packet.put_u8(id);
         if let Some(protocol) = protocol {
             packet.put_slice(&protocol);
         }
         packet.put_slice(data);
 
-        Ok(packet)
+        packet
     }
 
-    pub fn parse(mut data: Bytes) -> Result<Self, Error> {
-        if data.len() <= 3 {
+    fn parse(mut data: Bytes) -> Result<Self, Error> {
+        if data.is_empty() {
+            debug!("failed to parse session packet, data is empty");
             bail!(ErrorKind::BadProtocol);
         }
 
-        let packet_id = data.split_to(4)[3];
+        let packet_id = data.split_to(1)[0];
 
         if packet_id != PACKET_USER {
             return Ok(SessionPacket {
@@ -601,7 +586,8 @@ impl SessionPacket {
         }
 
         if data.len() < 3 {
-            bail!(ErrorKind::Decoder);
+            debug!("failed to parse session protocol packet, invalid length for protocol id");
+            bail!(ErrorKind::BadProtocol);
         }
 
         let mut protocol: ProtocolId = [0u8; 3];
@@ -624,21 +610,5 @@ impl fmt::Debug for SessionPacket {
             self.protocol,
             self.data.len()
         )
-    }
-}
-
-impl PacketSizer for SessionPacket {
-    fn packet_size(raw_packet: &Bytes) -> usize {
-        let buf = &mut raw_packet.into_buf() as &mut dyn Buf;
-        if buf.remaining() >= 3 {
-            let size = buf.get_uint_le(3) as usize;
-            if buf.remaining() >= size {
-                size + 3
-            } else {
-                0
-            }
-        } else {
-            0
-        }
     }
 }

--- a/tests/test_framework/mininode.py
+++ b/tests/test_framework/mininode.py
@@ -124,13 +124,16 @@ class P2PConnection(asyncore.dispatcher):
                 if len(self.recvbuf) < 3 + packet_size:
                     return
 
-                packet_id = self.recvbuf[3]
-                self._log_message("receive", packet_id)
-                payload = self.recvbuf[4:3 + packet_size]
-                self.recvbuf = self.recvbuf[3 + packet_size:]
+                self.recvbuf = self.recvbuf[3:]
+                packet = self.recvbuf[:packet_size]
+                self.recvbuf = self.recvbuf[packet_size:]
 
-                if self.on_handshake(packet_id, payload):
+                if self.on_handshake(packet):
                     continue
+
+                packet_id = packet[0]
+                self._log_message("receive", packet_id)
+                payload = packet[1:]
 
                 if packet_id != PACKET_HELLO and packet_id != PACKET_DISCONNECT and (not self.had_hello):
                     raise ValueError("bad protocol")
@@ -151,7 +154,7 @@ class P2PConnection(asyncore.dispatcher):
             logger.exception('Error reading message: ' + repr(e))
             raise
 
-    def on_handshake(self, packet_id, payload) -> bool:
+    def on_handshake(self, payload) -> bool:
         return False
 
     def on_hello(self, payload):
@@ -203,12 +206,19 @@ class P2PConnection(asyncore.dispatcher):
 
         This method takes a P2P payload, builds the P2P header and adds
         the message to the send buffer to be sent over the socket."""
+        self._log_message("send", packet_id)
+        buf = struct.pack("<B", packet_id)
+        buf += payload
+
+        self.send_data(buf)
+
+    
+    def send_data(self, data, pushbuf=False):
         if self.state != "connected" and not pushbuf:
             raise IOError('Not connected, no pushbuf')
-        self._log_message("send", packet_id)
-        buf = struct.pack("<L", len(payload) + 1)[:3]
-        buf += struct.pack("<B", packet_id)
-        buf += payload
+
+        buf = struct.pack("<L", len(data))[:3]
+        buf += data
 
         with mininode_lock:
             if (len(self.sendbuf) == 0 and not pushbuf):
@@ -398,7 +408,7 @@ class P2PInterface(P2PConnection):
 
     def on_close(self): pass
 
-    def on_handshake(self, packet_id, payload) -> bool:
+    def on_handshake(self, payload) -> bool:
         if self.handshake.state == "ReadingAck":
             self.handshake.read_ack(payload)
             return True
@@ -506,7 +516,7 @@ class Handshake:
 
     def write_auth(self):
         node_id = utils.decode_hex(self.peer.key)
-        self.peer.send_packet(255, node_id)
+        self.peer.send_data(node_id)
         self.state = "ReadingAck"
 
     def read_ack(self, remote_node_id: bytes):


### PR DESCRIPTION
1. Handle packet in Connection internally, e.g. prefix data with length. So that, Session, Handshake need not to append 3 bytes of length prior to RLP data.
2. Assemble packet to send after pop out of send queue. This is to support "Encrypted Connection" feature, which requires that packet encrypted and received in the same order.
3. Update throttling and high priority packets counter info in a struct with Drop implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/598)
<!-- Reviewable:end -->
