### PR TITLE
fix pivot chain switch bug

### DIFF
--- a/blockgen/src/lib.rs
+++ b/blockgen/src/lib.rs
@@ -512,7 +512,9 @@ impl BlockGenerator {
 
     pub fn generate_custom_block(
         &self, transactions: Vec<Arc<SignedTransaction>>,
-    ) -> H256 {
+        adaptive: Option<bool>,
+    ) -> H256
+    {
         let block_gas_limit = DEFAULT_MAX_BLOCK_GAS_LIMIT.into();
         // get the best block
         let (best_info, _) =
@@ -551,7 +553,7 @@ impl BlockGenerator {
             block_gas_limit,
             transactions,
             0,
-            None,
+            adaptive,
         );
 
         self.generate_block_impl(block)
@@ -595,6 +597,7 @@ impl BlockGenerator {
     pub fn generate_block_with_nonce_and_timestamp(
         &self, parent_hash: H256, referee: Vec<H256>,
         transactions: Vec<Arc<SignedTransaction>>, nonce: u64, timestamp: u64,
+        adaptive: bool,
     ) -> Result<H256, String>
     {
         let (
@@ -621,7 +624,7 @@ impl BlockGenerator {
             DEFAULT_MAX_BLOCK_GAS_LIMIT.into(),
             transactions,
             0,
-            None,
+            Some(adaptive),
         );
         block.block_header.set_nonce(nonce);
         block.block_header.set_timestamp(timestamp);

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -380,7 +380,7 @@ impl RpcImpl {
 
     fn generate_block_with_nonce_and_timestamp(
         &self, parent: H256, referees: Vec<H256>, raw: Bytes, nonce: u64,
-        timestamp: u64,
+        timestamp: u64, adaptive: bool,
     ) -> RpcResult<H256>
     {
         let transactions = self.decode_raw_txs(raw, 0)?;
@@ -390,6 +390,7 @@ impl RpcImpl {
             transactions,
             nonce,
             timestamp,
+            adaptive,
         ) {
             Ok(hash) => Ok(hash),
             Err(e) => Err(RpcError::invalid_params(e)),
@@ -429,11 +430,13 @@ impl RpcImpl {
     }
 
     fn generate_block_with_fake_txs(
-        &self, raw_txs_without_data: Bytes, tx_data_len: Option<usize>,
-    ) -> RpcResult<H256> {
+        &self, raw_txs_without_data: Bytes, adaptive: Option<bool>,
+        tx_data_len: Option<usize>,
+    ) -> RpcResult<H256>
+    {
         let transactions = self
             .decode_raw_txs(raw_txs_without_data, tx_data_len.unwrap_or(0))?;
-        Ok(self.block_gen.generate_custom_block(transactions))
+        Ok(self.block_gen.generate_custom_block(transactions, adaptive))
     }
 
     fn generate_block_with_blame_info(
@@ -598,12 +601,12 @@ impl TestRpc for TestRpcImpl {
         target self.rpc_impl {
             fn expire_block_gc(&self, timeout: u64) -> RpcResult<()>;
             fn generate_block_with_blame_info(&self, num_txs: usize, block_size_limit: usize, blame_info: BlameInfo) -> RpcResult<H256>;
-            fn generate_block_with_fake_txs(&self, raw_txs_without_data: Bytes, tx_data_len: Option<usize>) -> RpcResult<H256>;
+            fn generate_block_with_fake_txs(&self, raw_txs_without_data: Bytes, adaptive: Option<bool>, tx_data_len: Option<usize>) -> RpcResult<H256>;
             fn generate_custom_block(&self, parent_hash: H256, referee: Vec<H256>, raw_txs: Bytes, adaptive: Option<bool>) -> RpcResult<H256>;
             fn generate_fixed_block(&self, parent_hash: H256, referee: Vec<H256>, num_txs: usize, adaptive: bool, difficulty: Option<u64>) -> RpcResult<H256>;
             fn generate_one_block_special(&self, num_txs: usize, block_size_limit: usize, num_txs_simple: usize, num_txs_erc20: usize) -> RpcResult<()>;
             fn generate_one_block(&self, num_txs: usize, block_size_limit: usize) -> RpcResult<H256>;
-            fn generate_block_with_nonce_and_timestamp(&self, parent: H256, referees: Vec<H256>, raw: Bytes, nonce: u64, timestamp: u64) -> RpcResult<H256>;
+            fn generate_block_with_nonce_and_timestamp(&self, parent: H256, referees: Vec<H256>, raw: Bytes, nonce: u64, timestamp: u64, adaptive: bool) -> RpcResult<H256>;
             fn generate(&self, num_blocks: usize, num_txs: usize) -> RpcResult<Vec<H256>>;
             fn send_usable_genesis_accounts(& self, account_start_index: usize) -> RpcResult<Bytes>;
         }

--- a/client/src/rpc/impls/light.rs
+++ b/client/src/rpc/impls/light.rs
@@ -283,11 +283,11 @@ impl TestRpc for TestRpcImpl {
     not_supported! {
         fn expire_block_gc(&self, timeout: u64) -> RpcResult<()>;
         fn generate_block_with_blame_info(&self, num_txs: usize, block_size_limit: usize, blame_info: BlameInfo) -> RpcResult<H256>;
-        fn generate_block_with_fake_txs(&self, raw_txs_without_data: Bytes, tx_data_len: Option<usize>) -> RpcResult<H256>;
+        fn generate_block_with_fake_txs(&self, raw_txs_without_data: Bytes, adaptive: Option<bool>, tx_data_len: Option<usize>) -> RpcResult<H256>;
         fn generate_custom_block(&self, parent_hash: H256, referee: Vec<H256>, raw_txs: Bytes, adaptive: Option<bool>) -> RpcResult<H256>;
         fn generate_fixed_block(&self, parent_hash: H256, referee: Vec<H256>, num_txs: usize, adaptive: bool, difficulty: Option<u64>) -> RpcResult<H256>;
         fn generate_one_block_special(&self, num_txs: usize, block_size_limit: usize, num_txs_simple: usize, num_txs_erc20: usize) -> RpcResult<()>;
-        fn generate_block_with_nonce_and_timestamp(&self, parent: H256, referees: Vec<H256>, raw: Bytes, nonce: u64, timestamp: u64) -> RpcResult<H256>;
+        fn generate_block_with_nonce_and_timestamp(&self, parent: H256, referees: Vec<H256>, raw: Bytes, nonce: u64, timestamp: u64, adaptive: bool) -> RpcResult<H256>;
         fn generate_one_block(&self, num_txs: usize, block_size_limit: usize) -> RpcResult<H256>;
         fn generate(&self, num_blocks: usize, num_txs: usize) -> RpcResult<Vec<H256>>;
         fn send_usable_genesis_accounts(& self, account_start_index: usize) -> RpcResult<Bytes>;

--- a/client/src/rpc/traits/test.rs
+++ b/client/src/rpc/traits/test.rs
@@ -78,7 +78,7 @@ pub trait TestRpc {
 
     #[rpc(name = "test_generateblockwithfaketxs")]
     fn generate_block_with_fake_txs(
-        &self, raw: Bytes, tx_data_len: Option<usize>,
+        &self, raw: Bytes, adaptive: Option<bool>, tx_data_len: Option<usize>,
     ) -> RpcResult<H256>;
 
     #[rpc(name = "test_generateblockwithblameinfo")]
@@ -89,7 +89,7 @@ pub trait TestRpc {
     #[rpc(name = "test_generate_block_with_nonce_and_timestamp")]
     fn generate_block_with_nonce_and_timestamp(
         &self, parent: H256, referees: Vec<H256>, raw: Bytes, nonce: u64,
-        timestamp: u64,
+        timestamp: u64, adaptive: bool,
     ) -> RpcResult<H256>;
 
     #[rpc(name = "gettransactionreceipt")]

--- a/client/src/rpc/types/sync_graph_states.rs
+++ b/client/src/rpc/types/sync_graph_states.rs
@@ -13,6 +13,7 @@ pub struct SyncGraphBlockState {
     pub referees: Vec<H256>,
     pub nonce: u64,
     pub timestamp: u64,
+    pub adaptive: bool,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -36,6 +37,7 @@ impl SyncGraphStates {
                     .collect(),
                 nonce: block_state.nonce,
                 timestamp: block_state.timestamp,
+                adaptive: block_state.adaptive,
             })
         }
 

--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -873,7 +873,7 @@ impl ConsensusExecutionHandler {
         debug!(
             "Process tx epoch_id={}, block_count={}",
             epoch_hash,
-            epoch_blocks.len()
+            epoch_blocks.len(),
         );
 
         let mut state = State::new(

--- a/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
+++ b/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
@@ -1148,6 +1148,9 @@ impl ConsensusNewBlockHandler {
                             let mut heaviest = NULL;
                             let mut heaviest_weight = 0;
                             for index in &inner.arena[u].children {
+                                if inner.arena[*index].data.partial_invalid {
+                                    continue;
+                                }
                                 let weight = inner.weight_tree.get(*index);
                                 if heaviest == NULL
                                     || ConsensusGraphInner::is_heavier(

--- a/core/src/state_exposer/sync_graph_exposer.rs
+++ b/core/src/state_exposer/sync_graph_exposer.rs
@@ -11,6 +11,7 @@ pub struct SyncGraphBlockState {
     pub referees: Vec<H256>,
     pub nonce: u64,
     pub timestamp: u64,
+    pub adaptive: bool,
 }
 
 #[derive(Default)]

--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -1495,6 +1495,7 @@ impl SynchronizationGraph {
                             .clone(),
                         nonce: inner.arena[index].block_header.nonce(),
                         timestamp: inner.arena[index].block_header.timestamp(),
+                        adaptive: inner.arena[index].block_header.adaptive(),
                     },
                 );
             }

--- a/tests/conflux/rpc.py
+++ b/tests/conflux/rpc.py
@@ -105,9 +105,9 @@ class RpcClient:
         assert_is_hash_string(block_hash)
         return block_hash
 
-    def generate_block_with_fake_txs(self, txs: list, tx_data_len: int = 0) -> str:
+    def generate_block_with_fake_txs(self, txs: list, adaptive=False, tx_data_len: int = 0) -> str:
         encoded_txs = eth_utils.encode_hex(rlp.encode(txs))
-        block_hash = self.node.test_generateblockwithfaketxs(encoded_txs, tx_data_len)
+        block_hash = self.node.test_generateblockwithfaketxs(encoded_txs, adaptive, tx_data_len)
         assert_is_hash_string(block_hash)
         return block_hash
 


### PR DESCRIPTION
Currently, our pivot chain switch implementation will pick a partial invalid block into pivot chain if all children are partial invalid. This pull  request fix the bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/747)
<!-- Reviewable:end -->
