### PR TITLE
Add more response validation to light node (request id, payload)

### DIFF
--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -129,7 +129,6 @@ build_config! {
         (enable_state_expose, (bool), false)
         (get_logs_filter_max_limit, (Option<usize>), None)
         (throttling_conf, (Option<String>), None)
-        (unexpected_msgs_conf, (Option<String>), None)
     }
     {
         (

--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -129,6 +129,7 @@ build_config! {
         (enable_state_expose, (bool), false)
         (get_logs_filter_max_limit, (Option<usize>), None)
         (throttling_conf, (Option<String>), None)
+        (unexpected_msgs_conf, (Option<String>), None)
     }
     {
         (

--- a/client/src/light/mod.rs
+++ b/client/src/light/mod.rs
@@ -191,7 +191,7 @@ impl LightClient {
             consensus.clone(),
             sync_graph.clone(),
             network.clone(),
-            conf.raw_conf.unexpected_msgs_conf.clone(),
+            conf.raw_conf.throttling_conf.clone(),
         ));
         light.register().unwrap();
 

--- a/client/src/light/mod.rs
+++ b/client/src/light/mod.rs
@@ -191,6 +191,7 @@ impl LightClient {
             consensus.clone(),
             sync_graph.clone(),
             network.clone(),
+            conf.raw_conf.unexpected_msgs_conf.clone(),
         ));
         light.register().unwrap();
 

--- a/core/src/light_protocol/common/peers.rs
+++ b/core/src/light_protocol/common/peers.rs
@@ -21,6 +21,7 @@ pub struct FullPeerState {
     pub protocol_version: u8,
     pub terminals: HashSet<H256>,
     pub throttled_msgs: ThrottledManager<MsgId>,
+    pub unexpected_msgs: TokenBucketManager,
 }
 
 #[derive(Default)]

--- a/core/src/light_protocol/handler/mod.rs
+++ b/core/src/light_protocol/handler/mod.rs
@@ -40,6 +40,7 @@ use sync::{
     BlockTxs, Blooms, Epochs, HashSource, Headers, Receipts, StateEntries,
     StateRoots, TxInfos, Txs, Witnesses,
 };
+use throttling::token_bucket::TokenBucketManager;
 
 const SYNC_TIMER: TimerToken = 0;
 const REQUEST_CLEANUP_TIMER: TimerToken = 1;
@@ -86,6 +87,9 @@ pub struct Handler {
     // tx info sync manager
     pub tx_infos: TxInfos,
 
+    // path to unexpected messages config file
+    unexpected_msgs_config_file: Option<String>,
+
     // witness sync manager
     pub witnesses: Arc<Witnesses>,
 }
@@ -93,7 +97,9 @@ pub struct Handler {
 impl Handler {
     pub fn new(
         consensus: Arc<ConsensusGraph>, graph: Arc<SynchronizationGraph>,
-    ) -> Self {
+        unexpected_msgs_config_file: Option<String>,
+    ) -> Self
+    {
         let peers = Arc::new(Peers::new());
         let request_id_allocator = Arc::new(UniqueId::new());
 
@@ -175,6 +181,7 @@ impl Handler {
             state_roots,
             txs,
             tx_infos,
+            unexpected_msgs_config_file,
             witnesses,
         }
     }
@@ -371,36 +378,45 @@ impl Handler {
     }
 
     fn on_block_headers(
-        &self, io: &dyn NetworkContext, _peer: PeerId, rlp: &Rlp,
+        &self, io: &dyn NetworkContext, peer: PeerId, rlp: &Rlp,
     ) -> Result<(), Error> {
         let resp: GetBlockHeadersResponse = rlp.as_val()?;
         info!("on_block_headers resp={:?}", resp);
 
-        self.headers.receive(resp.headers.into_iter());
+        self.headers.receive(
+            peer,
+            resp.request_id,
+            resp.headers.into_iter(),
+        )?;
 
         self.start_sync(io);
         Ok(())
     }
 
     fn on_block_txs(
-        &self, io: &dyn NetworkContext, _peer: PeerId, rlp: &Rlp,
+        &self, io: &dyn NetworkContext, peer: PeerId, rlp: &Rlp,
     ) -> Result<(), Error> {
         let resp: GetBlockTxsResponse = rlp.as_val()?;
         info!("on_block_txs resp={:?}", resp);
 
-        self.block_txs.receive(resp.block_txs.into_iter())?;
+        self.block_txs.receive(
+            peer,
+            resp.request_id,
+            resp.block_txs.into_iter(),
+        )?;
 
         self.block_txs.sync(io);
         Ok(())
     }
 
     fn on_blooms(
-        &self, io: &dyn NetworkContext, _peer: PeerId, rlp: &Rlp,
+        &self, io: &dyn NetworkContext, peer: PeerId, rlp: &Rlp,
     ) -> Result<(), Error> {
         let resp: GetBloomsResponse = rlp.as_val()?;
         info!("on_blooms resp={:?}", resp);
 
-        self.blooms.receive(resp.blooms.into_iter())?;
+        self.blooms
+            .receive(peer, resp.request_id, resp.blooms.into_iter())?;
 
         self.blooms.sync(io);
         Ok(())
@@ -432,72 +448,90 @@ impl Handler {
     }
 
     fn on_receipts(
-        &self, io: &dyn NetworkContext, _peer: PeerId, rlp: &Rlp,
+        &self, io: &dyn NetworkContext, peer: PeerId, rlp: &Rlp,
     ) -> Result<(), Error> {
         let resp: GetReceiptsResponse = rlp.as_val()?;
         info!("on_receipts resp={:?}", resp);
 
-        self.receipts.receive(resp.receipts.into_iter())?;
+        self.receipts.receive(
+            peer,
+            resp.request_id,
+            resp.receipts.into_iter(),
+        )?;
 
         self.receipts.sync(io);
         Ok(())
     }
 
     fn on_state_entries(
-        &self, io: &dyn NetworkContext, _peer: PeerId, rlp: &Rlp,
+        &self, io: &dyn NetworkContext, peer: PeerId, rlp: &Rlp,
     ) -> Result<(), Error> {
         let resp: GetStateEntriesResponse = rlp.as_val()?;
         info!("on_state_entries resp={:?}", resp);
 
-        self.state_entries.receive(resp.entries.into_iter())?;
+        self.state_entries.receive(
+            peer,
+            resp.request_id,
+            resp.entries.into_iter(),
+        )?;
 
         self.state_entries.sync(io);
         Ok(())
     }
 
     fn on_state_roots(
-        &self, io: &dyn NetworkContext, _peer: PeerId, rlp: &Rlp,
+        &self, io: &dyn NetworkContext, peer: PeerId, rlp: &Rlp,
     ) -> Result<(), Error> {
         let resp: GetStateRootsResponse = rlp.as_val()?;
         info!("on_state_roots resp={:?}", resp);
 
-        self.state_roots.receive(resp.state_roots.into_iter())?;
+        self.state_roots.receive(
+            peer,
+            resp.request_id,
+            resp.state_roots.into_iter(),
+        )?;
 
         self.state_roots.sync(io);
         Ok(())
     }
 
     fn on_txs(
-        &self, io: &dyn NetworkContext, _peer: PeerId, rlp: &Rlp,
+        &self, io: &dyn NetworkContext, peer: PeerId, rlp: &Rlp,
     ) -> Result<(), Error> {
         let resp: GetTxsResponse = rlp.as_val()?;
         info!("on_txs resp={:?}", resp);
 
-        self.txs.receive(resp.txs.into_iter())?;
+        self.txs
+            .receive(peer, resp.request_id, resp.txs.into_iter())?;
 
         self.txs.sync(io);
         Ok(())
     }
 
     fn on_tx_infos(
-        &self, io: &dyn NetworkContext, _peer: PeerId, rlp: &Rlp,
+        &self, io: &dyn NetworkContext, peer: PeerId, rlp: &Rlp,
     ) -> Result<(), Error> {
         let resp: GetTxInfosResponse = rlp.as_val()?;
         info!("on_tx_infos resp={:?}", resp);
 
-        self.tx_infos.receive(resp.infos.into_iter())?;
+        self.tx_infos
+            .receive(peer, resp.request_id, resp.infos.into_iter())?;
 
         self.tx_infos.sync(io);
         Ok(())
     }
 
     fn on_witness_info(
-        &self, io: &dyn NetworkContext, _peer: PeerId, rlp: &Rlp,
+        &self, io: &dyn NetworkContext, peer: PeerId, rlp: &Rlp,
     ) -> Result<(), Error> {
         let resp: GetWitnessInfoResponse = rlp.as_val()?;
         info!("on_witness_info resp={:?}", resp);
 
-        self.witnesses.receive(resp.infos.into_iter())?;
+        self.witnesses.receive(
+            peer,
+            resp.request_id,
+            resp.infos.into_iter(),
+        )?;
 
         self.witnesses.sync(io);
         Ok(())
@@ -602,7 +636,19 @@ impl NetworkProtocolHandler for Handler {
         info!("on_peer_connected: peer={:?}", peer);
 
         match self.send_status(io, peer) {
-            Ok(_) => self.peers.insert(peer), // insert handshaking peer
+            Ok(_) => {
+                // insert handshaking peer
+                self.peers.insert(peer);
+
+                if let Some(ref file) = self.unexpected_msgs_config_file {
+                    let peer = self.peers.get(&peer).expect("peer not found");
+                    peer.write().unexpected_msgs = TokenBucketManager::load(
+                        file,
+                        Some("light_protocol::unexpected_msgs"),
+                    )
+                    .expect("invalid throttling configuration file");
+                }
+            }
             Err(e) => {
                 warn!("Error while sending status: {}", e);
                 handle_error(

--- a/core/src/light_protocol/handler/mod.rs
+++ b/core/src/light_protocol/handler/mod.rs
@@ -88,7 +88,7 @@ pub struct Handler {
     pub tx_infos: TxInfos,
 
     // path to unexpected messages config file
-    unexpected_msgs_config_file: Option<String>,
+    throttling_config_file: Option<String>,
 
     // witness sync manager
     pub witnesses: Arc<Witnesses>,
@@ -97,7 +97,7 @@ pub struct Handler {
 impl Handler {
     pub fn new(
         consensus: Arc<ConsensusGraph>, graph: Arc<SynchronizationGraph>,
-        unexpected_msgs_config_file: Option<String>,
+        throttling_config_file: Option<String>,
     ) -> Self
     {
         let peers = Arc::new(Peers::new());
@@ -181,7 +181,7 @@ impl Handler {
             state_roots,
             txs,
             tx_infos,
-            unexpected_msgs_config_file,
+            throttling_config_file,
             witnesses,
         }
     }
@@ -640,7 +640,7 @@ impl NetworkProtocolHandler for Handler {
                 // insert handshaking peer
                 self.peers.insert(peer);
 
-                if let Some(ref file) = self.unexpected_msgs_config_file {
+                if let Some(ref file) = self.throttling_config_file {
                     let peer = self.peers.get(&peer).expect("peer not found");
                     peer.write().unexpected_msgs = TokenBucketManager::load(
                         file,

--- a/core/src/light_protocol/handler/sync/block_txs.rs
+++ b/core/src/light_protocol/handler/sync/block_txs.rs
@@ -19,7 +19,7 @@ use crate::{
         message::{msgid, BlockTxsWithHash, GetBlockTxs},
         Error, ErrorKind,
     },
-    message::Message,
+    message::{Message, RequestId},
     network::{NetworkContext, PeerId},
     parameters::light::{
         BLOCK_TX_REQUEST_BATCH_SIZE, BLOCK_TX_REQUEST_TIMEOUT, CACHE_TIMEOUT,
@@ -104,30 +104,39 @@ impl BlockTxs {
 
     #[inline]
     pub fn receive(
-        &self, block_txs: impl Iterator<Item = BlockTxsWithHash>,
-    ) -> Result<(), Error> {
+        &self, peer: PeerId, id: RequestId,
+        block_txs: impl Iterator<Item = BlockTxsWithHash>,
+    ) -> Result<(), Error>
+    {
         for BlockTxsWithHash { hash, block_txs } in block_txs {
             info!("Validating block_txs {:?} with hash {}", block_txs, hash);
-            // validate and store each transaction
-            self.txs.receive(block_txs.clone().into_iter())?;
 
-            // validate block txs
-            self.validate_block_txs(hash, &block_txs)?;
-
-            // store block bodies by block hash
-            self.verified.write().insert(hash, block_txs);
-            self.sync_manager.remove_in_flight(&hash);
+            match self.sync_manager.check_if_requested(peer, id, &hash)? {
+                None => continue,
+                Some(_) => self.validate_and_store(hash, block_txs)?,
+            };
         }
 
         Ok(())
     }
 
     #[inline]
-    pub fn receive_single(
+    pub fn validate_and_store(
         &self, hash: H256, block_txs: Vec<SignedTransaction>,
     ) -> Result<(), Error> {
-        let item = BlockTxsWithHash { hash, block_txs };
-        self.receive(std::iter::once(item))
+        // validate and store each transaction
+        for tx in block_txs.clone() {
+            self.txs.validate_and_store(tx)?;
+        }
+
+        // validate block txs
+        self.validate_block_txs(hash, &block_txs)?;
+
+        // store block bodies by block hash
+        self.verified.write().insert(hash, block_txs);
+        self.sync_manager.remove_in_flight(&hash);
+
+        Ok(())
     }
 
     #[inline]
@@ -144,20 +153,19 @@ impl BlockTxs {
     #[inline]
     fn send_request(
         &self, io: &dyn NetworkContext, peer: PeerId, hashes: Vec<H256>,
-    ) -> Result<(), Error> {
+    ) -> Result<Option<RequestId>, Error> {
         info!("send_request peer={:?} hashes={:?}", peer, hashes);
 
         if hashes.is_empty() {
-            return Ok(());
+            return Ok(None);
         }
 
-        let msg: Box<dyn Message> = Box::new(GetBlockTxs {
-            request_id: self.request_id_allocator.next(),
-            hashes,
-        });
+        let request_id = self.request_id_allocator.next();
+        let msg: Box<dyn Message> =
+            Box::new(GetBlockTxs { request_id, hashes });
 
         msg.send(io, peer)?;
-        Ok(())
+        Ok(Some(request_id))
     }
 
     #[inline]

--- a/core/src/light_protocol/handler/sync/block_txs.rs
+++ b/core/src/light_protocol/handler/sync/block_txs.rs
@@ -125,8 +125,8 @@ impl BlockTxs {
         &self, hash: H256, block_txs: Vec<SignedTransaction>,
     ) -> Result<(), Error> {
         // validate and store each transaction
-        for tx in block_txs.clone() {
-            self.txs.validate_and_store(tx)?;
+        for tx in &block_txs {
+            self.txs.validate_and_store(tx.clone())?;
         }
 
         // validate block txs

--- a/core/src/light_protocol/handler/sync/common/sync_manager.rs
+++ b/core/src/light_protocol/handler/sync/common/sync_manager.rs
@@ -2,6 +2,15 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
+use super::{HasKey, PriorityQueue};
+use crate::{
+    light_protocol::{
+        common::{FullPeerFilter, FullPeerState, Peers},
+        Error, ErrorKind,
+    },
+    message::{MsgId, RequestId},
+    network::PeerId,
+};
 use parking_lot::RwLock;
 use std::{
     cmp::Ord,
@@ -11,28 +20,20 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
-
-use crate::{
-    light_protocol::{
-        common::{FullPeerState, Peers},
-        Error,
-    },
-    network::PeerId,
-};
-
-use super::{HasKey, PriorityQueue};
-use crate::{light_protocol::common::FullPeerFilter, message::MsgId};
+use throttling::token_bucket::ThrottleResult;
 
 #[derive(Debug)]
 struct InFlightRequest<T> {
     pub item: T,
+    pub request_id: RequestId,
     pub sent_at: Instant,
 }
 
 impl<T> InFlightRequest<T> {
-    pub fn new(item: T) -> Self {
+    pub fn new(item: T, request_id: RequestId) -> Self {
         InFlightRequest {
             item,
+            request_id,
             sent_at: Instant::now(),
         }
     }
@@ -78,10 +79,53 @@ where
     pub fn num_in_flight(&self) -> usize { self.in_flight.read().len() }
 
     #[inline]
-    pub fn insert_in_flight<I>(&self, missing: I)
+    pub fn insert_in_flight<I>(&self, missing: I, request_id: RequestId)
     where I: Iterator<Item = Item> {
-        let new = missing.map(|item| (item.key(), InFlightRequest::new(item)));
+        let new = missing
+            .map(|item| (item.key(), InFlightRequest::new(item, request_id)));
         self.in_flight.write().extend(new);
+    }
+
+    #[inline]
+    fn get_existing_peer_state(
+        &self, peer: PeerId,
+    ) -> Result<Arc<RwLock<FullPeerState>>, Error> {
+        match self.peers.get(&peer) {
+            Some(state) => Ok(state),
+            None => {
+                error!("Received message from unknown peer={:?}", peer);
+                Err(ErrorKind::InternalError.into())
+            }
+        }
+    }
+
+    #[inline]
+    pub fn check_if_requested(
+        &self, peer: PeerId, request_id: RequestId, key: &Key,
+    ) -> Result<Option<RequestId>, Error> {
+        let id = match self.in_flight.read().get(&key).map(|req| req.request_id)
+        {
+            Some(id) if id == request_id => return Ok(Some(id)),
+            x => x,
+        };
+
+        let peer = self.get_existing_peer_state(peer)?;
+
+        let bucket_name = self.request_msg_id.to_string();
+        let bucket = match peer.read().unexpected_msgs.get(&bucket_name) {
+            Some(bucket) => bucket,
+            None => return Ok(id),
+        };
+
+        let result = bucket.lock().throttle();
+
+        match result {
+            ThrottleResult::Success => Ok(id),
+            ThrottleResult::Throttled(_) => Ok(id),
+            ThrottleResult::AlreadyThrottled => {
+                Err(ErrorKind::UnexpectedResponse.into())
+            }
+        }
     }
 
     #[inline]
@@ -126,7 +170,7 @@ where
 
     pub fn sync(
         &self, max_in_flight: usize, batch_size: usize,
-        request: impl Fn(PeerId, Vec<Key>) -> Result<(), Error>,
+        request: impl Fn(PeerId, Vec<Key>) -> Result<Option<RequestId>, Error>,
     )
     {
         // check if there are any peers available
@@ -162,8 +206,12 @@ where
             let keys = batch.iter().map(|h| h.key()).collect();
 
             match request(peer, keys) {
-                Ok(_) => {
-                    self.insert_in_flight(batch.to_owned().into_iter());
+                Ok(None) => {}
+                Ok(Some(request_id)) => {
+                    self.insert_in_flight(
+                        batch.to_owned().into_iter(),
+                        request_id,
+                    );
                 }
                 Err(e) => {
                     warn!(
@@ -201,7 +249,7 @@ where
     #[inline]
     pub fn request_now<I>(
         &self, items: I,
-        request: impl Fn(PeerId, Vec<Key>) -> Result<(), Error>,
+        request: impl Fn(PeerId, Vec<Key>) -> Result<Option<RequestId>, Error>,
     ) where
         I: Iterator<Item = Item>,
     {
@@ -222,7 +270,7 @@ where
     #[inline]
     pub fn request_now_from_peer<I>(
         &self, items: I, peer: PeerId,
-        request: impl Fn(PeerId, Vec<Key>) -> Result<(), Error>,
+        request: impl Fn(PeerId, Vec<Key>) -> Result<Option<RequestId>, Error>,
     ) where
         I: Iterator<Item = Item>,
     {
@@ -230,7 +278,10 @@ where
         let keys = items.iter().map(|h| h.key()).collect();
 
         match request(peer, keys) {
-            Ok(_) => self.insert_in_flight(items.into_iter()),
+            Ok(None) => {}
+            Ok(Some(request_id)) => {
+                self.insert_in_flight(items.into_iter(), request_id)
+            }
             Err(e) => {
                 warn!("Failed to request {:?} from {:?}: {:?}", items, peer, e);
                 self.insert_waiting(items.into_iter());

--- a/core/src/light_protocol/handler/sync/state_roots.rs
+++ b/core/src/light_protocol/handler/sync/state_roots.rs
@@ -17,7 +17,7 @@ use crate::{
         message::{msgid, GetStateRoots, StateRootWithEpoch},
         Error, ErrorKind,
     },
-    message::Message,
+    message::{Message, RequestId},
     network::{NetworkContext, PeerId},
     parameters::light::{
         CACHE_TIMEOUT, MAX_STATE_ROOTS_IN_FLIGHT,
@@ -105,18 +105,35 @@ impl StateRoots {
 
     #[inline]
     pub fn receive(
-        &self, state_roots: impl Iterator<Item = StateRootWithEpoch>,
-    ) -> Result<(), Error> {
+        &self, peer: PeerId, id: RequestId,
+        state_roots: impl Iterator<Item = StateRootWithEpoch>,
+    ) -> Result<(), Error>
+    {
         for StateRootWithEpoch { epoch, state_root } in state_roots {
             info!(
                 "Validating state root {:?} with epoch {}",
                 state_root, epoch
             );
-            self.validate_state_root(epoch, &state_root)?;
 
-            self.verified.write().insert(epoch, state_root);
-            self.sync_manager.remove_in_flight(&epoch);
+            match self.sync_manager.check_if_requested(peer, id, &epoch)? {
+                None => continue,
+                Some(_) => self.validate_and_store(epoch, state_root)?,
+            };
         }
+
+        Ok(())
+    }
+
+    #[inline]
+    pub fn validate_and_store(
+        &self, epoch: u64, state_root: StateRoot,
+    ) -> Result<(), Error> {
+        // validate state root
+        self.validate_state_root(epoch, &state_root)?;
+
+        // store state root by epoch
+        self.verified.write().insert(epoch, state_root);
+        self.sync_manager.remove_in_flight(&epoch);
 
         Ok(())
     }
@@ -135,20 +152,19 @@ impl StateRoots {
     #[inline]
     fn send_request(
         &self, io: &dyn NetworkContext, peer: PeerId, epochs: Vec<u64>,
-    ) -> Result<(), Error> {
+    ) -> Result<Option<RequestId>, Error> {
         info!("send_request peer={:?} epochs={:?}", peer, epochs);
 
         if epochs.is_empty() {
-            return Ok(());
+            return Ok(None);
         }
 
-        let msg: Box<dyn Message> = Box::new(GetStateRoots {
-            request_id: self.request_id_allocator.next(),
-            epochs,
-        });
+        let request_id = self.request_id_allocator.next();
+        let msg: Box<dyn Message> =
+            Box::new(GetStateRoots { request_id, epochs });
 
         msg.send(io, peer)?;
-        Ok(())
+        Ok(Some(request_id))
     }
 
     #[inline]

--- a/core/src/light_protocol/handler/sync/witnesses.rs
+++ b/core/src/light_protocol/handler/sync/witnesses.rs
@@ -13,7 +13,7 @@ use crate::{
         message::{msgid, GetWitnessInfo, WitnessInfoWithHeight},
         Error, ErrorKind,
     },
-    message::Message,
+    message::{Message, RequestId},
     network::{NetworkContext, PeerId},
     parameters::{
         consensus::DEFERRED_STATE_EPOCH_COUNT,
@@ -144,17 +144,38 @@ impl Witnesses {
         Ok(())
     }
 
-    pub fn receive<I>(&self, witnesses: I) -> Result<(), Error>
-    where I: Iterator<Item = WitnessInfoWithHeight> {
+    pub fn receive(
+        &self, peer: PeerId, id: RequestId,
+        witnesses: impl Iterator<Item = WitnessInfoWithHeight>,
+    ) -> Result<(), Error>
+    {
         for item in witnesses {
-            let witness = item.height;
+            info!("Validating witness info {:?}", item);
 
-            // validate and store
-            self.handle_witness_info(item)?;
-
-            // signal receipt
-            self.sync_manager.remove_in_flight(&witness);
+            match self.sync_manager.check_if_requested(
+                peer,
+                id,
+                &item.height,
+            )? {
+                None => continue,
+                Some(_) => self.validate_and_store(item)?,
+            };
         }
+
+        Ok(())
+    }
+
+    #[inline]
+    pub fn validate_and_store(
+        &self, item: WitnessInfoWithHeight,
+    ) -> Result<(), Error> {
+        let witness = item.height;
+
+        // validate and store
+        self.handle_witness_info(item)?;
+
+        // signal receipt
+        self.sync_manager.remove_in_flight(&witness);
 
         Ok(())
     }
@@ -169,20 +190,22 @@ impl Witnesses {
     #[inline]
     fn send_request(
         &self, io: &dyn NetworkContext, peer: PeerId, witnesses: Vec<u64>,
-    ) -> Result<(), Error> {
+    ) -> Result<Option<RequestId>, Error> {
         info!("send_request peer={:?} witnesses={:?}", peer, witnesses);
 
         if witnesses.is_empty() {
-            return Ok(());
+            return Ok(None);
         }
 
+        let request_id = self.request_id_allocator.next();
+
         let msg: Box<dyn Message> = Box::new(GetWitnessInfo {
-            request_id: self.request_id_allocator.next(),
+            request_id,
             witnesses,
         });
 
         msg.send(io, peer)?;
-        Ok(())
+        Ok(Some(request_id))
     }
 
     #[inline]

--- a/core/src/light_protocol/message/protocol.rs
+++ b/core/src/light_protocol/message/protocol.rs
@@ -234,11 +234,12 @@ pub struct TxInfo {
     pub index: usize,
     pub epoch_receipts: Vec<Vec<PrimitiveReceipt>>,
     pub block_txs: Vec<SignedTransaction>,
+    pub tx_hash: H256,
 }
 
 impl Encodable for TxInfo {
     fn rlp_append(&self, stream: &mut RlpStream) {
-        stream.begin_list(5);
+        stream.begin_list(6);
         stream.append(&self.epoch);
         stream.append(&self.block_hash);
         stream.append(&self.index);
@@ -249,6 +250,7 @@ impl Encodable for TxInfo {
         }
 
         stream.append_list(&self.block_txs);
+        stream.append(&self.tx_hash);
     }
 }
 
@@ -265,6 +267,7 @@ impl Decodable for TxInfo {
             .collect::<Result<_, _>>()?;
 
         let block_txs = rlp.list_at(4)?;
+        let tx_hash = rlp.val_at(5)?;
 
         Ok(TxInfo {
             epoch,
@@ -272,6 +275,7 @@ impl Decodable for TxInfo {
             index,
             epoch_receipts,
             block_txs,
+            tx_hash,
         })
     }
 }

--- a/core/src/light_protocol/provider.rs
+++ b/core/src/light_protocol/provider.rs
@@ -221,6 +221,7 @@ impl Provider {
             .collect();
 
         Some(TxInfo {
+            tx_hash: hash,
             epoch,
             block_hash,
             index,

--- a/core/src/light_protocol/query_service.rs
+++ b/core/src/light_protocol/query_service.rs
@@ -59,13 +59,13 @@ impl QueryService {
     pub fn new(
         consensus: Arc<ConsensusGraph>, graph: Arc<SynchronizationGraph>,
         network: Arc<NetworkService>,
-        unexpected_msgs_config_file: Option<String>,
+        throttling_config_file: Option<String>,
     ) -> Self
     {
         let handler = Arc::new(LightHandler::new(
             consensus.clone(),
             graph,
-            unexpected_msgs_config_file,
+            throttling_config_file,
         ));
         let ledger = LedgerInfo::new(consensus.clone());
 

--- a/core/src/light_protocol/query_service.rs
+++ b/core/src/light_protocol/query_service.rs
@@ -58,8 +58,7 @@ pub struct QueryService {
 impl QueryService {
     pub fn new(
         consensus: Arc<ConsensusGraph>, graph: Arc<SynchronizationGraph>,
-        network: Arc<NetworkService>,
-        throttling_config_file: Option<String>,
+        network: Arc<NetworkService>, throttling_config_file: Option<String>,
     ) -> Self
     {
         let handler = Arc::new(LightHandler::new(

--- a/core/src/light_protocol/query_service.rs
+++ b/core/src/light_protocol/query_service.rs
@@ -59,9 +59,14 @@ impl QueryService {
     pub fn new(
         consensus: Arc<ConsensusGraph>, graph: Arc<SynchronizationGraph>,
         network: Arc<NetworkService>,
+        unexpected_msgs_config_file: Option<String>,
     ) -> Self
     {
-        let handler = Arc::new(LightHandler::new(consensus.clone(), graph));
+        let handler = Arc::new(LightHandler::new(
+            consensus.clone(),
+            graph,
+            unexpected_msgs_config_file,
+        ));
         let ledger = LedgerInfo::new(consensus.clone());
 
         QueryService {


### PR DESCRIPTION
**Overview**

This PR enhances light node sync by adding more response validation.

In particular, we check whether a response has a matching request id, and whether the response items had been requested. This helps us prevent attacks where the peer keeps sending unrequested items to fill the light node's cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/789)
<!-- Reviewable:end -->
