### PR TITLE
Enable rocksdb wal by default.

### DIFF
--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -113,6 +113,7 @@ build_config! {
         (tx_cache_count, (usize), 250000)
         (max_download_state_peers, (usize), 8)
         (block_db_type, (String), "rocksdb".to_string())
+        (rocksdb_disable_wal, (bool), false)
     }
     {
         (
@@ -234,6 +235,7 @@ impl Configuration {
             self.raw_conf.db_cache_size.clone(),
             compact_profile,
             NUM_COLUMNS.clone(),
+            self.raw_conf.rocksdb_disable_wal,
         )
     }
 

--- a/core/src/sync/utils.rs
+++ b/core/src/sync/utils.rs
@@ -83,6 +83,7 @@ pub fn initialize_synchronization_graph(
             Some(128),
             db::DatabaseCompactionProfile::default(),
             NUM_COLUMNS,
+            false,
         ),
     )
     .map_err(|e| format!("Failed to open database {:?}", e))

--- a/db/src/kvdb-rocksdb/src/lib.rs
+++ b/db/src/kvdb-rocksdb/src/lib.rs
@@ -167,6 +167,8 @@ pub struct DatabaseConfig {
 	pub compaction: CompactionProfile,
 	/// Set number of columns
 	pub columns: Option<u32>,
+    /// Disable write-ahead-log
+    pub disable_wal: bool,
 }
 
 impl DatabaseConfig {
@@ -194,6 +196,7 @@ impl Default for DatabaseConfig {
 			memory_budget: None,
 			compaction: CompactionProfile::default(),
 			columns: None,
+			disable_wal: false,
 		}
 	}
 }
@@ -295,7 +298,7 @@ impl OpenHandler<DBAndColumns> for DBAndColumns {
 		}
 
 		let mut write_opts = WriteOptions::default();
-		write_opts.disable_wal(true);
+		write_opts.disable_wal(config.disable_wal);
 		let read_opts = ReadOptions::default();
 		// TODO: add to upstream
 		// read_opts.set_verify_checksums(false);

--- a/db/src/rocksdb/mod.rs
+++ b/db/src/rocksdb/mod.rs
@@ -84,12 +84,14 @@ pub fn compaction_profile(
 pub fn db_config(
     path: &Path, db_cache_size: Option<usize>,
     db_compaction: DatabaseCompactionProfile, columns: Option<u32>,
+    disable_wal: bool,
 ) -> DatabaseConfig
 {
     let mut db_config = DatabaseConfig::with_columns(columns);
 
     db_config.memory_budget = db_cache_size;
     db_config.compaction = compaction_profile(&db_compaction, &path);
+    db_config.disable_wal = disable_wal;
 
     db_config
 }

--- a/tools/cfx-gen-dot/main.rs
+++ b/tools/cfx-gen-dot/main.rs
@@ -27,6 +27,7 @@ fn open_db(db_path: &str) -> std::io::Result<Arc<db::SystemDB>> {
         None,
         db::DatabaseCompactionProfile::default(),
         cfxcore::db::NUM_COLUMNS,
+        false,
     );
 
     db::open_database(db_path, &db_config)


### PR DESCRIPTION
Prevent inconsistency between sqlite and rocksdb.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/660)
<!-- Reviewable:end -->
