### PR TITLE
Refactor MptCursorRw and SnapshotMptNode to prepare for snapshot chunk validator.

### DIFF
--- a/core/src/storage/impls/merkle_patricia_trie/children_table.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/children_table.rs
@@ -80,12 +80,11 @@ where ChildrenTableItem<NodeRefT>: DefaultChildrenItem<NodeRefT>
     }
 }
 
-impl<NodeRefT: 'static + NodeRefTrait> VanillaChildrenTable<NodeRefT>
-where ChildrenTableItem<NodeRefT>: DefaultChildrenItem<NodeRefT>
-{
+impl<NodeRefT: 'static + NodeRefTrait> VanillaChildrenTable<NodeRefT> {
     // FIXME: put most method in a trait.
 
-    pub fn new_from_one_child(child_index: u8, child: &NodeRefT) -> Self {
+    pub fn new_from_one_child(child_index: u8, child: &NodeRefT) -> Self
+    where ChildrenTableItem<NodeRefT>: DefaultChildrenItem<NodeRefT> {
         let mut table = VanillaChildrenTable::default();
         table.children_count = 1;
         table.table[child_index as usize] = child.clone();
@@ -102,7 +101,8 @@ where ChildrenTableItem<NodeRefT>: DefaultChildrenItem<NodeRefT>
         &mut self.children_count
     }
 
-    pub fn get_child(&self, child_index: u8) -> Option<&NodeRefT> {
+    pub fn get_child(&self, child_index: u8) -> Option<&NodeRefT>
+    where ChildrenTableItem<NodeRefT>: DefaultChildrenItem<NodeRefT> {
         let child_ref =
             unsafe { self.table.get_unchecked(child_index as usize) };
         if child_ref.eq(ChildrenTableItem::<NodeRefT>::no_child()) {

--- a/core/src/storage/impls/merkle_patricia_trie/mpt_cursor.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/mpt_cursor.rs
@@ -1275,9 +1275,24 @@ impl<Mpt> OptionUnwrapBorrowAssumedSomeExtension<Mpt> for Option<Mpt> {
     fn as_mut_assumed_owner(&mut self) -> &mut Mpt { self.as_mut().unwrap() }
 }
 
-pub fn rlp_key_value_len(_key_len: u16, _value_len: usize) -> i64 {
-    // FIXME: implement
-    unimplemented!()
+pub fn rlp_str_len(len: usize) -> i64 {
+    if len <= 55 {
+        len as i64 + 1
+    } else {
+        let mut len_of_len = 0i32;
+        while (len >> (8 * len_of_len)) > 0 {
+            len_of_len += 1;
+        }
+
+        len as i64 + 1 + len_of_len as i64
+    }
+}
+
+/// We assume that the keys and values are serialized in separate vector,
+/// therefore we only add up those rlp string lenghts.
+/// The rlp bytes for the up-most structures are ignored for sync slicer.
+pub fn rlp_key_value_len(key_len: u16, value_len: usize) -> i64 {
+    rlp_str_len(key_len.into()) + rlp_str_len(value_len)
 }
 
 use super::{

--- a/core/src/storage/impls/merkle_patricia_trie/mpt_cursor.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/mpt_cursor.rs
@@ -1152,8 +1152,7 @@ impl<Mpt: GetRwMpt> ReadWritePathNode<Mpt> {
             // The node won't merge with its first children, because either the
             // node has value, or the child node is the second child. The
             // assumption here is that in db and rust string comparison a string
-            // that is a prefixcore/src/storage/impls/merkle_patricia_trie/
-            // mpt_cursor.rs:397:47 of another string is considered smaller.
+            // that is a prefix of another string is considered smaller.
             if self.trie_node.has_value() {
                 Ok(child_node.write_out()?)
             } else if self.first_realized_child_index != 0 {

--- a/core/src/storage/impls/merkle_patricia_trie/mpt_merger.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/mpt_merger.rs
@@ -20,7 +20,10 @@
 // TODO(yz): In future merge can be made into multiple threads easily by merging
 // different children in parallel then combine the root node.
 pub struct MptMerger<'a> {
-    rw_cursor: MptCursorRw<MergeMptsInRequest<'a>>,
+    rw_cursor: MptCursorRw<
+        MergeMptsInRequest<'a>,
+        ReadWritePathNode<MergeMptsInRequest<'a>>,
+    >,
 }
 
 impl<'a> MptMerger<'a> {

--- a/core/src/storage/impls/snapshot_sync/mpt_slicer.rs
+++ b/core/src/storage/impls/snapshot_sync/mpt_slicer.rs
@@ -65,10 +65,11 @@ impl<'a> MptSlicer<'a> {
 
         for (
             this_child_index,
-            &SubtreeMerkleWithSize(
-                ref _this_child_node_merkle_ref,
+            &SubtreeMerkleWithSize {
+                merkle: _,
                 ref subtree_size,
-            ),
+                delta_subtree_size: _,
+            },
         ) in current_node
             .trie_node
             .get_children_table_ref()

--- a/core/src/storage/impls/snapshot_sync/mpt_slicer.rs
+++ b/core/src/storage/impls/snapshot_sync/mpt_slicer.rs
@@ -43,7 +43,7 @@ impl<'a> MptSlicer<'a> {
         }
     }
 
-    pub fn advance(&mut self, mut rlp_size_limit: i64) -> Result<()> {
+    pub fn advance(&mut self, mut rlp_size_limit: u64) -> Result<()> {
         let current_node = self.cursor.current_node_mut();
         // First, check the value of this node, if we are the first time
         // visiting this node.
@@ -51,12 +51,14 @@ impl<'a> MptSlicer<'a> {
             let maybe_value = current_node.value_as_slice();
             match maybe_value {
                 MptValue::Some(value) => {
-                    rlp_size_limit -= rlp_key_value_len(
+                    let key_value_size = rlp_key_value_len(
                         current_node.get_path_to_node().path_size(),
                         value.len(),
                     );
-                    if rlp_size_limit <= 0 {
+                    if rlp_size_limit <= key_value_size {
                         return Ok(());
+                    } else {
+                        rlp_size_limit -= key_value_size;
                     }
                 }
                 _ => {}

--- a/core/src/storage/impls/snapshot_sync/mpt_slicer.rs
+++ b/core/src/storage/impls/snapshot_sync/mpt_slicer.rs
@@ -44,45 +44,41 @@ impl<'a> MptSlicer<'a> {
     }
 
     pub fn advance(&mut self, mut rlp_size_limit: i64) -> Result<()> {
-        let current_node = self.cursor.get_path_nodes().last().unwrap();
-        if current_node.1 <= rlp_size_limit {
-            // check root..
-            if self.cursor.get_path_nodes().len() == 1 {
-                // Already on root node.
-                return Ok(());
-            } else {
-                rlp_size_limit -= current_node.1;
-                drop(current_node);
-                self.cursor.pop_one_node()?;
-                return self.advance(rlp_size_limit);
-            }
-        } else {
-            let current_node = self.cursor.current_node_mut();
-            // First, check the value of this node, if we are the first time
-            // visiting this node.
-            if current_node.next_child_index == 0 {
-                let maybe_value = current_node.value_as_slice();
-                match maybe_value {
-                    MptValue::Some(value) => {
-                        rlp_size_limit -= rlp_key_value_len(
-                            current_node.get_path_to_node().path_size(),
-                            value.len(),
-                        );
-                        if rlp_size_limit <= 0 {
-                            return Ok(());
-                        }
+        let current_node = self.cursor.current_node_mut();
+        // First, check the value of this node, if we are the first time
+        // visiting this node.
+        if current_node.next_child_index == 0 {
+            let maybe_value = current_node.value_as_slice();
+            match maybe_value {
+                MptValue::Some(value) => {
+                    rlp_size_limit -= rlp_key_value_len(
+                        current_node.get_path_to_node().path_size(),
+                        value.len(),
+                    );
+                    if rlp_size_limit <= 0 {
+                        return Ok(());
                     }
-                    _ => {}
                 }
+                _ => {}
             }
+        }
 
-            for (this_child_index, _this_child_node_merkle_ref) in current_node
-                .trie_node
-                .get_children_table_ref()
-                .iter()
-                .set_start_index(current_node.next_child_index)
-            {
-                let mut child_node = unsafe {
+        for (
+            this_child_index,
+            &SubtreeMerkleWithSize(
+                ref _this_child_node_merkle_ref,
+                ref subtree_size,
+            ),
+        ) in current_node
+            .trie_node
+            .get_children_table_ref()
+            .iter()
+            .set_start_index(current_node.next_child_index)
+        {
+            if *subtree_size <= rlp_size_limit {
+                rlp_size_limit -= *subtree_size;
+            } else {
+                let child_node = unsafe {
                     // Mute Rust borrow checker because there is no way
                     // around. It's actually safe to open_child_index while
                     // we immutably borrows the trie_node, because
@@ -99,18 +95,18 @@ impl<'a> MptSlicer<'a> {
                 .open_child_index(this_child_index)?
                 // Unwrap is fine because the child is guaranteed to exist.
                 .unwrap();
-                let subtree_size = child_node.1;
-                if subtree_size <= rlp_size_limit {
-                    rlp_size_limit -= subtree_size;
-                    // Move back the mut ref to mpt to the current node.
-                    current_node.mpt = child_node.take_mpt();
-                } else {
-                    drop(current_node);
 
-                    self.cursor.push_node(child_node);
-                    return self.advance(rlp_size_limit);
-                }
+                drop(current_node);
+
+                self.cursor.push_node(child_node);
+                return self.advance(rlp_size_limit);
             }
+        }
+
+        // Pop-up because subtree isn't large enough.
+        if rlp_size_limit > 0 && self.cursor.get_path_nodes().len() > 1 {
+            self.cursor.pop_one_node()?;
+            return self.advance(rlp_size_limit);
         }
 
         Ok(())
@@ -118,7 +114,9 @@ impl<'a> MptSlicer<'a> {
 }
 
 use super::super::{
-    super::storage_db::snapshot_mpt::SnapshotMptTraitReadOnly,
+    super::storage_db::snapshot_mpt::{
+        SnapshotMptTraitReadOnly, SubtreeMerkleWithSize,
+    },
     errors::*,
     merkle_patricia_trie::{mpt_cursor::*, *},
 };

--- a/core/src/storage/impls/storage_db/snapshot_db_sqlite.rs
+++ b/core/src/storage/impls/storage_db/snapshot_db_sqlite.rs
@@ -24,8 +24,8 @@ lazy_static! {
         )
         .unwrap();
         let mpt_statements = KvdbSqliteStatements::make_statements(
-            &["node_rlp", "subtree_kv_rlp_size"],
-            &["BLOB", "INTEGER"],
+            &["node_rlp"],
+            &["BLOB"],
             SnapshotDbSqlite::SNAPSHOT_MPT_TABLE_NAME,
             false,
         )
@@ -274,12 +274,7 @@ impl SnapshotDbSqlite {
     ) -> Result<SnapshotMptValue> {
         let key = row.read::<Vec<u8>>(0)?;
         let value = row.read::<Vec<u8>>(1)?;
-        let subtree_size = row.read::<i64>(2)?;
-        Ok((
-            key.into_boxed_slice(),
-            value.into_boxed_slice(),
-            subtree_size,
-        ))
+        Ok((key.into_boxed_slice(), value.into_boxed_slice()))
     }
 
     fn open_snapshot_mpt_for_write(

--- a/core/src/storage/storage_db/snapshot_mpt.rs
+++ b/core/src/storage/storage_db/snapshot_mpt.rs
@@ -14,8 +14,8 @@ pub struct SnapshotMptNode(pub VanillaTrieNode<SubtreeMerkleWithSize>);
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct SubtreeMerkleWithSize {
     pub merkle: MerkleHash,
-    pub subtree_size: i64,
-    pub delta_subtree_size: i64,
+    pub subtree_size: u64,
+    pub delta_subtree_size: u64,
 }
 
 pub trait SnapshotMptTraitReadOnly {
@@ -67,11 +67,11 @@ impl SnapshotMptNode {
         Self(node)
     }
 
-    pub fn subtree_size(&self) -> i64 { Self::initial_subtree_size(&self.0) }
+    pub fn subtree_size(&self) -> u64 { Self::initial_subtree_size(&self.0) }
 
     fn initial_subtree_size(
         node: &VanillaTrieNode<SubtreeMerkleWithSize>,
-    ) -> i64 {
+    ) -> u64 {
         let mut size = 0;
         for (
             _child_index,
@@ -132,8 +132,8 @@ impl Decodable for SubtreeMerkleWithSize {
     fn decode(rlp: &Rlp) -> std::result::Result<Self, DecoderError> {
         Ok(Self {
             merkle: rlp.val_at(0)?,
-            subtree_size: rlp.val_at::<u64>(1)? as i64,
-            delta_subtree_size: rlp.val_at::<u64>(2)? as i64,
+            subtree_size: rlp.val_at::<u64>(1)?,
+            delta_subtree_size: rlp.val_at::<u64>(2)?,
         })
     }
 }
@@ -142,8 +142,8 @@ impl Encodable for SubtreeMerkleWithSize {
     fn rlp_append(&self, s: &mut RlpStream) {
         s.begin_list(2)
             .append(&self.merkle)
-            .append(&(self.subtree_size as u64))
-            .append(&(self.delta_subtree_size as u64));
+            .append(&self.subtree_size)
+            .append(&self.delta_subtree_size);
     }
 }
 

--- a/core/src/storage/storage_db/snapshot_mpt.rs
+++ b/core/src/storage/storage_db/snapshot_mpt.rs
@@ -2,12 +2,17 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-pub type SnapshotMptValue = (Box<[u8]>, Box<[u8]>, i64);
+pub type SnapshotMptValue = (Box<[u8]>, Box<[u8]>);
 
-make_tuple_with_index_ext!(SnapshotMptDbValue(Box<[u8]>: pub, i64: pub));
-// TODO: VanillaTrieNode<(MerkleHash, i64)>. Move the subtree size inside
-// children table to make seeking by rlp size posisition faster.
-make_tuple_with_index_ext!(SnapshotMptNode(VanillaTrieNode<MerkleHash>: pub, i64: pub));
+pub type SnapshotMptDbValue = Box<[u8]>;
+/// We use VanillaTrieNode<(MerkleHash, i64)> instead of
+/// (VanillaTrieNode<MerkleHash>, i64) to make seeking by rlp size position
+/// faster.
+#[derive(Clone, Default)]
+pub struct SnapshotMptNode(pub VanillaTrieNode<SubtreeMerkleWithSize>);
+
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct SubtreeMerkleWithSize(pub MerkleHash, pub i64);
 
 pub trait SnapshotMptTraitReadOnly {
     fn get_merkle_root(&self) -> &MerkleHash;
@@ -22,35 +27,84 @@ pub trait SnapshotMptTraitReadOnly {
 pub trait SnapshotMptTraitSingleWriter: SnapshotMptTraitReadOnly {
     fn as_readonly(&mut self) -> &mut dyn SnapshotMptTraitReadOnly;
     fn delete_node(&mut self, path: &dyn CompressedPathTrait) -> Result<()>;
+    // FIXME: It seems better to pass by value, however in one place we can't
+    // move away structure field in drop().
     fn write_node(
         &mut self, path: &dyn CompressedPathTrait, trie_node: &SnapshotMptNode,
     ) -> Result<()>;
-}
-
-pub trait SnapshotMptIteraterTrait:
-    FallibleIterator<
-    Item = (CompressedPathRaw, VanillaTrieNode<MerkleHash>, i64),
-    Error = Error,
->
-{
-}
-
-impl<
-        T: FallibleIterator<
-            Item = (CompressedPathRaw, VanillaTrieNode<MerkleHash>, i64),
-            Error = Error,
-        >,
-    > SnapshotMptIteraterTrait for T
-{
 }
 
 // TODO: A snapshot mpt iterator is suitable to work as base_mpt in MptMerger's
 // TODO: save-as mode, because MptMerger always access nodes in snapshot mpt in
 // TODO: increasing order. we need to make special generalization for MptMerger
 // TODO: to take SnapshotMptIteraterTrait as input.
+pub trait SnapshotMptIteraterTrait:
+    FallibleIterator<Item = (CompressedPathRaw, SnapshotMptNode), Error = Error>
+{
+}
+
+impl<
+        T: FallibleIterator<
+            Item = (CompressedPathRaw, SnapshotMptNode),
+            Error = Error,
+        >,
+    > SnapshotMptIteraterTrait for T
+{
+}
+
+impl SnapshotMptNode {
+    pub const EMPTY_CHILD: SubtreeMerkleWithSize =
+        SubtreeMerkleWithSize(MERKLE_NULL_NODE, 0);
+
+    pub fn new(node: VanillaTrieNode<SubtreeMerkleWithSize>) -> Self {
+        Self(node)
+    }
+
+    pub fn subtree_size(&self) -> i64 { Self::initial_subtree_size(&self.0) }
+
+    fn initial_subtree_size(
+        node: &VanillaTrieNode<SubtreeMerkleWithSize>,
+    ) -> i64 {
+        let mut size = 0;
+        for (
+            _child_index,
+            &SubtreeMerkleWithSize(ref _merkle, ref subtree_size),
+        ) in node.get_children_table_ref().iter()
+        {
+            size += subtree_size;
+        }
+
+        size
+    }
+
+    pub fn get_children_merkle(&self) -> MaybeMerkleTable {
+        if self.get_children_count() > 0 {
+            let mut merkle_table = Some(
+                [ChildrenTableItem::<MerkleHash>::no_child().clone();
+                    CHILDREN_COUNT],
+            );
+            for (
+                child_index,
+                &SubtreeMerkleWithSize(ref merkle, _subtree_size),
+            ) in self.get_children_table_ref().iter()
+            {
+                merkle_table.as_mut().unwrap()[child_index as usize] = *merkle;
+            }
+            merkle_table
+        } else {
+            None
+        }
+    }
+}
+
+impl Decodable for SnapshotMptNode {
+    fn decode(rlp: &Rlp) -> std::result::Result<Self, DecoderError> {
+        Ok(Self::new(rlp.as_val()?))
+    }
+}
 
 impl Deref for SnapshotMptNode {
-    type Target = VanillaTrieNode<MerkleHash>;
+    type Target = VanillaTrieNode<SubtreeMerkleWithSize>;
 
     fn deref(&self) -> &Self::Target { &self.0 }
 }
@@ -59,15 +113,37 @@ impl DerefMut for SnapshotMptNode {
     fn deref_mut(&mut self) -> &mut Self::Target { &mut self.0 }
 }
 
-use super::super::{
-    impls::{
-        errors::*,
-        merkle_patricia_trie::{
-            CompressedPathRaw, CompressedPathTrait, VanillaTrieNode,
-        },
+impl Decodable for SubtreeMerkleWithSize {
+    fn decode(rlp: &Rlp) -> std::result::Result<Self, DecoderError> {
+        Ok(Self(rlp.val_at(0)?, rlp.val_at::<u64>(1)? as i64))
+    }
+}
+
+impl Encodable for SubtreeMerkleWithSize {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        s.begin_list(2).append(&self.0).append(&(self.1 as u64));
+    }
+}
+
+impl NodeRefTrait for SubtreeMerkleWithSize {}
+
+impl DefaultChildrenItem<SubtreeMerkleWithSize>
+    for ChildrenTableItem<SubtreeMerkleWithSize>
+{
+    fn no_child() -> &'static SubtreeMerkleWithSize {
+        &SnapshotMptNode::EMPTY_CHILD
+    }
+}
+
+use super::super::impls::{
+    errors::*,
+    merkle_patricia_trie::{
+        merkle::MaybeMerkleTable, ChildrenTableItem, CompressedPathRaw,
+        CompressedPathTrait, DefaultChildrenItem, NodeRefTrait, TrieNodeTrait,
+        VanillaTrieNode, CHILDREN_COUNT,
     },
-    utils::tuple::*,
 };
 use fallible_iterator::FallibleIterator;
-use primitives::MerkleHash;
+use primitives::{MerkleHash, MERKLE_NULL_NODE};
+use rlp::*;
 use std::ops::{Deref, DerefMut};


### PR DESCRIPTION
SnapshotMptNode now keep all children subtree size in children table, to make the MptSlicer load fewer nodes.

Added a special subtree size for the "Delta" between a snapshot and its parent snapshot in SnapshotMptNode, to make it possible to cut chunks for OneStepSync.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/824)
<!-- Reviewable:end -->
