### PR TITLE
Unset `block_ready` for InvalidTransactionsRoot error.

### DIFF
--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -1593,6 +1593,14 @@ impl SynchronizationGraph {
                 )) => {
                     warn ! ("BlockTransactionRoot not match! inserted_block={:?} err={:?}", block, e);
                     insert_success = false;
+                    // If the transaction root does not match, it might be
+                    // caused by receiving wrong
+                    // transactions because of conflicting ShortId in
+                    // CompactBlock, or caused by
+                    // adversaries. In either case, we should request the block
+                    // again, and the received block body is
+                    // discarded.
+                    inner.arena[me].block_ready = false;
                     return (insert_success, need_to_relay);
                 }
                 Err(e) => {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/743)
<!-- Reviewable:end -->
