### PR TITLE
Light node improvements

### DIFF
--- a/core/src/light_protocol/handler/sync/headers.rs
+++ b/core/src/light_protocol/handler/sync/headers.rs
@@ -12,6 +12,9 @@ use std::{
     time::{Duration, Instant},
 };
 
+use cfx_types::H256;
+use primitives::BlockHeader;
+
 use crate::{
     light_protocol::{
         common::{Peers, UniqueId},
@@ -28,9 +31,7 @@ use crate::{
     sync::SynchronizationGraph,
 };
 
-use super::sync_manager::{HasKey, SyncManager};
-use cfx_types::H256;
-use primitives::BlockHeader;
+use super::{missing_item::HasKey, sync_manager::SyncManager};
 
 #[derive(Debug)]
 struct Statistics {
@@ -47,7 +48,7 @@ pub(super) enum HashSource {
     NewHash,    // hash received through a new hashes announcement
 }
 
-#[derive(Clone, Debug, Eq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct MissingHeader {
     pub hash: H256,
     pub since: Instant,
@@ -64,21 +65,12 @@ impl MissingHeader {
     }
 }
 
-impl PartialEq for MissingHeader {
-    fn eq(&self, other: &Self) -> bool { self.hash == other.hash }
-}
-
 // MissingHeader::cmp is used for prioritizing header requests
 impl Ord for MissingHeader {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
-        if self.eq(other) {
-            return cmp::Ordering::Equal;
-        }
-
         let cmp_source = self.source.cmp(&other.source);
         let cmp_since = self.since.cmp(&other.since).reverse();
         let cmp_hash = self.hash.cmp(&other.hash);
-
         cmp_source.then(cmp_since).then(cmp_hash)
     }
 }
@@ -144,6 +136,34 @@ impl Headers {
             .map(|h| MissingHeader::new(h, source.clone()));
 
         self.sync_manager.insert_waiting(headers);
+    }
+
+    #[inline]
+    pub fn request_now_from_peer<I>(
+        &self, io: &dyn NetworkContext, peer: PeerId, hashes: I,
+        source: HashSource,
+    ) where
+        I: Iterator<Item = H256>,
+    {
+        let hashes: Vec<_> = hashes
+            .filter(|h| !self.graph.contains_block_header(&h))
+            .collect();
+
+        let headers = hashes
+            .iter()
+            .cloned()
+            .map(|h| MissingHeader::new(h, source.clone()));
+
+        match self.send_request(io, peer, hashes.clone()) {
+            Ok(_) => self.sync_manager.insert_in_flight(headers),
+            Err(e) => {
+                warn!(
+                    "Failed to request {:?} from {:?}: {:?}",
+                    hashes, peer, e
+                );
+                self.sync_manager.insert_waiting(headers);
+            }
+        }
     }
 
     pub fn receive<I>(&self, headers: I)
@@ -228,10 +248,11 @@ impl Headers {
 
 #[cfg(test)]
 mod tests {
-    use super::{HashSource, MissingHeader};
+    use super::{
+        super::priority_queue::PriorityQueue, HashSource, MissingHeader,
+    };
     use rand::Rng;
     use std::{
-        collections::BinaryHeap,
         ops::Sub,
         time::{Duration, Instant},
     };
@@ -362,6 +383,7 @@ mod tests {
         };
 
         let mut headers = vec![];
+
         headers.push(h0.clone());
         headers.push(h1.clone());
         headers.push(h2.clone());
@@ -370,16 +392,10 @@ mod tests {
         headers.push(h5.clone());
         headers.push(h6.clone());
 
-        // NOTE: as `h5.hash == h6.hash`, BinaryHeap will
-        // insert another instance of `h5` in the last step;
-        // this is not optimal, but we have other checks to
-        // to ensure we don't request headers multiple times
-
         rand::thread_rng().shuffle(&mut headers);
-        let mut queue: BinaryHeap<MissingHeader> = BinaryHeap::new();
+        let mut queue = PriorityQueue::new();
         queue.extend(headers);
 
-        assert_deep_equal(queue.pop(), Some(h5.clone()));
         assert_deep_equal(queue.pop(), Some(h5));
         assert_deep_equal(queue.pop(), Some(h4));
         assert_deep_equal(queue.pop(), Some(h3));

--- a/core/src/light_protocol/handler/sync/headers.rs
+++ b/core/src/light_protocol/handler/sync/headers.rs
@@ -318,14 +318,6 @@ mod tests {
         };
 
         assert!(h4 < h6); // hash order
-
-        let h7 = MissingHeader {
-            hash: 6.into(),
-            since: one_ms_ago,
-            source: HashSource::Epoch,
-        };
-
-        assert_eq!(h6, h7); // identical hash
     }
 
     fn assert_deep_equal(h1: Option<MissingHeader>, h2: Option<MissingHeader>) {

--- a/core/src/light_protocol/handler/sync/missing_item.rs
+++ b/core/src/light_protocol/handler/sync/missing_item.rs
@@ -1,0 +1,129 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use std::{cmp::Ordering, time::Instant};
+
+pub trait HasKey<Key>
+where Key: Clone
+{
+    fn key(&self) -> Key;
+}
+
+/// Items whose priority is based on their creation times.
+/// I.e. items created earlier will have higher priority.
+/// Example: TimeOrdered(yesterday) > TimeOrdered(now)
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TimeOrdered<K> {
+    pub key: K,
+    pub since: Instant,
+}
+
+impl<K> TimeOrdered<K> {
+    pub fn new(key: K) -> Self {
+        TimeOrdered {
+            key,
+            since: Instant::now(),
+        }
+    }
+}
+
+impl<K> HasKey<K> for TimeOrdered<K>
+where K: Clone
+{
+    fn key(&self) -> K { self.key.clone() }
+}
+
+impl<K> Ord for TimeOrdered<K>
+where K: Eq
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.since.cmp(&other.since).reverse()
+    }
+}
+
+impl<K> PartialOrd for TimeOrdered<K>
+where K: Eq
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Items whose priority corresponds to their keys' priority.
+/// I.e. items with higher key will have higher priority.
+/// Example: KeyOrdered(3) > KeyOrdered(2)
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct KeyOrdered<K> {
+    pub key: K,
+    pub since: Instant,
+}
+
+impl<K> KeyOrdered<K> {
+    pub fn new(key: K) -> Self {
+        KeyOrdered {
+            key,
+            since: Instant::now(),
+        }
+    }
+}
+
+impl<K> HasKey<K> for KeyOrdered<K>
+where K: Clone
+{
+    fn key(&self) -> K { self.key.clone() }
+}
+
+impl<K> Ord for KeyOrdered<K>
+where K: Ord
+{
+    fn cmp(&self, other: &Self) -> Ordering { self.key.cmp(&other.key) }
+}
+
+impl<K> PartialOrd for KeyOrdered<K>
+where K: Ord
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Items whose priority is the reverse of their keys' priority.
+/// I.e. items with lower key will have higher priority.
+/// Example: KeyReverseOrdered(2) > KeyReverseOrdered(3)
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct KeyReverseOrdered<K> {
+    pub key: K,
+    pub since: Instant,
+}
+
+impl<K> KeyReverseOrdered<K> {
+    pub fn new(key: K) -> Self {
+        KeyReverseOrdered {
+            key,
+            since: Instant::now(),
+        }
+    }
+}
+
+impl<K> HasKey<K> for KeyReverseOrdered<K>
+where K: Clone
+{
+    fn key(&self) -> K { self.key.clone() }
+}
+
+impl<K> Ord for KeyReverseOrdered<K>
+where K: Ord
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.key.cmp(&other.key).reverse()
+    }
+}
+
+impl<K> PartialOrd for KeyReverseOrdered<K>
+where K: Ord
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/core/src/light_protocol/handler/sync/mod.rs
+++ b/core/src/light_protocol/handler/sync/mod.rs
@@ -7,6 +7,8 @@ mod blooms;
 mod epochs;
 mod future_item;
 mod headers;
+mod missing_item;
+mod priority_queue;
 mod receipts;
 mod sync_manager;
 mod witnesses;
@@ -220,8 +222,12 @@ impl SyncHandler {
             return Ok(());
         }
 
-        let hashes = msg.hashes.into_iter();
-        self.headers.request(hashes, HashSource::NewHash);
+        self.headers.request_now_from_peer(
+            io,
+            peer,
+            msg.hashes.into_iter(),
+            HashSource::NewHash,
+        );
 
         self.start_sync(io);
         Ok(())

--- a/core/src/light_protocol/handler/sync/priority_queue.rs
+++ b/core/src/light_protocol/handler/sync/priority_queue.rs
@@ -1,0 +1,129 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use std::{
+    collections::{BinaryHeap, HashSet},
+    hash::Hash,
+};
+
+use super::missing_item::HasKey;
+
+/// A data structure for storing unique elements and retrieving them according
+/// to some priority criteria.
+/// The value type `V` must implement `HasKey<K>`.
+/// Uniqueness in guaranteed with respect to the associated key.
+/// Priority is based on `Ord` (V::cmp/partial_cmp).
+pub struct PriorityQueue<K, V> {
+    keys: HashSet<K>,
+    values: BinaryHeap<V>,
+}
+
+impl<K, V> PriorityQueue<K, V>
+where
+    K: Clone + Eq + Hash,
+    V: HasKey<K> + Ord,
+{
+    pub fn new() -> Self {
+        let keys = HashSet::new();
+        let values = BinaryHeap::new();
+        Self { keys, values }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        assert!(self.keys.len() == self.values.len());
+        self.keys.len()
+    }
+
+    #[inline]
+    pub fn push(&mut self, value: V) {
+        if !self.keys.contains(&value.key()) {
+            self.keys.insert(value.key());
+            self.values.push(value);
+        }
+    }
+
+    #[inline]
+    pub fn pop(&mut self) -> Option<V> {
+        match self.values.pop() {
+            None => {
+                assert!(self.keys.is_empty());
+                None
+            }
+            Some(value) => {
+                assert!(self.keys.remove(&value.key()));
+                Some(value)
+            }
+        }
+    }
+}
+
+impl<K, V> Extend<V> for PriorityQueue<K, V>
+where
+    K: Clone + Eq + Hash,
+    V: Ord + HasKey<K>,
+{
+    fn extend<T: IntoIterator<Item = V>>(&mut self, iter: T) {
+        for value in iter {
+            self.push(value);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{super::missing_item::HasKey, PriorityQueue};
+    use std::cmp::Ordering;
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct Item {
+        pub key: u64,
+        pub value: u64,
+    }
+
+    impl Item {
+        pub fn new(key: u64, value: u64) -> Item { Item { key, value } }
+    }
+
+    impl HasKey<u64> for Item {
+        fn key(&self) -> u64 { self.key }
+    }
+
+    impl Ord for Item {
+        fn cmp(&self, other: &Self) -> Ordering { self.value.cmp(&other.value) }
+    }
+
+    impl PartialOrd for Item {
+        fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+
+    #[test]
+    fn test_priority_queue() {
+        let mut queue = PriorityQueue::new();
+
+        // push items with unique keys
+        queue.push(Item::new(0, 0));
+        queue.push(Item::new(1, 4));
+        queue.push(Item::new(2, 1));
+        queue.push(Item::new(3, 3));
+        queue.push(Item::new(4, 2));
+
+        // push items with dubplicate keys
+        queue.push(Item::new(0, 5));
+        queue.push(Item::new(1, 9));
+        queue.push(Item::new(2, 6));
+        queue.push(Item::new(3, 8));
+        queue.push(Item::new(4, 7));
+
+        // expect each key only once with values in descending order.
+        assert_eq!(queue.pop(), Some(Item::new(1, 4)));
+        assert_eq!(queue.pop(), Some(Item::new(3, 3)));
+        assert_eq!(queue.pop(), Some(Item::new(4, 2)));
+        assert_eq!(queue.pop(), Some(Item::new(2, 1)));
+        assert_eq!(queue.pop(), Some(Item::new(0, 0)));
+        assert_eq!(queue.pop(), None);
+    }
+}

--- a/core/src/light_protocol/handler/sync/receipts.rs
+++ b/core/src/light_protocol/handler/sync/receipts.rs
@@ -4,16 +4,10 @@
 
 extern crate futures;
 
-use std::{
-    cmp,
-    collections::HashMap,
-    sync::Arc,
-    time::{Duration, Instant},
-};
-
 use futures::Future;
 use parking_lot::RwLock;
 use primitives::Receipt;
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use crate::{
     consensus::ConsensusGraph,
@@ -32,8 +26,8 @@ use crate::{
 };
 
 use super::{
-    future_item::FutureItem,
-    sync_manager::{HasKey, SyncManager},
+    future_item::FutureItem, missing_item::KeyOrdered,
+    sync_manager::SyncManager,
 };
 
 #[derive(Debug)]
@@ -43,48 +37,8 @@ struct Statistics {
     waiting: usize,
 }
 
-#[derive(Clone, Debug, Eq)]
-pub(super) struct MissingReceipts {
-    pub epoch: u64,
-    pub since: Instant,
-}
-
-impl MissingReceipts {
-    pub fn new(epoch: u64) -> Self {
-        MissingReceipts {
-            epoch,
-            since: Instant::now(),
-        }
-    }
-}
-
-impl PartialEq for MissingReceipts {
-    fn eq(&self, other: &Self) -> bool { self.epoch == other.epoch }
-}
-
-// MissingReceipts::cmp is used for prioritizing bloom requests
-impl Ord for MissingReceipts {
-    fn cmp(&self, other: &Self) -> cmp::Ordering {
-        if self.eq(other) {
-            return cmp::Ordering::Equal;
-        }
-
-        let cmp_since = self.since.cmp(&other.since).reverse();
-        let cmp_epoch = self.epoch.cmp(&other.epoch).reverse();
-
-        cmp_since.then(cmp_epoch)
-    }
-}
-
-impl PartialOrd for MissingReceipts {
-    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl HasKey<u64> for MissingReceipts {
-    fn key(&self) -> u64 { self.epoch }
-}
+// prioritize higher epochs
+type MissingReceipts = KeyOrdered<u64>;
 
 pub struct Receipts {
     // series of unique request ids


### PR DESCRIPTION
**Overview**

This PR adds three main improvements to the light node implementation.

1. **Request new block headers from announcing peer**: Before, we sometimes requested new block headers from peers who did not have them. This added a long delay (~2s). `headers::request_now_from_peer` requests the headers immediately from a given peer.

2. **Ensure uniqueness of items in priority queue**: Whatever we request (headers, bloom filters, etc.), we do not want to request the same item twice unnecessarily. To reduce the chance of this, `PriorityQueue` defines a priority queue with unique elements. (Note: there still might be some duplication, if we are about to request new elements, but re-insert them to `waiting` before inserting them to `in_flight`. Handling this case does not seem urgent now.)

3. **Simplify request priority handling**: Different priority implementations have been moved to the `missing_items` module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/600)
<!-- Reviewable:end -->
