### PR TITLE
Optimize the process of inserting transactions into pool

### DIFF
--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -132,7 +132,7 @@ impl RpcImpl {
             })
             .and_then(|tx| {
                 let (signed_trans, failed_trans) = self.tx_pool.insert_new_transactions(
-                    &vec![tx],
+                    vec![tx],
                 );
                 if signed_trans.len() + failed_trans.len() > 1 {
                     // This should never happen

--- a/core/src/light_protocol/provider.rs
+++ b/core/src/light_protocol/provider.rs
@@ -346,7 +346,7 @@ impl Provider {
         info!("on_send_raw_tx req={:?}", req);
         let tx: TransactionWithSignature = rlp::decode(&req.raw)?;
 
-        let (passed, failed) = self.tx_pool.insert_new_transactions(&vec![tx]);
+        let (passed, failed) = self.tx_pool.insert_new_transactions(vec![tx]);
 
         match (passed.len(), failed.len()) {
             (0, 0) => {

--- a/core/src/sync/message/transactions.rs
+++ b/core/src/sync/message/transactions.rs
@@ -64,7 +64,7 @@ impl Handleable for Transactions {
             .graph
             .consensus
             .txpool
-            .insert_new_transactions(&transactions);
+            .insert_new_transactions(transactions);
 
         ctx.manager
             .request_manager
@@ -320,7 +320,7 @@ impl Handleable for GetTransactionsResponse {
             .graph
             .consensus
             .txpool
-            .insert_new_transactions(&self.transactions);
+            .insert_new_transactions(self.transactions);
 
         ctx.manager
             .request_manager

--- a/core/src/transaction_pool/mod.rs
+++ b/core/src/transaction_pool/mod.rs
@@ -31,8 +31,8 @@ use std::{collections::hash_map::HashMap, mem, ops::DerefMut, sync::Arc};
 use transaction_pool_inner::TransactionPoolInner;
 
 lazy_static! {
-    static ref TX_POOL_GAUGE: Arc<dyn Gauge<usize>> =
-        GaugeUsize::register_with_group("txpool", "unexecuted_size");
+    static ref TX_POOL_UNPACKED_GAUGE: Arc<dyn Gauge<usize>> =
+        GaugeUsize::register_with_group("txpool", "unpacked_size");
     static ref TX_POOL_READY_GAUGE: Arc<dyn Gauge<usize>> =
         GaugeUsize::register_with_group("txpool", "ready_size");
     static ref TX_POOL_INSERT_TIMER: Arc<dyn Meter> =
@@ -176,7 +176,7 @@ impl TransactionPool {
             }
         }
 
-        TX_POOL_GAUGE.update(inner.total_unpacked());
+        TX_POOL_UNPACKED_GAUGE.update(inner.total_unpacked());
         TX_POOL_READY_GAUGE.update(inner.total_ready_accounts());
 
         (passed_transactions, failure)

--- a/core/src/transaction_pool/mod.rs
+++ b/core/src/transaction_pool/mod.rs
@@ -176,8 +176,8 @@ impl TransactionPool {
             }
         }
 
-        TX_POOL_GAUGE.update(self.total_unpacked());
-        TX_POOL_READY_GAUGE.update(self.inner.read().total_ready_accounts());
+        TX_POOL_GAUGE.update(inner.total_unpacked());
+        TX_POOL_READY_GAUGE.update(inner.total_ready_accounts());
 
         (passed_transactions, failure)
     }

--- a/core/src/transaction_pool/transaction_pool_inner.rs
+++ b/core/src/transaction_pool/transaction_pool_inner.rs
@@ -13,8 +13,10 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-pub const FURTHEST_FUTURE_TRANSACTION_NONCE_OFFSET: u32 = 2000;
-pub const TIME_WINDOW: u64 = 100;
+const FURTHEST_FUTURE_TRANSACTION_NONCE_OFFSET: u32 = 2000;
+// By default, the capacity of tx pool is 500K, so the maximum TPS is
+// 500K / 50 = 10,000
+const TIME_WINDOW: u64 = 50;
 
 lazy_static! {
     static ref TX_POOL_RECALCULATE: Arc<dyn Meter> =

--- a/core/src/transaction_pool/transaction_pool_inner.rs
+++ b/core/src/transaction_pool/transaction_pool_inner.rs
@@ -289,8 +289,21 @@ impl TransactionPoolInner {
         }
     }
 
+    /// Collect garbage and return the remaining quota of the pool to insert new
+    /// transactions.
+    pub fn remaining_quota(&mut self) -> usize {
+        self.collect_garbage();
+
+        let len = self.garbage_collection_queue.len();
+        if len < self.capacity {
+            self.capacity - len
+        } else {
+            0
+        }
+    }
+
     // the new inserting will fail if tx_pool is full (even if `force` is true)
-    pub fn insert_transaction_without_readiness_check(
+    fn insert_transaction_without_readiness_check(
         &mut self, transaction: Arc<SignedTransaction>, packed: bool,
         force: bool,
     ) -> InsertResult

--- a/transactiongen/src/lib.rs
+++ b/transactiongen/src/lib.rs
@@ -261,7 +261,7 @@ impl TransactionGenerator {
             let mut tx_to_insert = Vec::new();
             tx_to_insert.push(signed_tx.transaction);
             let (txs, fail) =
-                txgen.txpool.insert_new_transactions(&tx_to_insert);
+                txgen.txpool.insert_new_transactions(tx_to_insert);
             if fail.len() == 0 {
                 txgen.sync.append_received_transactions(txs);
                 //tx successfully inserted into
@@ -396,7 +396,7 @@ impl TransactionGenerator {
                 let mut tx_to_insert = Vec::new();
                 tx_to_insert.push(signed_tx.transaction);
                 let (txs, _) =
-                    txgen.txpool.insert_new_transactions(&tx_to_insert);
+                    txgen.txpool.insert_new_transactions(tx_to_insert);
                 txgen.sync.append_received_transactions(txs);
                 last_account = Some(receiver_address);
                 TX_GEN_METER.mark(1);
@@ -466,7 +466,7 @@ impl TransactionGenerator {
             let mut tx_to_insert = Vec::new();
             tx_to_insert.push(signed_tx.transaction);
             let (txs, fail) =
-                txgen.txpool.insert_new_transactions(&tx_to_insert);
+                txgen.txpool.insert_new_transactions(tx_to_insert);
             if fail.len() == 0 {
                 txgen.sync.append_received_transactions(txs);
                 // tx successfully inserted into tx pool, so we can update our


### PR DESCRIPTION
The workload of recovering tx public key is very heavy in case of high TPS, e.g. > 8000. It's unnecessary to recover public key for those txs that:
- transaction is invalid, e.g. gas limit is too small.
- transaction pool has not enough quota to insert new transactions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/662)
<!-- Reviewable:end -->
