### PR TITLE
Serve old era epoch numbers from disk on archive nodes

### DIFF
--- a/client/src/rpc/types/block.rs
+++ b/client/src/rpc/types/block.rs
@@ -4,7 +4,7 @@
 
 use crate::rpc::types::{Receipt, Transaction, H160, H256, U256};
 use cfxcore::{
-    block_data_manager::BlockExecutionResultWithEpoch,
+    block_data_manager::{BlockDataManager, BlockExecutionResultWithEpoch},
     consensus::ConsensusGraphInner,
 };
 use jsonrpc_core::Error as RpcError;
@@ -129,7 +129,7 @@ pub struct Block {
 impl Block {
     pub fn new(
         b: &PrimitiveBlock, consensus_inner: &ConsensusGraphInner,
-        include_txs: bool,
+        data_man: &Arc<BlockDataManager>, include_txs: bool,
     ) -> Self
     {
         let transactions = match include_txs {
@@ -187,9 +187,7 @@ impl Block {
 
         let epoch_number = consensus_inner
             .get_block_epoch_number(&block_hash)
-            .or_else(|| {
-                consensus_inner.get_block_epoch_number_from_disk(&block_hash)
-            })
+            .or_else(|| data_man.block_epoch_number(&block_hash))
             .map(Into::into);
 
         Block {

--- a/core/src/block_data_manager/mod.rs
+++ b/core/src/block_data_manager/mod.rs
@@ -443,6 +443,13 @@ impl BlockDataManager {
         self.db_manager.block_execution_result_from_db(hash)
     }
 
+    pub fn block_epoch_number(&self, hash: &H256) -> Option<u64> {
+        self.block_execution_result_by_hash_from_db(&hash)
+            .map(|execution_result| execution_result.0)
+            .and_then(|pivot| self.block_header_by_hash(&pivot))
+            .map(|header| header.height())
+    }
+
     pub fn insert_block_results(
         &self, hash: H256, epoch: H256, receipts: Arc<Vec<Receipt>>,
         persistent: bool,

--- a/core/src/consensus/consensus_inner/mod.rs
+++ b/core/src/consensus/consensus_inner/mod.rs
@@ -2058,6 +2058,25 @@ impl ConsensusGraphInner {
         })
     }
 
+    pub fn get_block_epoch_number_from_disk(&self, hash: &H256) -> Option<u64> {
+        let pivot_hash = match self.block_execution_results_by_hash(
+            &hash, false, /* update_cache */
+        ) {
+            None => return None,
+            Some(execution_result) => execution_result.0,
+        };
+
+        let epoch_number = match self
+            .data_man
+            .block_by_hash(&pivot_hash, false /* update_cache */)
+        {
+            None => return None,
+            Some(block) => block.block_header.height(),
+        };
+
+        Some(epoch_number)
+    }
+
     pub fn all_blocks_with_topo_order(&self) -> Vec<H256> {
         let epoch_number = self.best_epoch_number();
         let mut current_number = 0;

--- a/core/src/consensus/consensus_inner/mod.rs
+++ b/core/src/consensus/consensus_inner/mod.rs
@@ -2058,25 +2058,6 @@ impl ConsensusGraphInner {
         })
     }
 
-    pub fn get_block_epoch_number_from_disk(&self, hash: &H256) -> Option<u64> {
-        let pivot_hash = match self.block_execution_results_by_hash(
-            &hash, false, /* update_cache */
-        ) {
-            None => return None,
-            Some(execution_result) => execution_result.0,
-        };
-
-        let epoch_number = match self
-            .data_man
-            .block_by_hash(&pivot_hash, false /* update_cache */)
-        {
-            None => return None,
-            Some(block) => block.block_header.height(),
-        };
-
-        Some(epoch_number)
-    }
-
     pub fn all_blocks_with_topo_order(&self) -> Vec<H256> {
         let epoch_number = self.best_epoch_number();
         let mut current_number = 0;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -71,6 +71,7 @@ pub mod vm_factory;
 pub mod test_helpers;
 
 pub use crate::{
+    block_data_manager::BlockDataManager,
     consensus::{BestInformation, ConsensusGraph, SharedConsensusGraph},
     light_protocol::{
         Provider as LightProvider, QueryService as LightQueryService,


### PR DESCRIPTION
**Overview**

When serving blocks through RPCs, the `epoch_number` field is populated using the in-memory consensus graph, which is pruned for old eras. This PR extends this behavior to read the epoch number from disk if it is not present in memory.

Fixes #727.

**Example**

Previous behavior (when latest epoch is `0x5ad49`):

```
% curl -X POST --data '{"jsonrpc":"2.0","method":"cfx_getBlockByEpochNumber","params":["0x1", false],"id":1}' -H "Content-Type: application/json" http://localhost:12537
{"jsonrpc":"2.0","result":{... "epochNumber":null ...}
```

New behavior:

```
% curl -X POST --data '{"jsonrpc":"2.0","method":"cfx_getBlockByEpochNumber","params":["0x1", false],"id":1}' -H "Content-Type: application/json" http://localhost:12537
{"jsonrpc":"2.0","result":{... "epochNumber":"0x1" ...}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/737)
<!-- Reviewable:end -->
