### PR TITLE
Support to send metrics to influxdb

### DIFF
--- a/client/src/archive/mod.rs
+++ b/client/src/archive/mod.rs
@@ -89,16 +89,7 @@ impl ArchiveClient {
     ) -> Result<ArchiveClientHandle, String> {
         info!("Working directory: {:?}", std::env::current_dir());
 
-        if conf.raw_conf.metrics_enabled {
-            metrics::enable();
-            let reporter = metrics::FileReporter::new(
-                conf.raw_conf.metrics_output_file.clone(),
-            );
-            metrics::report_async(
-                reporter,
-                Duration::from_millis(conf.raw_conf.metrics_report_interval_ms),
-            );
-        }
+        metrics::initialize(conf.metrics_config());
 
         let worker_thread_pool = Arc::new(Mutex::new(ThreadPool::with_name(
             "Tx Recover".into(),

--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -10,6 +10,7 @@ use cfxcore::{
     storage::{self, state_manager::StorageConfiguration},
     sync::{ProtocolConfiguration, SyncGraphConfig},
 };
+use metrics::MetricsConfiguration;
 use std::convert::TryInto;
 use txgen::TransactionGeneratorConfig;
 
@@ -106,8 +107,13 @@ build_config! {
         // FIXME: break into two options: one for enable, one for path.
         (debug_dump_dir_invalid_state_root, (String), "./storage/debug_dump_invalid_state_root/".to_string())
         (metrics_enabled, (bool), false)
-        (metrics_report_interval_ms, (u64), 5000)
-        (metrics_output_file, (String), "metrics.log".to_string())
+        (metrics_report_interval_ms, (u64), 3000)
+        (metrics_output_file, (Option<String>), Some("metrics.log".to_string()))
+        (metrics_influxdb_host, (Option<String>), None)
+        (metrics_influxdb_db, (String), "conflux".into())
+        (metrics_influxdb_username, (Option<String>), None)
+        (metrics_influxdb_password, (Option<String>), None)
+        (metrics_influxdb_node, (Option<String>), None)
         (min_peers_propagation, (usize), 8)
         (max_peers_propagation, (usize), 128)
         (future_block_buffer_capacity, (usize), 32768)
@@ -379,6 +385,27 @@ impl Configuration {
     pub fn sync_graph_config(&self) -> SyncGraphConfig {
         SyncGraphConfig {
             enable_state_expose: self.raw_conf.enable_state_expose,
+        }
+    }
+
+    pub fn metrics_config(&self) -> MetricsConfiguration {
+        MetricsConfiguration {
+            enabled: self.raw_conf.metrics_enabled,
+            report_interval: Duration::from_millis(
+                self.raw_conf.metrics_report_interval_ms,
+            ),
+            file_report_output: self.raw_conf.metrics_output_file.clone(),
+            influxdb_report_host: self.raw_conf.metrics_influxdb_host.clone(),
+            influxdb_report_db: self.raw_conf.metrics_influxdb_db.clone(),
+            influxdb_report_username: self
+                .raw_conf
+                .metrics_influxdb_username
+                .clone(),
+            influxdb_report_password: self
+                .raw_conf
+                .metrics_influxdb_password
+                .clone(),
+            influxdb_report_node: self.raw_conf.metrics_influxdb_node.clone(),
         }
     }
 }

--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -108,7 +108,7 @@ build_config! {
         (debug_dump_dir_invalid_state_root, (String), "./storage/debug_dump_invalid_state_root/".to_string())
         (metrics_enabled, (bool), false)
         (metrics_report_interval_ms, (u64), 3000)
-        (metrics_output_file, (Option<String>), Some("metrics.log".to_string()))
+        (metrics_output_file, (Option<String>), None)
         (metrics_influxdb_host, (Option<String>), None)
         (metrics_influxdb_db, (String), "conflux".into())
         (metrics_influxdb_username, (Option<String>), None)

--- a/client/src/full/mod.rs
+++ b/client/src/full/mod.rs
@@ -89,16 +89,7 @@ impl FullClient {
     ) -> Result<FullClientHandle, String> {
         info!("Working directory: {:?}", std::env::current_dir());
 
-        if conf.raw_conf.metrics_enabled {
-            metrics::enable();
-            let reporter = metrics::FileReporter::new(
-                conf.raw_conf.metrics_output_file.clone(),
-            );
-            metrics::report_async(
-                reporter,
-                Duration::from_millis(conf.raw_conf.metrics_report_interval_ms),
-            );
-        }
+        metrics::initialize(conf.metrics_config());
 
         let worker_thread_pool = Arc::new(Mutex::new(ThreadPool::with_name(
             "Tx Recover".into(),

--- a/client/src/light/mod.rs
+++ b/client/src/light/mod.rs
@@ -74,16 +74,7 @@ impl LightClient {
     ) -> Result<LightClientHandle, String> {
         info!("Working directory: {:?}", std::env::current_dir());
 
-        if conf.raw_conf.metrics_enabled {
-            metrics::enable();
-            let reporter = metrics::FileReporter::new(
-                conf.raw_conf.metrics_output_file.clone(),
-            );
-            metrics::report_async(
-                reporter,
-                Duration::from_millis(conf.raw_conf.metrics_report_interval_ms),
-            );
-        }
+        metrics::initialize(conf.metrics_config());
 
         let worker_thread_pool = Arc::new(Mutex::new(ThreadPool::with_name(
             "Tx Recover".into(),

--- a/util/metrics/Cargo.toml
+++ b/util/metrics/Cargo.toml
@@ -9,6 +9,8 @@ parking_lot = "0.8"
 timer = "0.2.0"
 time = "0.1"
 rand = "0.5"
+influx_db_client = "0.3.6"
+log = "0.4"
 
 [dev-dependencies]
 criterion = "0.2"

--- a/util/metrics/src/lib.rs
+++ b/util/metrics/src/lib.rs
@@ -12,6 +12,7 @@ mod metrics;
 mod queue;
 mod registry;
 mod report;
+mod report_influxdb;
 mod timer;
 
 pub use self::{
@@ -20,8 +21,7 @@ pub use self::{
     histogram::{Histogram, Sample},
     lock::{Lock, MutexExtensions, RwLockExtensions},
     meter::{register_meter, register_meter_with_group, Meter, MeterTimer},
-    metrics::enable,
+    metrics::{initialize, MetricsConfiguration},
     queue::{register_queue, register_queue_with_group, Queue},
-    report::{report_async, FileReporter},
     timer::{register_timer, register_timer_with_group, Timer},
 };

--- a/util/metrics/src/metrics.rs
+++ b/util/metrics/src/metrics.rs
@@ -2,8 +2,14 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use crate::report::Reportable;
-use std::sync::atomic::{AtomicBool, Ordering};
+use crate::{
+    report::{report_async, FileReporter, Reportable},
+    report_influxdb::{InfluxdbReportable, InfluxdbReporter},
+};
+use std::{
+    sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
+};
 
 pub static ORDER: Ordering = Ordering::Relaxed;
 
@@ -11,8 +17,62 @@ static ENABLED: AtomicBool = AtomicBool::new(false);
 
 pub fn is_enabled() -> bool { ENABLED.load(ORDER) }
 
-pub fn enable() { ENABLED.store(true, ORDER); }
+fn enable() { ENABLED.store(true, ORDER); }
 
-pub trait Metric: Send + Sync + Reportable {
+pub trait Metric: Send + Sync + Reportable + InfluxdbReportable {
     fn get_type(&self) -> &str;
+}
+
+pub struct MetricsConfiguration {
+    pub enabled: bool,
+    pub report_interval: Duration,
+
+    pub file_report_output: Option<String>,
+
+    pub influxdb_report_host: Option<String>,
+    pub influxdb_report_db: String,
+    pub influxdb_report_username: Option<String>,
+    pub influxdb_report_password: Option<String>,
+    pub influxdb_report_node: Option<String>,
+}
+
+pub fn initialize(config: MetricsConfiguration) {
+    if !config.enabled {
+        return;
+    }
+
+    enable();
+
+    // file reporter
+    if let Some(output) = config.file_report_output {
+        let reporter = FileReporter::new(output);
+        report_async(reporter, config.report_interval);
+    }
+
+    // influxdb reporter
+    if let Some(host) = config.influxdb_report_host {
+        let mut auth = None;
+
+        if let Some(username) = config.influxdb_report_username {
+            if let Some(password) = config.influxdb_report_password {
+                auth = Some((username, password));
+            }
+        }
+
+        let mut reporter = match auth {
+            Some((username, password)) => InfluxdbReporter::with_auth(
+                host,
+                config.influxdb_report_db,
+                username,
+                password,
+            ),
+            None => InfluxdbReporter::new(host, config.influxdb_report_db),
+        };
+
+        if let Some(node) = config.influxdb_report_node {
+            reporter.add_tag("node".into(), node);
+        }
+
+        report_async(reporter, config.report_interval);
+    }
 }

--- a/util/metrics/src/report_influxdb.rs
+++ b/util/metrics/src/report_influxdb.rs
@@ -1,0 +1,187 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use crate::{
+    counter::{Counter, CounterUsize},
+    gauge::{Gauge, GaugeUsize},
+    histogram::Histogram,
+    meter::{Meter, StandardMeter},
+    registry::{DEFAULT_GROUPING_REGISTRY, DEFAULT_REGISTRY},
+    report::Reporter,
+};
+use influx_db_client::{Client, Point, Points, Precision, Value};
+use log::debug;
+use std::collections::HashMap;
+
+pub struct InfluxdbReporter {
+    client: Client,
+    tags: HashMap<String, String>, // e.g. node=Node_0, region=east_asia
+}
+
+impl InfluxdbReporter {
+    pub fn new<T: ToString>(host: T, db: T) -> Self {
+        InfluxdbReporter {
+            client: Client::new(host, db),
+            tags: HashMap::new(),
+        }
+    }
+
+    pub fn with_auth<T: ToString, R: Into<String>>(
+        host: T, db: T, username: R, password: R,
+    ) -> Self {
+        InfluxdbReporter {
+            client: Client::new(host, db)
+                .set_authentication(username, password),
+            tags: HashMap::new(),
+        }
+    }
+
+    pub fn add_tag(&mut self, key: String, value: String) {
+        self.tags.insert(key, value);
+    }
+}
+
+impl Reporter for InfluxdbReporter {
+    fn report(&self) -> Result<(), String> {
+        let mut points = Points::create_new(Vec::new());
+
+        for (name, metric) in DEFAULT_REGISTRY.read().get_all() {
+            let mut point = Point::new(name);
+            metric.add_field(&mut point, None);
+
+            for (k, v) in &self.tags {
+                point.add_tag(k.clone(), Value::String(v.clone()));
+            }
+
+            points.push(point);
+        }
+
+        for (group_name, metrics) in DEFAULT_GROUPING_REGISTRY.read().get_all()
+        {
+            let mut point = Point::new(group_name);
+
+            for (metric_name, metric) in metrics {
+                metric.add_field(&mut point, Some(metric_name));
+            }
+
+            for (k, v) in &self.tags {
+                point.add_tag(k.clone(), Value::String(v.clone()));
+            }
+
+            points.push(point);
+        }
+
+        if let Err(e) = self.client.write_points(
+            points,
+            Some(Precision::Milliseconds),
+            None,
+        ) {
+            debug!("failed to write points to influxdb, {:?}", e);
+        }
+
+        Ok(())
+    }
+}
+
+pub trait InfluxdbReportable {
+    fn add_field(&self, point: &mut Point, prefix: Option<&String>);
+}
+
+fn field(name: &str, prefix: Option<&String>) -> String {
+    match prefix {
+        None => name.into(),
+        Some(prefix) => {
+            let mut field = prefix.clone();
+            field.push_str(".");
+            field.push_str(name);
+            field
+        }
+    }
+}
+
+impl InfluxdbReportable for CounterUsize {
+    fn add_field(&self, point: &mut Point, prefix: Option<&String>) {
+        point.add_field(
+            field("count", prefix),
+            Value::Integer(self.count() as i64),
+        );
+    }
+}
+
+impl InfluxdbReportable for GaugeUsize {
+    fn add_field(&self, point: &mut Point, prefix: Option<&String>) {
+        point.add_field(
+            field("value", prefix),
+            Value::Integer(self.value() as i64),
+        );
+    }
+}
+
+impl InfluxdbReportable for StandardMeter {
+    fn add_field(&self, point: &mut Point, prefix: Option<&String>) {
+        let snapshot = self.snapshot();
+        point.add_field(
+            field("count", prefix),
+            Value::Integer(snapshot.count() as i64),
+        );
+        point.add_field(field("m1", prefix), Value::Float(snapshot.rate1()));
+        point.add_field(field("m5", prefix), Value::Float(snapshot.rate5()));
+        point.add_field(field("m15", prefix), Value::Float(snapshot.rate15()));
+        point.add_field(
+            field("mean", prefix),
+            Value::Float(snapshot.rate_mean()),
+        );
+    }
+}
+
+impl<T: Histogram> InfluxdbReportable for T {
+    fn add_field(&self, point: &mut Point, prefix: Option<&String>) {
+        let snapshot = self.snapshot();
+        point.add_field(
+            field("count", prefix),
+            Value::Integer(snapshot.count() as i64),
+        );
+        point.add_field(
+            field("min", prefix),
+            Value::Integer(snapshot.min() as i64),
+        );
+        point.add_field(field("mean", prefix), Value::Float(snapshot.mean()));
+        point.add_field(
+            field("max", prefix),
+            Value::Integer(snapshot.max() as i64),
+        );
+        point.add_field(
+            field("stddev", prefix),
+            Value::Float(snapshot.stddev()),
+        );
+        point.add_field(
+            field("variance", prefix),
+            Value::Float(snapshot.variance()),
+        );
+        point.add_field(
+            field("p50", prefix),
+            Value::Integer(snapshot.percentile(0.5) as i64),
+        );
+        point.add_field(
+            field("p75", prefix),
+            Value::Integer(snapshot.percentile(0.75) as i64),
+        );
+        point.add_field(
+            field("p90", prefix),
+            Value::Integer(snapshot.percentile(0.9) as i64),
+        );
+        point.add_field(
+            field("p95", prefix),
+            Value::Integer(snapshot.percentile(0.95) as i64),
+        );
+        point.add_field(
+            field("p99", prefix),
+            Value::Integer(snapshot.percentile(0.99) as i64),
+        );
+        point.add_field(
+            field("p999", prefix),
+            Value::Integer(snapshot.percentile(0.999) as i64),
+        );
+    }
+}


### PR DESCRIPTION
Support to send all Conflux metrics to InfluxDB periodically, and user could configure Dashboard (e.g. via Grafana) to monitor the Conflux status. Unlike the "echart" version used in experiment, this is very helpful for Conflux testnet/mainnet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/710)
<!-- Reviewable:end -->
