### PR TITLE
Fix checkpoint sync bug and adds python tests

### DIFF
--- a/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
+++ b/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
@@ -289,10 +289,10 @@ impl ConsensusNewBlockHandler {
             .data_man
             .set_cur_consensus_era_genesis_hash(&cur_era_hash, &next_era_hash);
 
-        let epoch_id = SnapshotAndEpochIdRef::new(&cur_era_hash, None);
+        let epoch_id = SnapshotAndEpochIdRef::new(&next_era_hash, None);
         let has_state = inner.data_man.storage_manager.contains_state(epoch_id);
         if let Ok(true) = has_state {
-            CHECKPOINT_DUMP_MANAGER.read().dump_async(cur_era_hash);
+            CHECKPOINT_DUMP_MANAGER.read().dump_async(next_era_hash);
         }
     }
 

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -146,6 +146,9 @@ args:
         long: light
     - archive:
         long: archive
+    - full:
+        long: full
+        hidden: true
 subcommands:
     - account:
         about: Manage accounts

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,8 @@ mod command;
 use crate::command::rpc::RpcCommand;
 use clap::{load_yaml, App, ArgMatches};
 use client::{
-    archive::ArchiveClient, configuration::Configuration, light::LightClient,
+    archive::ArchiveClient, configuration::Configuration, full::FullClient,
+    light::LightClient,
 };
 use command::account::{AccountCmd, ImportAccounts, ListAccounts, NewAccount};
 use log::{info, LevelFilter};
@@ -130,6 +131,13 @@ fn main() -> Result<(), String> {
         let client_handle = ArchiveClient::start(conf, exit.clone())
             .map_err(|e| format!("failed to start archive client: {:?}", e))?;
         ArchiveClient::run_until_closed(exit, client_handle);
+    } else if matches.is_present("full") {
+        // todo this is to test full node in python code
+        // remove this branch when starts full node by default.
+        info!("Starting full client...");
+        let client_handle = FullClient::start(conf, exit.clone())
+            .map_err(|e| format!("failed to start full client: {:?}", e))?;
+        FullClient::run_until_closed(exit, client_handle);
     } else {
         info!("Starting full client...");
         let client_handle = ArchiveClient::start(conf, exit.clone())

--- a/tests/full_node_tests/sync_checkpoint_test.py
+++ b/tests/full_node_tests/sync_checkpoint_test.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+import os
+import sys
+from jsonrpcclient.exceptions import ReceivedErrorResponseError
+
+sys.path.insert(1, os.path.dirname(sys.path[0]))
+
+from test_framework.test_framework import ConfluxTestFramework
+from test_framework.util import sync_blocks, connect_nodes
+from conflux.rpc import RpcClient
+
+class SyncCheckpointTests(ConfluxTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+        self.conf_parameters = {
+            "era_epoch_count": "50",
+            "era_checkpoint_gap": "50",
+        }
+
+    def setup_network(self):
+        self.add_nodes(self.num_nodes)
+        self.start_node(0)
+
+    def run_test(self):
+        num_blocks = 200
+        checkpoint_epoch = 100
+
+        # Generate checkpoint on node[0]
+        client = RpcClient(self.nodes[0])
+        genesis_nonce = client.get_nonce(client.GENESIS_ADDR)
+        for _ in range(num_blocks):
+            tx = client.new_tx(nonce=genesis_nonce)
+            tx_hash = client.send_tx(tx)
+            assert tx_hash == tx.hash_hex()
+            genesis_nonce += 1
+            client.generate_block(100)
+
+        # Start node[1] as full node to sync checkpoint
+        # Change phase from CatchUpSyncBlockHeader to CatchUpCheckpoint
+        # only when there is at least one connected peer.
+        self.start_node(1, ["--full"], phase_to_wait=None)
+        connect_nodes(self.nodes, 1, 0)
+
+        # FIXME full node issue that hang at phase CatchUpRecoverBlockFromDbPhase
+        self.nodes[1].wait_for_phase(["CatchUpRecoverBlockFromDbPhase", "NormalSyncPhase"])
+
+        sync_blocks(self.nodes)
+
+        client = RpcClient(self.nodes[1])
+        
+        # FIXME conflux panics
+        # At epoch 1, block header exists while body not synchronized
+        # print(client.block_by_epoch(client.EPOCH_NUM(1)))
+
+        # There is no state from epoch 1 to checkpoint_epoch
+        # Note, state of genesis epoch always exists
+        assert client.epoch_number() >= checkpoint_epoch
+        for i in range(1, checkpoint_epoch):
+            try:
+                client.get_balance(client.GENESIS_ADDR, client.EPOCH_NUM(i))
+                raise AssertionError("should be not state for epoch {}".format(i))
+            except ReceivedErrorResponseError as e:
+                assert "State for epoch" in e.response.message
+                assert "does not exist" in e.response.message
+
+        # State should exist at checkpoint
+        client.get_balance(client.GENESIS_ADDR, client.EPOCH_NUM(checkpoint_epoch))
+
+        # FIXME conflux hang/panics at phase CatchUpRecoverBlockFromDbPhase
+        # There should be states after checkpoint
+        # for i in range(checkpoint_epoch + 1, client.epoch_number() + 1):
+        #     client.get_balance(client.GENESIS_ADDR, client.EPOCH_NUM(i))
+
+if __name__ == "__main__":
+    SyncCheckpointTests().main()

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -31,6 +31,7 @@ test_subdirs = [
     "", # include test_dir itself
     "light",
     "network_tests",
+    "full_node_tests",
 ]
 
 # By default, run all *_test.py files in the specified subfolders.

--- a/tests/test_framework/test_node.py
+++ b/tests/test_framework/test_node.py
@@ -196,7 +196,8 @@ class TestNode:
             retry += 1
 
         if retry > max_retry:
-            raise AssertionError(f"Node did not reach any of {phases} after {wait_time} seconds")
+            current_phase = self.current_sync_phase()
+            raise AssertionError(f"Node did not reach any of {phases} after {wait_time} seconds, current phase is {current_phase}")
 
     def wait_for_nodeid(self):
         pubkey, x, y = get_nodeid(self)


### PR DESCRIPTION
This pull request includes following changes:
1. Add temp argument `--full` to test full node. (Will remove when full node feature completed)
2. Do not sync checkpoint if state exists. There're 2 cases: 1) checkpoint is genesis; 2) restart and sync in the same era;
3. Notify the dumped checkpoint to new connected peers;
4. Add python test: full node sync checkpoint from archive node; Then, full node should has state from checkpoint to the `LATEST_STATE` epoch;

Note, the CatchUpRecoverBlockFromDbPhase have issues that block the new added python test:
- Hang due to invalid `latest_graph_ready_block`;
- Once above hang issue fixed, Conflux still panics due to unexpected `unwrap`;