### PR TITLE
Fix mac tests

### DIFF
--- a/core/benchmark/consensus/src/main.rs
+++ b/core/benchmark/consensus/src/main.rs
@@ -5,7 +5,7 @@
 #![allow(unused)]
 use cfx_types::{Address, H256, U256};
 use cfxcore::{
-    block_data_manager::{BlockDataManager, DataManagerConfiguration},
+    block_data_manager::{BlockDataManager, DataManagerConfiguration, DbType},
     cache_config::CacheConfig,
     cache_manager::CacheManager,
     consensus::{ConsensusConfig, ConsensusGraph, ConsensusInnerConfig},
@@ -181,6 +181,7 @@ fn main() {
         beta,
         h_ratio,
         era_epoch_count,
+        DbType::Sqlite
     );
 
     let mut hashes = Vec::new();

--- a/core/benchmark/consensus/src/main.rs
+++ b/core/benchmark/consensus/src/main.rs
@@ -181,7 +181,7 @@ fn main() {
         beta,
         h_ratio,
         era_epoch_count,
-        DbType::Sqlite
+        DbType::Sqlite,
     );
 
     let mut hashes = Vec::new();

--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -21,10 +21,17 @@ use primitives::{
     transaction::SignedTransaction, Block, BlockHeader, EpochNumber,
 };
 use slab::Slab;
-use std::{cmp::max, collections::{HashMap, HashSet, VecDeque}, mem, sync::{
-    mpsc::{self, Sender},
-    Arc,
-}, thread, time::{Duration, SystemTime, UNIX_EPOCH}, panic};
+use std::{
+    cmp::max,
+    collections::{HashMap, HashSet, VecDeque},
+    mem, panic,
+    sync::{
+        mpsc::{self, Sender},
+        Arc,
+    },
+    thread,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 use unexpected::{Mismatch, OutOfBounds};
 
 lazy_static! {

--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -21,17 +21,10 @@ use primitives::{
     transaction::SignedTransaction, Block, BlockHeader, EpochNumber,
 };
 use slab::Slab;
-use std::{
-    cmp::max,
-    collections::{HashMap, HashSet, VecDeque},
-    mem,
-    sync::{
-        mpsc::{self, Sender},
-        Arc,
-    },
-    thread,
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
+use std::{cmp::max, collections::{HashMap, HashSet, VecDeque}, mem, sync::{
+    mpsc::{self, Sender},
+    Arc,
+}, thread, time::{Duration, SystemTime, UNIX_EPOCH}, panic};
 use unexpected::{Mismatch, OutOfBounds};
 
 lazy_static! {

--- a/core/src/sync/tests/mod.rs
+++ b/core/src/sync/tests/mod.rs
@@ -14,12 +14,13 @@ use std::{
     thread::sleep,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
+use crate::block_data_manager::DbType;
 
 #[test]
 fn test_remove_expire_blocks() {
     {
         let (sync, _, _) =
-            initialize_synchronization_graph("./test.db/", 1, 1, 1, 1, 50000);
+            initialize_synchronization_graph("./test.db/", 1, 1, 1, 1, 50000, DbType::Rocksdb);
         // test initialization
         {
             let inner = sync.inner.read();

--- a/core/src/sync/tests/mod.rs
+++ b/core/src/sync/tests/mod.rs
@@ -2,9 +2,12 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use crate::sync::{
-    utils::{create_simple_block_impl, initialize_synchronization_graph},
-    SynchronizationGraphNode,
+use crate::{
+    block_data_manager::DbType,
+    sync::{
+        utils::{create_simple_block_impl, initialize_synchronization_graph},
+        SynchronizationGraphNode,
+    },
 };
 use cfx_types::{BigEndianHash, H256, U256};
 use primitives::Block;
@@ -14,13 +17,19 @@ use std::{
     thread::sleep,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
-use crate::block_data_manager::DbType;
 
 #[test]
 fn test_remove_expire_blocks() {
     {
-        let (sync, _, _) =
-            initialize_synchronization_graph("./test.db/", 1, 1, 1, 1, 50000, DbType::Rocksdb);
+        let (sync, _, _) = initialize_synchronization_graph(
+            "./test.db/",
+            1,
+            1,
+            1,
+            1,
+            50000,
+            DbType::Rocksdb,
+        );
         // test initialization
         {
             let inner = sync.inner.read();

--- a/core/src/sync/utils.rs
+++ b/core/src/sync/utils.rs
@@ -74,7 +74,7 @@ pub fn create_simple_block(
 /// This method is only used in tests and benchmarks.
 pub fn initialize_synchronization_graph(
     db_dir: &str, alpha_den: u64, alpha_num: u64, beta: u64, h: u64,
-    era_epoch_count: u64,
+    era_epoch_count: u64, dbtype: DbType,
 ) -> (Arc<SynchronizationGraph>, Arc<ConsensusGraph>, Arc<Block>)
 {
     let ledger_db = db::open_database(
@@ -125,7 +125,7 @@ pub fn initialize_synchronization_graph(
             false,                          /* do not record transaction
                                              * address */
             Duration::from_millis(300_000), /* max cached tx count */
-            DbType::Rocksdb,
+            dbtype,
         ),
     ));
 


### PR DESCRIPTION
RocksDb on Mac has an issue to potentially segfault when exit inside worker threads. This causes problems for testing. For now we use sqlite during the bench test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/911)
<!-- Reviewable:end -->
