### PR TITLE
Fix transient light node test failure caused by network partition

### DIFF
--- a/tests/light/tx_relay_test.py
+++ b/tests/light/tx_relay_test.py
@@ -83,11 +83,14 @@ class TxRelayTest(ConfluxTestFramework):
         for (hash, _, _) in txs:
             self.log.info(f"waiting for tx {hash}")
             self.rpc[FULLNODE0].wait_for_receipt(hash)
-            self.rpc[FULLNODE1].wait_for_receipt(hash)
 
         self.log.info(f"Pass 1 - all txs relayed\n")
         # ------------------------------------------------
         self.log.info(f"Retrieving txs through light node...")
+
+        # sync blocks to make sure the light client has the header with the latest state
+        self.log.info("syncing blocks...")
+        sync_blocks(self.nodes)
 
         for (hash, _, _) in txs:
             self.check_tx(hash)      # cfx_getTransactionByHash


### PR DESCRIPTION
**Overview**

Due to parallel mining with high block creation rate, the network used during tests acts like it was partitioned, effectively leading to long-living forks and deep chain reorgs (i.e. changes of the pivot chain).

The current light node design retrieves and verifies witness information eagerly, assuming that there are no deep chain reorgs (see [here](https://github.com/Conflux-Chain/conflux-rust/blob/291325bf314eff8451393adcaf0b6490af2d412e/core/src/light_protocol/handler/sync/witnesses.rs#L222)). When this assumption is violated, it can lead to rare and hard-to-reproduce test failures.

This PR changes the test to avoid such scenarios.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/772)
<!-- Reviewable:end -->
