### PR TITLE
Add code coverage script.

### DIFF
--- a/dev-support/ccov.sh
+++ b/dev-support/ccov.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+
+cd $ROOT_DIR
+echo "If you are running this script for the first time, please clean previous 
+debug build first by running \`rm -rf target/debug\`.
+This script requires cargo nightly, and is only tested on 1.43.0-nightly."
+
+# Install dependencies
+cargo install grcov
+
+# Build binary and run unit tests with code coverage.
+export CARGO_INCREMENTAL=0
+# FIXME Add -Clink-dead-code after fixing the HeapSizeOf issue of SharedCache
+export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Coverflow-checks=off -Zno-landing-pads"
+cargo +nightly build
+cargo +nightly test --all
+
+# Run python integration tests.
+export CONFLUX="`pwd`/target/debug/conflux"
+export CONFLUX_BENCH="`pwd`/target/debug/consensus_bench"
+./tests/test_all.py
+
+# Generate code coverage data
+mkdir ccov
+zip -0 ccov/ccov.zip `find . \( -name "*.gc*" \) -print`
+grcov ccov/ccov.zip -s . -t html --llvm --branch --ignore-not-existing --ignore "/*" -o ccov
+echo "Code coverage result is saved to directory 'ccov'. 
+You can open 'ccov/index.html' with a web brower to start.
+

--- a/tests/crash_archive_era150_test.py
+++ b/tests/crash_archive_era150_test.py
@@ -60,9 +60,11 @@ class CrashArchiveNodeTest(ConfluxTestFramework):
 
         for i in range(1, self.num_nodes):
             self.stop_node(i)
+        self.log.info("Stopped all other nodes except node 0")
         self.nodes[0].add_p2p_connection(P2PInterface())
         network_thread_start()
         self.nodes[0].p2p.wait_for_status()
+        self.log.info("p2p connection to node 0 connected")
         gas_price = 1
         value = 1
         receiver_sk, _ = ec_random_keys()

--- a/tests/ghast_consensus_test.py
+++ b/tests/ghast_consensus_test.py
@@ -41,8 +41,12 @@ TEST_INPUT = [
 test_dir = os.path.dirname(os.path.realpath(__file__))
 cur_dir = os.getcwd()
 os.chdir(cur_dir)
-bench_cmd = test_dir + "/../target/release/consensus_bench"
-test_input_dir = test_dir + "/../core/benchmark/consensus/test/"
+bench_cmd = os.getenv(
+    "CONFLUX_BENCH",
+    default=os.path.join(
+        test_dir,
+        "../target/release/conflux"))
+test_input_dir = os.path.join(test_dir, "../core/benchmark/consensus/test/")
 
 failed = set()
 for inp in TEST_INPUT:

--- a/tests/ghast_consensus_test.py
+++ b/tests/ghast_consensus_test.py
@@ -45,7 +45,7 @@ bench_cmd = os.getenv(
     "CONFLUX_BENCH",
     default=os.path.join(
         test_dir,
-        "../target/release/conflux"))
+        "../target/release/consensus_bench"))
 test_input_dir = os.path.join(test_dir, "../core/benchmark/consensus/test/")
 
 failed = set()


### PR DESCRIPTION
Run `/dev-support/ccov.sh` to get the total code coverage of our
unit tests and python integration tests. The result is in the directory `./ccov`.

Note that `./target/debug/` should be cleaned before running the scripts
for the first time. And the tools require the nightly version of Rust.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/933)
<!-- Reviewable:end -->
