### PR TITLE
Optimize some parameters.

### DIFF
--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -115,7 +115,7 @@ build_config! {
         (port, (Option<u16>), Some(32323))
 
         // Network parameters section.
-        (blocks_request_timeout_ms, (u64), 30_000)
+        (blocks_request_timeout_ms, (u64), 60_000)
         (check_request_period_ms, (u64), 1000)
         (chunk_size_byte, (u64), DEFAULT_CHUNK_SIZE)
         (data_propagate_enabled, (bool), false)
@@ -124,7 +124,7 @@ build_config! {
         (egress_queue_capacity, (usize), 256)
         (egress_min_throttle, (usize), 10)
         (egress_max_throttle, (usize), 64)
-        (headers_request_timeout_ms, (u64), 10_000)
+        (headers_request_timeout_ms, (u64), 30_000)
         (inflight_pending_tx_index_maintain_timeout_ms, (u64), 30_000)
         (min_peers_propagation, (usize), 8)
         (max_inflight_request_count, (u64), 64)
@@ -132,9 +132,9 @@ build_config! {
         (received_tx_index_maintain_timeout_ms, (u64), 300_000)
         (request_block_with_public, (bool), false)
         (send_tx_period_ms, (u64), 1300)
-        (snapshot_candidate_request_timeout_ms, (u64), 10_000)
+        (snapshot_candidate_request_timeout_ms, (u64), 30_000)
         (snapshot_chunk_request_timeout_ms, (u64), 30_000)
-        (snapshot_manifest_request_timeout_ms, (u64), 10_000)
+        (snapshot_manifest_request_timeout_ms, (u64), 30_000)
         (throttling_conf, (Option<String>), None)
         (transaction_request_timeout_ms, (u64), 30_000)
         (tx_maintained_for_peer_timeout_ms, (u64), 600_000)
@@ -179,7 +179,7 @@ build_config! {
         (future_block_buffer_capacity, (usize), 32768)
         (get_logs_filter_max_limit, (Option<usize>), None)
         (is_consortium, (bool), false)
-        (ledger_cache_size, (Option<usize>), Some(2048))
+        (ledger_cache_size, (Option<usize>), Some(1024))
         (max_trans_count_received_in_catch_up, (u64), 60_000)
         (max_download_state_peers, (usize), 8)
     }

--- a/core/src/storage/impls/delta_mpt/node_memory_manager.rs
+++ b/core/src/storage/impls/delta_mpt/node_memory_manager.rs
@@ -83,7 +83,7 @@ impl<
     /// introduces copies for committing.
     // TODO(yz): log the dirty size to monitor if other component produces too
     // many.
-    pub const MAX_DIRTY_AND_TEMPORARY_TRIE_NODES: u32 = 200_000;
+    pub const MAX_DIRTY_AND_TEMPORARY_TRIE_NODES: u32 = 2_000_000;
     /// If we do not swap out any node onto disk, the maximum tolerable nodes is
     /// about 27.6M, where there is about 4.6M leaf nodes. The total memory
     /// consumption is about (27.6 * 192 - 4.6 * 64) MB ~= 5GB. It can hold new
@@ -93,7 +93,7 @@ impl<
     /// leaf node. This assumption is for delta_trie.
     pub const MAX_TRIE_NODES_MEM_ONLY: u32 = 27_600_000;
     pub const R_LFU_FACTOR: f64 = 4.0;
-    pub const START_CAPACITY: u32 = 1_000_000;
+    pub const START_CAPACITY: u32 = 2_000_000;
 }
 
 impl<

--- a/transactiongen/src/lib.rs
+++ b/transactiongen/src/lib.rs
@@ -210,6 +210,8 @@ impl TransactionGenerator {
             balance_map.insert(address.clone(), balance.unwrap());
             address_secret_pair.insert(address, secret);
         }
+        // State cache can be large
+        drop(state);
 
         info!("Start Generating Workload");
         let start_time = Instant::now();


### PR DESCRIPTION
Now the memory occupied by tx_data_manager is not counted by cache
manager, so we should decrease the ledger_db_size to keep the total
memory usage at almost the same level.

The current MAX_DIRTY_AND_TEMPORARY_TRIE_NODES may not be sufficient if we
have both high throughput and large number of accounts.

Timeout is spotted for headers/blocks during catch-up, so increase it to avoid
timeout for honest peers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/924)
<!-- Reviewable:end -->
