### PR TITLE
avoid unnecessary memcpy in message

### DIFF
--- a/core/src/sync/message/capability.rs
+++ b/core/src/sync/message/capability.rs
@@ -11,7 +11,6 @@ use cfx_types::H256;
 use network::{NetworkContext, PeerId};
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 use rlp_derive::{RlpDecodableWrapper, RlpEncodableWrapper};
-use std::collections::HashMap;
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum DynamicCapability {
@@ -78,16 +77,16 @@ impl Decodable for DynamicCapability {
 
 #[derive(Debug, Default)]
 pub struct DynamicCapabilitySet {
-    caps: HashMap<u8, DynamicCapability>,
+    caps: [Option<DynamicCapability>; 3],
 }
 
 impl DynamicCapabilitySet {
     pub fn insert(&mut self, cap: DynamicCapability) {
-        self.caps.insert(cap.code(), cap);
+        self.caps[cap.code() as usize] = Some(cap);
     }
 
     pub fn contains(&self, cap: DynamicCapability) -> bool {
-        match self.caps.get(&cap.code()) {
+        match self.caps[cap.code() as usize].as_ref() {
             Some(cur_cap) => cur_cap == &cap,
             None => return false,
         }

--- a/core/src/sync/message/get_block_hashes_by_epoch.rs
+++ b/core/src/sync/message/get_block_hashes_by_epoch.rs
@@ -65,7 +65,7 @@ impl Handleable for GetBlockHashesByEpoch {
             });
 
         let response = GetBlockHashesResponse {
-            request_id: self.request_id.clone(),
+            request_id: self.request_id,
             hashes,
         };
 

--- a/core/src/sync/message/get_block_hashes_response.rs
+++ b/core/src/sync/message/get_block_hashes_response.rs
@@ -31,8 +31,8 @@ impl Handleable for GetBlockHashesResponse {
 
         // assume received everything
         // FIXME: peer should signal error?
-        let req = epoch_req.epochs.clone().into_iter().collect();
-        let rec = epoch_req.epochs.clone().into_iter().collect();
+        let req = epoch_req.epochs.iter().cloned().collect();
+        let rec = epoch_req.epochs.iter().cloned().collect();
         ctx.manager
             .request_manager
             .epochs_received(ctx.io, req, rec);

--- a/core/src/sync/message/get_block_txn.rs
+++ b/core/src/sync/message/get_block_txn.rs
@@ -64,8 +64,8 @@ impl Handleable for GetBlockTxn {
                     last += 1;
                 }
                 let response = GetBlockTxnResponse {
-                    request_id: self.request_id.clone(),
-                    block_hash: self.block_hash.clone(),
+                    request_id: self.request_id,
+                    block_hash: self.block_hash,
                     block_txn: tx_resp,
                 };
 
@@ -78,7 +78,7 @@ impl Handleable for GetBlockTxn {
                 );
 
                 let response = GetBlockTxnResponse {
-                    request_id: self.request_id.clone(),
+                    request_id: self.request_id,
                     block_hash: H256::default(),
                     block_txn: Vec::new(),
                 };

--- a/core/src/sync/message/get_blocks.rs
+++ b/core/src/sync/message/get_blocks.rs
@@ -83,7 +83,7 @@ impl GetBlocks {
         &self, ctx: &Context, blocks: Vec<Block>,
     ) -> Result<(), Error> {
         let mut response = GetBlocksWithPublicResponse {
-            request_id: self.request_id.clone(),
+            request_id: self.request_id,
             blocks,
         };
 
@@ -113,7 +113,7 @@ impl GetBlocks {
         &self, ctx: &Context, blocks: Vec<Block>,
     ) -> Result<(), Error> {
         let mut response = GetBlocksResponse {
-            request_id: self.request_id.clone(),
+            request_id: self.request_id,
             blocks,
         };
 

--- a/core/src/sync/message/get_compact_blocks.rs
+++ b/core/src/sync/message/get_compact_blocks.rs
@@ -82,7 +82,7 @@ impl Handleable for GetCompactBlocks {
         }
 
         let response = GetCompactBlocksResponse {
-            request_id: self.request_id.clone(),
+            request_id: self.request_id,
             compact_blocks,
             blocks,
         };

--- a/core/src/sync/message/get_compact_blocks_response.rs
+++ b/core/src/sync/message/get_compact_blocks_response.rs
@@ -129,7 +129,7 @@ impl Handleable for GetCompactBlocksResponse {
         ctx.manager.blocks_received(
             ctx.io,
             failed_blocks,
-            completed_blocks.clone().into_iter().collect(),
+            completed_blocks.iter().cloned().collect(),
             true,
             Some(ctx.peer),
         );

--- a/core/src/sync/message/get_terminal_block_hashes.rs
+++ b/core/src/sync/message/get_terminal_block_hashes.rs
@@ -24,7 +24,7 @@ impl Handleable for GetTerminalBlockHashes {
             None => best_info.bounded_terminal_block_hashes.clone(),
         };
         let response = GetTerminalBlockHashesResponse {
-            request_id: self.request_id.clone(),
+            request_id: self.request_id,
             hashes: terminal_hashes,
         };
         ctx.send_response(&response)

--- a/core/src/sync/message/new_block_hashes.rs
+++ b/core/src/sync/message/new_block_hashes.rs
@@ -22,7 +22,7 @@ impl Handleable for NewBlockHashes {
             if let Ok(info) = ctx.manager.syn.get_peer_info(&ctx.peer) {
                 let mut info = info.write();
                 self.block_hashes.iter().for_each(|h| {
-                    info.latest_block_hashes.insert(h.clone());
+                    info.latest_block_hashes.insert(*h);
                 });
             }
             return Ok(());

--- a/core/src/sync/message/transactions.rs
+++ b/core/src/sync/message/transactions.rs
@@ -103,6 +103,9 @@ impl Handleable for TransactionDigests {
             {
                 bail!(ErrorKind::TooManyTrans);
             }
+            if self.trans_short_ids.len() % Self::SHORT_ID_SIZE_IN_BYTES != 0 {
+                bail!(ErrorKind::InvalidMessageFormat);
+            }
         }
 
         ctx.manager
@@ -158,7 +161,7 @@ impl TransactionDigests {
         }
     }
 
-    pub fn get_decomposed_short_ids(&self) -> (Vec<u8>, Vec<TxPropagateId>) {
+    pub fn get_decomposed_short_ids(self) -> (Vec<u8>, Vec<TxPropagateId>) {
         let mut random_byte_vector: Vec<u8> = Vec::new();
         let mut fixed_bytes_vector: Vec<TxPropagateId> = Vec::new();
 
@@ -245,7 +248,7 @@ impl Handleable for GetTransactions {
             .request_manager
             .get_sent_transactions(self.window_index, &self.indices);
         let response = GetTransactionsResponse {
-            request_id: self.request_id.clone(),
+            request_id: self.request_id,
             transactions,
         };
         debug!(

--- a/core/src/sync/request_manager/mod.rs
+++ b/core/src/sync/request_manager/mod.rs
@@ -215,9 +215,9 @@ impl RequestManager {
         let _timer = MeterTimer::time_func(REQUEST_MANAGER_TX_TIMER.as_ref());
 
         let window_index: usize = transaction_digests.window_index;
+        let random_position: u8 = transaction_digests.random_position;
         let (random_byte_vector, fixed_bytes_vector) =
             transaction_digests.get_decomposed_short_ids();
-        let random_position: u8 = transaction_digests.random_position;
 
         if fixed_bytes_vector.is_empty() {
             return;

--- a/core/src/verification.rs
+++ b/core/src/verification.rs
@@ -31,12 +31,14 @@ impl VerificationConfig {
         }
     }
 
+    #[inline]
     pub fn compute_header_pow_quality(header: &mut BlockHeader) -> H256 {
         let pow_hash = pow::compute(header.nonce(), &header.problem_hash());
         header.pow_quality = pow::boundary_to_difficulty(&pow_hash);
         pow_hash
     }
 
+    #[inline]
     pub fn verify_pow(&self, header: &mut BlockHeader) -> Result<(), Error> {
         let pow_hash = Self::compute_header_pow_quality(header);
         if header.difficulty().is_zero() {
@@ -64,6 +66,7 @@ impl VerificationConfig {
         Ok(())
     }
 
+    #[inline]
     pub fn validate_header_timestamp(
         &self, header: &BlockHeader, now: u64,
     ) -> Result<(), SyncError> {
@@ -77,6 +80,7 @@ impl VerificationConfig {
 
     /// Check basic header parameters.
     /// This does not require header to be graph or parental tree ready.
+    #[inline]
     pub fn verify_header_params(
         &self, header: &mut BlockHeader,
     ) -> Result<(), Error> {
@@ -115,6 +119,7 @@ impl VerificationConfig {
     }
 
     /// Verify block data against header: transactions root
+    #[inline]
     fn verify_block_integrity(&self, block: &Block) -> Result<(), Error> {
         let expected_root =
             Block::compute_transaction_root(&block.transactions);
@@ -137,6 +142,7 @@ impl VerificationConfig {
     /// body again from others. However, if the body matches the header and
     /// the body is incorrect, this means the block is invalid, and we
     /// should discard this block and all its descendants.
+    #[inline]
     pub fn verify_block_basic(&self, block: &Block) -> Result<(), Error> {
         self.verify_block_integrity(block)?;
 


### PR DESCRIPTION
1. Use array in `DynamicCapabilitySet` and vector in `KeyContainer` to avoid unnecessary siphash in `HashMap`.
2. Add trans_short_ids  length check in `TransactionDigests`.
3. Avoid some unnecessary memcpy when handling request/response.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/612)
<!-- Reviewable:end -->
