### PR TITLE
Improve the process of inserting txs into pool based on experiment

### DIFF
--- a/core/src/sync/request_manager/tx_handler.rs
+++ b/core/src/sync/request_manager/tx_handler.rs
@@ -9,11 +9,11 @@ use std::{
 };
 lazy_static! {
     static ref TX_FIRST_MISS_METER: Arc<dyn Meter> =
-        register_meter_with_group("tx_pool", "tx_first_miss_size");
+        register_meter_with_group("tx_propagation", "tx_first_miss_size");
     static ref TX_FOR_COMPARE_METER: Arc<dyn Meter> =
-        register_meter_with_group("tx_pool", "tx_for_compare_size");
+        register_meter_with_group("tx_propagation", "tx_for_compare_size");
     static ref TX_RANDOM_BYTE_METER: Arc<dyn Meter> =
-        register_meter_with_group("tx_pool", "tx_random_byte_size");
+        register_meter_with_group("tx_propagation", "tx_random_byte_size");
 }
 const RECEIVED_TRANSACTION_CONTAINER_WINDOW_SIZE: usize = 64;
 

--- a/tests/remote_simulate.py
+++ b/tests/remote_simulate.py
@@ -154,7 +154,7 @@ class RemoteSimulate(ConfluxTestFramework):
         parser.add_argument(
             "--tx-pool-size",
             dest="tx_pool_size",
-            default=500000,
+            default=1000000,
             type=int,
         )
         parser.add_argument(

--- a/tests/scripts/exp_latency.py
+++ b/tests/scripts/exp_latency.py
@@ -168,13 +168,19 @@ class LatencyExperiment(ArgumentHolder):
             tag = self.tag(config)
             execute("./copy_file_from_slave.sh metrics.log {} > /dev/null".format(tag), 3, "collect metrics")
             if self.enable_flamegraph:
-                execute("./copy_file_from_slave.sh conflux.svg {} > /dev/null".format(tag), 10, "collect flamegraph")
+                try:
+                    execute("./copy_file_from_slave.sh conflux.svg {} > /dev/null".format(tag), 10, "collect flamegraph")
+                except:
+                    print("Failed to copy flamegraph file conflux.svg, please try again via copy_file_from_slave.sh in manual")
 
             execute("cp exp.log {}.exp.log".format(tag), 3, "copy exp.log")
 
         print("=========================================================")
         print("archive the experiment results into [{}] ...".format(self.stat_archive_file))
-        os.system("tar cvfz {} {} *.exp.log *nodes.csv *.metrics.log *.conflux.svg".format(self.stat_archive_file, self.stat_log_file))
+        cmd = "tar cvfz {} {} *.exp.log *nodes.csv *.metrics.log".format(self.stat_archive_file, self.stat_log_file)
+        if self.enable_flamegraph:
+            cmd = cmd + " *.conflux.svg"
+        os.system(cmd)
 
     def copy_remote_logs(self):
         execute("./copy_logs.sh > /dev/null", 3, "copy logs")

--- a/tests/scripts/one_click.sh
+++ b/tests/scripts/one_click.sh
@@ -34,7 +34,7 @@ run_latency_exp () {
     if [ $enable_flamegraph = true ]; then
         flamegraph_option="--enable-flamegraph"
     fi
-    ssh ubuntu@${master_ip} "cd ./conflux-rust/tests/scripts;python3 ./exp_latency.py --batch-config \"$exp_config\" --storage-memory-mb 16 --bandwidth 20 --slave-count $slave_count --tps $tps --enable-tx-propagation --send-tx-period-ms 50 $flamegraph_option"
+    ssh ubuntu@${master_ip} "cd ./conflux-rust/tests/scripts;python3 ./exp_latency.py --vms $slave_count --batch-config \"$exp_config\" --storage-memory-mb 16 --bandwidth 20 --slave-count $slave_count --tps $tps --enable-tx-propagation --send-tx-period-ms 50 $flamegraph_option"
 
     #5) Terminate slave instances
     rm -rf tmp_data

--- a/util/metrics/src/meter.rs
+++ b/util/metrics/src/meter.rs
@@ -222,6 +222,6 @@ impl MeterTimer {
 impl Drop for MeterTimer {
     fn drop(&mut self) {
         self.meter
-            .mark((Instant::now() - self.start).as_micros() as usize)
+            .mark((Instant::now() - self.start).as_nanos() as usize)
     }
 }


### PR DESCRIPTION
Once txpool is full, do not recover public key of txs, so as to reduce the CPU workload. According to the experiment result:
1. The Goodput could be increased to 7K in case of 8K TPS;
2. The block broadcast latency also decreased a lot, especially in high TPS (e.g. 8K)

Before opt:
![image](https://user-images.githubusercontent.com/35757521/65133783-d13bf480-da35-11e9-9d87-dc4dcbfe4eb9.png)


After opt:
![image](https://user-images.githubusercontent.com/35757521/65133740-b7021680-da35-11e9-929e-4964cbf9d495.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/666)
<!-- Reviewable:end -->
