### PR TITLE
Remove old items from light node cache

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -36,6 +36,7 @@ num = "0.2"
 parity-crypto = "0.3.0"
 bn = { git = "https://github.com/paritytech/bn", default-features = false }
 lru = "0.1.11"
+lru_time_cache = "0.9.0"
 threadpool = "1.0"
 rayon = "1.0"
 sqlite = "0.25"

--- a/core/src/light_protocol/common/ledger_info.rs
+++ b/core/src/light_protocol/common/ledger_info.rs
@@ -166,6 +166,10 @@ impl LedgerInfo {
     /// Returns a vector of receipts for each block in `epoch`.
     #[inline]
     pub fn receipts_of(&self, epoch: u64) -> Result<Vec<Vec<Receipt>>, Error> {
+        if epoch == 0 {
+            return Ok(vec![]);
+        }
+
         let pivot = self.pivot_hash_of(epoch)?;
         let hashes = self.block_hashes_in(epoch)?;
 
@@ -186,6 +190,10 @@ impl LedgerInfo {
     /// Get the aggregated bloom corresponding to the execution of `epoch`.
     #[inline]
     pub fn bloom_of(&self, epoch: u64) -> Result<Bloom, Error> {
+        if epoch == 0 {
+            return Ok(Bloom::zero());
+        }
+
         let pivot = self.pivot_hash_of(epoch)?;
         let hashes = self.block_hashes_in(epoch)?;
 

--- a/core/src/light_protocol/common/poll.rs
+++ b/core/src/light_protocol/common/poll.rs
@@ -8,7 +8,7 @@ use futures::{Async, Future, Stream};
 
 use crate::{
     light_protocol::{Error, ErrorKind},
-    parameters::light::POLL_PERIOD_MS,
+    parameters::light::POLL_PERIOD,
 };
 
 pub fn poll_future<T: Future>(future: &mut T) -> Result<T::Item, String>
@@ -33,8 +33,7 @@ where
         }
 
         trace!("sleeping...");
-        let d = std::time::Duration::from_millis(POLL_PERIOD_MS);
-        std::thread::sleep(d);
+        std::thread::sleep(*POLL_PERIOD);
     }
 
     unreachable!()
@@ -62,8 +61,7 @@ where
         }
 
         trace!("sleeping...");
-        let d = std::time::Duration::from_millis(POLL_PERIOD_MS);
-        std::thread::sleep(d);
+        std::thread::sleep(*POLL_PERIOD);
     }
 
     unreachable!()

--- a/core/src/light_protocol/handler/mod.rs
+++ b/core/src/light_protocol/handler/mod.rs
@@ -8,7 +8,7 @@ use cfx_types::H256;
 use io::TimerToken;
 use parking_lot::RwLock;
 use rlp::Rlp;
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use crate::{
     consensus::ConsensusGraph,
@@ -29,7 +29,7 @@ use crate::{
     message::{decode_msg, Message, MsgId},
     network::{NetworkContext, NetworkProtocolHandler, PeerId},
     parameters::light::{
-        CATCH_UP_EPOCH_LAG_THRESHOLD, CLEANUP_PERIOD_MS, SYNC_PERIOD_MS,
+        CATCH_UP_EPOCH_LAG_THRESHOLD, CLEANUP_PERIOD, SYNC_PERIOD,
     },
     sync::SynchronizationGraph,
 };
@@ -513,12 +513,10 @@ impl Handler {
 
 impl NetworkProtocolHandler for Handler {
     fn initialize(&self, io: &dyn NetworkContext) {
-        let period = Duration::from_millis(SYNC_PERIOD_MS);
-        io.register_timer(SYNC_TIMER, period)
+        io.register_timer(SYNC_TIMER, *SYNC_PERIOD)
             .expect("Error registering sync timer");
 
-        let period = Duration::from_millis(CLEANUP_PERIOD_MS);
-        io.register_timer(REQUEST_CLEANUP_TIMER, period)
+        io.register_timer(REQUEST_CLEANUP_TIMER, *CLEANUP_PERIOD)
             .expect("Error registering request cleanup timer");
     }
 

--- a/core/src/light_protocol/handler/sync/block_txs.rs
+++ b/core/src/light_protocol/handler/sync/block_txs.rs
@@ -3,12 +3,14 @@
 // See http://www.gnu.org/licenses/
 
 extern crate futures;
+extern crate lru_time_cache;
 
 use cfx_types::H256;
 use futures::Future;
+use lru_time_cache::LruCache;
 use parking_lot::RwLock;
 use primitives::{Block, SignedTransaction};
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use crate::{
     consensus::ConsensusGraph,
@@ -21,7 +23,7 @@ use crate::{
     network::{NetworkContext, PeerId},
     parameters::light::{
         BLOCK_TX_REQUEST_BATCH_SIZE, BLOCK_TX_REQUEST_TIMEOUT_MS,
-        MAX_BLOCK_TXS_IN_FLIGHT,
+        CACHE_TIMEOUT_SEC, MAX_BLOCK_TXS_IN_FLIGHT,
     },
 };
 
@@ -32,8 +34,8 @@ use super::{
 
 #[derive(Debug)]
 struct Statistics {
+    cached: usize,
     in_flight: usize,
-    verified: usize,
     waiting: usize,
 }
 
@@ -54,7 +56,7 @@ pub struct BlockTxs {
     txs: Arc<Txs>,
 
     // block txs received from full node
-    verified: Arc<RwLock<HashMap<H256, Vec<SignedTransaction>>>>,
+    verified: Arc<RwLock<LruCache<H256, Vec<SignedTransaction>>>>,
 }
 
 impl BlockTxs {
@@ -65,7 +67,10 @@ impl BlockTxs {
     {
         let ledger = LedgerInfo::new(consensus.clone());
         let sync_manager = SyncManager::new(peers.clone());
-        let verified = Arc::new(RwLock::new(HashMap::new()));
+
+        let timeout = Duration::from_secs(CACHE_TIMEOUT_SEC);
+        let cache = LruCache::with_expiry_duration(timeout);
+        let verified = Arc::new(RwLock::new(cache));
 
         BlockTxs {
             ledger,
@@ -79,8 +84,8 @@ impl BlockTxs {
     #[inline]
     fn get_statistics(&self) -> Statistics {
         Statistics {
+            cached: self.verified.read().len(),
             in_flight: self.sync_manager.num_in_flight(),
-            verified: self.verified.read().len(),
             waiting: self.sync_manager.num_waiting(),
         }
     }
@@ -118,9 +123,13 @@ impl BlockTxs {
 
     #[inline]
     pub fn clean_up(&self) {
+        // remove timeout in-flight requests
         let timeout = Duration::from_millis(BLOCK_TX_REQUEST_TIMEOUT_MS);
         let block_txs = self.sync_manager.remove_timeout_requests(timeout);
         self.sync_manager.insert_waiting(block_txs.into_iter());
+
+        // trigger cache cleanup
+        self.verified.write().get(&Default::default());
     }
 
     #[inline]

--- a/core/src/light_protocol/handler/sync/block_txs.rs
+++ b/core/src/light_protocol/handler/sync/block_txs.rs
@@ -10,7 +10,7 @@ use futures::Future;
 use lru_time_cache::LruCache;
 use parking_lot::RwLock;
 use primitives::{Block, SignedTransaction};
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use crate::{
     consensus::ConsensusGraph,
@@ -22,8 +22,8 @@ use crate::{
     message::Message,
     network::{NetworkContext, PeerId},
     parameters::light::{
-        BLOCK_TX_REQUEST_BATCH_SIZE, BLOCK_TX_REQUEST_TIMEOUT_MS,
-        CACHE_TIMEOUT_SEC, MAX_BLOCK_TXS_IN_FLIGHT,
+        BLOCK_TX_REQUEST_BATCH_SIZE, BLOCK_TX_REQUEST_TIMEOUT, CACHE_TIMEOUT,
+        MAX_BLOCK_TXS_IN_FLIGHT,
     },
 };
 
@@ -68,8 +68,7 @@ impl BlockTxs {
         let ledger = LedgerInfo::new(consensus.clone());
         let sync_manager = SyncManager::new(peers.clone());
 
-        let timeout = Duration::from_secs(CACHE_TIMEOUT_SEC);
-        let cache = LruCache::with_expiry_duration(timeout);
+        let cache = LruCache::with_expiry_duration(*CACHE_TIMEOUT);
         let verified = Arc::new(RwLock::new(cache));
 
         BlockTxs {
@@ -124,7 +123,7 @@ impl BlockTxs {
     #[inline]
     pub fn clean_up(&self) {
         // remove timeout in-flight requests
-        let timeout = Duration::from_millis(BLOCK_TX_REQUEST_TIMEOUT_MS);
+        let timeout = *BLOCK_TX_REQUEST_TIMEOUT;
         let block_txs = self.sync_manager.remove_timeout_requests(timeout);
         self.sync_manager.insert_waiting(block_txs.into_iter());
 

--- a/core/src/light_protocol/handler/sync/blooms.rs
+++ b/core/src/light_protocol/handler/sync/blooms.rs
@@ -9,7 +9,7 @@ use cfx_types::Bloom;
 use futures::Future;
 use lru_time_cache::LruCache;
 use parking_lot::RwLock;
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use crate::{
     hash::keccak,
@@ -21,7 +21,7 @@ use crate::{
     message::Message,
     network::{NetworkContext, PeerId},
     parameters::light::{
-        BLOOM_REQUEST_BATCH_SIZE, BLOOM_REQUEST_TIMEOUT_MS, CACHE_TIMEOUT_SEC,
+        BLOOM_REQUEST_BATCH_SIZE, BLOOM_REQUEST_TIMEOUT, CACHE_TIMEOUT,
         MAX_BLOOMS_IN_FLIGHT,
     },
 };
@@ -63,8 +63,7 @@ impl Blooms {
     {
         let sync_manager = SyncManager::new(peers.clone());
 
-        let timeout = Duration::from_secs(CACHE_TIMEOUT_SEC);
-        let cache = LruCache::with_expiry_duration(timeout);
+        let cache = LruCache::with_expiry_duration(*CACHE_TIMEOUT);
         let verified = Arc::new(RwLock::new(cache));
 
         Blooms {
@@ -118,7 +117,7 @@ impl Blooms {
     #[inline]
     pub fn clean_up(&self) {
         // remove timeout in-flight requests
-        let timeout = Duration::from_millis(BLOOM_REQUEST_TIMEOUT_MS);
+        let timeout = *BLOOM_REQUEST_TIMEOUT;
         let blooms = self.sync_manager.remove_timeout_requests(timeout);
         self.sync_manager.insert_waiting(blooms.into_iter());
 

--- a/core/src/light_protocol/handler/sync/blooms.rs
+++ b/core/src/light_protocol/handler/sync/blooms.rs
@@ -3,11 +3,13 @@
 // See http://www.gnu.org/licenses/
 
 extern crate futures;
+extern crate lru_time_cache;
 
 use cfx_types::Bloom;
 use futures::Future;
+use lru_time_cache::LruCache;
 use parking_lot::RwLock;
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use crate::{
     hash::keccak,
@@ -19,7 +21,7 @@ use crate::{
     message::Message,
     network::{NetworkContext, PeerId},
     parameters::light::{
-        BLOOM_REQUEST_BATCH_SIZE, BLOOM_REQUEST_TIMEOUT_MS,
+        BLOOM_REQUEST_BATCH_SIZE, BLOOM_REQUEST_TIMEOUT_MS, CACHE_TIMEOUT_SEC,
         MAX_BLOOMS_IN_FLIGHT,
     },
 };
@@ -31,8 +33,8 @@ use super::{
 
 #[derive(Debug)]
 struct Statistics {
+    cached: usize,
     in_flight: usize,
-    verified: usize,
     waiting: usize,
 }
 
@@ -45,8 +47,9 @@ pub struct Blooms {
 
     // sync and request manager
     sync_manager: SyncManager<u64, MissingBloom>,
+
     // bloom filters received from full node
-    verified: Arc<RwLock<HashMap<u64, Bloom>>>,
+    verified: Arc<RwLock<LruCache<u64, Bloom>>>,
 
     // witness sync manager
     witnesses: Arc<Witnesses>,
@@ -59,9 +62,10 @@ impl Blooms {
     ) -> Self
     {
         let sync_manager = SyncManager::new(peers.clone());
-        let verified = Arc::new(RwLock::new(HashMap::new()));
 
-        verified.write().insert(0, Bloom::zero());
+        let timeout = Duration::from_secs(CACHE_TIMEOUT_SEC);
+        let cache = LruCache::with_expiry_duration(timeout);
+        let verified = Arc::new(RwLock::new(cache));
 
         Blooms {
             request_id_allocator,
@@ -74,8 +78,8 @@ impl Blooms {
     #[inline]
     fn get_statistics(&self) -> Statistics {
         Statistics {
+            cached: self.verified.read().len(),
             in_flight: self.sync_manager.num_in_flight(),
-            verified: self.verified.read().len(),
             waiting: self.sync_manager.num_waiting(),
         }
     }
@@ -84,6 +88,10 @@ impl Blooms {
     pub fn request(
         &self, epoch: u64,
     ) -> impl Future<Item = Bloom, Error = Error> {
+        if epoch == 0 {
+            self.verified.write().insert(0, Bloom::zero());
+        }
+
         if !self.verified.read().contains_key(&epoch) {
             let missing = MissingBloom::new(epoch);
             self.sync_manager.insert_waiting(std::iter::once(missing));
@@ -109,9 +117,13 @@ impl Blooms {
 
     #[inline]
     pub fn clean_up(&self) {
+        // remove timeout in-flight requests
         let timeout = Duration::from_millis(BLOOM_REQUEST_TIMEOUT_MS);
         let blooms = self.sync_manager.remove_timeout_requests(timeout);
         self.sync_manager.insert_waiting(blooms.into_iter());
+
+        // trigger cache cleanup
+        self.verified.write().get(&Default::default());
     }
 
     #[inline]

--- a/core/src/light_protocol/handler/sync/epochs.rs
+++ b/core/src/light_protocol/handler/sync/epochs.rs
@@ -10,7 +10,7 @@ use std::{
         atomic::{AtomicU64, Ordering},
         Arc,
     },
-    time::{Duration, Instant},
+    time::Instant,
 };
 
 use crate::{
@@ -23,7 +23,7 @@ use crate::{
     message::{Message, RequestId},
     network::{NetworkContext, PeerId},
     parameters::light::{
-        EPOCH_REQUEST_BATCH_SIZE, EPOCH_REQUEST_TIMEOUT_MS,
+        EPOCH_REQUEST_BATCH_SIZE, EPOCH_REQUEST_TIMEOUT,
         MAX_PARALLEL_EPOCH_REQUESTS, NUM_EPOCHS_TO_REQUEST,
         NUM_WAITING_HEADERS_THRESHOLD,
     },
@@ -142,7 +142,7 @@ impl Epochs {
 
     pub fn clean_up(&self) {
         let mut in_flight = self.in_flight.write();
-        let timeout = Duration::from_millis(EPOCH_REQUEST_TIMEOUT_MS);
+        let timeout = *EPOCH_REQUEST_TIMEOUT;
 
         // collect timed-out requests
         let ids: Vec<_> = in_flight

--- a/core/src/light_protocol/handler/sync/headers.rs
+++ b/core/src/light_protocol/handler/sync/headers.rs
@@ -9,7 +9,7 @@ use std::{
         atomic::{AtomicU64, Ordering},
         Arc,
     },
-    time::{Duration, Instant},
+    time::Instant,
 };
 
 use cfx_types::H256;
@@ -24,7 +24,7 @@ use crate::{
     message::Message,
     network::{NetworkContext, PeerId},
     parameters::light::{
-        HEADER_REQUEST_BATCH_SIZE, HEADER_REQUEST_TIMEOUT_MS,
+        HEADER_REQUEST_BATCH_SIZE, HEADER_REQUEST_TIMEOUT,
         MAX_HEADERS_IN_FLIGHT,
     },
     sync::SynchronizationGraph,
@@ -204,7 +204,7 @@ impl Headers {
 
     #[inline]
     pub fn clean_up(&self) {
-        let timeout = Duration::from_millis(HEADER_REQUEST_TIMEOUT_MS);
+        let timeout = *HEADER_REQUEST_TIMEOUT;
         let headers = self.sync_manager.remove_timeout_requests(timeout);
         self.sync_manager.insert_waiting(headers.into_iter());
     }

--- a/core/src/light_protocol/handler/sync/receipts.rs
+++ b/core/src/light_protocol/handler/sync/receipts.rs
@@ -8,7 +8,7 @@ extern crate lru_time_cache;
 use futures::Future;
 use lru_time_cache::LruCache;
 use parking_lot::RwLock;
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use crate::{
     light_protocol::{
@@ -19,8 +19,8 @@ use crate::{
     message::Message,
     network::{NetworkContext, PeerId},
     parameters::light::{
-        CACHE_TIMEOUT_SEC, MAX_RECEIPTS_IN_FLIGHT, RECEIPT_REQUEST_BATCH_SIZE,
-        RECEIPT_REQUEST_TIMEOUT_MS,
+        CACHE_TIMEOUT, MAX_RECEIPTS_IN_FLIGHT, RECEIPT_REQUEST_BATCH_SIZE,
+        RECEIPT_REQUEST_TIMEOUT,
     },
     primitives::{BlockHeaderBuilder, Receipt},
 };
@@ -62,8 +62,7 @@ impl Receipts {
     {
         let sync_manager = SyncManager::new(peers.clone());
 
-        let timeout = Duration::from_secs(CACHE_TIMEOUT_SEC);
-        let cache = LruCache::with_expiry_duration(timeout);
+        let cache = LruCache::with_expiry_duration(*CACHE_TIMEOUT);
         let verified = Arc::new(RwLock::new(cache));
 
         Receipts {
@@ -117,7 +116,7 @@ impl Receipts {
     #[inline]
     pub fn clean_up(&self) {
         // remove timeout in-flight requests
-        let timeout = Duration::from_millis(RECEIPT_REQUEST_TIMEOUT_MS);
+        let timeout = *RECEIPT_REQUEST_TIMEOUT;
         let receiptss = self.sync_manager.remove_timeout_requests(timeout);
         self.sync_manager.insert_waiting(receiptss.into_iter());
 

--- a/core/src/light_protocol/handler/sync/receipts.rs
+++ b/core/src/light_protocol/handler/sync/receipts.rs
@@ -3,10 +3,12 @@
 // See http://www.gnu.org/licenses/
 
 extern crate futures;
+extern crate lru_time_cache;
 
 use futures::Future;
+use lru_time_cache::LruCache;
 use parking_lot::RwLock;
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use crate::{
     light_protocol::{
@@ -17,7 +19,7 @@ use crate::{
     message::Message,
     network::{NetworkContext, PeerId},
     parameters::light::{
-        MAX_RECEIPTS_IN_FLIGHT, RECEIPT_REQUEST_BATCH_SIZE,
+        CACHE_TIMEOUT_SEC, MAX_RECEIPTS_IN_FLIGHT, RECEIPT_REQUEST_BATCH_SIZE,
         RECEIPT_REQUEST_TIMEOUT_MS,
     },
     primitives::{BlockHeaderBuilder, Receipt},
@@ -30,8 +32,8 @@ use super::{
 
 #[derive(Debug)]
 struct Statistics {
+    cached: usize,
     in_flight: usize,
-    verified: usize,
     waiting: usize,
 }
 
@@ -46,7 +48,7 @@ pub struct Receipts {
     sync_manager: SyncManager<u64, MissingReceipts>,
 
     // epoch receipts received from full node
-    verified: Arc<RwLock<HashMap<u64, Vec<Vec<Receipt>>>>>,
+    verified: Arc<RwLock<LruCache<u64, Vec<Vec<Receipt>>>>>,
 
     // witness sync manager
     witnesses: Arc<Witnesses>,
@@ -59,9 +61,10 @@ impl Receipts {
     ) -> Self
     {
         let sync_manager = SyncManager::new(peers.clone());
-        let verified = Arc::new(RwLock::new(HashMap::new()));
 
-        verified.write().insert(0, vec![]);
+        let timeout = Duration::from_secs(CACHE_TIMEOUT_SEC);
+        let cache = LruCache::with_expiry_duration(timeout);
+        let verified = Arc::new(RwLock::new(cache));
 
         Receipts {
             request_id_allocator,
@@ -74,8 +77,8 @@ impl Receipts {
     #[inline]
     fn get_statistics(&self) -> Statistics {
         Statistics {
+            cached: self.verified.read().len(),
             in_flight: self.sync_manager.num_in_flight(),
-            verified: self.verified.read().len(),
             waiting: self.sync_manager.num_waiting(),
         }
     }
@@ -84,6 +87,10 @@ impl Receipts {
     pub fn request(
         &self, epoch: u64,
     ) -> impl Future<Item = Vec<Vec<Receipt>>, Error = Error> {
+        if epoch == 0 {
+            self.verified.write().insert(0, vec![]);
+        }
+
         if !self.verified.read().contains_key(&epoch) {
             let missing = MissingReceipts::new(epoch);
             self.sync_manager.insert_waiting(std::iter::once(missing));
@@ -109,9 +116,13 @@ impl Receipts {
 
     #[inline]
     pub fn clean_up(&self) {
+        // remove timeout in-flight requests
         let timeout = Duration::from_millis(RECEIPT_REQUEST_TIMEOUT_MS);
         let receiptss = self.sync_manager.remove_timeout_requests(timeout);
         self.sync_manager.insert_waiting(receiptss.into_iter());
+
+        // trigger cache cleanup
+        self.verified.write().get(&Default::default());
     }
 
     #[inline]

--- a/core/src/light_protocol/handler/sync/state_entries.rs
+++ b/core/src/light_protocol/handler/sync/state_entries.rs
@@ -8,7 +8,7 @@ extern crate lru_time_cache;
 use futures::Future;
 use lru_time_cache::LruCache;
 use parking_lot::RwLock;
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use crate::{
     light_protocol::{
@@ -19,8 +19,8 @@ use crate::{
     message::Message,
     network::{NetworkContext, PeerId},
     parameters::light::{
-        CACHE_TIMEOUT_SEC, MAX_STATE_ENTRIES_IN_FLIGHT,
-        STATE_ENTRY_REQUEST_BATCH_SIZE, STATE_ENTRY_REQUEST_TIMEOUT_MS,
+        CACHE_TIMEOUT, MAX_STATE_ENTRIES_IN_FLIGHT,
+        STATE_ENTRY_REQUEST_BATCH_SIZE, STATE_ENTRY_REQUEST_TIMEOUT,
     },
     storage::StateProof,
 };
@@ -75,8 +75,7 @@ impl StateEntries {
     {
         let sync_manager = SyncManager::new(peers.clone());
 
-        let timeout = Duration::from_secs(CACHE_TIMEOUT_SEC);
-        let cache = LruCache::with_expiry_duration(timeout);
+        let cache = LruCache::with_expiry_duration(*CACHE_TIMEOUT);
         let verified = Arc::new(RwLock::new(cache));
 
         StateEntries {
@@ -131,7 +130,7 @@ impl StateEntries {
     #[inline]
     pub fn clean_up(&self) {
         // remove timeout in-flight requests
-        let timeout = Duration::from_millis(STATE_ENTRY_REQUEST_TIMEOUT_MS);
+        let timeout = *STATE_ENTRY_REQUEST_TIMEOUT;
         let entries = self.sync_manager.remove_timeout_requests(timeout);
         self.sync_manager.insert_waiting(entries.into_iter());
 

--- a/core/src/light_protocol/handler/sync/state_entries.rs
+++ b/core/src/light_protocol/handler/sync/state_entries.rs
@@ -3,10 +3,12 @@
 // See http://www.gnu.org/licenses/
 
 extern crate futures;
+extern crate lru_time_cache;
 
 use futures::Future;
+use lru_time_cache::LruCache;
 use parking_lot::RwLock;
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use crate::{
     light_protocol::{
@@ -17,8 +19,8 @@ use crate::{
     message::Message,
     network::{NetworkContext, PeerId},
     parameters::light::{
-        MAX_STATE_ENTRIES_IN_FLIGHT, STATE_ENTRY_REQUEST_BATCH_SIZE,
-        STATE_ENTRY_REQUEST_TIMEOUT_MS,
+        CACHE_TIMEOUT_SEC, MAX_STATE_ENTRIES_IN_FLIGHT,
+        STATE_ENTRY_REQUEST_BATCH_SIZE, STATE_ENTRY_REQUEST_TIMEOUT_MS,
     },
     storage::StateProof,
 };
@@ -44,8 +46,8 @@ impl PartialOrd for StateKey {
 
 #[derive(Debug)]
 struct Statistics {
+    cached: usize,
     in_flight: usize,
-    verified: usize,
     waiting: usize,
 }
 
@@ -62,7 +64,7 @@ pub struct StateEntries {
     sync_manager: SyncManager<StateKey, MissingStateEntry>,
 
     // state entries received from full node
-    verified: Arc<RwLock<HashMap<StateKey, StateEntry>>>,
+    verified: Arc<RwLock<LruCache<StateKey, StateEntry>>>,
 }
 
 impl StateEntries {
@@ -72,7 +74,10 @@ impl StateEntries {
     ) -> Self
     {
         let sync_manager = SyncManager::new(peers.clone());
-        let verified = Arc::new(RwLock::new(HashMap::new()));
+
+        let timeout = Duration::from_secs(CACHE_TIMEOUT_SEC);
+        let cache = LruCache::with_expiry_duration(timeout);
+        let verified = Arc::new(RwLock::new(cache));
 
         StateEntries {
             request_id_allocator,
@@ -85,8 +90,8 @@ impl StateEntries {
     #[inline]
     fn get_statistics(&self) -> Statistics {
         Statistics {
+            cached: self.verified.read().len(),
             in_flight: self.sync_manager.num_in_flight(),
-            verified: self.verified.read().len(),
             waiting: self.sync_manager.num_waiting(),
         }
     }
@@ -125,9 +130,13 @@ impl StateEntries {
 
     #[inline]
     pub fn clean_up(&self) {
+        // remove timeout in-flight requests
         let timeout = Duration::from_millis(STATE_ENTRY_REQUEST_TIMEOUT_MS);
         let entries = self.sync_manager.remove_timeout_requests(timeout);
         self.sync_manager.insert_waiting(entries.into_iter());
+
+        // trigger cache cleanup
+        self.verified.write().get(&Default::default());
     }
 
     #[inline]

--- a/core/src/light_protocol/handler/sync/state_roots.rs
+++ b/core/src/light_protocol/handler/sync/state_roots.rs
@@ -9,7 +9,7 @@ use futures::Future;
 use lru_time_cache::LruCache;
 use parking_lot::RwLock;
 use primitives::StateRoot;
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use crate::{
     light_protocol::{
@@ -20,8 +20,8 @@ use crate::{
     message::Message,
     network::{NetworkContext, PeerId},
     parameters::light::{
-        CACHE_TIMEOUT_SEC, MAX_STATE_ROOTS_IN_FLIGHT,
-        STATE_ROOT_REQUEST_BATCH_SIZE, STATE_ROOT_REQUEST_TIMEOUT_MS,
+        CACHE_TIMEOUT, MAX_STATE_ROOTS_IN_FLIGHT,
+        STATE_ROOT_REQUEST_BATCH_SIZE, STATE_ROOT_REQUEST_TIMEOUT,
     },
 };
 
@@ -61,8 +61,7 @@ impl StateRoots {
     {
         let sync_manager = SyncManager::new(peers.clone());
 
-        let timeout = Duration::from_secs(CACHE_TIMEOUT_SEC);
-        let cache = LruCache::with_expiry_duration(timeout);
+        let cache = LruCache::with_expiry_duration(*CACHE_TIMEOUT);
         let verified = Arc::new(RwLock::new(cache));
 
         StateRoots {
@@ -124,7 +123,7 @@ impl StateRoots {
     #[inline]
     pub fn clean_up(&self) {
         // remove timeout in-flight requests
-        let timeout = Duration::from_millis(STATE_ROOT_REQUEST_TIMEOUT_MS);
+        let timeout = *STATE_ROOT_REQUEST_TIMEOUT;
         let state_roots = self.sync_manager.remove_timeout_requests(timeout);
         self.sync_manager.insert_waiting(state_roots.into_iter());
 

--- a/core/src/light_protocol/handler/sync/txs.rs
+++ b/core/src/light_protocol/handler/sync/txs.rs
@@ -3,12 +3,14 @@
 // See http://www.gnu.org/licenses/
 
 extern crate futures;
+extern crate lru_time_cache;
 
 use cfx_types::H256;
 use futures::Future;
+use lru_time_cache::LruCache;
 use parking_lot::RwLock;
 use primitives::SignedTransaction;
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use crate::{
     light_protocol::{
@@ -19,7 +21,8 @@ use crate::{
     message::Message,
     network::{NetworkContext, PeerId},
     parameters::light::{
-        MAX_TXS_IN_FLIGHT, TX_REQUEST_BATCH_SIZE, TX_REQUEST_TIMEOUT_MS,
+        CACHE_TIMEOUT_SEC, MAX_TXS_IN_FLIGHT, TX_REQUEST_BATCH_SIZE,
+        TX_REQUEST_TIMEOUT_MS,
     },
 };
 
@@ -27,8 +30,8 @@ use super::common::{FutureItem, SyncManager, TimeOrdered};
 
 #[derive(Debug)]
 struct Statistics {
+    cached: usize,
     in_flight: usize,
-    verified: usize,
     waiting: usize,
 }
 
@@ -43,7 +46,7 @@ pub struct Txs {
     sync_manager: SyncManager<H256, MissingTx>,
 
     // txs received from full node
-    verified: Arc<RwLock<HashMap<H256, SignedTransaction>>>,
+    verified: Arc<RwLock<LruCache<H256, SignedTransaction>>>,
 }
 
 impl Txs {
@@ -51,7 +54,10 @@ impl Txs {
         peers: Arc<Peers<FullPeerState>>, request_id_allocator: Arc<UniqueId>,
     ) -> Self {
         let sync_manager = SyncManager::new(peers.clone());
-        let verified = Arc::new(RwLock::new(HashMap::new()));
+
+        let timeout = Duration::from_secs(CACHE_TIMEOUT_SEC);
+        let cache = LruCache::with_expiry_duration(timeout);
+        let verified = Arc::new(RwLock::new(cache));
 
         Txs {
             request_id_allocator,
@@ -63,8 +69,8 @@ impl Txs {
     #[inline]
     fn get_statistics(&self) -> Statistics {
         Statistics {
+            cached: self.verified.read().len(),
             in_flight: self.sync_manager.num_in_flight(),
-            verified: self.verified.read().len(),
             waiting: self.sync_manager.num_waiting(),
         }
     }
@@ -102,9 +108,13 @@ impl Txs {
 
     #[inline]
     pub fn clean_up(&self) {
+        // remove timeout in-flight requests
         let timeout = Duration::from_millis(TX_REQUEST_TIMEOUT_MS);
         let txs = self.sync_manager.remove_timeout_requests(timeout);
         self.sync_manager.insert_waiting(txs.into_iter());
+
+        // trigger cache cleanup
+        self.verified.write().get(&Default::default());
     }
 
     #[inline]

--- a/core/src/light_protocol/handler/sync/txs.rs
+++ b/core/src/light_protocol/handler/sync/txs.rs
@@ -10,7 +10,7 @@ use futures::Future;
 use lru_time_cache::LruCache;
 use parking_lot::RwLock;
 use primitives::SignedTransaction;
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use crate::{
     light_protocol::{
@@ -21,8 +21,8 @@ use crate::{
     message::Message,
     network::{NetworkContext, PeerId},
     parameters::light::{
-        CACHE_TIMEOUT_SEC, MAX_TXS_IN_FLIGHT, TX_REQUEST_BATCH_SIZE,
-        TX_REQUEST_TIMEOUT_MS,
+        CACHE_TIMEOUT, MAX_TXS_IN_FLIGHT, TX_REQUEST_BATCH_SIZE,
+        TX_REQUEST_TIMEOUT,
     },
 };
 
@@ -55,8 +55,7 @@ impl Txs {
     ) -> Self {
         let sync_manager = SyncManager::new(peers.clone());
 
-        let timeout = Duration::from_secs(CACHE_TIMEOUT_SEC);
-        let cache = LruCache::with_expiry_duration(timeout);
+        let cache = LruCache::with_expiry_duration(*CACHE_TIMEOUT);
         let verified = Arc::new(RwLock::new(cache));
 
         Txs {
@@ -109,7 +108,7 @@ impl Txs {
     #[inline]
     pub fn clean_up(&self) {
         // remove timeout in-flight requests
-        let timeout = Duration::from_millis(TX_REQUEST_TIMEOUT_MS);
+        let timeout = *TX_REQUEST_TIMEOUT;
         let txs = self.sync_manager.remove_timeout_requests(timeout);
         self.sync_manager.insert_waiting(txs.into_iter());
 

--- a/core/src/light_protocol/handler/sync/witnesses.rs
+++ b/core/src/light_protocol/handler/sync/witnesses.rs
@@ -4,7 +4,7 @@
 
 use cfx_types::H256;
 use parking_lot::RwLock;
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc};
 
 use crate::{
     consensus::ConsensusGraph,
@@ -20,7 +20,7 @@ use crate::{
         light::{
             BLAME_CHECK_OFFSET, MAX_WITNESSES_IN_FLIGHT,
             NUM_WAITING_WITNESSES_THRESHOLD, WITNESS_REQUEST_BATCH_SIZE,
-            WITNESS_REQUEST_TIMEOUT_MS,
+            WITNESS_REQUEST_TIMEOUT,
         },
     },
 };
@@ -160,7 +160,7 @@ impl Witnesses {
 
     #[inline]
     pub fn clean_up(&self) {
-        let timeout = Duration::from_millis(WITNESS_REQUEST_TIMEOUT_MS);
+        let timeout = *WITNESS_REQUEST_TIMEOUT;
         let witnesses = self.sync_manager.remove_timeout_requests(timeout);
         self.sync_manager.insert_waiting(witnesses.into_iter());
     }

--- a/core/src/light_protocol/query_service.rs
+++ b/core/src/light_protocol/query_service.rs
@@ -6,7 +6,7 @@ extern crate futures;
 
 use cfx_types::{Bloom, H160, H256, KECCAK_EMPTY_BLOOM};
 use futures::{future, stream, Future, Stream};
-use std::{collections::BTreeSet, sync::Arc, time::Duration};
+use std::{collections::BTreeSet, sync::Arc};
 
 use primitives::{
     filter::{Filter, FilterError},
@@ -19,7 +19,7 @@ use crate::{
     network::{NetworkContext, NetworkService},
     parameters::{
         consensus::DEFERRED_STATE_EPOCH_COUNT,
-        light::{LOG_FILTERING_LOOKAHEAD, MAX_POLL_TIME_MS},
+        light::{LOG_FILTERING_LOOKAHEAD, MAX_POLL_TIME},
     },
     statedb::StorageKey,
     storage,
@@ -86,7 +86,7 @@ impl QueryService {
         trace!("retrieve_state_root epoch = {}", epoch);
 
         with_timeout(
-            Duration::from_millis(MAX_POLL_TIME_MS), /* timeout */
+            *MAX_POLL_TIME, /* timeout */
             format!("Timeout while retrieving state root for epoch {}", epoch), /* error */
             self.with_io(|io| self.handler.state_roots.request_now(io, epoch)),
         )
@@ -98,7 +98,7 @@ impl QueryService {
         trace!("retrieve_state_entry epoch = {}, key = {:?}", epoch, key);
 
         with_timeout(
-            Duration::from_millis(MAX_POLL_TIME_MS), /* timeout */
+            *MAX_POLL_TIME, /* timeout */
             format!("Timeout while retrieving state entry for epoch {} with key {:?}", epoch, key), /* error */
             self.with_io(|io| self.handler.state_entries.request_now(io, epoch, key.clone()))
         )
@@ -110,7 +110,7 @@ impl QueryService {
         trace!("retrieve_bloom epoch = {}", epoch);
 
         with_timeout(
-            Duration::from_millis(MAX_POLL_TIME_MS), /* timeout */
+            *MAX_POLL_TIME, /* timeout */
             format!("Timeout while retrieving bloom for epoch {}", epoch), /* error */
             self.handler.blooms.request(epoch),
         )
@@ -122,7 +122,7 @@ impl QueryService {
         trace!("retrieve_receipts epoch = {}", epoch);
 
         with_timeout(
-            Duration::from_millis(MAX_POLL_TIME_MS), /* timeout */
+            *MAX_POLL_TIME, /* timeout */
             format!("Timeout while retrieving receipts for epoch {}", epoch), /* error */
             self.handler.receipts.request(epoch),
         )
@@ -134,7 +134,7 @@ impl QueryService {
         trace!("retrieve_block_txs hash = {:?}", hash);
 
         with_timeout(
-            Duration::from_millis(MAX_POLL_TIME_MS), /* timeout */
+            *MAX_POLL_TIME, /* timeout */
             format!("Timeout while retrieving block txs for block {}", hash), /* error */
             self.handler.block_txs.request(hash),
         )
@@ -282,7 +282,7 @@ impl QueryService {
             let tx = self.with_io(|io| self.handler.txs.request_now(io, hash));
 
             with_timeout(
-                Duration::from_millis(MAX_POLL_TIME_MS), /* timeout */
+                *MAX_POLL_TIME,                                  /* timeout */
                 format!("Timeout while retrieving tx {}", hash), /* error */
                 tx,
             )

--- a/core/src/parameters.rs
+++ b/core/src/parameters.rs
@@ -116,35 +116,42 @@ pub mod block {
 }
 
 pub mod light {
+    use std::time::Duration;
+
+    lazy_static! {
+        /// Frequency of re-triggering sync.
+        pub static ref SYNC_PERIOD: Duration = Duration::from_secs(1);
+
+        /// Frequency of checking request timeouts.
+        pub static ref CLEANUP_PERIOD: Duration = Duration::from_secs(1);
+
+        /// Request timeouts.
+        pub static ref EPOCH_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+        pub static ref HEADER_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+        pub static ref WITNESS_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+        pub static ref BLOOM_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+        pub static ref RECEIPT_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+        pub static ref BLOCK_TX_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+        pub static ref STATE_ROOT_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+        pub static ref STATE_ENTRY_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+        pub static ref TX_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+
+        /// Maximum time period we wait for a response for an on-demand query.
+        /// After this timeout has been reached, we try another peer or give up.
+        pub static ref MAX_POLL_TIME: Duration = Duration::from_secs(4);
+
+        /// Period of time to sleep between subsequent polls for on-demand queries.
+        pub static ref POLL_PERIOD: Duration = Duration::from_millis(100);
+
+        /// Items not accessed for this amount of time are removed from the cache.
+        pub static ref CACHE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+    }
+
     /// The threshold controlling whether a node is in catch-up mode.
     /// A node is in catch-up mode if its local best epoch number is
     /// `CATCH_UP_EPOCH_LAG_THRESHOLD` behind the median of the epoch
     /// numbers of peers.
     pub const CATCH_UP_EPOCH_LAG_THRESHOLD: u64 = 3;
-
-    /// Frequency of checking request timeouts.
-    pub const CLEANUP_PERIOD_MS: u64 = 1000;
-
-    /// Frequency of re-triggering sync.
-    pub const SYNC_PERIOD_MS: u64 = 1000;
-
-    /// Request timeouts.
-    pub const EPOCH_REQUEST_TIMEOUT_MS: u64 = 2000;
-    pub const HEADER_REQUEST_TIMEOUT_MS: u64 = 2000;
-    pub const WITNESS_REQUEST_TIMEOUT_MS: u64 = 2000;
-    pub const BLOOM_REQUEST_TIMEOUT_MS: u64 = 2000;
-    pub const RECEIPT_REQUEST_TIMEOUT_MS: u64 = 2000;
-    pub const BLOCK_TX_REQUEST_TIMEOUT_MS: u64 = 2000;
-    pub const STATE_ROOT_REQUEST_TIMEOUT_MS: u64 = 2000;
-    pub const STATE_ENTRY_REQUEST_TIMEOUT_MS: u64 = 2000;
-    pub const TX_REQUEST_TIMEOUT_MS: u64 = 2000;
-
-    /// Maximum time period we wait for a response for an on-demand query.
-    /// After this timeout has been reached, we try another peer or give up.
-    pub const MAX_POLL_TIME_MS: u64 = 4000;
-
-    /// Period of time to sleep between subsequent polls for on-demand queries.
-    pub const POLL_PERIOD_MS: u64 = 100;
 
     /// (Maximum) number of items requested in a single request.
     pub const EPOCH_REQUEST_BATCH_SIZE: usize = 30;
@@ -196,9 +203,6 @@ pub mod light {
     /// there's always plenty of items in flight. This way, we can reduce idle
     /// time when we're waiting to recveive an item.
     pub const LOG_FILTERING_LOOKAHEAD: usize = 100;
-
-    /// Items not accessed for this amount of time are removed from the cache.
-    pub const CACHE_TIMEOUT_SEC: u64 = 5 * 60;
 }
 
 pub const WORKER_COMPUTATION_PARALLELISM: usize = 8;

--- a/core/src/parameters.rs
+++ b/core/src/parameters.rs
@@ -196,6 +196,9 @@ pub mod light {
     /// there's always plenty of items in flight. This way, we can reduce idle
     /// time when we're waiting to recveive an item.
     pub const LOG_FILTERING_LOOKAHEAD: usize = 100;
+
+    /// Items not accessed for this amount of time are removed from the cache.
+    pub const CACHE_TIMEOUT_SEC: u64 = 5 * 60;
 }
 
 pub const WORKER_COMPUTATION_PARALLELISM: usize = 8;


### PR DESCRIPTION
**Overview**

Bloom filters, receipts, transactions, state roots, and state entries are all cached on the light node. This PR add an LRU timeout to these caches: entries are deleted if they are not accessed for at least the given amount of time.

The library used also allows for specifying capacity (maximum number of items), which might be useful if we want to have more precise control in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/648)
<!-- Reviewable:end -->
