### PR TITLE
refactor sync protocol message struct

### DIFF
--- a/core/src/light_protocol/message/message.rs
+++ b/core/src/light_protocol/message/message.rs
@@ -4,7 +4,6 @@
 
 use super::protocol::*;
 use crate::message::{Message, MsgId};
-use std::any::Any;
 
 // generate `pub mod msgid`
 // TODO(thegaram): reorder message ids

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -8,7 +8,6 @@ pub type MsgId = u8;
 pub use cfx_bytes::Bytes;
 pub use priority_send_queue::SendQueuePriority;
 use rlp::{Encodable, Rlp};
-use std::any::Any;
 
 pub use crate::network::{
     throttling::THROTTLING_SERVICE, Error as NetworkError, NetworkContext,
@@ -118,21 +117,4 @@ macro_rules! build_msg_with_request_id_impl {
             }
         }
     };
-}
-
-/// Support to downcast trait to concrete request type.
-pub trait AsAny {
-    fn as_any(&self) -> &dyn Any;
-}
-
-impl<T: 'static> AsAny for T {
-    fn as_any(&self) -> &dyn Any { self }
-}
-
-pub trait AsMessage {
-    fn as_message(&self) -> &dyn Message;
-}
-
-impl<T: Message> AsMessage for T {
-    fn as_message(&self) -> &dyn Message { self }
 }

--- a/core/src/sync/message/capability.rs
+++ b/core/src/sync/message/capability.rs
@@ -2,10 +2,12 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use crate::sync::{
-    message::{Context, Handleable},
-    msg_sender::send_message,
-    Error, SynchronizationState,
+use crate::{
+    message::Message,
+    sync::{
+        message::{Context, Handleable},
+        Error, SynchronizationState,
+    },
 };
 use cfx_types::H256;
 use network::{NetworkContext, PeerId};
@@ -34,7 +36,7 @@ impl DynamicCapability {
         let msg = DynamicCapabilityChange { changed: self };
 
         for peer in peers {
-            if let Err(e) = send_message(io, peer, &msg) {
+            if let Err(e) = msg.send(io, peer) {
                 debug!("Failed to send capability change message, peer = {}, message = {:?}, err = {:?}", peer, msg, e);
             }
         }

--- a/core/src/sync/message/get_block_hashes_by_epoch.rs
+++ b/core/src/sync/message/get_block_hashes_by_epoch.rs
@@ -14,7 +14,7 @@ use crate::{
     },
 };
 use rlp_derive::{RlpDecodable, RlpEncodable};
-use std::{any::Any, time::Duration};
+use std::time::Duration;
 
 #[derive(Debug, PartialEq, Clone, RlpDecodable, RlpEncodable)]
 pub struct GetBlockHashesByEpoch {
@@ -23,10 +23,6 @@ pub struct GetBlockHashesByEpoch {
 }
 
 impl Request for GetBlockHashesByEpoch {
-    fn as_message(&self) -> &dyn Message { self }
-
-    fn as_any(&self) -> &dyn Any { self }
-
     fn timeout(&self, conf: &ProtocolConfiguration) -> Duration {
         conf.headers_request_timeout
     }

--- a/core/src/sync/message/get_block_headers.rs
+++ b/core/src/sync/message/get_block_headers.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use cfx_types::H256;
 use rlp_derive::{RlpDecodable, RlpEncodable};
-use std::{any::Any, time::Duration};
+use std::time::Duration;
 
 #[derive(Debug, PartialEq, Clone, RlpDecodable, RlpEncodable)]
 pub struct GetBlockHeaders {
@@ -24,10 +24,6 @@ pub struct GetBlockHeaders {
 }
 
 impl Request for GetBlockHeaders {
-    fn as_message(&self) -> &dyn Message { self }
-
-    fn as_any(&self) -> &dyn Any { self }
-
     fn timeout(&self, conf: &ProtocolConfiguration) -> Duration {
         conf.headers_request_timeout
     }

--- a/core/src/sync/message/get_block_txn.rs
+++ b/core/src/sync/message/get_block_txn.rs
@@ -3,7 +3,7 @@
 // See http://www.gnu.org/licenses/
 
 use crate::{
-    message::{Message, RequestId},
+    message::RequestId,
     sync::{
         message::{Context, GetBlockTxnResponse, Handleable, KeyContainer},
         request_manager::Request,
@@ -12,7 +12,7 @@ use crate::{
 };
 use cfx_types::H256;
 use rlp_derive::{RlpDecodable, RlpEncodable};
-use std::{any::Any, time::Duration};
+use std::time::Duration;
 
 #[derive(Debug, PartialEq, Default, RlpDecodable, RlpEncodable, Clone)]
 pub struct GetBlockTxn {
@@ -22,10 +22,6 @@ pub struct GetBlockTxn {
 }
 
 impl Request for GetBlockTxn {
-    fn as_message(&self) -> &dyn Message { self }
-
-    fn as_any(&self) -> &dyn Any { self }
-
     fn timeout(&self, conf: &ProtocolConfiguration) -> Duration {
         conf.blocks_request_timeout
     }

--- a/core/src/sync/message/get_blocks.rs
+++ b/core/src/sync/message/get_blocks.rs
@@ -17,7 +17,7 @@ use crate::{
 use cfx_types::H256;
 use primitives::Block;
 use rlp_derive::{RlpDecodable, RlpEncodable};
-use std::{any::Any, time::Duration};
+use std::time::Duration;
 
 #[derive(Debug, PartialEq, Default, Clone, RlpDecodable, RlpEncodable)]
 pub struct GetBlocks {
@@ -27,10 +27,6 @@ pub struct GetBlocks {
 }
 
 impl Request for GetBlocks {
-    fn as_message(&self) -> &dyn Message { self }
-
-    fn as_any(&self) -> &dyn Any { self }
-
     fn timeout(&self, conf: &ProtocolConfiguration) -> Duration {
         conf.blocks_request_timeout
     }

--- a/core/src/sync/message/get_compact_blocks.rs
+++ b/core/src/sync/message/get_compact_blocks.rs
@@ -3,7 +3,7 @@
 // See http://www.gnu.org/licenses/
 
 use crate::{
-    message::{Message, RequestId},
+    message::RequestId,
     parameters::sync::{MAX_BLOCKS_TO_SEND, MAX_HEADERS_TO_SEND},
     sync::{
         message::{
@@ -16,7 +16,7 @@ use crate::{
 };
 use cfx_types::H256;
 use rlp_derive::{RlpDecodable, RlpEncodable};
-use std::{any::Any, time::Duration};
+use std::time::Duration;
 
 #[derive(Debug, PartialEq, Default, RlpDecodable, RlpEncodable)]
 pub struct GetCompactBlocks {
@@ -25,10 +25,6 @@ pub struct GetCompactBlocks {
 }
 
 impl Request for GetCompactBlocks {
-    fn as_message(&self) -> &dyn Message { self }
-
-    fn as_any(&self) -> &dyn Any { self }
-
     fn timeout(&self, conf: &ProtocolConfiguration) -> Duration {
         conf.blocks_request_timeout
     }

--- a/core/src/sync/message/handleable.rs
+++ b/core/src/sync/message/handleable.rs
@@ -5,8 +5,7 @@
 use crate::{
     message::Message,
     sync::{
-        msg_sender::send_message, request_manager::RequestMessage, Error,
-        SynchronizationProtocolHandler,
+        request_manager::RequestMessage, Error, SynchronizationProtocolHandler,
     },
 };
 use cfx_types::H256;
@@ -29,7 +28,7 @@ impl<'a> Context<'a> {
     }
 
     pub fn send_response(&self, response: &dyn Message) -> Result<(), Error> {
-        send_message(self.io, self.peer, response)?;
+        response.send(self.io, self.peer)?;
         Ok(())
     }
 

--- a/core/src/sync/message/message.rs
+++ b/core/src/sync/message/message.rs
@@ -14,8 +14,7 @@ use crate::{
     },
 };
 pub use priority_send_queue::SendQueuePriority;
-use rlp::Rlp;
-use std::any::Any;
+use rlp::{Decodable, Rlp};
 
 // generate `pub mod msgid`
 build_msgid! {
@@ -56,23 +55,25 @@ build_msgid! {
 // high priority message types
 build_msg_impl! { Status, msgid::STATUS, "Status" }
 build_msg_impl! { NewBlockHashes, msgid::NEW_BLOCK_HASHES, "NewBlockHashes" }
-build_msg_impl! { GetBlockHashesResponse, msgid::GET_BLOCK_HASHES_RESPONSE, "GetBlockHashesResponse" }
-build_msg_impl! { GetBlockHeaders, msgid::GET_BLOCK_HEADERS, "GetBlockHeaders" }
-build_msg_impl! { GetBlockHeadersResponse, msgid::GET_BLOCK_HEADERS_RESPONSE, "GetBlockHeadersResponse" }
+build_msg_with_request_id_impl! { GetBlockHashesResponse, msgid::GET_BLOCK_HASHES_RESPONSE, "GetBlockHashesResponse" }
+build_msg_with_request_id_impl! { GetBlockHeaders, msgid::GET_BLOCK_HEADERS, "GetBlockHeaders" }
+build_msg_with_request_id_impl! { GetBlockHeadersResponse, msgid::GET_BLOCK_HEADERS_RESPONSE, "GetBlockHeadersResponse" }
 build_msg_impl! { NewBlock, msgid::NEW_BLOCK, "NewBlock" }
-build_msg_impl! { GetTerminalBlockHashesResponse, msgid::GET_TERMINAL_BLOCK_HASHES_RESPONSE, "GetTerminalBlockHashesResponse" }
-build_msg_impl! { GetTerminalBlockHashes, msgid::GET_TERMINAL_BLOCK_HASHES, "GetTerminalBlockHashes" }
-build_msg_impl! { GetBlocks, msgid::GET_BLOCKS, "GetBlocks" }
-build_msg_impl! { GetCompactBlocks, msgid::GET_CMPCT_BLOCKS, "GetCompactBlocks" }
-build_msg_impl! { GetCompactBlocksResponse, msgid::GET_CMPCT_BLOCKS_RESPONSE, "GetCompactBlocksResponse" }
-build_msg_impl! { GetBlockTxn, msgid::GET_BLOCK_TXN, "GetBlockTxn" }
+build_msg_with_request_id_impl! { GetTerminalBlockHashesResponse, msgid::GET_TERMINAL_BLOCK_HASHES_RESPONSE, "GetTerminalBlockHashesResponse" }
+build_msg_with_request_id_impl! { GetTerminalBlockHashes, msgid::GET_TERMINAL_BLOCK_HASHES, "GetTerminalBlockHashes" }
+build_msg_with_request_id_impl! { GetBlocks, msgid::GET_BLOCKS, "GetBlocks" }
+build_msg_with_request_id_impl! { GetCompactBlocks, msgid::GET_CMPCT_BLOCKS, "GetCompactBlocks" }
+build_msg_with_request_id_impl! { GetCompactBlocksResponse, msgid::GET_CMPCT_BLOCKS_RESPONSE, "GetCompactBlocksResponse" }
+build_msg_with_request_id_impl! { GetBlockTxn, msgid::GET_BLOCK_TXN, "GetBlockTxn" }
 build_msg_impl! { DynamicCapabilityChange, msgid::DYNAMIC_CAPABILITY_CHANGE, "DynamicCapabilityChange" }
-build_msg_impl! { GetBlockHashesByEpoch, msgid::GET_BLOCK_HASHES_BY_EPOCH, "GetBlockHashesByEpoch" }
+build_msg_with_request_id_impl! { GetBlockHashesByEpoch, msgid::GET_BLOCK_HASHES_BY_EPOCH, "GetBlockHashesByEpoch" }
+build_msg_with_request_id_impl! { SnapshotManifestRequest, msgid::GET_SNAPSHOT_MANIFEST, "SnapshotManifestRequest" }
+build_msg_with_request_id_impl! { SnapshotManifestResponse, msgid::GET_SNAPSHOT_MANIFEST_RESPONSE, "SnapshotManifestResponse" }
+build_msg_with_request_id_impl! { SnapshotChunkRequest, msgid::GET_SNAPSHOT_CHUNK, "SnapshotChunkRequest" }
+build_msg_with_request_id_impl! { SnapshotChunkResponse, msgid::GET_SNAPSHOT_CHUNK_RESPONSE, "SnapshotChunkResponse" }
 
 // normal priority and size-sensitive message types
 impl Message for Transactions {
-    fn as_any(&self) -> &dyn Any { self }
-
     fn msg_id(&self) -> MsgId { msgid::TRANSACTIONS }
 
     fn msg_name(&self) -> &'static str { "Transactions" }
@@ -81,8 +82,6 @@ impl Message for Transactions {
 }
 
 impl Message for GetBlocksResponse {
-    fn as_any(&self) -> &dyn Any { self }
-
     fn msg_id(&self) -> MsgId { msgid::GET_BLOCKS_RESPONSE }
 
     fn msg_name(&self) -> &'static str { "GetBlocksResponse" }
@@ -91,8 +90,6 @@ impl Message for GetBlocksResponse {
 }
 
 impl Message for GetBlocksWithPublicResponse {
-    fn as_any(&self) -> &dyn Any { self }
-
     fn msg_id(&self) -> MsgId { msgid::GET_BLOCKS_WITH_PUBLIC_RESPONSE }
 
     fn msg_name(&self) -> &'static str { "GetBlocksWithPublicResponse" }
@@ -101,8 +98,6 @@ impl Message for GetBlocksWithPublicResponse {
 }
 
 impl Message for GetBlockTxnResponse {
-    fn as_any(&self) -> &dyn Any { self }
-
     fn msg_id(&self) -> MsgId { msgid::GET_BLOCK_TXN_RESPONSE }
 
     fn msg_name(&self) -> &'static str { "GetBlockTxnResponse" }
@@ -111,8 +106,6 @@ impl Message for GetBlockTxnResponse {
 }
 
 impl Message for TransactionDigests {
-    fn as_any(&self) -> &dyn Any { self }
-
     fn msg_id(&self) -> MsgId { msgid::TRANSACTION_DIGESTS }
 
     fn msg_name(&self) -> &'static str { "TransactionDigests" }
@@ -123,8 +116,6 @@ impl Message for TransactionDigests {
 }
 
 impl Message for GetTransactions {
-    fn as_any(&self) -> &dyn Any { self }
-
     fn msg_id(&self) -> MsgId { msgid::GET_TRANSACTIONS }
 
     fn msg_name(&self) -> &'static str { "GetTransactions" }
@@ -132,9 +123,11 @@ impl Message for GetTransactions {
     fn priority(&self) -> SendQueuePriority { SendQueuePriority::Normal }
 }
 
-impl Message for GetTransactionsResponse {
-    fn as_any(&self) -> &dyn Any { self }
+impl HasRequestId for GetTransactions {
+    fn set_request_id(&mut self, id: RequestId) { self.request_id = id; }
+}
 
+impl Message for GetTransactionsResponse {
     fn msg_id(&self) -> MsgId { msgid::GET_TRANSACTIONS_RESPONSE }
 
     fn msg_name(&self) -> &'static str { "GetTransactionsResponse" }
@@ -144,15 +137,6 @@ impl Message for GetTransactionsResponse {
     fn priority(&self) -> SendQueuePriority { SendQueuePriority::Normal }
 }
 
-// generate `impl HasRequestId for _` for each request type
-build_has_request_id_impl! { GetBlockHashesByEpoch }
-build_has_request_id_impl! { GetBlockHeaders }
-build_has_request_id_impl! { GetBlockHeadersResponse }
-build_has_request_id_impl! { GetBlocks }
-build_has_request_id_impl! { GetBlockTxn }
-build_has_request_id_impl! { GetCompactBlocks }
-build_has_request_id_impl! { GetTransactions }
-
 /// handle the RLP encoded message with given context `ctx`.
 /// If the message not handled, return `Ok(false)`.
 /// Otherwise, return `Ok(true)` if handled successfully
@@ -161,78 +145,103 @@ pub fn handle_rlp_message(
     id: MsgId, ctx: &Context, rlp: &Rlp,
 ) -> Result<bool, Error> {
     match id {
-        msgid::STATUS => rlp.as_val::<Status>()?.handle(ctx)?,
-        msgid::NEW_BLOCK => rlp.as_val::<NewBlock>()?.handle(&ctx)?,
+        msgid::STATUS => handle_message::<Status>(ctx, rlp)?,
+        msgid::NEW_BLOCK => handle_message::<NewBlock>(ctx, rlp)?,
         msgid::NEW_BLOCK_HASHES => {
-            rlp.as_val::<NewBlockHashes>()?.handle(&ctx)?;
+            handle_message::<NewBlockHashes>(ctx, rlp)?;
         }
         msgid::GET_BLOCK_HEADERS => {
-            rlp.as_val::<GetBlockHeaders>()?.handle(ctx)?;
+            handle_message::<GetBlockHeaders>(ctx, rlp)?;
         }
         msgid::GET_BLOCK_HEADERS_RESPONSE => {
-            rlp.as_val::<GetBlockHeadersResponse>()?.handle(&ctx)?;
+            handle_message::<GetBlockHeadersResponse>(ctx, rlp)?;
         }
-        msgid::GET_BLOCKS => rlp.as_val::<GetBlocks>()?.handle(&ctx)?,
+        msgid::GET_BLOCKS => handle_message::<GetBlocks>(ctx, rlp)?,
         msgid::GET_BLOCKS_RESPONSE => {
-            rlp.as_val::<GetBlocksResponse>()?.handle(&ctx)?;
+            handle_message::<GetBlocksResponse>(ctx, rlp)?;
         }
         msgid::GET_BLOCKS_WITH_PUBLIC_RESPONSE => {
-            rlp.as_val::<GetBlocksWithPublicResponse>()?.handle(&ctx)?;
+            handle_message::<GetBlocksWithPublicResponse>(ctx, rlp)?;
         }
         msgid::GET_TERMINAL_BLOCK_HASHES => {
-            rlp.as_val::<GetTerminalBlockHashes>()?.handle(&ctx)?;
+            handle_message::<GetTerminalBlockHashes>(ctx, rlp)?;
         }
         msgid::GET_TERMINAL_BLOCK_HASHES_RESPONSE => {
-            rlp.as_val::<GetTerminalBlockHashesResponse>()?
-                .handle(&ctx)?;
+            handle_message::<GetTerminalBlockHashesResponse>(ctx, rlp)?;
         }
         msgid::GET_CMPCT_BLOCKS => {
-            rlp.as_val::<GetCompactBlocks>()?.handle(&ctx)?;
+            handle_message::<GetCompactBlocks>(ctx, rlp)?;
         }
         msgid::GET_CMPCT_BLOCKS_RESPONSE => {
-            rlp.as_val::<GetCompactBlocksResponse>()?.handle(&ctx)?;
+            handle_message::<GetCompactBlocksResponse>(ctx, rlp)?;
         }
         msgid::GET_BLOCK_TXN => {
-            rlp.as_val::<GetBlockTxn>()?.handle(&ctx)?;
+            handle_message::<GetBlockTxn>(ctx, rlp)?;
         }
         msgid::GET_BLOCK_TXN_RESPONSE => {
-            rlp.as_val::<GetBlockTxnResponse>()?.handle(&ctx)?;
+            handle_message::<GetBlockTxnResponse>(ctx, rlp)?;
         }
         msgid::TRANSACTIONS => {
-            rlp.as_val::<Transactions>()?.handle(&ctx)?;
+            handle_message::<Transactions>(ctx, rlp)?;
         }
         msgid::DYNAMIC_CAPABILITY_CHANGE => {
-            rlp.as_val::<DynamicCapabilityChange>()?.handle(&ctx)?;
+            handle_message::<DynamicCapabilityChange>(ctx, rlp)?;
         }
         msgid::TRANSACTION_DIGESTS => {
-            rlp.as_val::<TransactionDigests>()?.handle(&ctx)?;
+            handle_message::<TransactionDigests>(ctx, rlp)?;
         }
         msgid::GET_TRANSACTIONS => {
-            rlp.as_val::<GetTransactions>()?.handle(&ctx)?;
+            handle_message::<GetTransactions>(ctx, rlp)?;
         }
         msgid::GET_TRANSACTIONS_RESPONSE => {
-            rlp.as_val::<GetTransactionsResponse>()?.handle(&ctx)?;
+            handle_message::<GetTransactionsResponse>(ctx, rlp)?;
         }
         msgid::GET_BLOCK_HASHES_BY_EPOCH => {
-            rlp.as_val::<GetBlockHashesByEpoch>()?.handle(&ctx)?;
+            handle_message::<GetBlockHashesByEpoch>(ctx, rlp)?;
         }
         msgid::GET_BLOCK_HASHES_RESPONSE => {
-            rlp.as_val::<GetBlockHashesResponse>()?.handle(&ctx)?;
+            handle_message::<GetBlockHashesResponse>(ctx, rlp)?;
         }
         msgid::GET_SNAPSHOT_MANIFEST => {
-            rlp.as_val::<SnapshotManifestRequest>()?.handle(&ctx)?;
+            handle_message::<SnapshotManifestRequest>(ctx, rlp)?;
         }
         msgid::GET_SNAPSHOT_MANIFEST_RESPONSE => {
-            rlp.as_val::<SnapshotManifestResponse>()?.handle(&ctx)?;
+            handle_message::<SnapshotManifestResponse>(ctx, rlp)?;
         }
         msgid::GET_SNAPSHOT_CHUNK => {
-            rlp.as_val::<SnapshotChunkRequest>()?.handle(&ctx)?;
+            handle_message::<SnapshotChunkRequest>(ctx, rlp)?;
         }
         msgid::GET_SNAPSHOT_CHUNK_RESPONSE => {
-            rlp.as_val::<SnapshotChunkResponse>()?.handle(&ctx)?;
+            handle_message::<SnapshotChunkResponse>(ctx, rlp)?;
         }
         _ => return Ok(false),
     }
 
     Ok(true)
+}
+
+fn handle_message<T: Decodable + Handleable + Message>(
+    ctx: &Context, rlp: &Rlp,
+) -> Result<(), Error> {
+    let msg: T = rlp.as_val()?;
+
+    let msg_id = msg.msg_id();
+    let msg_name = msg.msg_name();
+    let req_id = msg.maybe_request_id();
+
+    trace!(
+        "handle sync protocol message, peer = {}, id = {}, name = {}, request_id = {:?}",
+        ctx.peer, msg_id, msg_name, req_id,
+    );
+
+    if let Err(e) = msg.handle(ctx) {
+        info!(
+            "failed to handle sync protocol message, peer = {}, id = {}, name = {}, request_id = {:?}, error_kind = {:?}",
+            ctx.peer, msg_id, msg_name, req_id, e.0,
+        );
+
+        return Err(e);
+    }
+
+    Ok(())
 }

--- a/core/src/sync/message/transactions.rs
+++ b/core/src/sync/message/transactions.rs
@@ -20,7 +20,7 @@ use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 use rlp_derive::{
     RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper,
 };
-use std::{any::Any, collections::HashSet, time::Duration};
+use std::{collections::HashSet, time::Duration};
 
 #[derive(Debug, PartialEq, RlpDecodableWrapper, RlpEncodableWrapper)]
 pub struct Transactions {
@@ -208,10 +208,6 @@ pub struct GetTransactions {
 }
 
 impl Request for GetTransactions {
-    fn as_message(&self) -> &dyn Message { self }
-
-    fn as_any(&self) -> &dyn Any { self }
-
     fn timeout(&self, conf: &ProtocolConfiguration) -> Duration {
         conf.transaction_request_timeout
     }

--- a/core/src/sync/mod.rs
+++ b/core/src/sync/mod.rs
@@ -47,9 +47,9 @@ pub mod random {
 
 pub mod msg_sender {
     use super::message::msgid;
-    use crate::message::Message;
+    use crate::message::MsgId;
     use metrics::{register_meter_with_group, Meter};
-    use network::{Error as NetworkError, NetworkContext, PeerId};
+    use network::PeerId;
     use std::sync::Arc;
 
     pub const NULL: usize = !0;
@@ -274,111 +274,97 @@ pub mod msg_sender {
             );
     }
 
-    pub fn send_message(
-        io: &dyn NetworkContext, peer: PeerId, msg: &dyn Message,
-    ) -> Result<(), NetworkError> {
-        send_message_with_throttling(
-            io, peer, msg, false, /* throttling_disabled */
-        )
-    }
-
-    pub fn send_message_with_throttling(
-        io: &dyn NetworkContext, peer: PeerId, msg: &dyn Message,
-        throttling_disabled: bool,
-    ) -> Result<(), NetworkError>
-    {
-        let size = msg.send_with_throttling(io, peer, throttling_disabled)?;
-
-        if peer != NULL {
-            match msg.msg_id().into() {
-                msgid::STATUS => ON_STATUS_METER.mark(size),
-                msgid::GET_BLOCK_HEADERS_RESPONSE => {
-                    GET_BLOCK_HEADER_RESPONSE_METER.mark(size);
-                    GET_BLOCK_HEADER_RESPONSE_COUNTER.mark(1);
-                }
-                msgid::GET_BLOCK_HEADERS => {
-                    GET_BLOCK_HEADERS_METER.mark(size);
-                    GET_BLOCK_HEADERS_COUNTER.mark(1);
-                }
-                msgid::GET_BLOCK_HEADER_CHAIN => {
-                    GET_BLOCK_HEADER_CHAIN_METER.mark(size);
-                    GET_BLOCK_HEADER_CHAIN_COUNTER.mark(1);
-                }
-                msgid::NEW_BLOCK => {
-                    NEW_BLOCK_METER.mark(size);
-                    NEW_BLOCK_COUNTER.mark(1);
-                }
-                msgid::NEW_BLOCK_HASHES => {
-                    NEW_BLOCK_HASHES_METER.mark(size);
-                    NEW_BLOCK_HASHES_COUNTER.mark(1);
-                }
-                msgid::GET_BLOCKS_RESPONSE => {
-                    GET_BLOCKS_RESPONSE_METER.mark(size);
-                    GET_BLOCKS_RESPONSE_COUNTER.mark(1);
-                }
-                msgid::GET_BLOCKS_WITH_PUBLIC_RESPONSE => {
-                    GET_BLOCKS_WITH_PUBLIC_RESPONSE_METER.mark(size);
-                    GET_BLOCKS_WITH_PUBLIC_RESPONSE_COUNTER.mark(1);
-                }
-                msgid::GET_BLOCKS => {
-                    GET_BLOCKS_METER.mark(size);
-                    GET_BLOCKS_COUNTER.mark(1);
-                }
-                msgid::GET_TERMINAL_BLOCK_HASHES_RESPONSE => {
-                    GET_TERMINAL_BLOCK_HASHES_RESPONSE_METER.mark(size);
-                    GET_TERMINAL_BLOCK_HASHES_RESPONSE_COUNTER.mark(1);
-                }
-                msgid::GET_TERMINAL_BLOCK_HASHES => {
-                    GET_TERMINAL_BLOCK_HASHES_METER.mark(size);
-                    GET_TERMINAL_BLOCK_HASHES_COUNTER.mark(1);
-                }
-                msgid::GET_CMPCT_BLOCKS => {
-                    GET_CMPCT_BLOCKS_METER.mark(size);
-                    GET_CMPCT_BLOCKS_COUNTER.mark(1);
-                }
-                msgid::GET_CMPCT_BLOCKS_RESPONSE => {
-                    GET_CMPCT_BLOCKS_RESPONSE_METER.mark(size);
-                    GET_CMPCT_BLOCKS_RESPONSE_COUNTER.mark(1);
-                }
-                msgid::GET_BLOCK_TXN => {
-                    GET_BLOCK_TXN_METER.mark(size);
-                    GET_BLOCK_TXN_COUNTER.mark(1);
-                }
-                msgid::GET_BLOCK_TXN_RESPONSE => {
-                    GET_BLOCK_TXN_RESPOPNSE_METER.mark(size);
-                    GET_BLOCK_TXN_RESPOPNSE_COUNTER.mark(1);
-                }
-                msgid::DYNAMIC_CAPABILITY_CHANGE => {
-                    DYNAMIC_CAPABILITY_CHANGE_METER.mark(size);
-                    DYNAMIC_CAPABILITY_CHANGE_COUNTER.mark(1);
-                }
-                msgid::TRANSACTION_DIGESTS => {
-                    TRANSACTION_DIGESTS_METER.mark(size);
-                    TRANSACTION_DIGESTS_COUNTER.mark(1);
-                }
-                msgid::GET_TRANSACTIONS => {
-                    GET_TRANSACTIONS_METER.mark(size);
-                    GET_TRANSACTIONS_COUNTER.mark(1);
-                }
-                msgid::GET_TRANSACTIONS_RESPONSE => {
-                    GET_TRANSACTIONS_RESPONSE_METER.mark(size);
-                    GET_TRANSACTIONS_RESPONSE_COUNTER.mark(1);
-                }
-                msgid::GET_BLOCK_HASHES_BY_EPOCH => {
-                    GET_BLOCK_HASHES_BY_EPOCH_METER.mark(size);
-                    GET_BLOCK_HASHES_BY_EPOCH_COUNTER.mark(1);
-                }
-                msgid::GET_BLOCK_HASHES_RESPONSE => {
-                    GET_BLOCK_HASHES_RESPONSE_METER.mark(size);
-                    GET_BLOCK_HASHES_RESPONSE_COUNTER.mark(1);
-                }
-                _ => {
-                    OTHER_HIGH_METER.mark(size);
-                    OTHER_HIGH_COUNTER.mark(1);
-                }
-            }
+    pub fn metric_message(peer: PeerId, msg_id: MsgId, size: usize) {
+        if peer == NULL {
+            return;
         }
 
-        Ok(())
+        match msg_id {
+            msgid::STATUS => ON_STATUS_METER.mark(size),
+            msgid::GET_BLOCK_HEADERS_RESPONSE => {
+                GET_BLOCK_HEADER_RESPONSE_METER.mark(size);
+                GET_BLOCK_HEADER_RESPONSE_COUNTER.mark(1);
+            }
+            msgid::GET_BLOCK_HEADERS => {
+                GET_BLOCK_HEADERS_METER.mark(size);
+                GET_BLOCK_HEADERS_COUNTER.mark(1);
+            }
+            msgid::GET_BLOCK_HEADER_CHAIN => {
+                GET_BLOCK_HEADER_CHAIN_METER.mark(size);
+                GET_BLOCK_HEADER_CHAIN_COUNTER.mark(1);
+            }
+            msgid::NEW_BLOCK => {
+                NEW_BLOCK_METER.mark(size);
+                NEW_BLOCK_COUNTER.mark(1);
+            }
+            msgid::NEW_BLOCK_HASHES => {
+                NEW_BLOCK_HASHES_METER.mark(size);
+                NEW_BLOCK_HASHES_COUNTER.mark(1);
+            }
+            msgid::GET_BLOCKS_RESPONSE => {
+                GET_BLOCKS_RESPONSE_METER.mark(size);
+                GET_BLOCKS_RESPONSE_COUNTER.mark(1);
+            }
+            msgid::GET_BLOCKS_WITH_PUBLIC_RESPONSE => {
+                GET_BLOCKS_WITH_PUBLIC_RESPONSE_METER.mark(size);
+                GET_BLOCKS_WITH_PUBLIC_RESPONSE_COUNTER.mark(1);
+            }
+            msgid::GET_BLOCKS => {
+                GET_BLOCKS_METER.mark(size);
+                GET_BLOCKS_COUNTER.mark(1);
+            }
+            msgid::GET_TERMINAL_BLOCK_HASHES_RESPONSE => {
+                GET_TERMINAL_BLOCK_HASHES_RESPONSE_METER.mark(size);
+                GET_TERMINAL_BLOCK_HASHES_RESPONSE_COUNTER.mark(1);
+            }
+            msgid::GET_TERMINAL_BLOCK_HASHES => {
+                GET_TERMINAL_BLOCK_HASHES_METER.mark(size);
+                GET_TERMINAL_BLOCK_HASHES_COUNTER.mark(1);
+            }
+            msgid::GET_CMPCT_BLOCKS => {
+                GET_CMPCT_BLOCKS_METER.mark(size);
+                GET_CMPCT_BLOCKS_COUNTER.mark(1);
+            }
+            msgid::GET_CMPCT_BLOCKS_RESPONSE => {
+                GET_CMPCT_BLOCKS_RESPONSE_METER.mark(size);
+                GET_CMPCT_BLOCKS_RESPONSE_COUNTER.mark(1);
+            }
+            msgid::GET_BLOCK_TXN => {
+                GET_BLOCK_TXN_METER.mark(size);
+                GET_BLOCK_TXN_COUNTER.mark(1);
+            }
+            msgid::GET_BLOCK_TXN_RESPONSE => {
+                GET_BLOCK_TXN_RESPOPNSE_METER.mark(size);
+                GET_BLOCK_TXN_RESPOPNSE_COUNTER.mark(1);
+            }
+            msgid::DYNAMIC_CAPABILITY_CHANGE => {
+                DYNAMIC_CAPABILITY_CHANGE_METER.mark(size);
+                DYNAMIC_CAPABILITY_CHANGE_COUNTER.mark(1);
+            }
+            msgid::TRANSACTION_DIGESTS => {
+                TRANSACTION_DIGESTS_METER.mark(size);
+                TRANSACTION_DIGESTS_COUNTER.mark(1);
+            }
+            msgid::GET_TRANSACTIONS => {
+                GET_TRANSACTIONS_METER.mark(size);
+                GET_TRANSACTIONS_COUNTER.mark(1);
+            }
+            msgid::GET_TRANSACTIONS_RESPONSE => {
+                GET_TRANSACTIONS_RESPONSE_METER.mark(size);
+                GET_TRANSACTIONS_RESPONSE_COUNTER.mark(1);
+            }
+            msgid::GET_BLOCK_HASHES_BY_EPOCH => {
+                GET_BLOCK_HASHES_BY_EPOCH_METER.mark(size);
+                GET_BLOCK_HASHES_BY_EPOCH_COUNTER.mark(1);
+            }
+            msgid::GET_BLOCK_HASHES_RESPONSE => {
+                GET_BLOCK_HASHES_RESPONSE_METER.mark(size);
+                GET_BLOCK_HASHES_RESPONSE_COUNTER.mark(1);
+            }
+            _ => {
+                OTHER_HIGH_METER.mark(size);
+                OTHER_HIGH_COUNTER.mark(1);
+            }
+        }
     }
 }

--- a/core/src/sync/request_manager/request_handler.rs
+++ b/core/src/sync/request_manager/request_handler.rs
@@ -2,7 +2,6 @@ use crate::{
     message::{HasRequestId, Message},
     sync::{
         message::{DynamicCapability, KeyContainer},
-        msg_sender::send_message,
         request_manager::RequestManager,
         synchronization_protocol_handler::ProtocolConfiguration,
         Error, ErrorKind,
@@ -110,8 +109,7 @@ impl RequestHandler {
         };
 
         request.set_request_id(request_id);
-        let message = request.as_message();
-        if send_message(io, peer, message).is_err() {
+        if request.send(io, peer).is_err() {
             return Err(request);
         }
 
@@ -312,8 +310,7 @@ impl RequestContainer {
                 if let Some(new_request_id) = self.get_next_request_id() {
                     let mut pending_msg = self.pop_pending_request().unwrap();
                     pending_msg.set_request_id(new_request_id);
-                    let send_res =
-                        send_message(io, self.peer_id, pending_msg.get_msg());
+                    let send_res = pending_msg.request.send(io, self.peer_id);
 
                     if send_res.is_err() {
                         warn!("Error while send_message, err={:?}", send_res);
@@ -374,16 +371,8 @@ impl<T: 'static + Request> AsAny for T {
     fn as_any(&self) -> &dyn Any { self }
 }
 
-pub trait AsMessage {
-    fn as_message(&self) -> &dyn Message;
-}
-
-impl<T: Message> AsMessage for T {
-    fn as_message(&self) -> &dyn Message { self }
-}
-
 /// Trait of request message
-pub trait Request: Send + Debug + HasRequestId + AsAny + AsMessage {
+pub trait Request: Send + Debug + HasRequestId + AsAny + Message {
     /// Request timeout for resend purpose.
     fn timeout(&self, conf: &ProtocolConfiguration) -> Duration;
 
@@ -426,8 +415,6 @@ impl RequestMessage {
     pub fn set_request_id(&mut self, request_id: u64) {
         self.request.set_request_id(request_id);
     }
-
-    pub fn get_msg(&self) -> &dyn Message { self.request.as_message() }
 
     /// Download cast request to specified request type.
     /// If downcast failed, resend the request again and return

--- a/core/src/sync/request_manager/request_handler.rs
+++ b/core/src/sync/request_manager/request_handler.rs
@@ -1,5 +1,5 @@
 use crate::{
-    message::{HasRequestId, Message},
+    message::{AsAny, AsMessage, HasRequestId, Message},
     sync::{
         message::{DynamicCapability, KeyContainer},
         msg_sender::send_message,
@@ -366,10 +366,7 @@ pub struct SynchronizationPeerRequest {
 }
 
 /// Trait of request message
-pub trait Request: Send + Debug + HasRequestId {
-    fn as_message(&self) -> &dyn Message;
-    /// Support to downcast trait to concrete request type.
-    fn as_any(&self) -> &dyn Any;
+pub trait Request: Send + Debug + HasRequestId + AsAny + AsMessage {
     /// Request timeout for resend purpose.
     fn timeout(&self, conf: &ProtocolConfiguration) -> Duration;
 

--- a/core/src/sync/request_manager/request_handler.rs
+++ b/core/src/sync/request_manager/request_handler.rs
@@ -1,5 +1,5 @@
 use crate::{
-    message::{AsAny, AsMessage, HasRequestId, Message},
+    message::{HasRequestId, Message},
     sync::{
         message::{DynamicCapability, KeyContainer},
         msg_sender::send_message,
@@ -363,6 +363,23 @@ impl RequestContainer {
 pub struct SynchronizationPeerRequest {
     pub message: RequestMessage,
     pub timed_req: Arc<TimedSyncRequests>,
+}
+
+/// Support to downcast trait to concrete request type.
+pub trait AsAny {
+    fn as_any(&self) -> &dyn Any;
+}
+
+impl<T: 'static + Request> AsAny for T {
+    fn as_any(&self) -> &dyn Any { self }
+}
+
+pub trait AsMessage {
+    fn as_message(&self) -> &dyn Message;
+}
+
+impl<T: Message> AsMessage for T {
+    fn as_message(&self) -> &dyn Message { self }
 }
 
 /// Trait of request message

--- a/core/src/sync/state/snapshot_chunk_request.rs
+++ b/core/src/sync/state/snapshot_chunk_request.rs
@@ -2,23 +2,18 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use crate::{
-    message::{HasRequestId, Message, MsgId, RequestId},
-    sync::{
-        message::{
-            msgid, Context, DynamicCapability, Handleable, KeyContainer,
-        },
-        request_manager::Request,
-        state::{
-            delta::{Chunk, ChunkKey},
-            snapshot_chunk_response::SnapshotChunkResponse,
-        },
-        Error, ProtocolConfiguration,
+use crate::sync::{
+    message::{Context, DynamicCapability, Handleable, KeyContainer},
+    request_manager::Request,
+    state::{
+        delta::{Chunk, ChunkKey},
+        snapshot_chunk_response::SnapshotChunkResponse,
     },
+    Error, ProtocolConfiguration,
 };
 use cfx_types::H256;
 use rlp_derive::{RlpDecodable, RlpEncodable};
-use std::{any::Any, time::Duration};
+use std::time::Duration;
 
 #[derive(Debug, Clone, RlpDecodable, RlpEncodable)]
 pub struct SnapshotChunkRequest {
@@ -37,9 +32,6 @@ impl SnapshotChunkRequest {
     }
 }
 
-build_msg_impl! { SnapshotChunkRequest, msgid::GET_SNAPSHOT_CHUNK, "SnapshotChunkRequest" }
-build_has_request_id_impl! { SnapshotChunkRequest }
-
 impl Handleable for SnapshotChunkRequest {
     fn handle(self, ctx: &Context) -> Result<(), Error> {
         let chunk = match Chunk::load(&self.checkpoint, &self.chunk_key) {
@@ -55,10 +47,6 @@ impl Handleable for SnapshotChunkRequest {
 }
 
 impl Request for SnapshotChunkRequest {
-    fn as_message(&self) -> &dyn Message { self }
-
-    fn as_any(&self) -> &dyn Any { self }
-
     fn timeout(&self, conf: &ProtocolConfiguration) -> Duration {
         conf.blocks_request_timeout
     }

--- a/core/src/sync/state/snapshot_chunk_response.rs
+++ b/core/src/sync/state/snapshot_chunk_response.rs
@@ -2,24 +2,18 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use crate::{
-    message::{Message, MsgId},
-    sync::{
-        message::{msgid, Context, Handleable},
-        state::{delta::Chunk, SnapshotChunkRequest},
-        Error, ErrorKind,
-    },
+use crate::sync::{
+    message::{Context, Handleable},
+    state::{delta::Chunk, SnapshotChunkRequest},
+    Error, ErrorKind,
 };
 use rlp_derive::{RlpDecodable, RlpEncodable};
-use std::any::Any;
 
 #[derive(RlpDecodable, RlpEncodable)]
 pub struct SnapshotChunkResponse {
     pub request_id: u64,
     pub chunk: Chunk,
 }
-
-build_msg_impl! { SnapshotChunkResponse, msgid::GET_SNAPSHOT_CHUNK_RESPONSE, "SnapshotChunkResponse" }
 
 impl Handleable for SnapshotChunkResponse {
     fn handle(self, ctx: &Context) -> Result<(), Error> {

--- a/core/src/sync/state/snapshot_manifest_request.rs
+++ b/core/src/sync/state/snapshot_manifest_request.rs
@@ -4,12 +4,9 @@
 
 use crate::{
     block_data_manager::BlockExecutionResult,
-    message::{HasRequestId, Message, MsgId, RequestId},
     parameters::consensus_internal::REWARD_EPOCH_COUNT,
     sync::{
-        message::{
-            msgid, Context, DynamicCapability, Handleable, KeyContainer,
-        },
+        message::{Context, DynamicCapability, Handleable, KeyContainer},
         request_manager::Request,
         state::{
             delta::{ChunkKey, RangedManifest},
@@ -20,7 +17,7 @@ use crate::{
 };
 use cfx_types::H256;
 use rlp_derive::{RlpDecodable, RlpEncodable};
-use std::{any::Any, time::Duration};
+use std::time::Duration;
 
 #[derive(Debug, Clone, RlpDecodable, RlpEncodable)]
 pub struct SnapshotManifestRequest {
@@ -29,9 +26,6 @@ pub struct SnapshotManifestRequest {
     pub start_chunk: Option<ChunkKey>,
     pub trusted_blame_block: Option<H256>,
 }
-
-build_msg_impl! { SnapshotManifestRequest, msgid::GET_SNAPSHOT_MANIFEST, "SnapshotManifestRequest" }
-build_has_request_id_impl! { SnapshotManifestRequest }
 
 impl Handleable for SnapshotManifestRequest {
     fn handle(self, ctx: &Context) -> Result<(), Error> {
@@ -223,10 +217,6 @@ impl SnapshotManifestRequest {
 }
 
 impl Request for SnapshotManifestRequest {
-    fn as_message(&self) -> &dyn Message { self }
-
-    fn as_any(&self) -> &dyn Any { self }
-
     fn timeout(&self, conf: &ProtocolConfiguration) -> Duration {
         conf.headers_request_timeout
     }

--- a/core/src/sync/state/snapshot_manifest_response.rs
+++ b/core/src/sync/state/snapshot_manifest_response.rs
@@ -4,16 +4,14 @@
 
 use crate::{
     block_data_manager::BlockExecutionResult,
-    message::{Message, MsgId},
     sync::{
-        message::{msgid, Context, Handleable},
+        message::{Context, Handleable},
         state::{delta::RangedManifest, SnapshotManifestRequest},
         Error, ErrorKind,
     },
 };
 use cfx_types::H256;
 use rlp_derive::{RlpDecodable, RlpEncodable};
-use std::any::Any;
 
 #[derive(RlpDecodable, RlpEncodable)]
 pub struct SnapshotManifestResponse {
@@ -25,8 +23,6 @@ pub struct SnapshotManifestResponse {
     pub bloom_blame_vec: Vec<H256>,
     pub block_receipts: Vec<BlockExecutionResult>,
 }
-
-build_msg_impl! { SnapshotManifestResponse, msgid::GET_SNAPSHOT_MANIFEST_RESPONSE, "SnapshotManifestResponse" }
 
 impl Handleable for SnapshotManifestResponse {
     fn handle(self, ctx: &Context) -> Result<(), Error> {

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -3,10 +3,8 @@
 // See http://www.gnu.org/licenses/
 
 use super::{
-    msg_sender::{send_message, NULL},
-    random,
-    request_manager::RequestManager,
-    Error, ErrorKind, SharedSynchronizationGraph, SynchronizationState,
+    msg_sender::NULL, random, request_manager::RequestManager, Error,
+    ErrorKind, SharedSynchronizationGraph, SynchronizationState,
 };
 use crate::{
     block_data_manager::BlockStatus,
@@ -822,7 +820,7 @@ impl SynchronizationProtocolHandler {
         }
 
         for id in peer_ids {
-            send_message(io, id, msg)?;
+            msg.send(io, id)?;
         }
 
         Ok(())
@@ -851,7 +849,7 @@ impl SynchronizationProtocolHandler {
     ) -> Result<(), NetworkError> {
         let status_message = self.produce_status_message();
         debug!("Sending status message to {:?}: {:?}", peer, status_message);
-        send_message(io, peer, &status_message)
+        status_message.send(io, peer)
     }
 
     fn broadcast_status(&self, io: &dyn NetworkContext) {
@@ -1001,7 +999,7 @@ impl SynchronizationProtocolHandler {
                 ordered_positions.pop().unwrap() as u8,
                 messages.pop().unwrap(),
             );
-            match send_message(io, peer_id, &tx_msg) {
+            match tx_msg.send(io, peer_id) {
                 Ok(_) => {
                     trace!(
                         "{:02} <- Transactions ({} entries)",


### PR DESCRIPTION
1. Remove unused `as_any` from `Message` trait;
2. Implement `as_any` and `as_message` for `Request` trait in common;
3. Add generic method to handle `Message`, so as to add necessary log in common; In addition, it will help to throttle the message in common;

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/749)
<!-- Reviewable:end -->
