### PR TITLE
Avoid memcpy for the protocol message

### DIFF
--- a/core/src/light_protocol/handler/mod.rs
+++ b/core/src/light_protocol/handler/mod.rs
@@ -24,7 +24,7 @@ use crate::{
         message::{msgid, NodeType, SendRawTx, StatusPing, StatusPong},
         Error, ErrorKind, LIGHT_PROTOCOL_VERSION,
     },
-    message::{Message, MsgId},
+    message::{decode_msg, Message, MsgId},
     network::{NetworkContext, NetworkProtocolHandler, PeerId},
     parameters::light::{CLEANUP_PERIOD_MS, SYNC_PERIOD_MS},
     sync::SynchronizationGraph,
@@ -214,17 +214,18 @@ impl NetworkProtocolHandler for Handler {
     fn on_message(&self, io: &dyn NetworkContext, peer: PeerId, raw: &[u8]) {
         trace!("on_message: peer={:?}, raw={:?}", peer, raw);
 
-        if raw.len() < 2 {
-            return handle_error(
-                io,
-                peer,
-                msgid::INVALID,
-                ErrorKind::InvalidMessageFormat.into(),
-            );
-        }
+        let (msg_id, rlp) = match decode_msg(raw) {
+            Some(msg) => msg,
+            None => {
+                return handle_error(
+                    io,
+                    peer,
+                    msgid::INVALID,
+                    ErrorKind::InvalidMessageFormat.into(),
+                )
+            }
+        };
 
-        let msg_id = raw[0];
-        let rlp = Rlp::new(&raw[1..]);
         debug!("on_message: peer={:?}, msgid={:?}", peer, msg_id);
 
         if let Err(e) = self.dispatch_message(io, peer, msg_id.into(), rlp) {

--- a/network/src/handshake.rs
+++ b/network/src/handshake.rs
@@ -234,7 +234,7 @@ impl Handshake {
         assert_eq!(data.len(), 64);
         self.id.clone_from_slice(data);
         self.connection
-            .send(io, public.as_ref(), SendQueuePriority::High)?;
+            .send(io, public.to_vec(), SendQueuePriority::High)?;
         self.state = HandshakeState::StartSession;
         Ok(())
     }
@@ -300,8 +300,7 @@ impl Handshake {
         let message = ecies::encrypt(&self.id, &[], &data)?;
 
         self.auth_cipher = message.clone();
-        self.connection
-            .send(io, &message, SendQueuePriority::High)?;
+        self.connection.send(io, message, SendQueuePriority::High)?;
         self.state = HandshakeState::ReadingAck;
 
         Ok(())
@@ -329,8 +328,7 @@ impl Handshake {
 
         let message = ecies::encrypt(&self.id, &[], &data)?;
         self.ack_cipher = message.clone();
-        self.connection
-            .send(io, &message, SendQueuePriority::High)?;
+        self.connection.send(io, message, SendQueuePriority::High)?;
         self.state = HandshakeState::StartSession;
         Ok(())
     }

--- a/network/src/service.rs
+++ b/network/src/service.rs
@@ -383,7 +383,7 @@ impl DelayedQueue {
             &context.io,
             Some(context.protocol),
             session::PACKET_USER,
-            &context.msg,
+            context.msg,
             context.priority,
         ) {
             Ok(_) => {}
@@ -1686,7 +1686,7 @@ impl<'a> NetworkContextTrait for NetworkContext<'a> {
                         self.io,
                         Some(self.protocol),
                         session::PACKET_USER,
-                        &msg,
+                        msg,
                         priority,
                     )?;
                 }

--- a/network/src/session.rs
+++ b/network/src/session.rs
@@ -396,14 +396,14 @@ impl Session {
     ) -> Result<SendQueueStatus, Error>
     {
         let packet = self.prepare_packet(protocol, packet_id, data)?;
-        self.connection_mut().send(io, &packet, priority)
+        self.connection_mut().send(io, packet, priority)
     }
 
     pub fn send_packet_immediately(
         &mut self, protocol: Option<ProtocolId>, packet_id: u8, data: Vec<u8>,
     ) -> Result<usize, Error> {
         let packet = self.prepare_packet(protocol, packet_id, data)?;
-        self.connection_mut().write_raw_data(&packet)
+        self.connection_mut().write_raw_data(packet)
     }
 
     pub fn send_disconnect(&mut self, reason: DisconnectReason) -> Error {

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -79,36 +79,26 @@ class MessageTest(ConfluxTestFramework):
     def test_socket_msg(self, node):
         self.log.info("testing invalid socket message ...")
 
-        # buf = struct.pack("<L", len(payload) + 1)[:3]
-        # buf += struct.pack("<B", packet_id)
-        # buf += payload
-
         # empty packet
         buf = struct.pack("<L", 0)[:3]
         assert node.p2p.state == "connected"
         node.p2p.send(buf)
         # node should disconnect this p2p connection
-        wait_until(lambda: node.p2p.state != "connected")
-
-        # empty payload
-        p2p = start_p2p_connection([self.nodes[0]])[0]
-        p2p.send_packet(PACKET_HELLO, b'')
-        wait_until(lambda: p2p.state != "connected")
+        wait_until(lambda: node.p2p.state != "connected", timeout=3)
 
         p2p = start_p2p_connection([self.nodes[0]])[0]
         p2p.send_packet(PACKET_DISCONNECT, b'')
-        wait_until(lambda: p2p.state != "connected")
+        wait_until(lambda: p2p.state != "connected", timeout=3)
 
         p2p = start_p2p_connection([self.nodes[0]])[0]
         p2p.send_packet(PACKET_PROTOCOL, b'')
-        wait_until(lambda: p2p.state != "connected")
+        wait_until(lambda: p2p.state != "connected", timeout=3)
 
         # legel payload
         p2p = start_p2p_connection([self.nodes[0]])[0]
         p2p.send_packet(PACKET_PING, b'')
         p2p.send_packet(PACKET_PONG, b'')
-        time.sleep(1)  # Give node 1s to disconnect if needed
-        assert p2p.state == "connected"
+        wait_until(lambda: p2p.state == "connected", timeout=3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, a protocol message is serialized in RLP format of type Vec<u8>, and copied multiple times before send to remote peer:
1. Prefix RLP message with message id.
2. Prefix packet id and protocol in Session.
3. Add into the send_queue of Connection.
4. Prefix 3-bytes of packet length before writing to TCP socket.

In case of 4M big packet, the 4 times' memcpy is really too heavy. So, we should always extend the RLP serialized Vec<u8> with extra information in 2 ways:
1. Append extra information in the end.
2. Swap the first n-bytes to the end, and prefix extra information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/604)
<!-- Reviewable:end -->
