### PR TITLE
Fix a deadlock in network crate.

### DIFF
--- a/network/src/service.rs
+++ b/network/src/service.rs
@@ -392,13 +392,14 @@ impl DelayedQueue {
 
     fn send_delayed_messages(&self, network_service: &NetworkServiceInner) {
         let context = self.queue.lock().pop().unwrap();
-        match context.session.write().send_packet(
+        let r = context.session.write().send_packet(
             &context.io,
             Some(context.protocol),
             session::PACKET_USER,
             context.msg,
             context.priority,
-        ) {
+        );
+        match r {
             Ok(_) => {}
             Err(Error(ErrorKind::Expired, _)) => {
                 // If a connection is set expired, it should have been killed

--- a/util/io/src/service_mio.rs
+++ b/util/io/src/service_mio.rs
@@ -455,15 +455,7 @@ where Message: Send + Sync + 'static
                 }
             }
             IoMessage::UpdateStreamRegistration { handler_id, token } => {
-                // We should release handlers lock before `update_stream` to
-                // avoid the deadlock between `handlers` and `session` within
-                // `kill_connection`
-                let maybe_arc_handler = self
-                    .handlers
-                    .read()
-                    .get(handler_id)
-                    .map(|handler| handler.clone());
-                if let Some(handler) = maybe_arc_handler {
+                if let Some(handler) = self.handlers.read().get(handler_id) {
                     handler.update_stream(
                         token,
                         Token(token + handler_id * TOKENS_PER_HANDLER),

--- a/util/io/src/service_mio.rs
+++ b/util/io/src/service_mio.rs
@@ -455,7 +455,15 @@ where Message: Send + Sync + 'static
                 }
             }
             IoMessage::UpdateStreamRegistration { handler_id, token } => {
-                if let Some(handler) = self.handlers.read().get(handler_id) {
+                // We should release handlers lock before `update_stream` to
+                // avoid the deadlock between `handlers` and `session` within
+                // `kill_connection`
+                let maybe_arc_handler = self
+                    .handlers
+                    .read()
+                    .get(handler_id)
+                    .map(|handler| handler.clone());
+                if let Some(handler) = maybe_arc_handler {
                     handler.update_stream(
                         token,
                         Token(token + handler_id * TOKENS_PER_HANDLER),


### PR DESCRIPTION
In `kill_connection`, we lock `session` before locking `handlers`.
In the handling of `UpdateStreamRegistration`, we lock `handlers` first and lock `session` within `update_stream`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/921)
<!-- Reviewable:end -->
