### PR TITLE
Support filter.block_hashes on light node

### DIFF
--- a/core/src/consensus/consensus_inner/mod.rs
+++ b/core/src/consensus/consensus_inner/mod.rs
@@ -1928,6 +1928,12 @@ impl ConsensusGraphInner {
         }
     }
 
+    pub fn get_epoch_number_from_hash(&self, hash: &H256) -> Option<u64> {
+        self.hash_to_arena_indices
+            .get(hash)
+            .map(|index| self.arena[*index].data.epoch_number)
+    }
+
     pub fn block_hashes_by_epoch(
         &self, epoch_number: u64,
     ) -> Result<Vec<H256>, String> {
@@ -1963,10 +1969,8 @@ impl ConsensusGraphInner {
     }
 
     fn get_epoch_hash_for_block(&self, hash: &H256) -> Option<H256> {
-        self.hash_to_arena_indices.get(hash).and_then(|index| {
-            let epoch_number = self.arena[*index].data.epoch_number;
-            self.epoch_hash(epoch_number)
-        })
+        self.get_epoch_number_from_hash(&hash)
+            .and_then(|epoch_number| self.epoch_hash(epoch_number))
     }
 
     pub fn get_balance(

--- a/core/src/consensus/consensus_inner/mod.rs
+++ b/core/src/consensus/consensus_inner/mod.rs
@@ -1929,9 +1929,12 @@ impl ConsensusGraphInner {
     }
 
     pub fn get_epoch_number_from_hash(&self, hash: &H256) -> Option<u64> {
-        self.hash_to_arena_indices
-            .get(hash)
-            .map(|index| self.arena[*index].data.epoch_number)
+        self.hash_to_arena_indices.get(hash).and_then(|index| {
+            match self.arena[*index].data.epoch_number {
+                NULLU64 => None,
+                epoch => Some(epoch),
+            }
+        })
     }
 
     pub fn block_hashes_by_epoch(

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -527,6 +527,10 @@ impl ConsensusGraph {
             })
     }
 
+    pub fn get_epoch_number_from_hash(&self, hash: &H256) -> Option<u64> {
+        self.inner.read().get_epoch_number_from_hash(&hash)
+    }
+
     pub fn get_transaction_info_by_hash(
         &self, hash: &H256,
     ) -> Option<(SignedTransaction, Receipt, TransactionAddress)> {

--- a/primitives/src/filter.rs
+++ b/primitives/src/filter.rs
@@ -33,6 +33,9 @@ pub enum FilterError {
     /// Roots for verifying the requested epochs are unavailable.
     UnableToVerify { epoch: u64, latest_verifiable: u64 },
 
+    /// The block requested does not exist
+    UnknownBlock { hash: H256 },
+
     /// Filter error with custom error message (e.g. timeout)
     Custom(String),
 }
@@ -54,6 +57,9 @@ impl fmt::Display for FilterError {
             } => format! {
                 "Unable to verify epoch {} (latest verifiable epoch is {})",
                 epoch, latest_verifiable
+            },
+            UnknownBlock { hash } => format! {
+                "Unable to identify block {}", hash
             },
             Custom(ref s) => s.clone(),
         };

--- a/tests/light/log_filtering_test.py
+++ b/tests/light/log_filtering_test.py
@@ -101,9 +101,8 @@ class LogFilteringTest(ConfluxTestFramework):
         self.check_filter(Filter())
         self.check_filter(Filter(from_epoch="0x0", to_epoch="0x0"))
 
-        # TODO(thegaram): support this
         # apply filter for specific block, we expect a single log with 3 topics
-        # self.check_filter(Filter(block_hashes=[receipt["blockHash"]]))
+        self.check_filter(Filter(block_hashes=[receipt["blockHash"]]))
 
         # apply filter for specific topics
         self.log.info("testing filter topics...")


### PR DESCRIPTION
**Overview**

Add support for `filter.block_hashes` during light node log filtering.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/615)
<!-- Reviewable:end -->
