### PR TITLE
Add dev mode to start a single node.

### DIFF
--- a/client/benches/benchmark.rs
+++ b/client/benches/benchmark.rs
@@ -23,7 +23,7 @@ use std::{sync::Arc, time::Duration};
 #[allow(dead_code)]
 fn txgen_benchmark(c: &mut Criterion) {
     let mut conf = Configuration::default();
-    conf.raw_conf.test_mode = true;
+    conf.raw_conf.mode = Some("test".to_owned());
     let exit = Arc::new((Mutex::new(false), Condvar::new()));
     let handler = ArchiveClient::start(conf, exit).unwrap();
     c.bench_function("Randomly generate 1 transaction", move |b| {
@@ -35,7 +35,7 @@ fn txgen_benchmark(c: &mut Criterion) {
 
 fn txexe_benchmark(c: &mut Criterion) {
     let mut conf = Configuration::default();
-    conf.raw_conf.test_mode = true;
+    conf.raw_conf.mode = Some("test".to_owned());
     let exit = Arc::new((Mutex::new(false), Condvar::new()));
     let handler = ArchiveClient::start(conf, exit).unwrap();
     let kp = KeyPair::from_secret(

--- a/client/src/archive/mod.rs
+++ b/client/src/archive/mod.rs
@@ -89,7 +89,7 @@ pub struct ArchiveClient {}
 impl ArchiveClient {
     // Start all key components of Conflux and pass out their handles
     pub fn start(
-        conf: Configuration, exit: Arc<(Mutex<bool>, Condvar)>,
+        mut conf: Configuration, exit: Arc<(Mutex<bool>, Condvar)>,
     ) -> Result<ArchiveClientHandle, String> {
         info!("Working directory: {:?}", std::env::current_dir());
 
@@ -371,12 +371,20 @@ impl ArchiveClient {
             ),
         )?;
 
+        if conf.is_dev_mode() {
+            if conf.raw_conf.jsonrpc_tcp_port.is_none() {
+                conf.raw_conf.jsonrpc_tcp_port = Some(12536);
+            }
+            if conf.raw_conf.jsonrpc_http_port.is_none() {
+                conf.raw_conf.jsonrpc_http_port = Some(12537);
+            }
+        };
         let rpc_tcp_server = super::rpc::start_tcp(
             super::rpc::TcpConfiguration::new(
                 None,
                 conf.raw_conf.jsonrpc_tcp_port,
             ),
-            if conf.is_test_mode() {
+            if conf.is_test_or_dev_mode() {
                 setup_debug_rpc_apis(
                     common_impl.clone(),
                     rpc_impl.clone(),

--- a/client/src/archive/mod.rs
+++ b/client/src/archive/mod.rs
@@ -137,7 +137,7 @@ impl ArchiveClient {
             });
         }
 
-        let genesis_accounts = if conf.raw_conf.test_mode {
+        let genesis_accounts = if conf.is_test_or_dev_mode() {
             match conf.raw_conf.genesis_secrets {
                 Some(ref file) => {
                     genesis::default(secret_store.as_ref());
@@ -231,7 +231,7 @@ impl ArchiveClient {
         ));
         sync.register().unwrap();
 
-        if conf.raw_conf.test_mode && conf.raw_conf.data_propagate_enabled {
+        if conf.is_test_mode() && conf.raw_conf.data_propagate_enabled {
             let dp = Arc::new(DataPropagation::new(
                 conf.raw_conf.data_propagate_interval_ms,
                 conf.raw_conf.data_propagate_size,
@@ -277,12 +277,24 @@ impl ArchiveClient {
                     BlockGenerator::start_mining(bg, 0);
                 })
                 .expect("Mining thread spawn error");
+        } else {
+            if conf.is_dev_mode() {
+                let bg = blockgen.clone();
+                let interval_ms = conf.raw_conf.dev_block_interval_ms;
+                info!("Start auto block generation");
+                thread::Builder::new()
+                    .name("auto_mining".into())
+                    .spawn(move || {
+                        bg.auto_block_generation(interval_ms);
+                    })
+                    .expect("Mining thread spawn error");
+            }
         }
 
         let tx_conf = conf.tx_gen_config();
         let txgen_handle = if tx_conf.generate_tx {
             let txgen_clone = txgen.clone();
-            let t = if conf.raw_conf.test_mode {
+            let t = if conf.is_test_mode() {
                 match conf.raw_conf.genesis_secrets {
                     Some(ref _file) => {
                         thread::Builder::new()
@@ -364,7 +376,7 @@ impl ArchiveClient {
                 None,
                 conf.raw_conf.jsonrpc_tcp_port,
             ),
-            if conf.raw_conf.test_mode {
+            if conf.is_test_mode() {
                 setup_debug_rpc_apis(
                     common_impl.clone(),
                     rpc_impl.clone(),
@@ -389,7 +401,7 @@ impl ArchiveClient {
                 conf.raw_conf.jsonrpc_cors.clone(),
                 conf.raw_conf.jsonrpc_http_keep_alive,
             ),
-            if conf.raw_conf.test_mode {
+            if conf.is_test_or_dev_mode() {
                 setup_debug_rpc_apis(common_impl, rpc_impl, None, &conf)
             } else {
                 setup_public_rpc_apis(common_impl, rpc_impl, None, &conf)

--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -145,6 +145,8 @@ build_config! {
         //
         // `dev` mode is for users to run a single node that automatically
         //     generates blocks with fixed intervals
+        //     * Open port 12536 for tcp rpc if `jsonrpc_tcp_port` is not provided.
+        //     * Open port 12537 for http rpc if `jsonrpc_http_port` is not provided.
         //     * generate blocks automatically without PoW if `start_mining` is false
         //     * Skip catch-up mode even there is no peer
         //

--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -59,7 +59,6 @@ build_config! {
         (discovery_housekeeping_timeout_ms, (u64), 1000)
         (node_table_timeout, (Option<u64>), Some(300))
         (node_table_promotion_timeout, (Option<u64>), Some(3 * 24 * 3600))
-        (test_mode, (bool), false)
         (db_cache_size, (Option<usize>), Some(128))
         (db_compaction_profile, (Option<String>), None)
         (db_dir, (Option<String>), Some("./blockchain_db".to_string()))
@@ -129,6 +128,31 @@ build_config! {
         (enable_state_expose, (bool), false)
         (get_logs_filter_max_limit, (Option<usize>), None)
         (throttling_conf, (Option<String>), None)
+
+        // Some preset configurations.
+        //
+        // For both `test` and `dev` modes, we will
+        //     * Set initial difficulty to 4
+        //     * Allow calling test and debug rpc from public port
+        //
+        // `test` mode is for Conflux testing and debugging, we will
+        //     * Add latency to peer connections
+        //     * Skip handshake encryption check
+        //     * Skip header timestamp verification
+        //     * Handle NewBlockHash even in catch-up mode
+        //     * Allow data propagation test
+        //     * Allow setting genesis accounts and generate tx from secrets
+        //
+        // `dev` mode is for users to run a single node that automatically
+        //     generates blocks with fixed intervals
+        //     * generate blocks automatically without PoW if `start_mining` is false
+        //     * Skip catch-up mode even there is no peer
+        //
+        (mode, (Option<String>), None)
+
+        // Controls block generation speed.
+        // Only effective in `dev` mode and `start_mining` is false
+        (dev_block_interval_ms, (u64), 250)
     }
     {
         (
@@ -206,7 +230,7 @@ impl Configuration {
             network_config.connection_lifetime_for_promotion =
                 Duration::from_secs(nt_promotion_timeout);
         }
-        network_config.test_mode = self.raw_conf.test_mode;
+        network_config.test_mode = self.is_test_mode();
         network_config.subnet_quota = self.raw_conf.subnet_quota;
         network_config.session_ip_limit_config =
             self.raw_conf.session_ip_limits.clone().try_into().map_err(
@@ -302,7 +326,7 @@ impl Configuration {
                     .expect("Stratum secret should be 64-digit hex string without 0x prefix"));
 
         ProofOfWorkConfig::new(
-            self.raw_conf.test_mode,
+            self.is_test_or_dev_mode(),
             self.raw_conf.use_stratum,
             self.raw_conf.initial_difficulty,
             stratum_listen_addr,
@@ -312,7 +336,7 @@ impl Configuration {
     }
 
     pub fn verification_config(&self) -> VerificationConfig {
-        VerificationConfig::new(self.raw_conf.test_mode)
+        VerificationConfig::new(self.is_test_mode())
     }
 
     pub fn tx_gen_config(&self) -> TransactionGeneratorConfig {
@@ -375,7 +399,8 @@ impl Configuration {
                 .raw_conf
                 .future_block_buffer_capacity,
             max_download_state_peers: self.raw_conf.max_download_state_peers,
-            test_mode: self.raw_conf.test_mode,
+            test_mode: self.is_test_mode(),
+            dev_mode: self.is_dev_mode(),
             throttling_config_file: self.raw_conf.throttling_conf.clone(),
         }
     }
@@ -433,6 +458,27 @@ impl Configuration {
     pub fn rpc_impl_config(&self) -> RpcImplConfiguration {
         RpcImplConfiguration {
             get_logs_filter_max_limit: self.raw_conf.get_logs_filter_max_limit,
+        }
+    }
+
+    pub fn is_test_mode(&self) -> bool {
+        match self.raw_conf.mode.as_ref().map(|s| s.as_str()) {
+            Some("test") => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_dev_mode(&self) -> bool {
+        match self.raw_conf.mode.as_ref().map(|s| s.as_str()) {
+            Some("dev") => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_test_or_dev_mode(&self) -> bool {
+        match self.raw_conf.mode.as_ref().map(|s| s.as_str()) {
+            Some("dev") | Some("test") => true,
+            _ => false,
         }
     }
 }

--- a/client/src/full/mod.rs
+++ b/client/src/full/mod.rs
@@ -370,7 +370,6 @@ impl FullClient {
             ),
         )?;
 
-
         if conf.is_dev_mode() {
             if conf.raw_conf.jsonrpc_tcp_port.is_none() {
                 conf.raw_conf.jsonrpc_tcp_port = Some(12536);

--- a/client/src/full/mod.rs
+++ b/client/src/full/mod.rs
@@ -89,7 +89,7 @@ pub struct FullClient {}
 impl FullClient {
     // Start all key components of Conflux and pass out their handles
     pub fn start(
-        conf: Configuration, exit: Arc<(Mutex<bool>, Condvar)>,
+        mut conf: Configuration, exit: Arc<(Mutex<bool>, Condvar)>,
     ) -> Result<FullClientHandle, String> {
         info!("Working directory: {:?}", std::env::current_dir());
 
@@ -370,6 +370,15 @@ impl FullClient {
             ),
         )?;
 
+
+        if conf.is_dev_mode() {
+            if conf.raw_conf.jsonrpc_tcp_port.is_none() {
+                conf.raw_conf.jsonrpc_tcp_port = Some(12536);
+            }
+            if conf.raw_conf.jsonrpc_http_port.is_none() {
+                conf.raw_conf.jsonrpc_http_port = Some(12537);
+            }
+        };
         let rpc_tcp_server = super::rpc::start_tcp(
             super::rpc::TcpConfiguration::new(
                 None,

--- a/client/src/light/mod.rs
+++ b/client/src/light/mod.rs
@@ -117,7 +117,7 @@ impl LightClient {
             });
         }
 
-        let genesis_accounts = if conf.raw_conf.test_mode {
+        let genesis_accounts = if conf.is_test_mode() {
             match conf.raw_conf.genesis_secrets {
                 Some(ref file) => {
                     genesis::default(secret_store.as_ref());
@@ -219,7 +219,7 @@ impl LightClient {
                 None,
                 conf.raw_conf.jsonrpc_tcp_port,
             ),
-            if conf.raw_conf.test_mode {
+            if conf.is_test_mode() {
                 setup_debug_rpc_apis_light(
                     common_impl.clone(),
                     rpc_impl.clone(),
@@ -241,7 +241,7 @@ impl LightClient {
                 conf.raw_conf.jsonrpc_cors.clone(),
                 conf.raw_conf.jsonrpc_http_keep_alive,
             ),
-            if conf.raw_conf.test_mode {
+            if conf.is_test_mode() {
                 setup_debug_rpc_apis_light(common_impl, rpc_impl)
             } else {
                 setup_public_rpc_apis_light(common_impl, rpc_impl, &conf)

--- a/client/src/tests/blockgen_tests.rs
+++ b/client/src/tests/blockgen_tests.rs
@@ -55,7 +55,7 @@ fn test_mining_10_epochs_inner(handle: &ArchiveClientHandle) {
 #[test]
 fn test_mining_10_epochs() {
     let mut conf = Configuration::default();
-    conf.raw_conf.test_mode = true;
+    conf.raw_conf.mode = Some("test".to_owned());
     conf.raw_conf.initial_difficulty = Some(10_000);
 
     let tmp_dir = TempDir::new("conflux-test").unwrap();

--- a/client/src/tests/load_chain_tests.rs
+++ b/client/src/tests/load_chain_tests.rs
@@ -52,7 +52,7 @@ fn get_expected_best_hash() -> String {
 #[test]
 fn test_load_chain() {
     let mut conf = Configuration::default();
-    conf.raw_conf.test_mode = true;
+    conf.raw_conf.mode = Some("test".to_owned());
     let tmp_dir = TempDir::new("conflux-test").unwrap();
     conf.raw_conf.db_dir = Some(
         tmp_dir

--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -324,7 +324,7 @@ impl ConsensusExecutor {
                 let height = inner.arena[pivot_arena_index].height;
                 if !self.consensus_graph_bench_mode
                 {
-                    info!(
+                    debug!(
                         "wait_and_compute_state_valid_locked, idx = {}, \
                          height = {}, era stable height = {}",
                         pivot_arena_index, height, inner.cur_era_stable_height

--- a/core/src/light_protocol/provider.rs
+++ b/core/src/light_protocol/provider.rs
@@ -595,7 +595,7 @@ impl Provider {
         msg: &dyn Message,
     ) -> Result<(), Error>
     {
-        info!("broadcast peers={:?}", peers);
+        debug!("broadcast peers={:?}", peers);
 
         let throttle_ratio = THROTTLING_SERVICE.read().get_throttling_ratio();
         let total = peers.len();
@@ -618,7 +618,7 @@ impl Provider {
     }
 
     pub fn relay_hashes(&self, hashes: Vec<H256>) -> Result<(), Error> {
-        info!("relay_hashes hashes={:?}", hashes);
+        debug!("relay_hashes hashes={:?}", hashes);
 
         if hashes.is_empty() {
             return Ok(());

--- a/core/src/storage/impls/state_manager.rs
+++ b/core/src/storage/impls/state_manager.rs
@@ -51,7 +51,7 @@ impl StateManager {
             None => {}
             Some(node) => {
                 // Debugging log.
-                info!("State root committed for epoch {:?}", epoch_id);
+                debug!("State root committed for epoch {:?}", epoch_id);
                 delta_trie.set_parent_epoch(parent_epoch_id, epoch_id.clone());
                 delta_trie.set_epoch_root(epoch_id, node.clone());
                 delta_trie.set_root_node_ref(merkle_root.clone(), node.clone());

--- a/core/src/sync/synchronization_phases.rs
+++ b/core/src/sync/synchronization_phases.rs
@@ -583,7 +583,11 @@ impl SynchronizationPhaseTrait for CatchUpSyncBlockPhase {
         // FIXME: use target_height instead.
         let middle_epoch = self.syn.get_middle_epoch();
         if middle_epoch.is_none() {
-            return self.phase_type();
+            if self.syn.is_dev_mode() {
+                return SyncPhaseType::Normal;
+            } else {
+                return self.phase_type();
+            }
         }
         let middle_epoch = middle_epoch.unwrap();
         // FIXME: OK, what if the chain height is close, or even local height is

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -260,6 +260,7 @@ pub struct ProtocolConfiguration {
     pub future_block_buffer_capacity: usize,
     pub max_download_state_peers: usize,
     pub test_mode: bool,
+    pub dev_mode: bool,
     pub throttling_config_file: Option<String>,
 }
 
@@ -271,7 +272,10 @@ impl SynchronizationProtocolHandler {
         light_provider: Arc<LightProvider>,
     ) -> Self
     {
-        let sync_state = Arc::new(SynchronizationState::new(is_full_node));
+        let sync_state = Arc::new(SynchronizationState::new(
+            is_full_node,
+            protocol_config.dev_mode,
+        ));
         let request_manager =
             Arc::new(RequestManager::new(&protocol_config, sync_state.clone()));
 

--- a/core/src/sync/synchronization_state.rs
+++ b/core/src/sync/synchronization_state.rs
@@ -55,15 +55,17 @@ pub type SynchronizationPeers =
 
 pub struct SynchronizationState {
     is_full_node: bool,
+    is_dev_mode: bool,
     pub peers: RwLock<SynchronizationPeers>,
     pub handshaking_peers: RwLock<HashMap<PeerId, Instant>>,
     pub last_sent_transaction_hashes: RwLock<HashSet<H256>>,
 }
 
 impl SynchronizationState {
-    pub fn new(is_full_node: bool) -> Self {
+    pub fn new(is_full_node: bool, is_dev_mode: bool) -> Self {
         SynchronizationState {
             is_full_node,
+            is_dev_mode,
             peers: Default::default(),
             handshaking_peers: Default::default(),
             last_sent_transaction_hashes: Default::default(),
@@ -130,6 +132,8 @@ impl SynchronizationState {
     }
 
     pub fn is_full_node(&self) -> bool { self.is_full_node }
+
+    pub fn is_dev_mode(&self) -> bool { self.is_dev_mode }
 
     // FIXME: use median instead, because it's so confusing without context.
     // FIXME: median_chain_height_from_peers.

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -3,6 +3,12 @@ about: Conflux client.
 author: The Conflux Team
 
 args:
+    - mode:
+        help: Use the preset testing configurations.
+        long: mode
+        value_name: MODE
+        takes_value: true
+        possible_values: [dev, test]
     - port:
         help: Specify the port for P2P connections.
         short: p

--- a/tests/test_framework/util.py
+++ b/tests/test_framework/util.py
@@ -265,7 +265,7 @@ def initialize_datadir(dirname, n, conf_parameters):
                         "jsonrpc_local_http_port": str(rpc_port(n)),
                         "jsonrpc_http_port": str(remote_rpc_port(n)),
                         "log_file": "\'{}\'".format(os.path.join(datadir, "conflux.log")),
-                        "test_mode": "true",
+                        "mode": "\'test\'",
                         "log_level": "\"trace\"",
                         "storage_cache_size": "200000",
                         "storage_cache_start_size": "200000",


### PR DESCRIPTION
We can now start a single node with
```
./conflux --mode dev
```
By default, it will start packing transactions and generating blocks with 4 blocks/s. It will also listen on port 12527 to serve HTTP RPC requests.

The previous configuration `test_mode=true` is changed to `mode="test"`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/821)
<!-- Reviewable:end -->
