### PR TITLE
throttle UDP discovery messages: PING/FIND_NODE

### DIFF
--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -34,3 +34,4 @@ byte-unit = "1.1.0"
 priority-send-queue = { path = "../util/priority-send-queue" }
 metrics = { path = "../util/metrics" }
 rustc-hex = "1.0"
+throttling = { path = "../util/throttling" }

--- a/network/src/error.rs
+++ b/network/src/error.rs
@@ -92,6 +92,7 @@ impl fmt::Display for DisconnectReason {
 pub enum ThrottlingReason {
     QueueFull,
     Throttled,
+    PacketThrottled(&'static str),
 }
 
 impl fmt::Display for ThrottlingReason {
@@ -101,6 +102,10 @@ impl fmt::Display for ThrottlingReason {
                 f.write_str("egress queue capacity reached")
             }
             ThrottlingReason::Throttled => f.write_str("egress throttled"),
+            ThrottlingReason::PacketThrottled(name) => {
+                let msg = format!("packet {} throttled", name);
+                f.write_str(msg.as_str())
+            }
         }
     }
 }

--- a/util/throttling/Cargo.toml
+++ b/util/throttling/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "throttling"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+parking_lot = "0.8"
+toml = "0.4"

--- a/util/throttling/src/lib.rs
+++ b/util/throttling/src/lib.rs
@@ -1,0 +1,6 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+pub mod time_window_bucket;
+pub mod token_bucket;

--- a/util/throttling/src/time_window_bucket.rs
+++ b/util/throttling/src/time_window_bucket.rs
@@ -1,0 +1,114 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use std::{
+    cmp::Ordering,
+    collections::{binary_heap::PeekMut, BinaryHeap, HashMap},
+    hash::Hash,
+    time::{Duration, Instant},
+};
+
+pub struct TimeWindowBucket<KEY: Eq + Hash + Clone> {
+    interval: Duration,
+    limit: usize,
+    timeouts: BinaryHeap<Item<KEY>>,
+    counters: HashMap<KEY, usize>,
+}
+
+impl<KEY: Eq + Hash + Clone> TimeWindowBucket<KEY> {
+    pub fn new(interval: Duration, limit: usize) -> Self {
+        TimeWindowBucket {
+            interval,
+            limit,
+            timeouts: BinaryHeap::new(),
+            counters: HashMap::new(),
+        }
+    }
+
+    fn refresh(&mut self) {
+        while let Some(item) = self.timeouts.peek_mut() {
+            if item.time.elapsed() <= self.interval {
+                break;
+            }
+
+            let item = PeekMut::pop(item);
+            let counter = self
+                .counters
+                .get_mut(&item.data)
+                .expect("data inconsistent");
+            if *counter <= 1 {
+                self.counters.remove(&item.data);
+            } else {
+                *counter -= 1;
+            }
+        }
+    }
+
+    pub fn try_acquire(&mut self, key: KEY) -> bool {
+        self.refresh();
+
+        let counter = self.counters.entry(key.clone()).or_default();
+        if *counter >= self.limit {
+            return false;
+        }
+
+        *counter += 1;
+        self.timeouts.push(Item::new(key));
+
+        true
+    }
+}
+
+struct Item<T> {
+    time: Instant,
+    data: T,
+}
+
+impl<T> Item<T> {
+    fn new(data: T) -> Self {
+        Item {
+            time: Instant::now(),
+            data,
+        }
+    }
+}
+
+impl<T> PartialEq for Item<T> {
+    fn eq(&self, other: &Self) -> bool { self.time.eq(&other.time) }
+}
+
+impl<T> Eq for Item<T> {}
+
+impl<T> PartialOrd for Item<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        other.time.partial_cmp(&self.time)
+    }
+}
+
+impl<T> Ord for Item<T> {
+    fn cmp(&self, other: &Self) -> Ordering { other.time.cmp(&self.time) }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::time_window_bucket::TimeWindowBucket;
+    use std::{thread::sleep, time::Duration};
+
+    #[test]
+    fn test_acquire() {
+        let interval = Duration::from_millis(10);
+        let mut bucket = TimeWindowBucket::new(interval, 2);
+
+        assert_eq!(bucket.try_acquire(3), true);
+        assert_eq!(bucket.try_acquire(3), true);
+        assert_eq!(bucket.try_acquire(3), false);
+        assert_eq!(bucket.try_acquire(4), true);
+
+        sleep(interval + Duration::from_millis(1));
+
+        assert_eq!(bucket.try_acquire(3), true);
+        assert_eq!(bucket.try_acquire(3), true);
+        assert_eq!(bucket.try_acquire(3), false);
+    }
+}

--- a/util/throttling/src/token_bucket.rs
+++ b/util/throttling/src/token_bucket.rs
@@ -1,0 +1,182 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use parking_lot::Mutex;
+use std::{
+    cmp::min,
+    collections::HashMap,
+    fs::read_to_string,
+    str::FromStr,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+pub struct TokenBucket {
+    max_tokens: u64,    // maximum tokens allowed in bucket
+    cur_tokens: u64,    // current tokens in bucket
+    recharge_rate: u64, // recharge N tokens per second
+    default_cost: u64,  // default tokens to acquire once
+    last_update: Instant,
+
+    // once acquire failed, record the next time to acquire tokens
+    throttled: Option<Instant>,
+}
+
+impl TokenBucket {
+    pub fn new(
+        max_tokens: u64, cur_tokens: u64, recharge_rate: u64, default_cost: u64,
+    ) -> Self {
+        assert!(cur_tokens <= max_tokens);
+
+        TokenBucket {
+            max_tokens,
+            cur_tokens,
+            recharge_rate,
+            default_cost,
+            last_update: Instant::now(),
+            throttled: None,
+        }
+    }
+
+    pub fn full(
+        max_tokens: u64, recharge_rate: u64, default_cost: u64,
+    ) -> Self {
+        Self::new(max_tokens, max_tokens, recharge_rate, default_cost)
+    }
+
+    pub fn empty(
+        max_tokens: u64, recharge_rate: u64, default_cost: u64,
+    ) -> Self {
+        Self::new(max_tokens, 0, recharge_rate, default_cost)
+    }
+
+    fn refresh(&mut self) {
+        let elapsed_secs = self.last_update.elapsed().as_secs();
+        if elapsed_secs == 0 {
+            return;
+        }
+
+        let recharged = self.recharge_rate * elapsed_secs;
+        self.cur_tokens = min(self.max_tokens, self.cur_tokens + recharged);
+        self.last_update += Duration::from_secs(elapsed_secs);
+    }
+
+    pub fn try_acquire(&mut self) -> Result<(), Duration> {
+        self.try_acquire_cost(self.default_cost)
+    }
+
+    pub fn try_acquire_cost(&mut self, cost: u64) -> Result<(), Duration> {
+        self.refresh();
+
+        if cost <= self.cur_tokens {
+            self.cur_tokens -= cost;
+            self.throttled = None;
+            return Ok(());
+        }
+
+        let recharge_secs = ((cost - self.cur_tokens) as f64
+            / self.recharge_rate as f64)
+            .ceil() as u64;
+
+        let next_time = self.last_update + Duration::from_secs(recharge_secs);
+        self.throttled = Some(next_time);
+
+        let now = Instant::now();
+        if next_time > now {
+            Err(next_time - now)
+        } else {
+            Err(Duration::default())
+        }
+    }
+
+    pub fn update_recharge_rate(&mut self, rate: u64) {
+        self.refresh();
+
+        self.recharge_rate = rate;
+    }
+
+    pub fn throttled(&self) -> Option<Instant> { self.throttled }
+}
+
+impl FromStr for TokenBucket {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, String> {
+        let fields: Vec<&str> = s.split(",").collect();
+
+        if fields.len() != 4 {
+            return Err(format!(
+                "invalid number of fields, expected = 4, actual = {}",
+                fields.len()
+            ));
+        }
+
+        let mut nums = Vec::new();
+
+        for f in fields {
+            let num = u64::from_str(f)
+                .map_err(|e| format!("failed to parse number: {:?}", e))?;
+            nums.push(num);
+        }
+
+        Ok(TokenBucket::new(nums[0], nums[1], nums[2], nums[3]))
+    }
+}
+
+#[derive(Default)]
+pub struct TokenBucketManager {
+    // manage buckets by name
+    buckets: HashMap<String, Arc<Mutex<TokenBucket>>>,
+}
+
+impl TokenBucketManager {
+    pub fn register(&mut self, name: String, bucket: TokenBucket) {
+        if self.buckets.contains_key(&name) {
+            panic!("token bucket {:?} already registered", name);
+        }
+
+        self.buckets.insert(name, Arc::new(Mutex::new(bucket)));
+    }
+
+    pub fn get(&self, name: &String) -> Option<Arc<Mutex<TokenBucket>>> {
+        self.buckets.get(name).cloned()
+    }
+
+    pub fn load(
+        toml_file: &String, section: Option<&str>,
+    ) -> Result<Self, String> {
+        let content = read_to_string(toml_file)
+            .map_err(|e| format!("failed to read toml file: {:?}", e))?;
+        let toml_val = content
+            .parse::<toml::Value>()
+            .map_err(|e| format!("failed to parse toml file: {:?}", e))?;
+
+        let val = match section {
+            Some(section) => match toml_val.get(section) {
+                Some(val) => val,
+                None => return Err(format!("section [{}] not found", section)),
+            },
+            None => &toml_val,
+        };
+        let table = val.as_table().expect("not table value");
+
+        let mut manager = TokenBucketManager::default();
+
+        for (k, v) in table.iter() {
+            let v = match v.as_str() {
+                Some(v) => v,
+                None => {
+                    return Err(format!(
+                        "invalid value type {:?}, string type required",
+                        v.type_str()
+                    ))
+                }
+            };
+
+            manager.register(k.into(), TokenBucket::from_str(v)?);
+        }
+
+        Ok(manager)
+    }
+}


### PR DESCRIPTION
This PR is iteration 1 of Conflux throttling, including:
1. Add library for common throttling algorithm.
2. Throttle UDP discovery messages: `PING`, `FIND_NODE`. As for `PONG` and `NEIGHBORS`, it will be handled once the runtime information mismatch.

TODO:
- Throttle on sync protocol messages according to user configuration.
- Throttle RPC requests according to user configuration.
- Throttle light protocol messages according to user configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/751)
<!-- Reviewable:end -->
