### PR TITLE
sync checkpoint state based on delta MPT

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -54,6 +54,7 @@ fallible-iterator = "0.2"
 strfmt = "0.1"
 rustc-hex = "1.0"
 parity-bytes = "0.1"
+zip = "0.5.3"
 
 [dev-dependencies]
 criterion = "0.2"

--- a/core/examples/restore_checkpoint_delta.rs
+++ b/core/examples/restore_checkpoint_delta.rs
@@ -25,7 +25,7 @@ use std::{
     cmp::min,
     env::current_dir,
     fs::{create_dir_all, remove_dir_all},
-    path::{Path, PathBuf},
+    path::Path,
     str::FromStr,
     sync::Arc,
     time::{Duration, Instant},

--- a/core/examples/restore_checkpoint_delta.rs
+++ b/core/examples/restore_checkpoint_delta.rs
@@ -190,11 +190,13 @@ fn prepare_checkpoint(
 
     println!("all accounts added in {:?}", start.elapsed());
 
-    let root = manager.get_state_no_commit(SnapshotAndEpochIdRef::new(&checkpoint, None))?
+    let root = manager
+        .get_state_no_commit(SnapshotAndEpochIdRef::new(&checkpoint, None))?
         .unwrap()
         .get_state_root()?
         .unwrap()
-        .state_root.delta_root;
+        .state_root
+        .delta_root;
     println!("checkpoint root: {:?}", root);
 
     Ok((checkpoint, root))

--- a/core/examples/restore_checkpoint_delta.rs
+++ b/core/examples/restore_checkpoint_delta.rs
@@ -1,0 +1,148 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use cfx_types::H256;
+use cfxcore::{
+    db::NUM_COLUMNS,
+    storage::{
+        state::StateTrait,
+        state_manager::{
+            StateManager, StateManagerTrait, StorageConfiguration,
+        },
+        SnapshotAndEpochIdRef,
+    },
+    sync::{
+        delta::{Chunk, ChunkReader, StateDumper},
+        Error,
+    },
+};
+use rlp::Rlp;
+use std::{
+    fs::{create_dir_all, remove_dir_all},
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+// cargo run --release -p cfxcore --example restore_checkpoint_delta
+fn main() -> Result<(), Error> {
+    let test_dir = PathBuf::from("E:\\zzzzzz");
+    if test_dir.exists() {
+        remove_dir_all(&test_dir)?;
+    }
+
+    // setup node 1
+    println!("====================================================");
+    println!("Setup node 1 ...");
+    let sm1 = new_state_manager(test_dir.join("db1").to_str().unwrap())?;
+    let genesis_hash = initialize_genesis(&sm1)?;
+    let checkpoint = prepare_checkpoint(&sm1, &genesis_hash)?;
+    let chunk_store_dir = test_dir
+        .join("state_checkpoints")
+        .to_str()
+        .unwrap()
+        .to_string();
+    StateDumper::new(chunk_store_dir.clone(), checkpoint, 30).dump(&sm1)?;
+
+    // setup node 2
+    println!("====================================================");
+    println!("Setup node 2 ...");
+    let sm2 = new_state_manager(test_dir.join("db2").to_str().unwrap())?;
+    initialize_genesis(&sm2)?;
+
+    // restore chunks for checkpoint
+    println!("====================================================");
+    println!("Simulate network sync ...");
+    let reader =
+        ChunkReader::new(chunk_store_dir.clone(), &checkpoint).unwrap();
+    let manifest = reader.chunks()?;
+    println!("manifest: {:#?}", manifest);
+
+    for hash in manifest {
+        let raw_chunk = reader.chunk_raw(&hash)?.unwrap();
+        let chunk = Rlp::new(&raw_chunk).as_val::<Chunk>()?;
+
+        let epoch_id = SnapshotAndEpochIdRef::new(&checkpoint, None);
+        let mut state = sm2
+            .get_state_no_commit(epoch_id)?
+            .unwrap_or_else(|| sm2.get_state_for_genesis_write());
+        let root = chunk.restore(&mut state, Some(checkpoint))?.unwrap();
+        println!("restored root: {:?}", root.state_root.delta_root);
+    }
+    println!("checkpoint state restoration completed.");
+
+    // validate restoration
+    let epoch_id = SnapshotAndEpochIdRef::new(&checkpoint, None);
+    let state = sm2.get_state_no_commit(epoch_id)?.unwrap();
+
+    assert_eq!(
+        state.get("123".as_bytes())?,
+        Some(vec![1, 2, 3].into_boxed_slice())
+    );
+    assert_eq!(
+        state.get("124".as_bytes())?,
+        Some(vec![1, 2, 4].into_boxed_slice())
+    );
+    assert_eq!(
+        state.get("234".as_bytes())?,
+        Some(vec![2, 3, 4].into_boxed_slice())
+    );
+    assert_eq!(
+        state.get("235".as_bytes())?,
+        Some(vec![2, 3, 5].into_boxed_slice())
+    );
+
+    Ok(())
+}
+
+fn new_state_manager(db_dir: &str) -> Result<StateManager, Error> {
+    create_dir_all(db_dir)?;
+
+    let db_config = db::db_config(
+        Path::new(db_dir),
+        Some(128),
+        db::DatabaseCompactionProfile::default(),
+        NUM_COLUMNS.clone(),
+        false,
+    );
+    let db = db::open_database(db_dir, &db_config)?;
+
+    Ok(StateManager::new(db, StorageConfiguration::default()))
+}
+
+fn initialize_genesis(manager: &StateManager) -> Result<H256, Error> {
+    let mut state = manager.get_state_for_genesis_write();
+
+    state.set("123".as_bytes(), vec![1, 2, 3].into_boxed_slice())?;
+    state.set("124".as_bytes(), vec![1, 2, 4].into_boxed_slice())?;
+
+    let root = state.compute_state_root()?;
+    println!("genesis root: {:?}", root.state_root.delta_root);
+
+    let genesis_hash = H256::from_str(
+        "fa4e44bc69cca4cb2ae88a8fd452826faab9e8764e7eed934feede46c98962fa",
+    )
+    .unwrap();
+    state.commit(genesis_hash.clone())?;
+
+    Ok(genesis_hash)
+}
+
+fn prepare_checkpoint(
+    manager: &StateManager, parent: &H256,
+) -> Result<H256, Error> {
+    let mut state = manager
+        .get_state_for_next_epoch(SnapshotAndEpochIdRef::new(parent, None))?
+        .unwrap();
+
+    state.set("234".as_bytes(), vec![2, 3, 4].into_boxed_slice())?;
+    state.set("235".as_bytes(), vec![2, 3, 5].into_boxed_slice())?;
+
+    let root = state.compute_state_root()?;
+    println!("checkpoint root: {:?}", root.state_root.delta_root);
+
+    let checkpoint = H256::random();
+    state.commit(checkpoint)?;
+
+    Ok(checkpoint)
+}

--- a/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/mpt_merger.rs
+++ b/core/src/storage/impls/multi_version_merkle_patricia_trie/merkle_patricia_trie/mpt_merger.rs
@@ -61,7 +61,7 @@ impl<'a> MptMerger<'a> {
             }
         }
 
-        inserter.iterate(Merger { merger: self })?;
+        inserter.iterate(&mut Merger { merger: self })?;
 
         self.rw_cursor.finish()
     }

--- a/core/src/storage/impls/snapshot_sync/mod.rs
+++ b/core/src/storage/impls/snapshot_sync/mod.rs
@@ -35,5 +35,5 @@ where DbType:
 use super::{
     super::storage_db::*, errors::*, storage_db::snapshot_mpt::SnapshotMpt,
 };
-use crate::sync::RangedManifest;
+use crate::sync::delta::RangedManifest;
 use std::borrow::BorrowMut;

--- a/core/src/storage/impls/state.rs
+++ b/core/src/storage/impls/state.rs
@@ -458,6 +458,17 @@ impl<'a> State<'a> {
             }
         }
     }
+
+    pub fn dump<DUMPER: KVInserter<(Vec<u8>, Box<[u8]>)>>(
+        &self, dumper: &mut DUMPER,
+    ) -> Result<()> {
+        let inserter = DeltaMptInserter {
+            mpt: self.delta_trie.clone(),
+            maybe_root_node: self.delta_trie_root.clone(),
+        };
+
+        inserter.iterate(dumper)
+    }
 }
 
 use super::{
@@ -482,3 +493,5 @@ use std::{
     hint::unreachable_unchecked,
     sync::{atomic::Ordering, Arc},
 };
+use crate::storage::impls::multi_version_merkle_patricia_trie::merkle_patricia_trie::cow_node_ref::KVInserter;
+use crate::storage::impls::storage_manager::DeltaMptInserter;

--- a/core/src/storage/impls/storage_db/snapshot_db_sqlite.rs
+++ b/core/src/storage/impls/storage_db/snapshot_db_sqlite.rs
@@ -355,7 +355,7 @@ impl SnapshotDbSqlite {
             .finish_ignore_rows()?;
 
         // Dump code.
-        delta_mpt.iterate(DeltaMptDumperSqlite::new(self))
+        delta_mpt.iterate(&mut DeltaMptDumperSqlite::new(self))
     }
 
     /// Dropping is optional, because these tables are necessary to provide

--- a/core/src/storage/impls/storage_manager/storage_manager.rs
+++ b/core/src/storage/impls/storage_manager/storage_manager.rs
@@ -166,7 +166,7 @@ pub struct DeltaMptInserter {
 
 impl DeltaMptInserter {
     pub fn iterate<'a, DeltaMptDumper: KVInserter<(Vec<u8>, Box<[u8]>)>>(
-        &self, mut dumper: DeltaMptDumper,
+        &self, dumper: &mut DeltaMptDumper,
     ) -> Result<()> {
         match &self.maybe_root_node {
             None => {}
@@ -186,7 +186,7 @@ impl DeltaMptInserter {
                     &self.mpt,
                     guarded_trie_node,
                     CompressedPathRaw::new_zeroed(0, 0),
-                    &mut dumper,
+                    dumper,
                     db,
                 )?;
             }

--- a/core/src/storage/mod.rs
+++ b/core/src/storage/mod.rs
@@ -22,7 +22,9 @@ pub use self::{
         defaults,
         errors::{Error, ErrorKind, Result},
         multi_version_merkle_patricia_trie::{
-            guarded_value::GuardedValue, MultiVersionMerklePatriciaTrie,
+            guarded_value::GuardedValue,
+            merkle_patricia_trie::cow_node_ref::KVInserter,
+            MultiVersionMerklePatriciaTrie,
         },
         snapshot_sync::MptSlicer,
         storage_db::{

--- a/core/src/sync/error.rs
+++ b/core/src/sync/error.rs
@@ -5,6 +5,7 @@
 use crate::storage;
 use network;
 use rlp::DecoderError;
+use std::io;
 
 error_chain! {
     links {
@@ -14,6 +15,7 @@ error_chain! {
 
     foreign_links {
         Decoder(DecoderError);
+        Io(io::Error);
     }
 
     errors {

--- a/core/src/sync/mod.rs
+++ b/core/src/sync/mod.rs
@@ -18,7 +18,7 @@ pub mod utils;
 
 pub use self::{
     error::{Error, ErrorKind},
-    state::delta,
+    state::{delta, restore},
     synchronization_graph::{
         SharedSynchronizationGraph, SyncGraphConfig, SyncGraphStatistics,
         SynchronizationGraph, SynchronizationGraphInner,

--- a/core/src/sync/mod.rs
+++ b/core/src/sync/mod.rs
@@ -18,7 +18,7 @@ pub mod utils;
 
 pub use self::{
     error::{Error, ErrorKind},
-    state::RangedManifest,
+    state::delta,
     synchronization_graph::{
         SharedSynchronizationGraph, SyncGraphConfig, SyncGraphStatistics,
         SynchronizationGraph, SynchronizationGraphInner,

--- a/core/src/sync/state/delta/chunk.rs
+++ b/core/src/sync/state/delta/chunk.rs
@@ -5,7 +5,9 @@
 use crate::{
     storage::state::{State, StateTrait},
     sync::{
-        state::delta::{ChunkKey, ChunkReader, StateDumper},
+        state::delta::{
+            compress::write_single_zip_file, ChunkKey, ChunkReader, StateDumper,
+        },
         Error, ErrorKind,
     },
 };
@@ -15,7 +17,7 @@ use primitives::StateRootWithAuxInfo;
 use rlp::{Encodable, Rlp};
 use rlp_derive::{RlpDecodable, RlpEncodable};
 use std::{
-    fs::{create_dir_all, write},
+    fs::create_dir_all,
     io::Error as IoError,
     path::{Path, PathBuf},
     str::FromStr,
@@ -67,7 +69,7 @@ impl Chunk {
         let hash = keccak(&content);
 
         let file_path = Self::chunk_file_path(dir, &hash);
-        write(file_path, &content)?;
+        write_single_zip_file(file_path.as_path(), &content)?;
 
         Ok(Some(hash))
     }

--- a/core/src/sync/state/delta/chunk.rs
+++ b/core/src/sync/state/delta/chunk.rs
@@ -1,0 +1,159 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use crate::{
+    storage::state::{State, StateTrait},
+    sync::{
+        state::delta::{ChunkKey, ChunkReader, StateDumper},
+        Error, ErrorKind,
+    },
+};
+use cfx_types::H256;
+use keccak_hash::keccak;
+use primitives::StateRootWithAuxInfo;
+use rlp::{Encodable, Rlp};
+use rlp_derive::{RlpDecodable, RlpEncodable};
+use std::{
+    fs::{create_dir_all, write},
+    io::Error as IoError,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+#[derive(Default, RlpDecodable, RlpEncodable)]
+pub struct Chunk {
+    metadata: Vec<usize>,
+    data: Vec<u8>,
+}
+
+impl Chunk {
+    pub fn estimate_size(&self) -> usize {
+        self.data.len() + self.metadata.len() * 8
+    }
+
+    pub fn insert(&mut self, key: &[u8], value: &[u8]) {
+        self.data.extend_from_slice(key);
+        self.data.extend_from_slice(value);
+        self.metadata.push(key.len());
+        self.metadata.push(value.len());
+    }
+
+    pub fn chunk_file_path(dir: &Path, hash: &H256) -> PathBuf {
+        dir.join(format!("chunk_{:?}", hash)).to_path_buf()
+    }
+
+    pub fn parse_hash(path: &Path) -> Option<H256> {
+        if !path.is_file() {
+            return None;
+        }
+
+        let filename = path.file_name()?.to_str()?;
+        if !filename.starts_with("chunk_0x") {
+            return None;
+        }
+
+        H256::from_str(&filename["chunk_0x".len()..]).ok()
+    }
+
+    pub fn dump(&self, dir: &Path) -> Result<Option<H256>, IoError> {
+        if self.metadata.is_empty() {
+            return Ok(None);
+        }
+
+        create_dir_all(dir)?;
+
+        let content = self.rlp_bytes();
+        let hash = keccak(&content);
+
+        let file_path = Self::chunk_file_path(dir, &hash);
+        write(file_path, &content)?;
+
+        Ok(Some(hash))
+    }
+
+    pub fn validate(&self, _key: &ChunkKey) -> Result<(), Error> {
+        self.validate_internal()
+    }
+
+    fn validate_internal(&self) -> Result<(), Error> {
+        if self.metadata.is_empty() {
+            return Err(ErrorKind::InvalidSnapshotChunk(
+                "chunk metadata is empty".into(),
+            )
+            .into());
+        }
+
+        if self.metadata.len() % 2 == 1 {
+            return Err(ErrorKind::InvalidSnapshotChunk(
+                "chunk metadata len is odd".into(),
+            )
+            .into());
+        }
+
+        if self.data.len() != self.metadata.iter().sum::<usize>() {
+            return Err(ErrorKind::InvalidSnapshotChunk(
+                "chunk data len mismatch with metadata".into(),
+            )
+            .into());
+        }
+
+        for size in self.metadata.iter() {
+            if *size == 0 {
+                return Err(ErrorKind::InvalidSnapshotChunk(
+                    "chunk key or value is empty".into(),
+                )
+                .into());
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn load(
+        checkpoint: &H256, chunk_key: &ChunkKey,
+    ) -> Result<Option<Chunk>, Error> {
+        let root_dir = StateDumper::default_root_dir();
+
+        let reader = match ChunkReader::new(root_dir, checkpoint) {
+            Some(reader) => reader,
+            None => return Ok(None),
+        };
+
+        let chunk_raw = match reader.chunk_raw(chunk_key)? {
+            Some(raw) => raw,
+            None => return Ok(None),
+        };
+
+        Ok(Some(Rlp::new(&chunk_raw).as_val()?))
+    }
+
+    pub fn restore(
+        &self, state: &mut State, commit_epoch: Option<H256>,
+    ) -> Result<Option<StateRootWithAuxInfo>, Error> {
+        self.validate_internal()?;
+
+        let mut index = 0;
+        let mut data_pos = 0;
+
+        while index < self.metadata.len() {
+            let key = &self.data[data_pos..data_pos + self.metadata[index]];
+            data_pos += self.metadata[index];
+            let value =
+                &self.data[data_pos..data_pos + self.metadata[index + 1]];
+            data_pos += self.metadata[index + 1];
+            index += 2;
+
+            state.set(key, value.to_vec().into_boxed_slice())?;
+        }
+
+        let epoch = match commit_epoch {
+            Some(epoch) => epoch,
+            None => return Ok(None),
+        };
+
+        let root = state.compute_state_root()?;
+        state.commit(epoch)?;
+        Ok(Some(root))
+    }
+}

--- a/core/src/sync/state/delta/compress.rs
+++ b/core/src/sync/state/delta/compress.rs
@@ -1,0 +1,30 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use std::{
+    fs::File,
+    io::{Error as IoError, Read, Write},
+    path::Path,
+};
+use zip::{write::FileOptions, ZipArchive, ZipWriter};
+
+pub fn write_single_zip_file(
+    path: &Path, content: &[u8],
+) -> Result<(), IoError> {
+    let file = File::create(path)?;
+    let mut zip = ZipWriter::new(file);
+    zip.start_file("0", FileOptions::default())?;
+    zip.write_all(content)?;
+    zip.finish()?;
+    Ok(())
+}
+
+pub fn read_single_zip_file(path: &Path) -> Result<Vec<u8>, IoError> {
+    let file = File::open(path)?;
+    let mut zip = ZipArchive::new(file)?;
+    let mut zip_file = zip.by_index(0)?;
+    let mut content = Vec::new();
+    zip_file.read_to_end(&mut content)?;
+    Ok(content)
+}

--- a/core/src/sync/state/delta/dumper.rs
+++ b/core/src/sync/state/delta/dumper.rs
@@ -1,0 +1,91 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use crate::{
+    storage::{
+        state_manager::{StateManager, StateManagerTrait},
+        Error as StorageError, KVInserter, SnapshotAndEpochIdRef,
+    },
+    sync::{state::delta::chunk::Chunk, Error},
+};
+use cfx_types::H256;
+use std::{env::current_dir, fs::remove_dir_all, path::PathBuf};
+
+pub struct StateDumper {
+    epoch: H256,
+    epoch_dir: PathBuf,
+    max_chunk_size: usize,
+    dumping_chunk: Chunk,
+}
+
+impl StateDumper {
+    pub fn default_root_dir() -> String {
+        current_dir()
+            .unwrap_or(PathBuf::from("./"))
+            .join("state_checkpoints")
+            .to_str()
+            .expect("state chunk directory should not be empty")
+            .to_string()
+    }
+
+    pub fn epoch_dir(root_dir: String, epoch: &H256) -> PathBuf {
+        PathBuf::from(root_dir).join(format!("epoch_{:?}", epoch))
+    }
+
+    pub fn new(root_dir: String, epoch: H256, max_chunk_size: usize) -> Self {
+        let epoch_dir = Self::epoch_dir(root_dir, &epoch);
+
+        Self {
+            epoch,
+            epoch_dir,
+            max_chunk_size,
+            dumping_chunk: Chunk::default(),
+        }
+    }
+
+    pub fn dump(
+        &mut self, state_manager: &StateManager,
+    ) -> Result<bool, Error> {
+        let epoch_id = SnapshotAndEpochIdRef::new(&self.epoch, None);
+        let state = match state_manager.get_state_no_commit(epoch_id)? {
+            Some(state) => state,
+            None => return Ok(false),
+        };
+
+        state.dump(self)?;
+
+        // dump last chunk
+        self.dumping_chunk.dump(self.epoch_dir.as_path())?;
+
+        Ok(true)
+    }
+
+    pub fn remove(root_dir: String, epoch: Option<H256>) -> Result<(), Error> {
+        let epoch = match epoch {
+            Some(epoch) => epoch,
+            None => {
+                remove_dir_all(root_dir)?;
+                return Ok(());
+            }
+        };
+
+        let epoch_dir = Self::epoch_dir(root_dir, &epoch);
+        remove_dir_all(epoch_dir)?;
+
+        Ok(())
+    }
+}
+
+impl KVInserter<(Vec<u8>, Box<[u8]>)> for StateDumper {
+    fn push(&mut self, v: (Vec<u8>, Box<[u8]>)) -> Result<(), StorageError> {
+        self.dumping_chunk.insert(&v.0, &v.1);
+
+        if self.dumping_chunk.estimate_size() > self.max_chunk_size {
+            self.dumping_chunk.dump(self.epoch_dir.as_path())?;
+            self.dumping_chunk = Chunk::default();
+        }
+
+        Ok(())
+    }
+}

--- a/core/src/sync/state/delta/manifest.rs
+++ b/core/src/sync/state/delta/manifest.rs
@@ -1,0 +1,52 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use crate::sync::{
+    state::delta::{ChunkReader, StateDumper},
+    Error, ErrorKind,
+};
+use cfx_types::H256;
+use primitives::MerkleHash;
+use rlp_derive::{RlpDecodableWrapper, RlpEncodableWrapper};
+
+pub type ChunkKey = H256;
+
+#[derive(Default, RlpDecodableWrapper, RlpEncodableWrapper)]
+pub struct Manifest {
+    chunks: Vec<ChunkKey>,
+}
+
+impl Manifest {
+    pub fn validate(
+        &self, _snapshot_root: &MerkleHash, _start_chunk: &Option<ChunkKey>,
+    ) -> Result<(), Error> {
+        if self.chunks.is_empty() {
+            return Err(ErrorKind::InvalidSnapshotManifest(
+                "empty chunks".into(),
+            )
+            .into());
+        }
+
+        Ok(())
+    }
+
+    pub fn next_chunk(&self) -> Option<ChunkKey> { None }
+
+    pub fn into_chunks(self) -> Vec<ChunkKey> { self.chunks }
+
+    pub fn load(
+        checkpoint: &H256, _start_key: Option<ChunkKey>,
+    ) -> Result<Option<Manifest>, Error> {
+        let root_dir = StateDumper::default_root_dir();
+
+        let reader = match ChunkReader::new(root_dir, checkpoint) {
+            Some(reader) => reader,
+            None => return Ok(None),
+        };
+
+        Ok(Some(Manifest {
+            chunks: reader.chunks()?,
+        }))
+    }
+}

--- a/core/src/sync/state/delta/mod.rs
+++ b/core/src/sync/state/delta/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+mod chunk;
+mod dumper;
+mod manifest;
+mod reader;
+
+pub use self::{
+    chunk::Chunk,
+    dumper::StateDumper,
+    manifest::{ChunkKey, Manifest as RangedManifest},
+    reader::ChunkReader,
+};

--- a/core/src/sync/state/delta/mod.rs
+++ b/core/src/sync/state/delta/mod.rs
@@ -3,6 +3,7 @@
 // See http://www.gnu.org/licenses/
 
 mod chunk;
+mod compress;
 mod dumper;
 mod manifest;
 mod reader;

--- a/core/src/sync/state/delta/reader.rs
+++ b/core/src/sync/state/delta/reader.rs
@@ -1,0 +1,54 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use crate::sync::{
+    state::delta::{Chunk, StateDumper},
+    Error,
+};
+use cfx_types::H256;
+use std::{
+    fs::{read, read_dir},
+    path::PathBuf,
+};
+
+pub struct ChunkReader {
+    epoch_dir: PathBuf,
+}
+
+impl ChunkReader {
+    pub fn new(root_dir: String, epoch: &H256) -> Option<ChunkReader> {
+        let epoch_dir = StateDumper::epoch_dir(root_dir, epoch);
+        Self::new_with_epoch_dir(epoch_dir)
+    }
+
+    pub fn new_with_epoch_dir(epoch_dir: PathBuf) -> Option<ChunkReader> {
+        if !epoch_dir.is_dir() {
+            return None;
+        }
+
+        Some(ChunkReader { epoch_dir })
+    }
+
+    pub fn chunks(&self) -> Result<Vec<H256>, Error> {
+        let mut hashes = Vec::new();
+
+        for entry in read_dir(&self.epoch_dir)? {
+            if let Some(hash) = Chunk::parse_hash(entry?.path().as_path()) {
+                hashes.push(hash);
+            }
+        }
+
+        Ok(hashes)
+    }
+
+    pub fn chunk_raw(&self, hash: &H256) -> Result<Option<Vec<u8>>, Error> {
+        let path = Chunk::chunk_file_path(self.epoch_dir.as_path(), hash);
+
+        if !path.is_file() {
+            return Ok(None);
+        }
+
+        Ok(Some(read(path)?))
+    }
+}

--- a/core/src/sync/state/delta/reader.rs
+++ b/core/src/sync/state/delta/reader.rs
@@ -3,14 +3,11 @@
 // See http://www.gnu.org/licenses/
 
 use crate::sync::{
-    state::delta::{Chunk, StateDumper},
+    state::delta::{compress::read_single_zip_file, Chunk, StateDumper},
     Error,
 };
 use cfx_types::H256;
-use std::{
-    fs::{read, read_dir},
-    path::PathBuf,
-};
+use std::{fs::read_dir, path::PathBuf};
 
 pub struct ChunkReader {
     epoch_dir: PathBuf,
@@ -49,6 +46,6 @@ impl ChunkReader {
             return Ok(None);
         }
 
-        Ok(Some(read(path)?))
+        Ok(Some(read_single_zip_file(path.as_path())?))
     }
 }

--- a/core/src/sync/state/mod.rs
+++ b/core/src/sync/state/mod.rs
@@ -3,7 +3,7 @@
 // See http://www.gnu.org/licenses/
 
 pub mod delta;
-mod restore;
+pub mod restore;
 mod snapshot_chunk_request;
 mod snapshot_chunk_response;
 mod snapshot_chunk_sync;

--- a/core/src/sync/state/mod.rs
+++ b/core/src/sync/state/mod.rs
@@ -2,13 +2,14 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
+pub mod delta;
 mod restore;
 mod snapshot_chunk_request;
 mod snapshot_chunk_response;
 mod snapshot_chunk_sync;
 mod snapshot_manifest_request;
 mod snapshot_manifest_response;
-mod storage;
+//mod storage;
 
 pub use self::{
     snapshot_chunk_request::SnapshotChunkRequest,
@@ -16,5 +17,4 @@ pub use self::{
     snapshot_chunk_sync::{SnapshotChunkSync, Status},
     snapshot_manifest_request::SnapshotManifestRequest,
     snapshot_manifest_response::SnapshotManifestResponse,
-    storage::RangedManifest,
 };

--- a/core/src/sync/state/restore.rs
+++ b/core/src/sync/state/restore.rs
@@ -2,14 +2,22 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use crate::sync::state::storage::{Chunk, ChunkKey};
-use keccak_hash::keccak;
+use crate::{
+    storage::{
+        state::StateTrait,
+        state_manager::{StateManager, StateManagerTrait},
+        SnapshotAndEpochIdRef,
+    },
+    sync::state::delta::{Chunk, ChunkKey, ChunkReader, StateDumper},
+};
+use cfx_types::H256;
 use parking_lot::RwLock;
 use primitives::StateRoot;
-use rlp::{Encodable, Rlp};
+use rlp::Rlp;
 use std::{
     collections::VecDeque,
-    fs,
+    env::current_dir,
+    fs::remove_dir_all,
     path::PathBuf,
     sync::{
         atomic::{AtomicUsize, Ordering::Relaxed},
@@ -18,21 +26,15 @@ use std::{
     thread,
 };
 
-#[derive(Debug)]
-struct ChunkMetadata {
-    key: ChunkKey,
-    file: PathBuf,
-}
-
 #[derive(Default)]
 struct State {
-    pending: VecDeque<ChunkMetadata>,
-    restoring: Option<ChunkMetadata>,
-    restored: Vec<ChunkMetadata>,
+    pending: VecDeque<ChunkKey>,
+    restoring: Option<ChunkKey>,
+    restored: Vec<ChunkKey>,
 }
 
 impl State {
-    fn next(&mut self) -> Option<&ChunkMetadata> {
+    fn next(&mut self) -> Option<&ChunkKey> {
         if let Some(chunk) = self.restoring.take() {
             self.restored.push(chunk);
         }
@@ -44,67 +46,77 @@ impl State {
     }
 }
 
-#[derive(Default)]
 pub struct Restorer {
     state: Arc<RwLock<State>>,
     progress: Arc<RestoreProgress>,
-    dir: String,
+    dir: PathBuf,
+    checkpoint: H256,
+}
+
+impl Default for Restorer {
+    fn default() -> Self { Self::new_with_default_root_dir(H256::zero()) }
 }
 
 impl Restorer {
+    pub fn new_with_default_root_dir(checkpoint: H256) -> Self {
+        let root_dir = current_dir()
+            .unwrap_or(PathBuf::from("./"))
+            .join("state_checkpoints_restoration")
+            .to_str()
+            .expect("state chunk restoration directory should not be empty")
+            .to_string();
+
+        Self::new(root_dir, checkpoint)
+    }
+
+    pub fn new(root_dir: String, checkpoint: H256) -> Self {
+        Restorer {
+            state: Default::default(),
+            progress: Default::default(),
+            dir: StateDumper::epoch_dir(root_dir, &checkpoint),
+            checkpoint,
+        }
+    }
+
     /// Append a chunk for restoration.
     pub fn append(&self, key: ChunkKey, chunk: Chunk) {
-        let file = match self.write_chunk_to_file(&key, chunk) {
-            Some(file) => file,
-            None => return,
-        };
+        chunk
+            .dump(self.dir.as_path())
+            .expect("failed to dump chunk to file");
 
         self.progress.total.fetch_add(1, Relaxed);
 
         let mut state = self.state.write();
-        state.pending.push_back(ChunkMetadata { key, file });
-    }
-
-    fn write_chunk_to_file(
-        &self, key: &ChunkKey, chunk: Chunk,
-    ) -> Option<PathBuf> {
-        if let Err(e) = fs::create_dir_all(&self.dir) {
-            panic!("failed to create directory to store snapshot chunks: directory = {:?}, error = {:?}", self.dir, e);
-        }
-
-        let contents = chunk.rlp_bytes();
-        let hash = keccak(contents.as_slice());
-        let filename = format!("chunk_{:?}", hash);
-        let mut file = PathBuf::from(&self.dir);
-        file.push(&filename);
-
-        if file.exists() {
-            warn!("snapshot chunk already exists, key = {:?}", key);
-            return None;
-        }
-
-        if let Err(e) = fs::write(&file, contents.as_slice()) {
-            panic!("failed to store snapshot chunk for restoration: file = {:?}, error = {:?}", file, e);
-        }
-
-        Some(file)
+        state.pending.push_back(key);
     }
 
     /// Start to restore chunks asynchronously.
-    pub fn start_to_restore(&self) {
+    pub fn start_to_restore(&self, state_manager: Arc<StateManager>) {
         let state_cloned = self.state.clone();
         let progress_cloned = self.progress.clone();
+        let chunk_reader = ChunkReader::new_with_epoch_dir(self.dir.clone())
+            .expect("cannot find the chunk store for restoration");
+        let checkpoint = self.checkpoint.clone();
 
         thread::Builder::new()
             .name("SyncCheckpoint".into())
             .spawn(move || {
                 let total = progress_cloned.total.load(Relaxed);
                 debug!("start to restore snapshot chunks, total = {}", total);
+                let mut state = state_manager.get_state_for_genesis_write();
 
-                while let Some(metadata) = state_cloned.write().next() {
-                    let _chunk = Self::read_chunk_from_file(&metadata.file);
+                while let Some(key) = state_cloned.write().next() {
+                    let chunk = chunk_reader
+                        .chunk_raw(key)
+                        .expect("failed to read chunk from restoration store")
+                        .expect("cannot find chunk for restoration");
+                    let chunk = Rlp::new(&chunk)
+                        .as_val::<Chunk>()
+                        .expect("failed to decode chunk for restoration");
 
-                    // todo use storage API to restore the chunk
+                    chunk
+                        .restore(&mut state, Some(checkpoint))
+                        .expect("failed to restore chunk");
 
                     progress_cloned.completed.fetch_add(1, Relaxed);
                 }
@@ -117,28 +129,32 @@ impl Restorer {
             .expect("failed to create thread to synchronize checkpoint state");
     }
 
-    fn read_chunk_from_file(file: &PathBuf) -> Chunk {
-        let contents = match fs::read(file) {
-            Ok(contents) => contents,
-            Err(e) => {
-                panic!("failed to read snapshot chunk for restoration: file = {:?}, error = {:?}", file, e);
-            }
-        };
+    pub fn progress(&self) -> &RestoreProgress { self.progress.as_ref() }
 
-        match Rlp::new(&contents).as_val::<Chunk>() {
-            Ok(val) => val,
-            Err(e) => {
-                panic!("failed to restore snapshot chunk due to decode error: file = {:?}, error = {:?}", file, e);
+    pub fn restored_state_root(
+        &self, state_manager: Arc<StateManager>,
+    ) -> StateRoot {
+        let epoch_id = SnapshotAndEpochIdRef::new(&self.checkpoint, None);
+        let state = state_manager
+            .get_state_no_commit(epoch_id)
+            .expect("failed to get checkpoint state")
+            .expect("cannot find the checkpoint state");
+        state
+            .get_state_root()
+            .expect("failed to get state root")
+            .expect("restored checkpoint state root not found")
+            .state_root
+    }
+}
+
+impl Drop for Restorer {
+    fn drop(&mut self) {
+        if !self.checkpoint.is_zero() {
+            if let Err(e) = remove_dir_all(&self.dir) {
+                error!("failed to cleanup checkpoint chunk store: {:?}", e);
             }
         }
     }
-
-    pub fn progress(&self) -> &RestoreProgress { self.progress.as_ref() }
-
-    pub fn restored_state_root(&self) -> StateRoot { unimplemented!() }
-
-    // todo delete all the temp snapshot chunk files after restoration succeeded
-    // todo cleanup and start to sync new checkpoint
 }
 
 #[derive(Default, Debug)]

--- a/core/src/sync/state/snapshot_chunk_request.rs
+++ b/core/src/sync/state/snapshot_chunk_request.rs
@@ -10,8 +10,8 @@ use crate::{
         },
         request_manager::Request,
         state::{
+            delta::{Chunk, ChunkKey},
             snapshot_chunk_response::SnapshotChunkResponse,
-            storage::{Chunk, ChunkKey},
         },
         Error, ProtocolConfiguration,
     },

--- a/core/src/sync/state/snapshot_chunk_response.rs
+++ b/core/src/sync/state/snapshot_chunk_response.rs
@@ -6,7 +6,7 @@ use crate::{
     message::{Message, MsgId},
     sync::{
         message::{msgid, Context, Handleable},
-        state::{storage::Chunk, SnapshotChunkRequest},
+        state::{delta::Chunk, SnapshotChunkRequest},
         Error, ErrorKind,
     },
 };

--- a/core/src/sync/state/snapshot_manifest_request.rs
+++ b/core/src/sync/state/snapshot_manifest_request.rs
@@ -10,8 +10,8 @@ use crate::{
         },
         request_manager::Request,
         state::{
+            delta::{ChunkKey, RangedManifest},
             snapshot_manifest_response::SnapshotManifestResponse,
-            storage::ChunkKey, RangedManifest,
         },
         Error, ProtocolConfiguration,
     },

--- a/core/src/sync/state/snapshot_manifest_response.rs
+++ b/core/src/sync/state/snapshot_manifest_response.rs
@@ -6,7 +6,7 @@ use crate::{
     message::{Message, MsgId},
     sync::{
         message::{msgid, Context, Handleable},
-        state::{RangedManifest, SnapshotManifestRequest},
+        state::{delta::RangedManifest, SnapshotManifestRequest},
         Error, ErrorKind,
     },
 };

--- a/core/src/sync/synchronization_phases.rs
+++ b/core/src/sync/synchronization_phases.rs
@@ -312,7 +312,9 @@ impl SynchronizationPhaseTrait for CatchUpCheckpointPhase {
 
         if self.state_sync.checkpoint() == checkpoint {
             if let Status::Restoring(_) = self.state_sync.status() {
-                self.state_sync.update_restore_progress();
+                self.state_sync.update_restore_progress(
+                    sync_handler.graph.data_man.storage_manager.clone(),
+                );
             }
 
             if self.state_sync.status() == Status::Completed {

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -409,6 +409,7 @@ impl SynchronizationProtocolHandler {
                 op = Some(UpdateNodeOperation::Demotion)
             }
             ErrorKind::Decoder(_) => op = Some(UpdateNodeOperation::Remove),
+            ErrorKind::Io(_) => disconnect = false,
             ErrorKind::Network(kind) => match kind {
                 network::ErrorKind::AddressParse => disconnect = false,
                 network::ErrorKind::AddressResolve(_) => disconnect = false,


### PR DESCRIPTION
This PR is a workaround to sync checkpoint state due to snapshot unavailable to test full node. This PR is only for the checkpoint sync part, including:
1. Expose a `dump` method in storage `State` struct to dump Delta trie in KV format.
2. Add Delta trie based sync implementation, and replace the APIs based on previous snapshot version. The new way will dump Delta trie KVs into chunks and saved into file system.
3. Implement chunk restoration based on Delta trie KVs.
4. Add example `restore_checkpoint_delta` for the Delta trie based restoration. Note, the example panics (in storage code) when inserting 10M accounts into storage.

TODO:
- Dump checkpoint state when new era started. (API ready, but need more test)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/728)
<!-- Reviewable:end -->
