### PR TITLE
Add error handling to light node log filtering

### DIFF
--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -25,8 +25,7 @@ use network::{
     throttling, SessionDetails, UpdateNodeOperation,
 };
 use primitives::{
-    filter::FilterError, Action, SignedTransaction, Transaction,
-    TransactionWithSignature,
+    Action, SignedTransaction, Transaction, TransactionWithSignature,
 };
 use rlp::Rlp;
 use std::{collections::BTreeMap, net::SocketAddr, sync::Arc};
@@ -371,11 +370,8 @@ impl RpcImpl {
         info!("RPC Request: cfx_getLogs({:?})", filter);
         self.consensus
             .logs(filter.into())
-            .map_err(|e| match e {
-                FilterError::InvalidEpochNumber { .. } => {
-                    RpcError::invalid_params(format!("{}", e))
-                }
-            })
+            .map_err(|e| format!("{}", e))
+            .map_err(RpcError::invalid_params)
             .map(|logs| logs.iter().cloned().map(RpcLog::from).collect())
     }
 

--- a/client/src/rpc/impls/light.rs
+++ b/client/src/rpc/impls/light.rs
@@ -109,7 +109,7 @@ impl RpcImpl {
         self.light
             .get_logs(filter.into())
             .map(|logs| logs.iter().cloned().map(RpcLog::from).collect())
-            .map_err(|e| format!("Log filtering failed: {:?}", e))
+            .map_err(|e| format!("{}", e))
             .map_err(RpcError::invalid_params)
     }
 

--- a/core/src/light_protocol/common/mod.rs
+++ b/core/src/light_protocol/common/mod.rs
@@ -5,17 +5,19 @@
 mod ledger_info;
 mod ledger_proof;
 mod peers;
+mod timeout;
 mod unique_id;
 mod validate;
 
 pub use ledger_info::LedgerInfo;
 pub use ledger_proof::LedgerProof;
 pub use peers::Peers;
+pub use timeout::{with_timeout, Timeout};
 pub use unique_id::UniqueId;
 pub use validate::Validate;
 
 extern crate futures;
-use crate::parameters::light::{MAX_POLL_TIME_MS, POLL_PERIOD_MS};
+use crate::parameters::light::POLL_PERIOD_MS;
 use futures::{Async, Stream};
 use std::cmp;
 
@@ -34,12 +36,7 @@ where
     T::Item: std::fmt::Debug,
     T::Error: std::fmt::Debug,
 {
-    // poll stream result
-    // TODO(thegaram): come up with something better
-    // we can consider returning the stream/future directly
-    let max_poll_num = MAX_POLL_TIME_MS / POLL_PERIOD_MS;
-
-    for ii in 0..max_poll_num {
+    for ii in 0.. {
         trace!("poll number {}", ii);
         match stream.poll() {
             Ok(Async::Ready(resp)) => {
@@ -61,6 +58,5 @@ where
         std::thread::sleep(d);
     }
 
-    trace!("poll timeout");
-    Err(ErrorKind::NoResponse.into())
+    unreachable!()
 }

--- a/core/src/light_protocol/common/timeout.rs
+++ b/core/src/light_protocol/common/timeout.rs
@@ -1,0 +1,55 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+extern crate futures;
+
+use futures::{Async, Future, Poll};
+use std::{
+    marker::PhantomData,
+    ops::Add,
+    time::{Duration, Instant},
+};
+
+use crate::light_protocol::{Error, ErrorKind};
+
+pub struct Timeout<T> {
+    t: Instant,
+    msg: String,
+    phantom: PhantomData<T>,
+}
+
+impl<T> Timeout<T> {
+    pub fn after(dt: Duration, msg: String) -> Timeout<T> {
+        Timeout {
+            t: Instant::now().add(dt),
+            msg,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> Future for Timeout<T> {
+    type Error = Error;
+    type Item = T;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        match Instant::now() {
+            t if t < self.t => Ok(Async::NotReady),
+            _ => Err(ErrorKind::Msg(self.msg.clone()).into()),
+        }
+    }
+}
+
+/// Consume `future` and return a new one that raises and error with `msg` if
+/// `future` is not ready before the given duration `d`.
+pub fn with_timeout<Item>(
+    d: Duration, msg: String, future: impl Future<Item = Item, Error = Error>,
+) -> impl Future<Item = Item, Error = Error> {
+    future
+        .select(Timeout::<Item>::after(d, msg))
+        .then(|x| match x {
+            Ok((a, _)) => Ok(a),
+            Err((a, _)) => Err(a),
+        })
+}

--- a/primitives/src/filter.rs
+++ b/primitives/src/filter.rs
@@ -29,6 +29,12 @@ use std::{error, fmt};
 pub enum FilterError {
     /// Filter has wrong epoch numbers set.
     InvalidEpochNumber { from_epoch: u64, to_epoch: u64 },
+
+    /// Roots for verifying the requested epochs are unavailable.
+    UnableToVerify { epoch: u64, latest_verifiable: u64 },
+
+    /// Filter error with custom error message (e.g. timeout)
+    Custom(String),
 }
 
 impl fmt::Display for FilterError {
@@ -42,9 +48,17 @@ impl fmt::Display for FilterError {
                 "Filter has wrong epoch numbers set (from: {}, to: {})",
                 from_epoch, to_epoch
             },
+            UnableToVerify {
+                epoch,
+                latest_verifiable,
+            } => format! {
+                "Unable to verify epoch {} (latest verifiable epoch is {})",
+                epoch, latest_verifiable
+            },
+            Custom(ref s) => s.clone(),
         };
 
-        f.write_fmt(format_args!("Filter error ({})", msg))
+        f.write_fmt(format_args!("Filter error: {}", msg))
     }
 }
 


### PR DESCRIPTION
**Overview**

This PR adds error messages to the light node log filtering process. We return an error if

1. The requested epochs cannot be verified.
2. We reach a timeout at any step of the process.

The previous behavior was to just return an empty vector, which is misleading.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/608)
<!-- Reviewable:end -->
