### PR TITLE
Check db for headers in request_missing_terminals.

### DIFF
--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -557,7 +557,10 @@ impl SynchronizationProtocolHandler {
 
                 let to_request = terminals
                     .difference(&requested)
-                    .filter(|h| !self.graph.contains_block_header(&h))
+                    .filter(|h| {
+                        // Request never-seen blocks
+                        self.graph.data_man.block_header_by_hash(*h).is_none()
+                    })
                     .cloned()
                     .collect::<Vec<H256>>();
 


### PR DESCRIPTION
Catching-up nodes will send Status with old terminals , and they are not in the in-mem sync_graph, so we need to check db to filter them out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/935)
<!-- Reviewable:end -->
