### PR TITLE
Fix issue in snapshot mpt merging where delta kv should be retrieved from dumped delta tables.

### DIFF
--- a/core/src/storage/storage_db/snapshot_db.rs
+++ b/core/src/storage/storage_db/snapshot_db.rs
@@ -68,19 +68,15 @@ pub trait SnapshotDbTrait:
     // FIXME: what should be stored after a snapshot is created?
     fn create(snapshot_path: &str) -> Result<Self>;
 
-    fn direct_merge(
-        &mut self, delta_mpt: &DeltaMptIterator,
-    ) -> Result<MerkleHash>;
+    fn direct_merge(&mut self) -> Result<MerkleHash>;
 
-    // FIXME: the type of old_snapshot_db is not Self, but
-    // FIXME: a Box<dyn 'a + KeyValueDbTraitOwnedRead>
     fn copy_and_merge(
-        &mut self, old_snapshot_db: &mut Self, delta_mpt: &DeltaMptIterator,
+        &mut self, old_snapshot_db: &mut Self,
     ) -> Result<MerkleHash>;
 }
 
 use super::{
-    super::impls::{errors::*, storage_manager::DeltaMptIterator},
+    super::impls::errors::*,
     key_value_db::{
         KeyValueDbToOwnedReadTrait, KeyValueDbTraitOwnedRead,
         KeyValueDbTraitSingleWriter,

--- a/core/src/storage/utils/deref_plus_impl_or_borrow_self.rs
+++ b/core/src/storage/utils/deref_plus_impl_or_borrow_self.rs
@@ -23,7 +23,6 @@ pub trait DerefMutPlusSelf {
 /// the compiler can not rule out the possibility for D: Deref + Sized with
 /// D::Target == D. For a local type, compiler will first check if Deref is
 /// implemented for that type, and if D::Target == D.
-#[allow(unused)]
 macro_rules! enable_deref_for_self {
     ($type:ty) => {
         impl DerefPlusSelf for $type {


### PR DESCRIPTION
Delta kv is dumped from DeltaMpt in wrong key format and order, while it should be retrieved
from dumped delta tables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/855)
<!-- Reviewable:end -->
