### PR TITLE
verify states correctly

### DIFF
--- a/core/src/block_data_manager/mod.rs
+++ b/core/src/block_data_manager/mod.rs
@@ -201,8 +201,14 @@ impl BlockDataManager {
             );
             data_man.insert_epoch_execution_commitments(
                 *data_man.genesis_hash(),
-                *genesis_block.block_header.deferred_receipts_root(),
-                *genesis_block.block_header.deferred_logs_bloom_hash(),
+                *data_man
+                    .true_genesis_block
+                    .block_header
+                    .deferred_receipts_root(),
+                *data_man
+                    .true_genesis_block
+                    .block_header
+                    .deferred_logs_bloom_hash(),
             );
         } else {
             // for other era genesis, we need to change the instance_id


### PR DESCRIPTION
Since we ask more states (more than `trusted_blame_block.blame() + 1`), we should verify them too. According to `trusted_blame_block`, we can find a list of trusted blocks which are enough to cover the required states vector. And using this list of trusted blocks, it is easy to verify the whole states vector.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/746)
<!-- Reviewable:end -->
