### PR TITLE
Fix OutOfMem error in Storage.

### DIFF
--- a/core/src/storage/impls/state.rs
+++ b/core/src/storage/impls/state.rs
@@ -578,8 +578,6 @@ impl State {
     fn do_db_commit(
         &mut self, epoch_id: EpochId, merkle_root: &MerkleHash,
     ) -> Result<()> {
-        self.dirty = false;
-
         let maybe_existing_merkle_root =
             self.delta_trie.get_merkle_root_by_epoch_id(&epoch_id)?;
         if maybe_existing_merkle_root.is_some() {
@@ -596,6 +594,7 @@ impl State {
                 Some(*merkle_root),
                 "Overwriting computed state with a different merkle root."
             );
+            self.revert();
             return Ok(());
         }
 
@@ -712,6 +711,8 @@ impl State {
             self.parent_epoch_id,
             self.delta_trie_root.clone(),
         );
+
+        self.dirty = false;
 
         Ok(())
     }

--- a/core/src/storage/impls/storage_manager/storage_manager.rs
+++ b/core/src/storage/impls/storage_manager/storage_manager.rs
@@ -870,20 +870,25 @@ impl StorageManager {
             .map(Clone::clone)
     }
 
-    /// FIXME Enable later.
     pub fn log_usage(&self) {
-        // FIXME: log usage for all delta mpt.
-        // Log the usage of the delta mpt for the first snapshot.
-        // FIXME: due to initialization problems the delta mpt may not be
-        // available?
-        //        self.snapshot_associated_mpts_by_epoch
-        //            .read()
-        //            .get(&NULL_EPOCH)
-        //            .unwrap()
-        //            .1
-        //            .as_ref()
-        //            .unwrap()
-        //            .log_usage();
+        let mut delta_mpts = HashMap::new();
+        for (_snapshot_epoch_id, associated_delta_mpts) in
+            &*self.snapshot_associated_mpts_by_epoch.read()
+        {
+            if let Some(delta_mpt) = associated_delta_mpts.0.as_ref() {
+                delta_mpts.insert(delta_mpt.get_mpt_id(), delta_mpt.clone());
+            }
+            if let Some(delta_mpt) = associated_delta_mpts.1.as_ref() {
+                delta_mpts.insert(delta_mpt.get_mpt_id(), delta_mpt.clone());
+            }
+        }
+        if let Some((_mpt_id, delta_mpt)) = delta_mpts.iter().next() {
+            delta_mpt.log_usage();
+
+            // Now delta_mpt calls log_usage of the singleton
+            // node_memory_manager, so there is no need to log_usage
+            // on second delta_mpt.
+        }
     }
 
     pub fn load_persist_state(&self) -> Result<()> {

--- a/core/src/storage/impls/storage_manager/storage_manager.rs
+++ b/core/src/storage/impls/storage_manager/storage_manager.rs
@@ -377,10 +377,10 @@ impl StorageManager {
     ) -> Result<()>
     {
         let this_cloned = this.clone();
-        let mut in_progress_snapshoting_tasks =
+        let mut in_progress_snapshotting_tasks =
             this_cloned.in_progress_snapshotting_tasks.write();
 
-        if !in_progress_snapshoting_tasks.contains_key(&snapshot_epoch_id)
+        if !in_progress_snapshotting_tasks.contains_key(&snapshot_epoch_id)
             && !this
                 .snapshot_info_map_by_epoch
                 .read()
@@ -493,7 +493,7 @@ impl StorageManager {
                 task_result
             })?;
 
-            in_progress_snapshoting_tasks.insert(
+            in_progress_snapshotting_tasks.insert(
                 snapshot_epoch_id,
                 Arc::new(RwLock::new(InProgressSnapshotTask {
                     snapshot_info: in_progress_snapshot_info,


### PR DESCRIPTION
Two cases of OOM error are fixed.

The 1st error happens when the (adaptive sized) slab is full a read-only
access to Storage triggers db load. The db load requires a temporary
space in slab. All read-only storage method now calls slab enlarge at
the beginning of the call.

The 2nd error happens when a storage recomputation happened, the commitment is cancelled, but the dirty MPT nodes were forgotten to revert. 

Re-enable storage logging and fix an unrelated typo along with this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/938)
<!-- Reviewable:end -->
