### PR TITLE
three way handshake to exchange node id

### DIFF
--- a/tests/network_tests/handshake.py
+++ b/tests/network_tests/handshake.py
@@ -24,7 +24,7 @@ class HandshakeTests(ConfluxTestFramework):
         wait_until(lambda: peer.had_status, timeout=3)
 
         # full node handshake
-        connect_nodes(self.nodes, 0, 1)
+        connect_nodes(self.nodes, 0, 1, timeout=3)
 
 if __name__ == "__main__":
     HandshakeTests().main()

--- a/tests/test_framework/util.py
+++ b/tests/test_framework/util.py
@@ -373,7 +373,7 @@ def get_peer_addr(connection):
     return "{}:{}".format(connection.ip, connection.port)
 
 
-def connect_nodes(nodes, a, node_num):
+def connect_nodes(nodes, a, node_num, timeout=60):
     """
     Let node[a] connect to node[node_num]
     """
@@ -384,7 +384,7 @@ def connect_nodes(nodes, a, node_num):
     from_connection.addnode(key, peer_addr)
     # poll until hello handshake complete to avoid race conditions
     # with transaction relaying
-    wait_until(lambda: check_handshake(from_connection, to_connection.key))
+    wait_until(lambda: check_handshake(from_connection, to_connection.key), timeout=timeout)
 
 
 def sync_blocks(rpc_connections, *, sync_count=True, wait=1, timeout=60):


### PR DESCRIPTION
AES based encrypted connection is time consuming in case of high TPS (20% CPU time), so cannot leverage the encrypted connection for the verification of node id. Instead, use typical three-way handshake to exchange the node id.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/637)
<!-- Reviewable:end -->
