### PR TITLE
fix several bugs in full node syncing

### DIFF
--- a/core/src/block_data_manager/mod.rs
+++ b/core/src/block_data_manager/mod.rs
@@ -175,7 +175,7 @@ impl BlockDataManager {
             );
             data_man.insert_epoch_execution_commitments(
                 data_man.true_genesis.hash(),
-                data_man.genesis_state_root(),
+                data_man.true_genesis_state_root(),
                 *data_man.true_genesis.block_header.deferred_receipts_root(),
                 *data_man
                     .true_genesis
@@ -234,7 +234,7 @@ impl BlockDataManager {
     }
 
     /// This will return the state root of true genesis block.
-    pub fn genesis_state_root(&self) -> StateRootWithAuxInfo {
+    pub fn true_genesis_state_root(&self) -> StateRootWithAuxInfo {
         self.storage_manager
             .get_state_no_commit(SnapshotAndEpochIdRef::new_for_readonly(
                 &self.true_genesis.hash(),

--- a/core/src/block_data_manager/mod.rs
+++ b/core/src/block_data_manager/mod.rs
@@ -80,7 +80,7 @@ pub struct BlockDataManager {
     db_manager: DBManager,
 
     /// This is the original genesis block.
-    pub true_genesis_block: Arc<Block>,
+    pub true_genesis: Arc<Block>,
     pub storage_manager: Arc<StorageManager>,
     cache_man: Arc<Mutex<CacheManager<CacheId>>>,
     pub target_difficulty_manager: TargetDifficultyManager,
@@ -88,13 +88,12 @@ pub struct BlockDataManager {
 
 impl BlockDataManager {
     pub fn new(
-        cache_conf: CacheConfig, genesis_block: Arc<Block>, db: Arc<SystemDB>,
+        cache_conf: CacheConfig, true_genesis: Arc<Block>, db: Arc<SystemDB>,
         storage_manager: Arc<StorageManager>,
         worker_pool: Arc<Mutex<ThreadPool>>, config: DataManagerConfiguration,
     ) -> Self
     {
-        let mut genesis_block = genesis_block.clone();
-        let mut genesis_hash = genesis_block.hash();
+        let mut cur_era_genesis = true_genesis.clone();
         let mb = 1024 * 1024;
         let max_cache_size = cache_conf.ledger_mb() * mb;
         let pref_cache_size = max_cache_size * 3 / 4;
@@ -121,14 +120,14 @@ impl BlockDataManager {
             epoch_execution_commitments: Default::default(),
             epoch_execution_contexts: Default::default(),
             invalid_block_set: Default::default(),
-            true_genesis_block: genesis_block.clone(),
+            true_genesis: true_genesis.clone(),
             storage_manager,
             cache_man,
             instance_id: Mutex::new(0),
             config,
             target_difficulty_manager: TargetDifficultyManager::new(),
-            cur_consensus_era_genesis_hash: RwLock::new(genesis_hash),
-            cur_consensus_era_stable_hash: RwLock::new(genesis_hash),
+            cur_consensus_era_genesis_hash: RwLock::new(true_genesis.hash()),
+            cur_consensus_era_stable_hash: RwLock::new(true_genesis.hash()),
             tx_data_manager,
             db_manager,
         };
@@ -138,7 +137,7 @@ impl BlockDataManager {
         if let Some((checkpoint_hash, stable_hash)) =
             data_man.db_manager.checkpoint_hashes_from_db()
         {
-            if checkpoint_hash != genesis_hash {
+            if checkpoint_hash != cur_era_genesis.hash() {
                 if let Some(checkpoint_block) = data_man.block_by_hash(
                     &checkpoint_hash,
                     false, /* update_cache */
@@ -147,15 +146,14 @@ impl BlockDataManager {
                         checkpoint_hash;
                     *data_man.cur_consensus_era_stable_hash.write() =
                         stable_hash;
-                    genesis_hash = checkpoint_hash;
-                    genesis_block = checkpoint_block.clone();
+                    cur_era_genesis = checkpoint_block.clone();
                 }
             }
         }
 
         // FIXME: Set execution context and past_num_blocks with data on disk
         data_man.insert_epoch_execution_context(
-            genesis_hash,
+            cur_era_genesis.hash(),
             EpochExecutionContext {
                 start_block_number: 0,
             },
@@ -163,12 +161,12 @@ impl BlockDataManager {
         );
 
         data_man
-            .insert_block(genesis_block.clone(), true /* persistent */);
+            .insert_block(cur_era_genesis.clone(), true /* persistent */);
 
-        if genesis_hash == data_man.true_genesis_block.hash() {
+        if cur_era_genesis.hash() == data_man.true_genesis.hash() {
             // persist local_block_info for true genesis
             data_man.db_manager.insert_local_block_info_to_db(
-                &data_man.true_genesis_block.hash(),
+                &data_man.true_genesis.hash(),
                 &LocalBlockInfo::new(
                     BlockStatus::Valid,
                     0,
@@ -176,25 +174,23 @@ impl BlockDataManager {
                 ),
             );
             data_man.insert_epoch_execution_commitments(
-                data_man.true_genesis_block.hash(),
+                data_man.true_genesis.hash(),
                 data_man.genesis_state_root(),
+                *data_man.true_genesis.block_header.deferred_receipts_root(),
                 *data_man
-                    .true_genesis_block
-                    .block_header
-                    .deferred_receipts_root(),
-                *data_man
-                    .true_genesis_block
+                    .true_genesis
                     .block_header
                     .deferred_logs_bloom_hash(),
             );
         } else {
             // for other era genesis, we need to change the instance_id
-            if let Some(mut local_block_info) =
-                data_man.db_manager.local_block_info_from_db(&genesis_hash)
+            if let Some(mut local_block_info) = data_man
+                .db_manager
+                .local_block_info_from_db(&cur_era_genesis.hash())
             {
                 local_block_info.instance_id = data_man.get_instance_id();
                 data_man.db_manager.insert_local_block_info_to_db(
-                    &genesis_hash,
+                    &cur_era_genesis.hash(),
                     &local_block_info,
                 );
             }
@@ -237,10 +233,11 @@ impl BlockDataManager {
         self.db_manager.insert_instance_id_to_db(*my_instance_id);
     }
 
+    /// This will return the state root of true genesis block.
     pub fn genesis_state_root(&self) -> StateRootWithAuxInfo {
         self.storage_manager
             .get_state_no_commit(SnapshotAndEpochIdRef::new_for_readonly(
-                &self.get_cur_consensus_era_genesis_hash(),
+                &self.true_genesis.hash(),
                 &StateRootWithAuxInfo::default(),
             ))
             .unwrap()
@@ -597,7 +594,7 @@ impl BlockDataManager {
         if epoch_number != 0 {
             self.db_manager.epoch_set_hashes_from_db(epoch_number)
         } else {
-            Some(vec![self.true_genesis_block.hash()])
+            Some(vec![self.true_genesis.hash()])
         }
     }
 

--- a/core/src/consensus/consensus_inner/confirmation_meter.rs
+++ b/core/src/consensus/consensus_inner/confirmation_meter.rs
@@ -56,6 +56,19 @@ impl ConfirmationMeter {
         }
     }
 
+    pub fn reset(&self) {
+        let mut inner = self.inner.write();
+        inner.total_weight_in_past_2d = TotalWeightInPastMovingDelta {
+            old: 0,
+            cur: 0,
+            delta: 0,
+        };
+        inner.finality_manager = FinalityManager {
+            lowest_epoch_num: 0,
+            risks_less_than: VecDeque::new(),
+        };
+    }
+
     pub fn update_total_weight_in_past(&self) {
         let mut inner = self.inner.write();
         let total_weight = &mut inner.total_weight_in_past_2d;

--- a/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
+++ b/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
@@ -1431,7 +1431,7 @@ impl ConsensusNewBlockHandler {
         {
             let arena_index = inner.pivot_chain[pivot_index];
             let pivot_hash = inner.arena[arena_index].hash;
-            if pivot_hash == inner.data_man.true_genesis_block.hash() {
+            if pivot_hash == inner.data_man.true_genesis.hash() {
                 continue;
             }
             let exec_pivot_index =

--- a/core/src/consensus/consensus_inner/mod.rs
+++ b/core/src/consensus/consensus_inner/mod.rs
@@ -2513,7 +2513,7 @@ impl ConsensusGraphInner {
         }
         while !stack.is_empty() {
             let (stage, me) = stack.pop().unwrap();
-            if !to_visit.contains(&me) {
+            if !to_visit.contains(&me) || self.arena[me].era_block == NULL {
                 continue;
             }
             let parent = self.arena[me].parent;
@@ -2521,11 +2521,9 @@ impl ConsensusGraphInner {
                 if to_update.contains(&me) {
                     to_update.remove(&me);
                     stack.push((1, me));
-                    if self.arena[me].era_block != NULL {
-                        stack.push((0, parent));
-                        for referee in &self.arena[me].referees {
-                            stack.push((0, *referee));
-                        }
+                    stack.push((0, parent));
+                    for referee in &self.arena[me].referees {
+                        stack.push((0, *referee));
                     }
                 }
             } else if stage == 1 && me != self.cur_era_genesis_block_arena_index

--- a/core/src/consensus/consensus_inner/mod.rs
+++ b/core/src/consensus/consensus_inner/mod.rs
@@ -2521,11 +2521,11 @@ impl ConsensusGraphInner {
                 if to_update.contains(&me) {
                     to_update.remove(&me);
                     stack.push((1, me));
-                    if parent != NULL {
+                    if self.arena[me].era_block != NULL {
                         stack.push((0, parent));
-                    }
-                    for referee in &self.arena[me].referees {
-                        stack.push((0, *referee));
+                        for referee in &self.arena[me].referees {
+                            stack.push((0, *referee));
+                        }
                     }
                 }
             } else if stage == 1 && me != self.cur_era_genesis_block_arena_index

--- a/core/src/consensus/consensus_inner/mod.rs
+++ b/core/src/consensus/consensus_inner/mod.rs
@@ -2275,8 +2275,7 @@ impl ConsensusGraphInner {
             let exec_info = ConsensusGraphExecutionInfo {
                 deferred_state_root_with_aux_info: self
                     .data_man
-                    .genesis_state_root(),
-
+                    .true_genesis_state_root(),
                 original_deferred_state_root: *self
                     .data_man
                     .true_genesis

--- a/core/src/consensus/consensus_inner/mod.rs
+++ b/core/src/consensus/consensus_inner/mod.rs
@@ -2523,14 +2523,20 @@ impl ConsensusGraphInner {
                 if to_update.contains(&me) {
                     to_update.remove(&me);
                     stack.push((1, me));
-                    stack.push((0, parent));
+                    if parent != NULL {
+                        stack.push((0, parent));
+                    }
                     for referee in &self.arena[me].referees {
                         stack.push((0, *referee));
                     }
                 }
             } else if stage == 1 && me != self.cur_era_genesis_block_arena_index
             {
-                let mut last_pivot = self.arena[parent].last_pivot_in_past;
+                let mut last_pivot = if parent == NULL {
+                    0
+                } else {
+                    self.arena[parent].last_pivot_in_past
+                };
                 for referee in &self.arena[me].referees {
                     let x = self.arena[*referee].last_pivot_in_past;
                     last_pivot = max(last_pivot, x);

--- a/core/src/consensus/consensus_inner/mod.rs
+++ b/core/src/consensus/consensus_inner/mod.rs
@@ -419,18 +419,17 @@ impl ConsensusGraphInner {
         } else {
             cur_era_genesis_height + inner_conf.era_epoch_count
         };
-        let first_trusted_blame_block = first_trusted_blame_block
-            .unwrap_or(data_man.true_genesis_block.hash());
-        let first_trusted_blame_block_height = if first_trusted_blame_block
-            == data_man.true_genesis_block.hash()
-        {
-            0
-        } else {
-            data_man
-                .block_header_by_hash(&first_trusted_blame_block)
-                .expect("first_trusted_blame_block should exist here")
-                .height()
-        };
+        let first_trusted_blame_block =
+            first_trusted_blame_block.unwrap_or(data_man.true_genesis.hash());
+        let first_trusted_blame_block_height =
+            if first_trusted_blame_block == data_man.true_genesis.hash() {
+                0
+            } else {
+                data_man
+                    .block_header_by_hash(&first_trusted_blame_block)
+                    .expect("first_trusted_blame_block should exist here")
+                    .height()
+            };
         let initial_difficulty = pow_config.initial_difficulty;
         let mut inner = ConsensusGraphInner {
             arena: Slab::new(),
@@ -2280,17 +2279,17 @@ impl ConsensusGraphInner {
 
                 original_deferred_state_root: *self
                     .data_man
-                    .true_genesis_block
+                    .true_genesis
                     .block_header
                     .deferred_state_root(),
                 original_deferred_receipt_root: *self
                     .data_man
-                    .true_genesis_block
+                    .true_genesis
                     .block_header
                     .deferred_receipts_root(),
                 original_deferred_logs_bloom_hash: *self
                     .data_man
-                    .true_genesis_block
+                    .true_genesis
                     .block_header
                     .deferred_logs_bloom_hash(),
             };

--- a/core/src/light_protocol/handler/mod.rs
+++ b/core/src/light_protocol/handler/mod.rs
@@ -217,7 +217,7 @@ impl Handler {
 
     #[inline]
     fn validate_genesis_hash(&self, genesis: H256) -> Result<(), Error> {
-        match self.consensus.data_man.true_genesis_block.hash() {
+        match self.consensus.data_man.true_genesis.hash() {
             h if h == genesis => Ok(()),
             h => {
                 debug!(
@@ -309,7 +309,7 @@ impl Handler {
         &self, io: &dyn NetworkContext, peer: PeerId,
     ) -> Result<(), Error> {
         let msg: Box<dyn Message> = Box::new(StatusPing {
-            genesis_hash: self.consensus.data_man.true_genesis_block.hash(),
+            genesis_hash: self.consensus.data_man.true_genesis.hash(),
             node_type: NodeType::Light,
             protocol_version: LIGHT_PROTOCOL_VERSION,
         });

--- a/core/src/light_protocol/provider.rs
+++ b/core/src/light_protocol/provider.rs
@@ -228,7 +228,7 @@ impl Provider {
         &self, io: &dyn NetworkContext, peer: PeerId,
     ) -> Result<(), Error> {
         let best_info = self.consensus.get_best_info();
-        let genesis_hash = self.consensus.data_man.true_genesis_block.hash();
+        let genesis_hash = self.consensus.data_man.true_genesis.hash();
 
         let terminals = match &best_info.terminal_block_hashes {
             Some(x) => x.clone(),
@@ -257,7 +257,7 @@ impl Provider {
 
     #[inline]
     fn validate_genesis_hash(&self, genesis: H256) -> Result<(), Error> {
-        match self.consensus.data_man.true_genesis_block.hash() {
+        match self.consensus.data_man.true_genesis.hash() {
             h if h == genesis => Ok(()),
             h => {
                 debug!(

--- a/core/src/sync/message/get_block_headers_response.rs
+++ b/core/src/sync/message/get_block_headers_response.rs
@@ -34,13 +34,6 @@ pub struct GetBlockHeadersResponse {
 
 impl Handleable for GetBlockHeadersResponse {
     fn handle(self, ctx: &Context) -> Result<(), Error> {
-        // We may receive some messages from peer during recover from db
-        // phase. We should ignore it, since it may cause some
-        // inconsistency.
-        if ctx.manager.in_recover_from_db_phase() {
-            return Ok(());
-        }
-
         let _timer = MeterTimer::time_func(BLOCK_HEADER_HANDLE_TIMER.as_ref());
 
         for header in &self.headers {
@@ -56,6 +49,13 @@ impl Handleable for GetBlockHeadersResponse {
             let requested = self.headers.iter().map(|h| h.hash()).collect();
 
             self.handle_block_headers(ctx, &self.headers, requested, None);
+            return Ok(());
+        }
+
+        // We may receive some messages from peer during recover from db
+        // phase. We should ignore it, since it may cause some
+        // inconsistency.
+        if ctx.manager.in_recover_from_db_phase() {
             return Ok(());
         }
 

--- a/core/src/sync/message/get_block_headers_response.rs
+++ b/core/src/sync/message/get_block_headers_response.rs
@@ -133,6 +133,13 @@ impl GetBlockHeadersResponse {
                 }
             }
 
+            // We may receive some messages from peer during recover from db
+            // phase. We should ignore it, since it may cause some
+            // inconsistency.
+            if ctx.manager.in_recover_from_db_phase() {
+                continue;
+            }
+
             // check whether block is in old era
             let (era_genesis_hash, era_genesis_height) = ctx
                 .manager

--- a/core/src/sync/message/get_block_headers_response.rs
+++ b/core/src/sync/message/get_block_headers_response.rs
@@ -104,6 +104,13 @@ impl GetBlockHeadersResponse {
         requested: HashSet<H256>, chosen_peer: Option<usize>,
     )
     {
+        // We may receive some messages from peer during recover from db
+        // phase. We should ignore it, since it may cause some
+        // inconsistency.
+        if ctx.manager.in_recover_from_db_phase() {
+            return;
+        }
+
         // This stores the block hashes for blocks without block body.
         let mut hashes = Vec::new();
         let mut dependent_hashes_bounded = HashSet::new();
@@ -131,13 +138,6 @@ impl GetBlockHeadersResponse {
                     ctx.manager.future_blocks.insert(header.clone());
                     continue;
                 }
-            }
-
-            // We may receive some messages from peer during recover from db
-            // phase. We should ignore it, since it may cause some
-            // inconsistency.
-            if ctx.manager.in_recover_from_db_phase() {
-                continue;
             }
 
             // check whether block is in old era

--- a/core/src/sync/message/new_block.rs
+++ b/core/src/sync/message/new_block.rs
@@ -55,6 +55,12 @@ fn on_new_decoded_block(
 ) -> Result<Vec<H256>, Error> {
     let hash = block.block_header.hash();
     let mut need_to_relay = Vec::new();
+    // We may receive some messages from peer during recover from db
+    // phase. We should ignore it, since it may cause some
+    // inconsistency.
+    if ctx.manager.in_recover_from_db_phase() {
+        return Ok(need_to_relay);
+    }
     match ctx.manager.graph.block_header_by_hash(&hash) {
         Some(header) => block.block_header = header,
         None => {

--- a/core/src/sync/message/new_block.rs
+++ b/core/src/sync/message/new_block.rs
@@ -19,6 +19,12 @@ impl Handleable for NewBlock {
     // TODO This is only used in tests now. Maybe we can add a rpc to send full
     // block and remove NEW_BLOCK from p2p
     fn handle(self, ctx: &Context) -> Result<(), Error> {
+        // We may receive some messages from peer during recover from db
+        // phase. We should ignore it, since it may cause some
+        // inconsistency.
+        if ctx.manager.in_recover_from_db_phase() {
+            return Ok(());
+        }
         let mut block = self.block;
         ctx.manager.graph.data_man.recover_block(&mut block)?;
 
@@ -55,12 +61,6 @@ fn on_new_decoded_block(
 ) -> Result<Vec<H256>, Error> {
     let hash = block.block_header.hash();
     let mut need_to_relay = Vec::new();
-    // We may receive some messages from peer during recover from db
-    // phase. We should ignore it, since it may cause some
-    // inconsistency.
-    if ctx.manager.in_recover_from_db_phase() {
-        return Ok(need_to_relay);
-    }
     match ctx.manager.graph.block_header_by_hash(&hash) {
         Some(header) => block.block_header = header,
         None => {

--- a/core/src/sync/message/status.rs
+++ b/core/src/sync/message/status.rs
@@ -29,7 +29,7 @@ impl Handleable for Status {
     fn handle(self, ctx: &Context) -> Result<(), Error> {
         debug!("on_status, msg=:{:?}", self);
 
-        let genesis_hash = ctx.manager.graph.data_man.true_genesis_block.hash();
+        let genesis_hash = ctx.manager.graph.data_man.true_genesis.hash();
         if genesis_hash != self.genesis_hash {
             debug!(
                 "Peer {:?} genesis hash mismatches (ours: {:?}, theirs: {:?})",

--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -1420,8 +1420,18 @@ impl SynchronizationGraph {
             inner.insert_invalid(header_arc.clone())
         };
 
+        // Currently, `inner.arena[me].graph_status` will only be
+        //   1. `BLOCK_GRAPH_READY` for genesis block.
+        //   2. `BLOCK_HEADER_ONLY` for non genesis block.
+        //   3. `BLOCK_INVALID` for invalid block.
         if inner.arena[me].graph_status != BLOCK_GRAPH_READY {
             inner.not_ready_blocks_count += 1;
+            // This block will become a new `not_ready_blocks_frontier` if
+            //   1. It's parent block has not inserted yet.
+            //   2. We are in `Catch Up Blocks Phase` and the graph status of
+            // parent block is `BLOCK_GRAPH_READY`.
+            //   3. We are in `Catch Up Headers Phase` and the graph status of
+            // parent block is `BLOCK_HEADER_GRAPH_READY`.
             if inner.arena[me].parent == NULL
                 || inner.arena[inner.arena[me].parent].graph_status
                     == BLOCK_GRAPH_READY

--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -315,11 +315,11 @@ impl SynchronizationGraphInner {
         // Get the sequence number of genesis block.
         // FIXME: we may store `genesis_sequence_number` in data_man to avoid db
         // access.
-        let genesis_hash = self.data_man.genesis_hash();
+        let genesis_hash = self.data_man.get_cur_consensus_era_genesis_hash();
         let genesis_seq_num = self
             .data_man
             .local_block_info_from_db(&genesis_hash)
-            .unwrap()
+            .expect("local_block_info for genesis must exist")
             .get_seq_num();
 
         // This function decides graph-ready based on block info from db
@@ -919,9 +919,9 @@ impl SynchronizationGraph {
     ) -> Self
     {
         let data_man = consensus.data_man.clone();
-        let genesis_hash = data_man.genesis_hash();
+        let genesis_hash = data_man.get_cur_consensus_era_genesis_hash();
         let genesis_block_header = data_man
-            .block_header_by_hash(genesis_hash)
+            .block_header_by_hash(&genesis_hash)
             .expect("genesis block header should exist here");
         let (consensus_sender, consensus_receiver) = mpsc::channel();
         let inner = Arc::new(RwLock::new(
@@ -939,7 +939,7 @@ impl SynchronizationGraph {
             verification_config,
             consensus: consensus.clone(),
             statistics: consensus.statistics.clone(),
-            latest_graph_ready_block: Mutex::new(*genesis_hash),
+            latest_graph_ready_block: Mutex::new(genesis_hash),
             consensus_sender: Mutex::new(consensus_sender),
             is_full_node,
         };
@@ -1021,9 +1021,9 @@ impl SynchronizationGraph {
 
         // Recover the initial sequence number in consensus graph
         // based on the sequence number of genesis block in db.
-        let genesis_hash = self.data_man.genesis_hash();
+        let genesis_hash = self.data_man.get_cur_consensus_era_genesis_hash();
         let genesis_local_info =
-            self.data_man.local_block_info_from_db(genesis_hash);
+            self.data_man.local_block_info_from_db(&genesis_hash);
         if genesis_local_info.is_none() {
             // Local info of genesis block must exist.
             panic!(
@@ -1036,9 +1036,13 @@ impl SynchronizationGraph {
             .inner
             .write()
             .set_initial_sequence_number(genesis_seq_num);
+        let genesis_header =
+            self.data_man.block_header_by_hash(&genesis_hash).unwrap();
         debug!(
-            "Get current genesis_block hash={:?}, seq_num={}",
-            genesis_hash, genesis_seq_num
+            "Get current genesis_block hash={:?}, height={}, seq_num={}",
+            genesis_hash,
+            genesis_header.height(),
+            genesis_seq_num
         );
 
         // Get terminals stored in db.
@@ -1068,7 +1072,7 @@ impl SynchronizationGraph {
         // peers.
         let mut missed_hashes = self.initial_missed_block_hashes.lock();
         while let Some(hash) = queue.pop_front() {
-            if hash == *genesis_hash {
+            if hash == genesis_hash {
                 // Genesis block is already in consensus graph.
                 continue;
             }
@@ -1135,7 +1139,10 @@ impl SynchronizationGraph {
         debug!("Initial missed blocks {:?}", *missed_hashes);
 
         // Resolve out-of-era dependencies for graph-unready blocks.
-        self.resolve_outside_dependencies(true /* recover_from_db */);
+        self.resolve_outside_dependencies(
+            true,        /* recover_from_db */
+            header_only, /* insert_header_into_consensus */
+        );
         debug!(
             "Current frontier after recover from db: {:?}",
             self.inner.read().not_ready_blocks_frontier.get_frontier()
@@ -1190,8 +1197,6 @@ impl SynchronizationGraph {
     pub fn block_by_hash(&self, hash: &H256) -> Option<Arc<Block>> {
         self.data_man.block_by_hash(hash, true /* update_cache */)
     }
-
-    pub fn genesis_hash(&self) -> H256 { *self.data_man.genesis_hash() }
 
     pub fn contains_block_header(&self, hash: &H256) -> bool {
         self.inner.read().hash_to_arena_indices.contains_key(hash)
@@ -1284,6 +1289,12 @@ impl SynchronizationGraph {
                                 true,
                             ))
                             .expect("Receiver not dropped");
+                        // maintain not_ready_blocks_frontier
+                        inner.not_ready_blocks_count -= 1;
+                        inner.not_ready_blocks_frontier.remove(&index);
+                        for child in &inner.arena[index].children {
+                            inner.not_ready_blocks_frontier.insert(*child);
+                        }
                     }
 
                     // Passed verification on header_arc.
@@ -1307,7 +1318,7 @@ impl SynchronizationGraph {
                         }
                     }
                 } else if inner.new_to_be_header_parental_tree_ready(index) {
-                    trace!("BlockIndex {} parent_index {} hash {} is header parental tree ready", index,
+                    debug!("BlockIndex {} parent_index {} hash {} is header parental tree ready", index,
                            inner.arena[index].parent, inner.arena[index].block_header.hash());
                     if index == header_index_to_insert {
                         self.data_man.insert_block_header(
@@ -1327,7 +1338,7 @@ impl SynchronizationGraph {
                         queue.push_back(*child);
                     }
                 } else {
-                    trace!(
+                    debug!(
                         "BlockIndex {} parent_index {} hash {} is not ready",
                         index,
                         inner.arena[index].parent,
@@ -1414,6 +1425,9 @@ impl SynchronizationGraph {
             if inner.arena[me].parent == NULL
                 || inner.arena[inner.arena[me].parent].graph_status
                     == BLOCK_GRAPH_READY
+                || (insert_to_consensus
+                    && inner.arena[inner.arena[me].parent].graph_status
+                        == BLOCK_HEADER_GRAPH_READY)
             {
                 inner.not_ready_blocks_frontier.insert(me);
             }
@@ -1707,7 +1721,7 @@ impl SynchronizationGraph {
     /// consensus.on_new_block() will be called in sync mode with
     /// `ignore_body` being true.
     pub fn resolve_outside_dependencies(
-        &self, recover_from_db: bool,
+        &self, recover_from_db: bool, insert_header_to_consensus: bool,
     ) -> Vec<H256> {
         // Maintains the set of blocks that just become block-graph-ready
         // and may need to be relayed to peers.
@@ -1729,6 +1743,10 @@ impl SynchronizationGraph {
                 "Recover blocks into graph_ready {:?}",
                 new_graph_ready_blocks
             );
+            debug!(
+                "Recover blocks into header graph_ready {:?}",
+                new_header_graph_ready_blocks
+            );
 
             for index in &new_graph_ready_blocks {
                 to_relay_blocks.push(inner.arena[*index].block_header.hash());
@@ -1749,10 +1767,10 @@ impl SynchronizationGraph {
                 .propagate_header_graph_status(
                     inner,
                     new_header_graph_ready_blocks,
-                    true,  /* need_to_verify */
-                    NULL,  /* header_index_to_insert */
-                    false, /* insert_to_consensus */
-                    true,  /* persistent */
+                    true, /* need_to_verify */
+                    NULL, /* header_index_to_insert */
+                    insert_header_to_consensus,
+                    true, /* persistent */
                 );
             inner.process_invalid_blocks(&invalid_set);
             for hash in need_to_relay {

--- a/core/src/sync/synchronization_phases.rs
+++ b/core/src/sync/synchronization_phases.rs
@@ -530,7 +530,7 @@ impl SynchronizationPhaseTrait for CatchUpRecoverBlockFromDbPhase {
             *old_sync_inner = new_sync_inner;
 
             // If `checkpoint` is true genesis, `state_valid` must be true.
-            if checkpoint == self.graph.data_man.true_genesis_block.hash()
+            if checkpoint == self.graph.data_man.true_genesis.hash()
                 && pivot_block_state_valid_map.contains_key(&checkpoint)
             {
                 assert!(pivot_block_state_valid_map

--- a/core/src/sync/synchronization_phases.rs
+++ b/core/src/sync/synchronization_phases.rs
@@ -516,6 +516,8 @@ impl SynchronizationPhaseTrait for CatchUpRecoverBlockFromDbPhase {
             );
             self.graph.consensus.update_best_info(&new_consensus_inner);
             *old_consensus_inner = new_consensus_inner;
+            // FIXME: We may need to some information of `confirmation_meter`.
+            self.graph.consensus.confirmation_meter.reset();
             let new_sync_inner = SynchronizationGraphInner::with_genesis_block(
                 self.graph
                     .data_man

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -861,7 +861,7 @@ impl SynchronizationProtocolHandler {
 
         Status {
             protocol_version: SYNCHRONIZATION_PROTOCOL_VERSION,
-            genesis_hash: self.graph.data_man.true_genesis_block.hash(),
+            genesis_hash: self.graph.data_man.true_genesis.hash(),
             best_epoch: best_info.best_epoch_number,
             terminal_block_hashes: terminal_hashes,
         }

--- a/core/src/transaction_pool/mod.rs
+++ b/core/src/transaction_pool/mod.rs
@@ -107,7 +107,7 @@ impl TransactionPool {
             best_executed_epoch: Mutex::new(SnapshotAndEpochId::from_ref(
                 SnapshotAndEpochIdRef::new_for_readonly(
                     &genesis_hash,
-                    &data_man.genesis_state_root(),
+                    &data_man.true_genesis_state_root(),
                 ),
             )),
             consensus_best_info: Mutex::new(Arc::new(Default::default())),

--- a/core/src/transaction_pool/mod.rs
+++ b/core/src/transaction_pool/mod.rs
@@ -96,7 +96,7 @@ pub type SharedTransactionPool = Arc<TransactionPool>;
 
 impl TransactionPool {
     pub fn new(config: TxPoolConfig, data_man: Arc<BlockDataManager>) -> Self {
-        let genesis_hash = data_man.genesis_hash();
+        let genesis_hash = data_man.get_cur_consensus_era_genesis_hash();
         let inner = TransactionPoolInner::with_capacity(config.capacity);
         TransactionPool {
             config,
@@ -106,7 +106,7 @@ impl TransactionPool {
             spec: vm::Spec::new_spec(),
             best_executed_epoch: Mutex::new(SnapshotAndEpochId::from_ref(
                 SnapshotAndEpochIdRef::new_for_readonly(
-                    genesis_hash,
+                    &genesis_hash,
                     &data_man.genesis_state_root(),
                 ),
             )),

--- a/core/src/transaction_pool/mod.rs
+++ b/core/src/transaction_pool/mod.rs
@@ -96,7 +96,7 @@ pub type SharedTransactionPool = Arc<TransactionPool>;
 
 impl TransactionPool {
     pub fn new(config: TxPoolConfig, data_man: Arc<BlockDataManager>) -> Self {
-        let genesis_hash = data_man.get_cur_consensus_era_genesis_hash();
+        let genesis_hash = data_man.true_genesis.hash();
         let inner = TransactionPoolInner::with_capacity(config.capacity);
         TransactionPool {
             config,

--- a/tests/full_node_tests/p2p_era_test.py
+++ b/tests/full_node_tests/p2p_era_test.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+import sys, os
+from eth_utils import decode_hex
+from rlp.sedes import Binary, BigEndianInt
+
+sys.path.insert(1, os.path.dirname(sys.path[0]))
+
+from conflux import utils
+from conflux.rpc import RpcClient
+from conflux.utils import encode_hex, bytes_to_int, privtoaddr, parse_as_int
+from test_framework.blocktools import create_block
+from test_framework.test_framework import ConfluxTestFramework
+from test_framework.mininode import *
+from test_framework.util import *
+
+class P2PTest(ConfluxTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 8
+        self.conf_parameters["generate_tx"] = "true"
+        # Every node generates 1 tx every second
+        self.conf_parameters["generate_tx_period_us"] = "100000"
+        self.conf_parameters["log_level"] = "\"debug\""
+        self.conf_parameters["era_epoch_count"] = "50"
+        self.conf_parameters["era_checkpoint_gap"] = "150"
+
+    def setup_nodes(self):
+        self.add_nodes(self.num_nodes)
+        self.start_node(0)
+        for i in range(1, self.num_nodes):
+            self.start_node(i, extra_args=["--full"], phase_to_wait=None)
+
+    def setup_network(self):
+        self.setup_nodes()
+        connect_sample_nodes(self.nodes, self.log)
+        sync_blocks(self.nodes)
+
+    def run_test(self):
+        block_number = 2000
+
+        # Setup balance for each node
+        client = RpcClient(self.nodes[0])
+        for i in range(self.num_nodes):
+            pub_key = self.nodes[i].key
+            addr = self.nodes[i].addr
+            self.log.info("%d has addr=%s pubkey=%s", i, encode_hex(addr), pub_key)
+            tx = client.new_tx(value=int(default_config["TOTAL_COIN"]/self.num_nodes) - 21000, receiver=encode_hex(addr), nonce=i)
+            client.send_tx(tx)
+        for i in range(1, block_number):
+            chosen_peer = random.randint(0, self.num_nodes - 1)
+            if random.random() <= 0.01 and chosen_peer != 0:
+                self.log.info("stop %s", chosen_peer)
+                self.stop_node(chosen_peer)
+                self.start_node(chosen_peer, wait_time=120, phase_to_wait=("NormalSyncPhase"))
+            self.log.debug("%d try to generate", chosen_peer)
+            block_hash = RpcClient(self.nodes[chosen_peer]).generate_block(random.randint(10, 100))
+            self.log.info("%d generate block %s", chosen_peer, block_hash)
+            time.sleep(random.random()/15)
+        self.log.info("sync blocks")
+        for i in range(1, self.num_nodes):
+            self.nodes[i].expireblockgc(1000000)
+        sync_blocks(self.nodes, timeout=120, sync_count=False)
+        self.log.info("block count:%d", self.nodes[0].getblockcount())
+        hasha = self.nodes[0].best_block_hash()
+        block_a = client.block_by_hash(hasha)
+        self.log.info("Final height = %s", block_a['height'])
+        self.log.info("Pass")
+
+
+if __name__ == "__main__":
+    P2PTest().main()


### PR DESCRIPTION
This pull request fixed several bugs during full node syncing.

1. The validation for epoch receipts forgets to consider the `DEFERRED_STATE_EPOCH_COUNT` and the  function for retrieving blame_states can not handle the case when `blame=0`.

2. Remove useless `genesis_hash` in `BlockDataManager` and use `cur_consensus_era_genesis_hash` instead.

3. During recover block from db phase for full node, some messages related block headers will be received from peer, and this will cause that we may not request body for some blocks. 

4. Make `not_ready_blocks_frontier` also handle `BLOCK_HEADER_GRAPH_READY` blocks during catch up header phase.

5. The confirmation meter may have some bugs, but I don't figure it out yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/766)
<!-- Reviewable:end -->
