### PR TITLE
MptSliceVerifier for Snapshot Sync.

### DIFF
--- a/core/src/storage/impls/delta_mpt/mem_optimized_trie_node.rs
+++ b/core/src/storage/impls/delta_mpt/mem_optimized_trie_node.rs
@@ -287,6 +287,12 @@ impl<CacheAlgoDataT: CacheAlgoDataTrait> TrieNodeTrait
         );
     }
 
+    unsafe fn get_child_mut_unchecked(
+        &mut self, child_index: u8,
+    ) -> &mut Self::NodeRefType {
+        self.children_table.get_child_mut_unchecked(child_index)
+    }
+
     unsafe fn replace_child_unchecked<T>(&mut self, child_index: u8, child: T)
     where ChildrenTableItem<NodeRefDeltaMptCompact>:
             WrappedCreateFrom<T, NodeRefDeltaMptCompact> {

--- a/core/src/storage/impls/errors.rs
+++ b/core/src/storage/impls/errors.rs
@@ -100,5 +100,10 @@ error_chain! {
             description("Trie proof is invalid."),
             display("Trie proof is invalid."),
         }
+
+        InvalidSnapshotSyncProof {
+            description("Snapshot sync proof is invalid"),
+            display("Snapshot sync proof is invalid"),
+        }
     }
 }

--- a/core/src/storage/impls/errors.rs
+++ b/core/src/storage/impls/errors.rs
@@ -95,5 +95,10 @@ error_chain! {
             description("Can't find requested Delta MPT in registry."),
             display("Can't find requested Delta MPT in registry."),
         }
+
+        InvalidTrieProof {
+            description("Trie proof is invalid."),
+            display("Trie proof is invalid."),
+        }
     }
 }

--- a/core/src/storage/impls/merkle_patricia_trie/children_table.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/children_table.rs
@@ -97,7 +97,7 @@ impl<NodeRefT: 'static + NodeRefTrait> VanillaChildrenTable<NodeRefT> {
 
     pub fn get_children_count(&self) -> u8 { self.children_count }
 
-    pub fn get_children_count_mut(&mut self) -> &mut u8 {
+    pub unsafe fn get_children_count_mut(&mut self) -> &mut u8 {
         &mut self.children_count
     }
 

--- a/core/src/storage/impls/merkle_patricia_trie/children_table.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/children_table.rs
@@ -248,9 +248,15 @@ impl<NodeRefT: NodeRefTrait> CompactedChildrenTable<NodeRefT> {
         }
     }
 
+    pub unsafe fn get_child_mut_unchecked(
+        &mut self, index: u8,
+    ) -> &mut NodeRefT {
+        &mut *self.table_ptr.add(Self::lower_bound(self.bitmap, index))
+    }
+
     /// Unsafe because child must already exist at the index.
     pub unsafe fn set_child_unchecked(&mut self, index: u8, value: NodeRefT) {
-        (*self.table_ptr.add(Self::lower_bound(self.bitmap, index))) =
+        *self.table_ptr.add(Self::lower_bound(self.bitmap, index)) =
             value.clone();
     }
 

--- a/core/src/storage/impls/merkle_patricia_trie/compressed_path.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/compressed_path.rs
@@ -12,6 +12,13 @@ pub trait CompressedPathTrait {
         self.path_size() * 2 - (self.end_mask() != 0) as u16
     }
 
+    fn as_ref(&self) -> CompressedPathRef {
+        CompressedPathRef {
+            path_slice: self.path_slice(),
+            end_mask: self.end_mask(),
+        }
+    }
+
     // TODO(yz): the format can be optimized to save 1 or 2 bytes: a string with
     // 0 prefix means path_slice with even length, a string with 1 prefix
     // means path_slice with odd length.
@@ -37,7 +44,7 @@ impl<'a> CompressedPathTrait for &'a [u8] {
     fn end_mask(&self) -> u8 { 0 }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub struct CompressedPathRef<'a> {
     path_slice: &'a [u8],
     end_mask: u8,
@@ -279,6 +286,12 @@ impl PartialEq<Self> for CompressedPathRaw {
     fn eq(&self, other: &Self) -> bool { self.as_ref().eq(&other.as_ref()) }
 }
 
+impl Eq for CompressedPathRaw {}
+
+impl Hash for CompressedPathRaw {
+    fn hash<H: Hasher>(&self, state: &mut H) { self.as_ref().hash(state) }
+}
+
 impl Debug for CompressedPathRaw {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         self.as_ref().fmt(f)
@@ -286,21 +299,32 @@ impl Debug for CompressedPathRaw {
 }
 
 impl CompressedPathRaw {
-    pub fn as_ref(&self) -> CompressedPathRef {
-        CompressedPathRef {
-            path_slice: self.path_slice(),
-            end_mask: self.end_mask,
-        }
-    }
-
     pub fn path_slice_mut(&mut self) -> &mut [u8] {
         self.path.get_slice_mut(self.path_size as usize)
     }
 }
 
+impl<'a> PartialEq<Self> for dyn CompressedPathTrait + 'a {
+    fn eq(&self, other: &(dyn CompressedPathTrait + 'a)) -> bool {
+        self.as_ref().eq(&other.as_ref())
+    }
+}
+
+impl<'a> Eq for dyn CompressedPathTrait + 'a {}
+
+impl<'a> Hash for dyn CompressedPathTrait + 'a {
+    fn hash<H: Hasher>(&self, state: &mut H) { self.as_ref().hash(state) }
+}
+
+impl<'a> Borrow<dyn CompressedPathTrait + 'a> for CompressedPathRaw {
+    fn borrow(&self) -> &(dyn CompressedPathTrait + 'a) { self }
+}
+
 use super::maybe_in_place_byte_array::*;
 use rlp::*;
 use std::{
+    borrow::Borrow,
     fmt::{Debug, Error, Formatter},
+    hash::{Hash, Hasher},
     result::Result,
 };

--- a/core/src/storage/impls/merkle_patricia_trie/mod.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/mod.rs
@@ -16,6 +16,9 @@ pub mod trie_node;
 pub mod trie_proof;
 pub(super) mod walk;
 
+#[cfg(test)]
+mod tests;
+
 pub use self::{
     children_table::*,
     compressed_path::{

--- a/core/src/storage/impls/merkle_patricia_trie/mpt_cursor.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/mpt_cursor.rs
@@ -36,9 +36,8 @@ impl<Mpt: GetReadMpt, PathNode: PathNodeTrait<Mpt>> MptCursor<Mpt, PathNode> {
         let mut trie_nodes = Vec::with_capacity(self.path_nodes.len());
         for node in &self.path_nodes {
             let trie_node = &node.get_basic_path_node().trie_node;
-            trie_nodes.push(TrieProofNode(VanillaTrieNode::new(
-                trie_node.get_merkle().clone(),
-                trie_node.get_children_merkle().map_or_else(
+            trie_nodes.push(TrieProofNode::new(
+                trie_node.get_children_merkles().map_or_else(
                     || VanillaChildrenTable::default(),
                     |merkle_table| merkle_table.into(),
                 ),
@@ -47,9 +46,12 @@ impl<Mpt: GetReadMpt, PathNode: PathNodeTrait<Mpt>> MptCursor<Mpt, PathNode> {
                     .into_option()
                     .map(|slice| slice.into()),
                 trie_node.compressed_path_ref().into(),
-            )))
+            ))
         }
-        TrieProof::new(trie_nodes)
+
+        // Unwrap is fine because the TrieProof must be valid unless the Mpt is
+        // being modified.
+        TrieProof::new(trie_nodes).unwrap()
     }
 
     pub fn push_node(&mut self, node: PathNode) { self.path_nodes.push(node); }
@@ -329,7 +331,7 @@ impl<Mpt: GetRwMpt, PathNode: RwPathNodeTrait<Mpt>> MptCursorRw<Mpt, PathNode> {
                 }
                 let new_node = PathNode::new(
                     BasicPathNode::new(
-                        SnapshotMptNode::new(VanillaTrieNode::new(
+                        SnapshotMptNode(VanillaTrieNode::new(
                             MERKLE_NULL_NODE,
                             Default::default(),
                             Some(value),
@@ -371,7 +373,7 @@ impl<Mpt: GetRwMpt, PathNode: RwPathNodeTrait<Mpt>> MptCursorRw<Mpt, PathNode> {
                 let insert_value_at_fork = key_child_index.is_none();
                 let mut fork_node = PathNode::new(
                     BasicPathNode::new(
-                        SnapshotMptNode::new(VanillaTrieNode::new(
+                        SnapshotMptNode(VanillaTrieNode::new(
                             MERKLE_NULL_NODE,
                             VanillaChildrenTable::new_from_one_child(
                                 unmatched_child_index,
@@ -427,7 +429,7 @@ impl<Mpt: GetRwMpt, PathNode: RwPathNodeTrait<Mpt>> MptCursorRw<Mpt, PathNode> {
 
                         let value_node = PathNode::new(
                             BasicPathNode::new(
-                                SnapshotMptNode::new(VanillaTrieNode::new(
+                                SnapshotMptNode(VanillaTrieNode::new(
                                     MERKLE_NULL_NODE,
                                     Default::default(),
                                     Some(value),
@@ -846,8 +848,7 @@ impl<Mpt: GetReadMpt> PathNodeTrait<Mpt> for BasicPathNode<Mpt> {
             None => Ok(None),
             Some(&SubtreeMerkleWithSize {
                 merkle: ref supposed_merkle_hash,
-                subtree_size: _,
-                delta_subtree_size: _,
+                ..
             }) => {
                 let mpt = self.mpt.take();
                 Ok(Some(Self::load_into(
@@ -995,7 +996,7 @@ impl<Mpt> ReadWritePathNode<Mpt> {
     fn compute_merkle(&mut self) -> MerkleHash {
         let path_merkle = self
             .trie_node
-            .compute_merkle(self.trie_node.get_children_merkle().as_ref());
+            .compute_merkle(self.trie_node.get_children_merkles().as_ref());
         self.trie_node.set_merkle(&path_merkle);
 
         path_merkle
@@ -1044,8 +1045,7 @@ impl<Mpt: GetRwMpt> ReadWritePathNode<Mpt> {
             this_child_index,
             &SubtreeMerkleWithSize {
                 merkle: ref this_child_node_merkle_ref,
-                subtree_size: _,
-                delta_subtree_size: _,
+                ..
             },
         ) in self
             .basic_node

--- a/core/src/storage/impls/merkle_patricia_trie/tests/mod.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/tests/mod.rs
@@ -2,8 +2,4 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-pub mod offer;
-pub mod restoration;
-
-pub use offer::*;
-pub use restoration::*;
+mod trie_proof_test;

--- a/core/src/storage/impls/merkle_patricia_trie/tests/trie_proof_test.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/tests/trie_proof_test.rs
@@ -1,0 +1,207 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use super::super::{
+    trie_proof::TrieProofNode, CompressedPathRaw, CompressedPathTrait,
+    TrieNodeTrait, TrieProof, VanillaChildrenTable,
+};
+use primitives::MERKLE_NULL_NODE;
+
+#[test]
+fn test_rlp() {
+    let node1 = TrieProofNode::new(
+        Default::default(),
+        Some(Box::new([0x03, 0x04, 0x05])),
+        CompressedPathRaw::new(
+            &[0x00, 0x01, 0x02],
+            CompressedPathRaw::first_nibble_mask(),
+        ),
+    );
+    assert_eq!(node1, rlp::decode(&rlp::encode(&node1)).unwrap());
+
+    let root_node = {
+        let mut children_table = VanillaChildrenTable::default();
+        unsafe {
+            *children_table.get_child_mut_unchecked(2) = *node1.get_merkle();
+            *children_table.get_children_count_mut() = 1;
+        }
+        TrieProofNode::new(children_table, None, CompressedPathRaw::default())
+    };
+
+    assert_eq!(root_node, rlp::decode(&rlp::encode(&root_node)).unwrap());
+
+    let proof = TrieProof::default();
+    assert_eq!(proof, rlp::decode(&rlp::encode(&proof)).unwrap());
+
+    let nodes = [root_node, node1]
+        .iter()
+        .cloned()
+        .cycle()
+        .take(20)
+        .collect();
+    let proof = TrieProof::new(nodes).unwrap();
+    assert_eq!(proof, rlp::decode(&rlp::encode(&proof)).unwrap());
+}
+
+#[test]
+fn test_proofs() {
+    //       ------|path: []|-----
+    //      |                     |
+    //      |              |path: [0x00, 0x00]|
+    //      |                     |
+    // |path: [0x20]|   |path: [0x30]            |
+    // |val : [0x02]|   |val : [0x00, 0x00, 0x03]|
+
+    let (key1, value1) = ([0x20], [0x02]);
+    let (key2, value2) = ([0x00, 0x00, 0x30], [0x00, 0x00, 0x03]);
+
+    let leaf1 = TrieProofNode::new(
+        Default::default(),
+        Some(Box::new(value1)),
+        (&[0x20u8][..]).into(),
+    );
+
+    let leaf2 = TrieProofNode::new(
+        Default::default(),
+        Some(Box::new(value2)),
+        (&[0x30u8][..]).into(),
+    );
+
+    let ext = {
+        let mut children = [MERKLE_NULL_NODE; 16];
+        children[0x03] = leaf2.get_merkle().clone();
+
+        TrieProofNode::new(
+            children.into(),
+            None,
+            (&[0x00u8, 0x00u8][..]).into(),
+        )
+    };
+
+    let branch = {
+        let mut children = [MERKLE_NULL_NODE; 16];
+        children[0x00] = ext.get_merkle().clone();
+        children[0x02] = leaf1.get_merkle().clone();
+
+        TrieProofNode::new(children.into(), None, Default::default())
+    };
+
+    let leaf1_hash = leaf1.get_merkle();
+    let leaf2_hash = leaf2.get_merkle();
+    let ext_hash = ext.get_merkle();
+    let branch_hash = branch.get_merkle();
+    let root = branch_hash;
+    let null = &MERKLE_NULL_NODE;
+
+    // empty proof
+    let proof = TrieProof::new(vec![]).unwrap();
+    assert!(proof.is_valid_kv(&[0x00], None, null));
+    assert!(!proof.is_valid_kv(&[0x00], None, leaf1_hash));
+    assert!(!proof.is_valid_kv(&key1, Some(&[0x00]), null));
+
+    // missing node
+    let proof = TrieProof::new(vec![branch.clone(), ext.clone()]).unwrap();
+    assert!(!proof.is_valid_kv(&key2, Some(&value2), root));
+
+    // wrong hash
+    let mut leaf2_wrong = leaf2.clone();
+    let mut wrong_merkle = leaf2_wrong.get_merkle().clone();
+    wrong_merkle.as_bytes_mut()[0] = 0x00;
+    leaf2_wrong.set_merkle(&wrong_merkle);
+
+    let proof = TrieProof::new(vec![
+        branch.clone(),
+        ext.clone(),
+        leaf1.clone(),
+        leaf2_wrong,
+    ]);
+    assert!(proof.is_err());
+
+    // wrong value
+    let proof = TrieProof::new(vec![
+        branch.clone(),
+        ext.clone(),
+        leaf1.clone(),
+        leaf2.clone(),
+    ])
+    .unwrap();
+    assert!(!proof.is_valid_kv(&key2, Some(&[0x00, 0x00, 0x04]), root));
+
+    // valid proof
+    let proof = TrieProof::new(vec![
+        branch.clone(),
+        ext.clone(),
+        leaf1.clone(),
+        leaf2.clone(),
+    ])
+    .unwrap();
+
+    assert!(proof.is_valid_kv(&key1, Some(&value1), root));
+    assert!(proof.is_valid_kv(&key2, Some(&value2), root));
+    assert!(proof.is_valid_kv(&[0x01], None, root));
+
+    // wrong root
+    assert!(!proof.is_valid_kv(&key2, Some(&value2), leaf1_hash));
+
+    // path to `branch` (root)
+    let key = &[];
+    assert!(proof.is_valid_path_to(key, branch_hash, root));
+    assert!(!proof.is_valid_path_to(key, leaf1_hash, root));
+    assert!(!proof.is_valid_path_to(key, ext_hash, root));
+    assert!(!proof.is_valid_path_to(key, leaf2_hash, root));
+
+    // path to `leaf1`
+    let compressed_path_ref = leaf1.compressed_path_ref();
+    let path = compressed_path_ref.path_slice();
+    assert!(proof.is_valid_path_to(path, leaf1_hash, root));
+    assert!(!proof.is_valid_path_to(path, branch_hash, root));
+    assert!(!proof.is_valid_path_to(path, ext_hash, root));
+    assert!(!proof.is_valid_path_to(path, leaf2_hash, root));
+
+    // path to `ext`
+    let compressed_path_ref = ext.compressed_path_ref();
+    let path = compressed_path_ref.path_slice();
+    assert!(proof.is_valid_path_to(path, ext_hash, root));
+    assert!(!proof.is_valid_path_to(path, branch_hash, root));
+    assert!(!proof.is_valid_path_to(path, leaf1_hash, root));
+    assert!(!proof.is_valid_path_to(path, leaf2_hash, root));
+
+    // path to `leaf2`
+    let path = &key2[..];
+    assert!(proof.is_valid_path_to(path, leaf2_hash, root));
+    assert!(!proof.is_valid_path_to(path, branch_hash, root));
+    assert!(!proof.is_valid_path_to(path, leaf1_hash, root));
+    assert!(!proof.is_valid_path_to(path, ext_hash, root));
+
+    // non-existent prefix
+    let path = &[0x00];
+    assert!(proof.is_valid_path_to(path, null, root));
+    assert!(!proof.is_valid_path_to(path, branch_hash, root));
+    assert!(!proof.is_valid_path_to(path, leaf1_hash, root));
+    assert!(!proof.is_valid_path_to(path, ext_hash, root));
+    assert!(!proof.is_valid_path_to(path, leaf2_hash, root));
+
+    // non-existent path
+    let path = &[0x10];
+    assert!(proof.is_valid_path_to(path, null, root));
+    assert!(!proof.is_valid_path_to(path, branch_hash, root));
+    assert!(!proof.is_valid_path_to(path, leaf1_hash, root));
+    assert!(!proof.is_valid_path_to(path, ext_hash, root));
+    assert!(!proof.is_valid_path_to(path, leaf2_hash, root));
+
+    // non-existent path with existing prefix
+    let path = &[0x00, 0x00, 0x30, 0x04];
+    assert!(proof.is_valid_path_to(path, null, root));
+    assert!(!proof.is_valid_path_to(path, branch_hash, root));
+    assert!(!proof.is_valid_path_to(path, ext_hash, root));
+    assert!(!proof.is_valid_path_to(path, leaf1_hash, root));
+    assert!(!proof.is_valid_path_to(path, leaf2_hash, root));
+
+    // empty trie
+    assert!(proof.is_valid_path_to(&[], null, null));
+    assert!(proof.is_valid_path_to(&[0x00], null, null));
+
+    assert!(!proof.is_valid_path_to(&[], branch_hash, null));
+    assert!(!proof.is_valid_path_to(&[0x00], branch_hash, null));
+}

--- a/core/src/storage/impls/merkle_patricia_trie/trie_node.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/trie_node.rs
@@ -28,6 +28,11 @@ pub trait TrieNodeTrait: Default {
             WrappedCreateFrom<T, Self::NodeRefType>;
 
     /// Unsafe because it's assumed that the child_index already exists.
+    unsafe fn get_child_mut_unchecked(
+        &mut self, child_index: u8,
+    ) -> &mut Self::NodeRefType;
+
+    /// Unsafe because it's assumed that the child_index already exists.
     unsafe fn replace_child_unchecked<T>(&mut self, child_index: u8, child: T)
     where ChildrenTableItem<Self::NodeRefType>:
             WrappedCreateFrom<T, Self::NodeRefType>;
@@ -135,6 +140,12 @@ where ChildrenTableItem<NodeRefT>: DefaultChildrenItem<NodeRefT>
             child,
         );
         *self.children_table.get_children_count_mut() += 1;
+    }
+
+    unsafe fn get_child_mut_unchecked(
+        &mut self, child_index: u8,
+    ) -> &mut NodeRefT {
+        self.children_table.get_child_mut_unchecked(child_index)
     }
 
     unsafe fn replace_child_unchecked<T>(&mut self, child_index: u8, child: T)

--- a/core/src/storage/impls/merkle_patricia_trie/trie_node.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/trie_node.rs
@@ -201,7 +201,7 @@ impl<NodeRefT: NodeRefTrait> VanillaTrieNode<NodeRefT> {
 }
 
 impl VanillaTrieNode<MerkleHash> {
-    pub fn get_children_merkle(&self) -> MaybeMerkleTableRef {
+    pub fn get_children_merkles(&self) -> MaybeMerkleTableRef {
         if self.get_children_count() > 0 {
             Some(&self.children_table.get_children_table())
         } else {

--- a/core/src/storage/impls/merkle_patricia_trie/trie_proof.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/trie_proof.rs
@@ -2,86 +2,142 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use cfx_types::H256;
-use primitives::{MerkleHash, MERKLE_NULL_NODE};
-use std::{
-    collections::HashMap,
-    ops::{Deref, DerefMut},
-};
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct TrieProof {
+    /// The first node must be the root node. Child node must come later than
+    /// parent node.
+    pub nodes: Vec<TrieProofNode>,
+    pub merkle_to_node_index: HashMap<MerkleHash, usize>,
+    /// Root node doesn't have parent, so we set an invalid parent_index:
+    /// number_nodes.
+    pub parent_node_index: Vec<usize>,
+    // Root node doesn't have parent, so we leave child_index[0]
+    // default-initialized to 0.
+    pub child_index: Vec<u8>,
+    pub number_leaf_nodes: u32,
+}
 
-use super::{
-    merkle::compute_merkle,
-    walk::{access_mode::Read, TrieNodeWalkTrait, WalkStop},
-    TrieNodeTrait, VanillaTrieNode,
-};
-use rlp_derive::{RlpDecodable, RlpEncodable};
-
-#[derive(Clone, Debug, Default, PartialEq, RlpDecodable, RlpEncodable)]
-// FIXME: in rlp encode / decode, children_count should be omitted.
-pub struct TrieProofNode(pub VanillaTrieNode<MerkleHash>);
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct TrieProofNode(VanillaTrieNode<MerkleHash>);
 
 impl TrieProofNode {
-    pub fn is_valid(&self) -> bool {
-        self.compute_merkle().eq(self.get_merkle())
+    pub fn new(
+        children_table: VanillaChildrenTable<MerkleHash>,
+        maybe_value: Option<Box<[u8]>>, compressed_path: CompressedPathRaw,
+    ) -> Self
+    {
+        let merkle = Self::compute_merkle(
+            compressed_path.as_ref(),
+            if children_table.get_children_count() == 0 {
+                None
+            } else {
+                Some(children_table.get_children_table())
+            },
+            maybe_value.as_ref().map(|v| v.as_ref()),
+        );
+        Self(VanillaTrieNode::new(
+            merkle,
+            children_table,
+            maybe_value,
+            compressed_path,
+        ))
     }
 
     // \w  path: keccak([mask, [path...], keccak(rlp([[children...]?, value]))])
     // \wo path: keccak(rlp([[children...]?, value]))
-    pub fn compute_merkle(&self) -> MerkleHash {
-        compute_merkle(
-            self.compressed_path_ref(),
-            self.get_children_merkle(),
-            self.value_as_slice().into_option(),
-        )
+    pub fn compute_merkle(
+        compressed_path_ref: CompressedPathRef,
+        children_merkles: MaybeMerkleTableRef, maybe_value: Option<&[u8]>,
+    ) -> MerkleHash
+    {
+        compute_merkle(compressed_path_ref, children_merkles, maybe_value)
     }
 }
 
-impl Deref for TrieProofNode {
-    type Target = VanillaTrieNode<MerkleHash>;
-
-    fn deref(&self) -> &Self::Target { &self.0 }
-}
-
-impl DerefMut for TrieProofNode {
-    fn deref_mut(&mut self) -> &mut <Self as Deref>::Target { &mut self.0 }
-}
-
-#[derive(Clone, Debug, Default, PartialEq, RlpEncodable, RlpDecodable)]
-pub struct TrieProof {
-    pub nodes: Vec<TrieProofNode>,
-}
-
 impl TrieProof {
-    pub fn new(nodes: Vec<TrieProofNode>) -> Self { TrieProof { nodes } }
+    /// Makes sure that the proof nodes are valid and connected at the time of
+    /// creation.
+    pub fn new(nodes: Vec<TrieProofNode>) -> Result<Self> {
+        let merkle_to_node_index = nodes
+            .iter()
+            .enumerate()
+            .map(|(index, node)| (node.get_merkle().clone(), index))
+            .collect::<HashMap<H256, usize>>();
+        let number_nodes = nodes.len();
+        let mut parent_node_index = Vec::with_capacity(number_nodes);
+        let mut child_index = Vec::with_capacity(number_nodes);
+        let mut is_non_leaf = vec![false; number_nodes];
+
+        // Connectivity check.
+        let mut connected_child_parent_map =
+            HashMap::<MerkleHash, (usize, u8), RandomState>::default();
+        match nodes.get(0) {
+            None => {}
+            Some(node) => {
+                connected_child_parent_map
+                    .insert(node.get_merkle().clone(), (number_nodes, 0));
+            }
+        }
+        for (parent_index, node) in nodes.iter().enumerate() {
+            match connected_child_parent_map.get(node.get_merkle()) {
+                // Not connected.
+                None => bail!(ErrorKind::InvalidTrieProof),
+                Some((parent_index, child_index_of_parent)) => {
+                    parent_node_index.push(*parent_index);
+                    child_index.push(*child_index_of_parent);
+                    if *parent_index < number_nodes {
+                        is_non_leaf[*parent_index] = true;
+                    }
+                }
+            }
+            for (child_index, child_merkle) in
+                node.get_children_table_ref().iter()
+            {
+                connected_child_parent_map
+                    .insert(child_merkle.clone(), (parent_index, child_index));
+            }
+        }
+
+        let mut number_leaf_nodes = 0;
+        for non_leaf in is_non_leaf {
+            if !non_leaf {
+                number_leaf_nodes += 1;
+            }
+        }
+
+        Ok(TrieProof {
+            nodes,
+            merkle_to_node_index,
+            parent_node_index,
+            child_index,
+            number_leaf_nodes,
+        })
+    }
 
     /// Verify that the trie `root` has `value` under `key`.
     /// Use `None` for exclusion proofs (i.e. there is no value under `key`).
     // NOTE: This API cannot be used to prove that there is a value under `key`
     // but it does not equal a given value. We add this later on if it's needed.
     pub fn is_valid_kv(
-        &self, key: &[u8], value: Option<&[u8]>, root: MerkleHash,
+        &self, key: &[u8], value: Option<&[u8]>, root: &MerkleHash,
     ) -> bool {
-        self.is_valid(key, &root, |node| match node {
+        self.is_valid(key, root, |node| match node {
             None => value == None,
             Some(node) => value == node.value_as_slice().into_option(),
         })
     }
 
+    #[cfg(test)]
     /// Verify that the trie `root` has a node with `hash` under `path`.
     /// Use `MERKLE_NULL_NODE` for exclusion proofs (i.e. `path` does not exist
     /// or leads to another hash).
     pub fn is_valid_path_to(
-        &self, path: &[u8], hash: MerkleHash, root: MerkleHash,
+        &self, path: &[u8], hash: &MerkleHash, root: &MerkleHash,
     ) -> bool {
-        self.is_valid(path, &root, |node| match node {
-            None => hash == MERKLE_NULL_NODE,
-            Some(node) => hash == *node.get_merkle(),
+        self.is_valid(path, root, |node| match node {
+            None => hash.eq(&MERKLE_NULL_NODE),
+            Some(node) => hash == node.get_merkle(),
         })
-    }
-
-    /// Verify that the trie `root` has a node under `key`.
-    pub fn is_valid_key(&self, key: &[u8], root: &MerkleHash) -> bool {
-        self.is_valid(key, root, |node| node.is_some())
     }
 
     fn is_valid(
@@ -97,31 +153,21 @@ impl TrieProof {
         // NOTE: an empty proof is only valid if it is an
         // exclusion proof for an empty trie, covered above
 
-        // store (hash -> node) mapping
-        let nodes = self
-            .nodes
-            .iter()
-            .map(|node| (node.get_merkle(), node))
-            .collect::<HashMap<&H256, &TrieProofNode>>();
-
         // traverse the trie along `path`
         let mut key = path;
         let mut hash = root;
 
         loop {
-            let node = match nodes.get(hash) {
-                Some(node) => node,
+            let node = match self.merkle_to_node_index.get(hash) {
+                Some(node_index) =>
+                // The node_index is guaranteed to exist so it's actually safe.
+                unsafe { self.nodes.get_unchecked(*node_index) }
                 None => {
-                    // missing node
-                    debug_assert!(!hash.eq(&MERKLE_NULL_NODE)); // this should lead to `ChildNotFound`
+                    // Missing node. The proof can be invalid or incomplete for
+                    // the key.
                     return false;
                 }
             };
-
-            // node hash does not match its contents
-            if !node.is_valid() {
-                return false;
-            }
 
             match node.walk::<Read>(key) {
                 WalkStop::Arrived => {
@@ -144,223 +190,74 @@ impl TrieProof {
             }
         }
     }
-}
 
-#[cfg(test)]
-mod tests {
-    use super::{
-        super::{
-            CompressedPathRaw, CompressedPathTrait, TrieNodeTrait,
-            VanillaTrieNode,
-        },
-        TrieProof, TrieProofNode,
-    };
-    use primitives::MERKLE_NULL_NODE;
+    #[inline]
+    pub fn number_nodes(&self) -> usize { self.nodes.len() }
 
-    #[test]
-    fn test_rlp() {
-        let node1 = TrieProofNode::default();
-        assert_eq!(node1, rlp::decode(&rlp::encode(&node1)).unwrap());
+    pub fn compute_paths_for_all_nodes(&self) -> Vec<CompressedPathRaw> {
+        let mut paths = Vec::with_capacity(self.nodes.len());
+        for i in 0..self.nodes.len() {
+            paths.push(CompressedPathRaw::concat(
+                &paths[self.parent_node_index[i]],
+                self.child_index[i],
+                &self.nodes[i].compressed_path_ref(),
+            ))
+        }
 
-        let node2 = {
-            let mut node = TrieProofNode(VanillaTrieNode::new(
-                MERKLE_NULL_NODE,
-                Default::default(),
-                Some(Box::new([0x03, 0x04, 0x05])),
-                CompressedPathRaw::new(
-                    &[0x00, 0x01, 0x02],
-                    CompressedPathRaw::first_nibble_mask(),
-                ),
-            ));
-            // Use .0 to avoid annoying rust compiler error: "cannot borrow
-            // `node` as immutable because it is also borrowed as mutable"
-            node.0.set_merkle(&node.compute_merkle());
-            node
-        };
-
-        assert_eq!(node2, rlp::decode(&rlp::encode(&node2)).unwrap());
-
-        let proof = TrieProof::default();
-        assert_eq!(proof, rlp::decode(&rlp::encode(&proof)).unwrap());
-
-        let nodes = [node1, node2].iter().cloned().cycle().take(20).collect();
-        let proof = TrieProof::new(nodes);
-        assert_eq!(proof, rlp::decode(&rlp::encode(&proof)).unwrap());
-    }
-
-    #[test]
-    fn test_proofs() {
-        //       ------|path: []|-----
-        //      |                     |
-        //      |              |path: [0x00, 0x00]|
-        //      |                     |
-        // |path: [0x20]|   |path: [0x30]            |
-        // |val : [0x02]|   |val : [0x00, 0x00, 0x03]|
-
-        let (key1, value1) = ([0x20], [0x02]);
-        let (key2, value2) = ([0x00, 0x00, 0x30], [0x00, 0x00, 0x03]);
-
-        let leaf1 = {
-            let mut node = TrieProofNode(VanillaTrieNode::new(
-                MERKLE_NULL_NODE,
-                Default::default(),
-                Some(Box::new(value1)),
-                (&[0x20u8][..]).into(),
-            ));
-            node.0.set_merkle(&node.compute_merkle());
-            node
-        };
-
-        let leaf2 = {
-            let mut node = TrieProofNode(VanillaTrieNode::new(
-                MERKLE_NULL_NODE,
-                Default::default(),
-                Some(Box::new(value2)),
-                (&[0x30u8][..]).into(),
-            ));
-            node.0.set_merkle(&node.compute_merkle());
-            node
-        };
-
-        let ext = {
-            let mut children = [MERKLE_NULL_NODE; 16];
-            children[0x03] = leaf2.get_merkle().clone();
-
-            let mut node = TrieProofNode(VanillaTrieNode::new(
-                MERKLE_NULL_NODE,
-                children.into(),
-                None,
-                (&[0x00u8, 0x00u8][..]).into(),
-            ));
-            node.0.set_merkle(&node.compute_merkle());
-
-            node
-        };
-
-        let branch = {
-            let mut children = [MERKLE_NULL_NODE; 16];
-            children[0x00] = ext.compute_merkle();
-            children[0x02] = leaf1.compute_merkle();
-
-            let mut node = TrieProofNode(VanillaTrieNode::new(
-                MERKLE_NULL_NODE,
-                children.into(),
-                None,
-                Default::default(),
-            ));
-            node.0.set_merkle(&node.compute_merkle());
-
-            node
-        };
-
-        let leaf1_hash = leaf1.compute_merkle();
-        let leaf2_hash = leaf2.compute_merkle();
-        let ext_hash = ext.compute_merkle();
-        let branch_hash = branch.compute_merkle();
-        let root = branch_hash.clone();
-        let null = MERKLE_NULL_NODE;
-
-        // empty proof
-        let proof = TrieProof::new(vec![]);
-        assert!(proof.is_valid_kv(&[0x00], None, null));
-        assert!(!proof.is_valid_kv(&[0x00], None, leaf1_hash));
-        assert!(!proof.is_valid_kv(&key1, Some(&[0x00]), null));
-
-        // missing node
-        let proof = TrieProof::new(vec![ext.clone(), branch.clone()]);
-        assert!(!proof.is_valid_kv(&key2, Some(&value2), root));
-
-        // wrong hash
-        let mut leaf2_wrong = leaf2.clone();
-        let mut wrong_merkle = leaf2_wrong.get_merkle().clone();
-        wrong_merkle.as_bytes_mut()[0] = 0x00;
-        leaf2_wrong.set_merkle(&wrong_merkle);
-
-        let proof = TrieProof::new(vec![
-            leaf1.clone(),
-            leaf2_wrong,
-            ext.clone(),
-            branch.clone(),
-        ]);
-        assert!(!proof.is_valid_kv(&key2, Some(&value2), root));
-
-        // wrong value
-        assert!(!proof.is_valid_kv(&key2, Some(&[0x00, 0x00, 0x04]), root));
-
-        // valid proof
-        let proof = TrieProof::new(vec![
-            leaf1.clone(),
-            leaf2.clone(),
-            ext.clone(),
-            branch.clone(),
-        ]);
-
-        assert!(proof.is_valid_kv(&key1, Some(&value1), root));
-        assert!(proof.is_valid_kv(&key2, Some(&value2), root));
-        assert!(proof.is_valid_kv(&[0x01], None, root));
-
-        // wrong root
-        assert!(!proof.is_valid_kv(&key2, Some(&value2), leaf1_hash));
-
-        // path to `branch` (root)
-        let key = &[];
-        assert!(proof.is_valid_path_to(key, branch_hash, root));
-        assert!(!proof.is_valid_path_to(key, leaf1_hash, root));
-        assert!(!proof.is_valid_path_to(key, ext_hash, root));
-        assert!(!proof.is_valid_path_to(key, leaf2_hash, root));
-
-        // path to `leaf1`
-        let compressed_path_ref = leaf1.compressed_path_ref();
-        let path = compressed_path_ref.path_slice();
-        assert!(proof.is_valid_path_to(path, leaf1_hash, root));
-        assert!(!proof.is_valid_path_to(path, branch_hash, root));
-        assert!(!proof.is_valid_path_to(path, ext_hash, root));
-        assert!(!proof.is_valid_path_to(path, leaf2_hash, root));
-
-        // path to `ext`
-        let compressed_path_ref = ext.compressed_path_ref();
-        let path = compressed_path_ref.path_slice();
-        assert!(proof.is_valid_path_to(path, ext_hash, root));
-        assert!(!proof.is_valid_path_to(path, branch_hash, root));
-        assert!(!proof.is_valid_path_to(path, leaf1_hash, root));
-        assert!(!proof.is_valid_path_to(path, leaf2_hash, root));
-
-        // path to `leaf2`
-        let path = &key2[..];
-        assert!(proof.is_valid_path_to(path, leaf2_hash, root));
-        assert!(!proof.is_valid_path_to(path, branch_hash, root));
-        assert!(!proof.is_valid_path_to(path, leaf1_hash, root));
-        assert!(!proof.is_valid_path_to(path, ext_hash, root));
-
-        // non-existent prefix
-        let path = &[0x00];
-        assert!(proof.is_valid_path_to(path, null, root));
-        assert!(!proof.is_valid_path_to(path, branch_hash, root));
-        assert!(!proof.is_valid_path_to(path, leaf1_hash, root));
-        assert!(!proof.is_valid_path_to(path, ext_hash, root));
-        assert!(!proof.is_valid_path_to(path, leaf2_hash, root));
-
-        // non-existent path
-        let path = &[0x10];
-        assert!(proof.is_valid_path_to(path, null, root));
-        assert!(!proof.is_valid_path_to(path, branch_hash, root));
-        assert!(!proof.is_valid_path_to(path, leaf1_hash, root));
-        assert!(!proof.is_valid_path_to(path, ext_hash, root));
-        assert!(!proof.is_valid_path_to(path, leaf2_hash, root));
-
-        // non-existent path with existing prefix
-        let path = &[0x00, 0x00, 0x30, 0x04];
-        assert!(proof.is_valid_path_to(path, null, root));
-        assert!(!proof.is_valid_path_to(path, branch_hash, root));
-        assert!(!proof.is_valid_path_to(path, ext_hash, root));
-        assert!(!proof.is_valid_path_to(path, leaf1_hash, root));
-        assert!(!proof.is_valid_path_to(path, leaf2_hash, root));
-
-        // empty trie
-        assert!(proof.is_valid_path_to(&[], null, null));
-        assert!(proof.is_valid_path_to(&[0x00], null, null));
-
-        assert!(!proof.is_valid_path_to(&[], branch_hash, null));
-        assert!(!proof.is_valid_path_to(&[0x00], branch_hash, null));
+        paths
     }
 }
+
+impl Encodable for TrieProof {
+    fn rlp_append(&self, s: &mut RlpStream) { s.append_list(&self.nodes); }
+}
+
+impl Decodable for TrieProof {
+    fn decode(rlp: &Rlp) -> std::result::Result<Self, DecoderError> {
+        match Self::new(rlp.as_list()?) {
+            Err(_) => Err(DecoderError::Custom("Invalid TrieProof")),
+            Ok(proof) => Ok(proof),
+        }
+    }
+}
+
+// FIXME: in rlp encode / decode, children_count and merkle_hash should be
+// omitted.
+impl Encodable for TrieProofNode {
+    fn rlp_append(&self, s: &mut RlpStream) { s.append_internal(&self.0); }
+}
+
+impl From<TrieProofNode> for VanillaTrieNode<MerkleHash> {
+    fn from(x: TrieProofNode) -> Self { x.0 }
+}
+
+impl Decodable for TrieProofNode {
+    fn decode(rlp: &Rlp) -> std::result::Result<Self, DecoderError> {
+        Ok(Self(rlp.as_val()?))
+    }
+}
+
+impl Deref for TrieProofNode {
+    type Target = VanillaTrieNode<MerkleHash>;
+
+    fn deref(&self) -> &Self::Target { &self.0 }
+}
+
+impl DerefMut for TrieProofNode {
+    fn deref_mut(&mut self) -> &mut <Self as Deref>::Target { &mut self.0 }
+}
+
+use super::{
+    super::errors::*,
+    merkle::{compute_merkle, MaybeMerkleTableRef},
+    walk::{access_mode::Read, TrieNodeWalkTrait, WalkStop},
+    CompressedPathRaw, CompressedPathRef, CompressedPathTrait, TrieNodeTrait,
+    VanillaChildrenTable, VanillaTrieNode,
+};
+use cfx_types::H256;
+use primitives::{MerkleHash, MERKLE_NULL_NODE};
+use rlp::*;
+use std::{
+    collections::{hash_map::RandomState, HashMap},
+    ops::{Deref, DerefMut},
+};

--- a/core/src/storage/impls/merkle_patricia_trie/trie_proof.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/trie_proof.rs
@@ -26,7 +26,7 @@ impl TrieProofNode {
         maybe_value: Option<Box<[u8]>>, compressed_path: CompressedPathRaw,
     ) -> Self
     {
-        let merkle = Self::compute_merkle(
+        let merkle = compute_merkle(
             compressed_path.as_ref(),
             if children_table.get_children_count() == 0 {
                 None
@@ -41,16 +41,6 @@ impl TrieProofNode {
             maybe_value,
             compressed_path,
         ))
-    }
-
-    // \w  path: keccak([mask, [path...], keccak(rlp([[children...]?, value]))])
-    // \wo path: keccak(rlp([[children...]?, value]))
-    pub fn compute_merkle(
-        compressed_path_ref: CompressedPathRef,
-        children_merkles: MaybeMerkleTableRef, maybe_value: Option<&[u8]>,
-    ) -> MerkleHash
-    {
-        compute_merkle(compressed_path_ref, children_merkles, maybe_value)
     }
 }
 
@@ -223,7 +213,10 @@ impl TrieProof {
 
     pub fn compute_paths_for_all_nodes(&self) -> Vec<CompressedPathRaw> {
         let mut paths = Vec::with_capacity(self.nodes.len());
-        for i in 0..self.nodes.len() {
+        if let Some(node) = self.nodes.get(0) {
+            paths.push(node.compressed_path_ref().into());
+        }
+        for i in 1..self.nodes.len() {
             paths.push(CompressedPathRaw::concat(
                 &paths[self.parent_node_index[i]],
                 self.child_index[i],
@@ -275,9 +268,9 @@ impl DerefMut for TrieProofNode {
 
 use super::{
     super::errors::*,
-    merkle::{compute_merkle, MaybeMerkleTableRef},
+    merkle::compute_merkle,
     walk::{access_mode::Read, TrieNodeWalkTrait, WalkStop},
-    CompressedPathRaw, CompressedPathRef, CompressedPathTrait, TrieNodeTrait,
+    CompressedPathRaw, CompressedPathTrait, TrieNodeTrait,
     VanillaChildrenTable, VanillaTrieNode,
 };
 use cfx_types::H256;

--- a/core/src/storage/impls/snapshot_sync/offer/mod.rs
+++ b/core/src/storage/impls/snapshot_sync/offer/mod.rs
@@ -1,0 +1,39 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+pub mod mpt_slicer;
+
+pub use self::mpt_slicer::MptSlicer;
+
+impl<
+        DbType: KeyValueDbTraitOwnedRead<ValueType = SnapshotMptDbValue> + ?Sized,
+        BorrowType: BorrowMut<DbType>,
+    > SnapshotMpt<DbType, BorrowType>
+where DbType:
+        for<'db> KeyValueDbIterableTrait<'db, SnapshotMptValue, Error, [u8]>
+{
+    #[allow(unused)]
+    fn compute_sync_manifest(
+        &mut self, key: &[u8],
+    ) -> Result<Option<RangedManifest>> {
+        let mut slicer = MptSlicer::new_from_key(self, key)?;
+
+        // FIXME: there is no chunk size passed, use a hardcoded number as demo.
+        slicer.advance(1048576)?;
+        let _proof_0 = slicer.to_proof();
+        let _chunk_end_key_0 = slicer.get_range_end_key();
+
+        // The chunk itself should be obtained from the SnapshotDb, not
+        // SnapshotMPT, with iter_range(key, _chunk_end_key_0).
+
+        slicer.advance(1048576)?;
+        unimplemented!()
+    }
+}
+
+use super::super::{
+    super::storage_db::*, errors::*, storage_db::snapshot_mpt::SnapshotMpt,
+};
+use crate::sync::delta::RangedManifest;
+use std::borrow::BorrowMut;

--- a/core/src/storage/impls/snapshot_sync/offer/mpt_slicer.rs
+++ b/core/src/storage/impls/snapshot_sync/offer/mpt_slicer.rs
@@ -2,6 +2,7 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
+#[allow(unused)]
 pub struct MptSlicer<'a> {
     cursor: MptCursor<
         &'a mut dyn SnapshotMptTraitReadOnly,
@@ -68,9 +69,7 @@ impl<'a> MptSlicer<'a> {
         for (
             this_child_index,
             &SubtreeMerkleWithSize {
-                merkle: _,
-                ref subtree_size,
-                delta_subtree_size: _,
+                ref subtree_size, ..
             },
         ) in current_node
             .trie_node
@@ -116,7 +115,7 @@ impl<'a> MptSlicer<'a> {
     }
 }
 
-use super::super::{
+use super::super::super::{
     super::storage_db::snapshot_mpt::{
         SnapshotMptTraitReadOnly, SubtreeMerkleWithSize,
     },

--- a/core/src/storage/impls/snapshot_sync/restoration/full_sync_verifier.rs
+++ b/core/src/storage/impls/snapshot_sync/restoration/full_sync_verifier.rs
@@ -136,6 +136,9 @@ impl FullSyncVerifier {
             for (path, node) in chunk_rebuilder.inner_nodes_to_write {
                 snapshot_mpt.write_node(&path, &node);
             }
+
+            // Combine changes around boundary nodes.
+            // TODO: this loop can be moved to constructor.
             for (path, node) in chunk_rebuilder.boundary_nodes {
                 let mut children_table = VanillaChildrenTable::default();
                 unsafe {

--- a/core/src/storage/impls/snapshot_sync/restoration/full_sync_verifier.rs
+++ b/core/src/storage/impls/snapshot_sync/restoration/full_sync_verifier.rs
@@ -2,4 +2,5 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
+#[allow(dead_code)]
 pub struct FullSyncVerifier {}

--- a/core/src/storage/impls/snapshot_sync/restoration/full_sync_verifier.rs
+++ b/core/src/storage/impls/snapshot_sync/restoration/full_sync_verifier.rs
@@ -2,5 +2,223 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-#[allow(dead_code)]
-pub struct FullSyncVerifier {}
+use crate::storage::impls::merkle_patricia_trie::VanillaChildrenTable;
+
+pub struct FullSyncVerifier {
+    number_chunks: usize,
+    merkle_root: MerkleHash,
+    chunk_boundaries: Vec<Vec<u8>>,
+    chunk_boundary_proofs: Vec<TrieProof>,
+    chunk_verified: Vec<bool>,
+    number_incomplete_chunk: usize,
+
+    pending_boundary_nodes: HashMap<CompressedPathRaw, SnapshotMptNode>,
+    boundary_subtree_total_size: HashMap<BoundarySubtreeIndex, u64>,
+
+    temp_snapshot_db: SnapshotDb,
+}
+
+#[allow(unused)]
+impl FullSyncVerifier {
+    pub fn new(
+        number_chunks: usize, chunk_boundaries: Vec<Vec<u8>>,
+        chunk_boundary_proofs: Vec<TrieProof>, merkle_root: MerkleHash,
+        snapshot_db_manager: SnapshotDbManager, epoch_id: &EpochId,
+    ) -> Result<Self>
+    {
+        if number_chunks != chunk_boundaries.len() + 1 {
+            bail!(ErrorKind::InvalidSnapshotSyncProof)
+        }
+        if number_chunks != chunk_boundary_proofs.len() + 1 {
+            bail!(ErrorKind::InvalidSnapshotSyncProof)
+        }
+        for (chunk_boundary, proof) in
+            chunk_boundaries.iter().zip(chunk_boundary_proofs.iter())
+        {
+            if merkle_root.ne(proof.get_merkle_root()) {
+                bail!(ErrorKind::InvalidSnapshotSyncProof)
+            }
+            // We don't want the proof to carry extra nodes.
+            if proof.number_leaf_nodes() != 1 {
+                bail!(ErrorKind::InvalidSnapshotSyncProof)
+            }
+            if proof.if_proves_key(&*chunk_boundary)
+                != (true, proof.get_proof_nodes().last())
+            {
+                bail!(ErrorKind::InvalidSnapshotSyncProof)
+            }
+        }
+
+        Ok(Self {
+            number_chunks,
+            merkle_root,
+            chunk_boundaries,
+            chunk_boundary_proofs,
+            chunk_verified: vec![false; number_chunks],
+            number_incomplete_chunk: number_chunks,
+            pending_boundary_nodes: Default::default(),
+            boundary_subtree_total_size: Default::default(),
+            temp_snapshot_db: snapshot_db_manager
+                .new_temp_snapshot_for_full_sync(epoch_id, &merkle_root)?,
+        })
+    }
+
+    pub fn is_completed(&self) -> bool { self.number_incomplete_chunk == 0 }
+
+    // FIXME: multi-threading, where &mut can be dropped.
+    pub fn restore_chunk<Key: Borrow<[u8]>>(
+        &mut self, chunk_index: usize, keys: &Vec<Key>, values: Vec<Box<[u8]>>,
+    ) -> Result<bool> {
+        // Check key monotone.
+        if !keys.is_empty() {
+            let mut previous = keys.first().unwrap();
+            for key in &keys[1..] {
+                if key.borrow().le(previous.borrow()) {
+                    return Ok(false);
+                }
+                previous = key;
+            }
+        }
+
+        let key_range_left;
+        let key_range_right_excl;
+        let maybe_left_proof;
+        let maybe_right_proof;
+        if chunk_index == 0 {
+            key_range_left = vec![];
+            maybe_left_proof = None;
+        } else {
+            key_range_left = self.chunk_boundaries[chunk_index - 1].clone();
+            maybe_left_proof = self.chunk_boundary_proofs.get(chunk_index - 1);
+
+            // Check key boundary.
+            if let Some(first_key) = keys.first() {
+                if first_key.borrow().lt(&*key_range_left) {
+                    return Ok(false);
+                }
+            }
+        };
+        if chunk_index == self.number_chunks - 1 {
+            key_range_right_excl = vec![];
+            maybe_right_proof = None;
+        } else {
+            key_range_right_excl = self.chunk_boundaries[chunk_index].clone();
+            maybe_right_proof = self.chunk_boundary_proofs.get(chunk_index);
+
+            // Check key boundary.
+            if let Some(last_key) = keys.last() {
+                if last_key.borrow().ge(&*key_range_right_excl) {
+                    return Ok(false);
+                }
+            }
+        }
+
+        // FIXME: multi-threading.
+        // Restore.
+        let chunk_verifier = MptSliceVerifier::new(
+            maybe_left_proof,
+            maybe_right_proof,
+            self.merkle_root.clone(),
+        );
+
+        let mut chunk_rebuilder = chunk_verifier.restore(keys, &values)?;
+        if chunk_rebuilder.is_valid {
+            self.chunk_verified[chunk_index] = true;
+
+            // Commit key-values.
+            for (key, value) in keys.into_iter().zip(values.into_iter()) {
+                self.temp_snapshot_db.put(key.borrow(), &value)?;
+            }
+
+            // Commit inner nodes.
+            let mut snapshot_mpt =
+                self.temp_snapshot_db.open_snapshot_mpt_for_write()?;
+            for (path, node) in chunk_rebuilder.inner_nodes_to_write {
+                snapshot_mpt.write_node(&path, &node);
+            }
+            for (path, node) in chunk_rebuilder.boundary_nodes {
+                let mut children_table = VanillaChildrenTable::default();
+                unsafe {
+                    *children_table.get_children_count_mut() =
+                        node.get_children_count();
+                }
+                self.pending_boundary_nodes.insert(
+                    path,
+                    SnapshotMptNode(VanillaTrieNode::new(
+                        node.get_merkle().clone(),
+                        children_table,
+                        node.value_as_slice()
+                            .into_option()
+                            .map(|ref_v| ref_v.into()),
+                        node.compressed_path_ref().into(),
+                    )),
+                );
+            }
+            for (subtree_index, subtree_size) in
+                chunk_rebuilder.boundary_subtree_total_size
+            {
+                self.boundary_subtree_total_size
+                    .insert(subtree_index, subtree_size);
+            }
+        }
+
+        if self.is_completed() {
+            self.finalize()?
+        }
+
+        Ok(chunk_rebuilder.is_valid)
+    }
+
+    // FIXME: multi-threading
+    /// Combine and write boundary subtree nodes after all chunks have been
+    /// completed.
+    pub fn finalize(&mut self) -> Result<()> {
+        let mut snapshot_mpt =
+            self.temp_snapshot_db.open_snapshot_mpt_for_write()?;
+
+        for (path, mut node) in self.pending_boundary_nodes.drain() {
+            let merkle = node.get_merkle().clone();
+            let mut subtree_index = BoundarySubtreeIndex {
+                parent_node: merkle,
+                child_index: 0,
+            };
+            for child_index in 0..CHILDREN_COUNT as u8 {
+                subtree_index.child_index = child_index;
+                if let Some(subtree_size) =
+                    self.boundary_subtree_total_size.get(&subtree_index)
+                {
+                    // Actually safe.
+                    unsafe {
+                        node.get_child_mut_unchecked(child_index)
+                            .subtree_size = *subtree_size;
+                    }
+                }
+            }
+
+            snapshot_mpt.write_node(&path, &node)?;
+        }
+
+        Ok(())
+    }
+}
+
+use crate::storage::{
+    impls::{
+        errors::*,
+        merkle_patricia_trie::{
+            trie_node::TrieNodeTrait, CompressedPathRaw, VanillaTrieNode,
+            CHILDREN_COUNT,
+        },
+        snapshot_sync::restoration::mpt_slice_verifier::{
+            BoundarySubtreeIndex, MptSliceVerifier,
+        },
+        state_manager::{SnapshotDb, SnapshotDbManager},
+    },
+    storage_db::{
+        key_value_db::KeyValueDbTraitSingleWriter, SnapshotDbManagerTrait,
+        SnapshotMptNode, SnapshotMptTraitSingleWriter,
+    },
+    TrieProof,
+};
+use primitives::{EpochId, MerkleHash};
+use std::{borrow::Borrow, collections::HashMap};

--- a/core/src/storage/impls/snapshot_sync/restoration/full_sync_verifier.rs
+++ b/core/src/storage/impls/snapshot_sync/restoration/full_sync_verifier.rs
@@ -2,8 +2,4 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-pub mod offer;
-pub mod restoration;
-
-pub use offer::*;
-pub use restoration::*;
+pub struct FullSyncVerifier {}

--- a/core/src/storage/impls/snapshot_sync/restoration/mod.rs
+++ b/core/src/storage/impls/snapshot_sync/restoration/mod.rs
@@ -3,4 +3,4 @@
 // See http://www.gnu.org/licenses/
 
 pub mod full_sync_verifier;
-pub mod mpt_slice_verifier;
+pub(self) mod mpt_slice_verifier;

--- a/core/src/storage/impls/snapshot_sync/restoration/mod.rs
+++ b/core/src/storage/impls/snapshot_sync/restoration/mod.rs
@@ -2,8 +2,5 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-pub mod offer;
-pub mod restoration;
-
-pub use offer::*;
-pub use restoration::*;
+pub mod full_sync_verifier;
+pub mod mpt_slice_verifier;

--- a/core/src/storage/impls/snapshot_sync/restoration/mpt_slice_verifier.rs
+++ b/core/src/storage/impls/snapshot_sync/restoration/mpt_slice_verifier.rs
@@ -29,6 +29,7 @@ struct BoundarySubtreeIndex {
 }
 
 impl MptSliceVerifier {
+    #[allow(dead_code)]
     /// Validity of the inputs should be already checked.
     pub fn new(
         key_range_left: Vec<u8>, key_range_right_excl: Vec<u8>,

--- a/core/src/storage/impls/snapshot_sync/restoration/mpt_slice_verifier.rs
+++ b/core/src/storage/impls/snapshot_sync/restoration/mpt_slice_verifier.rs
@@ -125,7 +125,7 @@ impl SnapshotMptTraitSingleWriter for SliceMptRebuilder {
     fn as_readonly(&mut self) -> &mut dyn SnapshotMptTraitReadOnly { self }
 
     fn delete_node(&mut self, _path: &dyn CompressedPathTrait) -> Result<()> {
-        // It's impossible to delete a node for FullSync / OneStepSync.
+        // It's impossible to delete a node for FullSync.
         unsafe { unreachable_unchecked() }
     }
 
@@ -165,7 +165,6 @@ impl SnapshotMptTraitSingleWriter for SliceMptRebuilder {
         } else {
             self.inner_nodes_to_write.push((
                 CompressedPathRaw::from(path.as_ref()),
-                // FIXME: check if it's possible to pass by value...
                 trie_node.clone(),
             ));
         }

--- a/core/src/storage/impls/snapshot_sync/restoration/mpt_slice_verifier.rs
+++ b/core/src/storage/impls/snapshot_sync/restoration/mpt_slice_verifier.rs
@@ -1,0 +1,191 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+// The MptSliceVerifier can be used in restoration of Snapshot MPT and
+// Delta MPT. For OneStepSync of Snapshot MPT, the verified slice can be applied
+// to MptMerger to create the updated snapshot MPT.
+#[allow(unused)]
+pub struct MptSliceVerifier {
+    key_value_inserter:
+        MptCursorRw<SliceMptRebuilder, ReadWritePathNode<SliceMptRebuilder>>,
+    key_range_left: Vec<u8>,
+    key_range_right_excl: Vec<u8>,
+}
+
+struct SliceMptRebuilder {
+    merkle_root: MerkleHash,
+    boundary_nodes: HashMap<CompressedPathRaw, VanillaTrieNode<MerkleHash>>,
+    new_nodes: Vec<(CompressedPathRaw, SnapshotMptDbValue)>,
+    boundary_subtree_total_size: HashMap<BoundarySubtreeIndex, u64>,
+
+    is_valid: bool,
+}
+
+#[derive(PartialEq, Eq, Hash)]
+struct BoundarySubtreeIndex {
+    node: MerkleHash,
+    child_index: u8,
+}
+
+impl MptSliceVerifier {
+    /// Validity of the inputs should be already checked.
+    pub fn new(
+        key_range_left: Vec<u8>, key_range_right_excl: Vec<u8>,
+        left_proof: TrieProof, right_proof: TrieProof, merkle_root: MerkleHash,
+    ) -> Self
+    {
+        let mut boundary_nodes = HashMap::default();
+
+        let left_node_paths = left_proof.compute_paths_for_all_nodes();
+        for (path, trie_proof_node) in left_node_paths
+            .into_iter()
+            .zip(left_proof.nodes.into_iter())
+        {
+            boundary_nodes.insert(path, trie_proof_node.into());
+        }
+        let right_node_paths = right_proof.compute_paths_for_all_nodes();
+        for (path, trie_proof_node) in right_node_paths
+            .into_iter()
+            .zip(right_proof.nodes.into_iter())
+        {
+            boundary_nodes.insert(path, trie_proof_node.into());
+        }
+        Self {
+            key_range_left,
+            key_range_right_excl,
+            key_value_inserter: MptCursorRw::new(SliceMptRebuilder {
+                merkle_root,
+                boundary_nodes,
+                new_nodes: Default::default(),
+                boundary_subtree_total_size: Default::default(),
+                is_valid: true,
+            }),
+        }
+    }
+}
+
+impl SnapshotMptTraitReadOnly for SliceMptRebuilder {
+    fn get_merkle_root(&self) -> &H256 { &self.merkle_root }
+
+    fn load_node(
+        &mut self, path: &dyn CompressedPathTrait,
+    ) -> Result<Option<SnapshotMptNode>> {
+        Ok(self.boundary_nodes.get(path).map(|node| {
+            let mut children_table = VanillaChildrenTable::default();
+            for (child_index, merkle) in node.get_children_table_ref().iter() {
+                unsafe {
+                    *children_table.get_child_mut_unchecked(child_index) =
+                        SubtreeMerkleWithSize {
+                            merkle: *merkle,
+                            subtree_size: 0,
+                            delta_subtree_size: 0,
+                        };
+                    *children_table.get_children_count_mut() += 1;
+                }
+            }
+            SnapshotMptNode(VanillaTrieNode::new(
+                node.get_merkle().clone(),
+                children_table,
+                node.value_as_slice()
+                    .into_option()
+                    .map(|value| value.into()),
+                node.compressed_path_ref().into(),
+            ))
+        }))
+    }
+
+    fn iterate_subtree_trie_nodes_without_root(
+        &mut self, _path: &dyn CompressedPathTrait,
+    ) -> Result<Box<dyn SnapshotMptIteraterTrait>> {
+        // The validator runs the MptCursorRW in in-place mode, where subtree
+        // iteration is unnecessary.
+        unsafe { unreachable_unchecked() }
+    }
+}
+
+impl SnapshotMptTraitSingleWriter for SliceMptRebuilder {
+    fn as_readonly(&mut self) -> &mut dyn SnapshotMptTraitReadOnly { self }
+
+    fn delete_node(&mut self, _path: &dyn CompressedPathTrait) -> Result<()> {
+        // It's impossible to delete a node for FullSync / OneStepSync.
+        unsafe { unreachable_unchecked() }
+    }
+
+    fn write_node(
+        &mut self, path: &dyn CompressedPathTrait, trie_node: &SnapshotMptNode,
+    ) -> Result<()> {
+        if self.boundary_nodes.get(path).is_some() {
+            let boundary_node = self.boundary_nodes.get(path).unwrap();
+            for (
+                child_index,
+                &SubtreeMerkleWithSize {
+                    ref merkle,
+                    ref subtree_size,
+                    ..
+                },
+            ) in trie_node.get_children_table_ref().iter()
+            {
+                match boundary_node.get_child(child_index) {
+                    None => self.is_valid = false,
+                    Some(expected_merkle) => {
+                        if merkle != expected_merkle {
+                            self.is_valid = false;
+                        } else {
+                            self.boundary_subtree_total_size.insert(
+                                BoundarySubtreeIndex {
+                                    node: merkle.clone(),
+                                    child_index,
+                                },
+                                *subtree_size,
+                            );
+                        }
+                    }
+                }
+            }
+        } else {
+            self.new_nodes.push((
+                CompressedPathRaw::from(path.as_ref()),
+                trie_node.rlp_bytes().into_boxed_slice(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+impl GetReadMpt for SliceMptRebuilder {
+    fn get_merkle_root(&self) -> &MerkleHash { &self.merkle_root }
+
+    fn get_read_mpt(&mut self) -> &mut dyn SnapshotMptTraitReadOnly { self }
+}
+
+impl GetRwMpt for SliceMptRebuilder {
+    fn get_write_mpt(&mut self) -> &mut dyn SnapshotMptTraitSingleWriter {
+        self
+    }
+
+    fn get_write_and_read_mpt(
+        &mut self,
+    ) -> (
+        &mut dyn SnapshotMptTraitSingleWriter,
+        Option<&mut dyn SnapshotMptTraitReadOnly>,
+    ) {
+        (self, None)
+    }
+
+    fn is_save_as_write(&self) -> bool { false }
+
+    fn is_in_place_update(&self) -> bool { true }
+}
+
+use super::super::super::{
+    super::storage_db::snapshot_mpt::*,
+    errors::*,
+    merkle_patricia_trie::{mpt_cursor::*, *},
+};
+use crate::storage::impls::merkle_patricia_trie::walk::GetChildTrait;
+use cfx_types::H256;
+use primitives::MerkleHash;
+use rlp::*;
+use std::{collections::HashMap, hint::unreachable_unchecked};

--- a/core/src/storage/impls/state.rs
+++ b/core/src/storage/impls/state.rs
@@ -142,14 +142,16 @@ impl<'a> State<'a> {
                 }
             };
 
-        // TODO: get from snapshot
-        // self.get_from_snapshot(access_key)
+        let maybe_value = self.get_from_snapshot(&access_key.to_key_bytes())?;
+        if with_proof {
+            // FIMXE: implement snapshot proof.
+        }
 
         let proof = StateProof::default()
             .with_delta(maybe_delta_proof)
             .with_intermediate(maybe_intermediate_proof);
 
-        Ok((None, proof))
+        Ok((maybe_value, proof))
     }
 }
 

--- a/core/src/storage/impls/state_proof.rs
+++ b/core/src/storage/impls/state_proof.rs
@@ -31,9 +31,9 @@ impl StateProof {
     pub fn is_valid_kv(
         &self, key: &Vec<u8>, value: Option<&[u8]>, root: StateRoot,
     ) -> bool {
-        let delta_root = root.delta_root;
-        let intermediate_root = root.intermediate_delta_root;
-        let snapshot_root = root.snapshot_root;
+        let delta_root = &root.delta_root;
+        let intermediate_root = &root.intermediate_delta_root;
+        let snapshot_root = &root.snapshot_root;
 
         let delta_mpt_padding =
             StorageKey::delta_mpt_padding(&snapshot_root, &intermediate_root);
@@ -67,14 +67,14 @@ impl StateProof {
             // proof of non-existence with a single trie
             (None, Some(p1), None, None) => {
                 p1.is_valid_kv(key, None, delta_root)
-                    && intermediate_root == MERKLE_NULL_NODE
-                    && snapshot_root == MERKLE_NULL_NODE
+                    && intermediate_root.eq(&MERKLE_NULL_NODE)
+                    && snapshot_root.eq(&MERKLE_NULL_NODE)
             }
             // proof of non-existence with two tries
             (None, Some(p1), Some(p2), None) => {
                 p1.is_valid_kv(&delta_mpt_key, None, delta_root)
                     && p2.is_valid_kv(key, None, intermediate_root)
-                    && snapshot_root == MERKLE_NULL_NODE
+                    && snapshot_root.eq(&MERKLE_NULL_NODE)
             }
             // proof of non-existence with all tries
             (None, Some(p1), Some(p2), Some(p3)) => {
@@ -85,9 +85,9 @@ impl StateProof {
             // no proofs available
             (_, None, None, None) => {
                 value.is_none()
-                    && delta_root == MERKLE_NULL_NODE
-                    && intermediate_root == MERKLE_NULL_NODE
-                    && snapshot_root == MERKLE_NULL_NODE
+                    && delta_root.eq(&MERKLE_NULL_NODE)
+                    && intermediate_root.eq(&MERKLE_NULL_NODE)
+                    && snapshot_root.eq(&MERKLE_NULL_NODE)
             }
             _ => false,
         }

--- a/core/src/storage/impls/storage_db/snapshot_db_manager_sqlite.rs
+++ b/core/src/storage/impls/storage_db/snapshot_db_manager_sqlite.rs
@@ -36,6 +36,15 @@ impl SnapshotDbManagerSqlite {
             + &delta_merkle_root.to_hex()
     }
 
+    fn get_full_sync_temp_snapshot_db_path(
+        &self, snapshot_epoch_id: &EpochId, merkle_root: &MerkleHash,
+    ) -> String {
+        self.snapshot_path.clone()
+            + "full_sync_temp_"
+            + &snapshot_epoch_id.to_hex()
+            + &merkle_root.to_hex()
+    }
+
     /// Returns error when cow copy fails; Ok(true) when cow copy succeeded;
     /// Ok(false) when cow copy isn't supported.
     fn try_make_cow_copy_impl(
@@ -206,6 +215,16 @@ impl SnapshotDbManagerTrait for SnapshotDbManagerSqlite {
         Ok(fs::remove_file(
             self.get_snapshot_db_path(snapshot_epoch_id),
         )?)
+    }
+
+    fn new_temp_snapshot_for_full_sync(
+        &self, snapshot_epoch_id: &EpochId, merkle_root: &MerkleHash,
+    ) -> Result<Self::SnapshotDb> {
+        let temp_db_name = self.get_full_sync_temp_snapshot_db_path(
+            snapshot_epoch_id,
+            merkle_root,
+        );
+        Self::SnapshotDb::create(&temp_db_name)
     }
 }
 

--- a/core/src/storage/impls/storage_db/snapshot_db_sqlite.rs
+++ b/core/src/storage/impls/storage_db/snapshot_db_sqlite.rs
@@ -277,7 +277,7 @@ impl SnapshotDbSqlite {
         Ok((key.into_boxed_slice(), value.into_boxed_slice()))
     }
 
-    fn open_snapshot_mpt_for_write(
+    pub fn open_snapshot_mpt_for_write(
         &mut self,
     ) -> Result<
         SnapshotMpt<

--- a/core/src/storage/impls/storage_db/snapshot_mpt.rs
+++ b/core/src/storage/impls/storage_db/snapshot_mpt.rs
@@ -84,9 +84,7 @@ where DbType:
         let key = mpt_node_path_to_db_key(path);
         match self.db.borrow_mut().get_mut(&key)? {
             None => Ok(None),
-            Some(rlp) => {
-                Ok(Some(SnapshotMptNode::new(Rlp::new(&rlp).as_val()?)))
-            }
+            Some(rlp) => Ok(Some(SnapshotMptNode(Rlp::new(&rlp).as_val()?))),
         }
     }
 

--- a/core/src/storage/impls/storage_manager/storage_manager.rs
+++ b/core/src/storage/impls/storage_manager/storage_manager.rs
@@ -288,6 +288,7 @@ impl StorageManager {
         }
 
         let in_progress_snapshot_info = SnapshotInfo {
+            serve_one_step_sync: true,
             height: height as u64,
             parent_snapshot_height: height - SNAPSHOT_EPOCHS_CAPACITY,
             // This is unknown for now, and we don't care.

--- a/core/src/storage/storage_db/snapshot_db.rs
+++ b/core/src/storage/storage_db/snapshot_db.rs
@@ -4,6 +4,8 @@
 
 #[derive(Clone)]
 pub struct SnapshotInfo {
+    pub serve_one_step_sync: bool,
+
     pub merkle_root: MerkleHash,
     pub parent_snapshot_height: u64,
     pub height: u64,
@@ -16,6 +18,7 @@ pub struct SnapshotInfo {
 impl SnapshotInfo {
     pub fn genesis_snapshot_info() -> Self {
         Self {
+            serve_one_step_sync: false,
             merkle_root: MERKLE_NULL_NODE,
             parent_snapshot_height: 0,
             height: 0,

--- a/core/src/storage/storage_db/snapshot_db_manager.rs
+++ b/core/src/storage/storage_db/snapshot_db_manager.rs
@@ -2,10 +2,6 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-// FIXME: Even for full node it should keep corresponding db
-// FIXME: to do verifiable proof for light client.
-// FIXME: And archive node may store all wire-formats and
-// FIXME: some other dbs to answer verifiable proofs.
 /// The trait for database manager of Snapshot.
 pub trait SnapshotDbManagerTrait {
     type SnapshotDb: SnapshotDbTrait;
@@ -18,6 +14,10 @@ pub trait SnapshotDbManagerTrait {
         &self, epoch_id: &EpochId,
     ) -> Result<Option<Self::SnapshotDb>>;
     fn destroy_snapshot(&self, snapshot_epoch_id: &EpochId) -> Result<()>;
+
+    fn new_temp_snapshot_for_full_sync(
+        &self, snapshot_epoch_id: &EpochId, merkle_root: &MerkleHash,
+    ) -> Result<Self::SnapshotDb>;
 }
 
 use super::{
@@ -26,4 +26,4 @@ use super::{
     },
     snapshot_db::*,
 };
-use primitives::EpochId;
+use primitives::{EpochId, MerkleHash};

--- a/core/src/storage/storage_db/snapshot_mpt.rs
+++ b/core/src/storage/storage_db/snapshot_mpt.rs
@@ -63,10 +63,6 @@ impl SnapshotMptNode {
         delta_subtree_size: 0,
     };
 
-    pub fn new(node: VanillaTrieNode<SubtreeMerkleWithSize>) -> Self {
-        Self(node)
-    }
-
     pub fn subtree_size(&self) -> u64 { Self::initial_subtree_size(&self.0) }
 
     fn initial_subtree_size(
@@ -76,9 +72,7 @@ impl SnapshotMptNode {
         for (
             _child_index,
             &SubtreeMerkleWithSize {
-                merkle: _,
-                ref subtree_size,
-                delta_subtree_size: _,
+                ref subtree_size, ..
             },
         ) in node.get_children_table_ref().iter()
         {
@@ -88,20 +82,14 @@ impl SnapshotMptNode {
         size
     }
 
-    pub fn get_children_merkle(&self) -> MaybeMerkleTable {
+    pub fn get_children_merkles(&self) -> MaybeMerkleTable {
         if self.get_children_count() > 0 {
             let mut merkle_table = Some(
                 [ChildrenTableItem::<MerkleHash>::no_child().clone();
                     CHILDREN_COUNT],
             );
-            for (
-                child_index,
-                &SubtreeMerkleWithSize {
-                    ref merkle,
-                    subtree_size: _,
-                    delta_subtree_size: _,
-                },
-            ) in self.get_children_table_ref().iter()
+            for (child_index, &SubtreeMerkleWithSize { ref merkle, .. }) in
+                self.get_children_table_ref().iter()
             {
                 merkle_table.as_mut().unwrap()[child_index as usize] = *merkle;
             }
@@ -114,7 +102,7 @@ impl SnapshotMptNode {
 
 impl Decodable for SnapshotMptNode {
     fn decode(rlp: &Rlp) -> std::result::Result<Self, DecoderError> {
-        Ok(Self::new(rlp.as_val()?))
+        Ok(Self(rlp.as_val()?))
     }
 }
 

--- a/core/src/storage/storage_db/snapshot_mpt.rs
+++ b/core/src/storage/storage_db/snapshot_mpt.rs
@@ -31,8 +31,6 @@ pub trait SnapshotMptTraitReadOnly {
 pub trait SnapshotMptTraitSingleWriter: SnapshotMptTraitReadOnly {
     fn as_readonly(&mut self) -> &mut dyn SnapshotMptTraitReadOnly;
     fn delete_node(&mut self, path: &dyn CompressedPathTrait) -> Result<()>;
-    // FIXME: It seems better to pass by value, however in one place we can't
-    // move away structure field in drop().
     fn write_node(
         &mut self, path: &dyn CompressedPathTrait, trie_node: &SnapshotMptNode,
     ) -> Result<()>;

--- a/core/src/storage/tests/state.rs
+++ b/core/src/storage/tests/state.rs
@@ -556,9 +556,12 @@ fn test_proofs() {
             let mut wrong_merkle = delta_proof.nodes[0].get_merkle().clone();
             wrong_merkle.as_bytes_mut()[0] = 0x00;
             delta_proof.nodes[0].set_merkle(&wrong_merkle);
-        }
 
-        assert!(!invalid_proof.is_valid_kv(key, value, root.clone()));
+            let mut wrong_state_root = root.clone();
+            wrong_state_root.delta_root = wrong_merkle;
+
+            assert!(!invalid_proof.is_valid_kv(key, value, wrong_state_root));
+        }
 
         // test rlp
         assert_eq!(proof, rlp::decode(&rlp::encode(&proof)).unwrap());

--- a/core/src/storage/tests/state.rs
+++ b/core/src/storage/tests/state.rs
@@ -550,22 +550,11 @@ fn test_proofs() {
         // invalid value
         assert!(!proof.is_valid_kv(key, Some(&[0x00; 100][..]), root.clone()));
 
-        // invalid hash
-        let mut invalid_proof = proof.clone();
-        if let Some(delta_proof) = &mut invalid_proof.delta_proof {
-            let mut wrong_merkle = delta_proof.nodes[0].get_merkle().clone();
-            wrong_merkle.as_bytes_mut()[0] = 0x00;
-            delta_proof.nodes[0].set_merkle(&wrong_merkle);
-
-            let mut wrong_state_root = root.clone();
-            wrong_state_root.delta_root = wrong_merkle;
-
-            assert!(!invalid_proof.is_valid_kv(key, value, wrong_state_root));
-        }
+        // invalid non-existence.
+        assert!(!proof.is_valid_kv(key, None, root.clone()));
 
         // test rlp
         assert_eq!(proof, rlp::decode(&rlp::encode(&proof)).unwrap());
-        assert_ne!(proof, rlp::decode(&rlp::encode(&invalid_proof)).unwrap());
     }
 
     let nonexistent_keys: Vec<[u8; 4]> = generate_keys(DEFAULT_NUMBER_OF_KEYS)

--- a/primitives/src/storage_key.rs
+++ b/primitives/src/storage_key.rs
@@ -315,10 +315,7 @@ mod delta_mpt_storage_key {
         address: &[u8], storage_key: &[u8], padding: &DeltaMptKeyPadding,
     ) -> Vec<u8> {
         let mut key = Vec::with_capacity(
-            ACCOUNT_KEYPART_BYTES
-                + StorageKey::STORAGE_PREFIX_LEN
-                + KEY_PADDING_BYTES
-                + storage_key.len(),
+            ACCOUNT_KEYPART_BYTES + KEY_PADDING_BYTES + storage_key.len(),
         );
         extend_storage_root(&mut key, address, padding);
         extend_storage_key(&mut key, storage_key, padding);


### PR DESCRIPTION
MptSliceVerifier verifies a chunk based on the trie proof on two boundaries. To implement MptSliceVerifier there are some additional changes listed below.

Make CompressedPathRaw eligible for a HashMap Key.
When constructing a Trie proof, check if the nodes in the trie proof are connected, etc.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/833)
<!-- Reviewable:end -->
