### PR TITLE
Add a lock on getting states to fix jenkins CI.

### DIFF
--- a/core/src/storage/impls/state_manager.rs
+++ b/core/src/storage/impls/state_manager.rs
@@ -183,11 +183,11 @@ impl StateManager {
             None => {
                 // This is the special scenario when the snapshot isn't
                 // available but the snapshot at the intermediate epoch exists.
-                if let Some(snapshot_got) = self
+                if let Some(guarded_snapshot) = self
                     .storage_manager
                     .wait_for_snapshot(&state_index.intermediate_epoch_id)?
                 {
-                    snapshot = snapshot_got;
+                    snapshot = guarded_snapshot;
                     maybe_intermediate_mpt = None;
                     maybe_intermediate_mpt_key_padding = None;
                     delta_mpt = match self
@@ -215,8 +215,8 @@ impl StateManager {
                     return Ok(None);
                 }
             }
-            Some(snapshot_got) => {
-                snapshot = snapshot_got;
+            Some(guarded_snapshot) => {
+                snapshot = guarded_snapshot;
                 maybe_intermediate_mpt_key_padding =
                     state_index.maybe_intermediate_mpt_key_padding;
                 maybe_intermediate_mpt = if maybe_intermediate_mpt_key_padding
@@ -248,7 +248,7 @@ impl StateManager {
         };
 
         Self::get_state_trees_internal(
-            snapshot,
+            snapshot.into().1,
             state_index.snapshot_epoch_id,
             *state_index.snapshot_merkle_root,
             maybe_intermediate_mpt,
@@ -320,7 +320,7 @@ impl StateManager {
                             );
                             return Ok(None);
                         }
-                        Some(snapshot_got) => snapshot = snapshot_got,
+                        Some(guarded_snapshot) => snapshot = guarded_snapshot,
                     }
                     maybe_intermediate_mpt = None;
                     maybe_intermediate_mpt_key_padding = None;
@@ -342,8 +342,8 @@ impl StateManager {
                         Some(mpt) => delta_mpt = mpt,
                     }
                 }
-                Some(snapshot_got) => {
-                    snapshot = snapshot_got;
+                Some(guarded_snapshot) => {
+                    snapshot = guarded_snapshot;
 
                     snapshot_merkle_root = match self
                         .storage_manager
@@ -403,11 +403,11 @@ impl StateManager {
                     // This is the special scenario when the snapshot isn't
                     // available but the snapshot at the intermediate epoch
                     // exists.
-                    if let Some(snapshot_got) = self
+                    if let Some(guarded_snapshot) = self
                         .storage_manager
                         .wait_for_snapshot(&intermediate_epoch_id)?
                     {
-                        snapshot = snapshot_got;
+                        snapshot = guarded_snapshot;
                         maybe_intermediate_mpt = None;
                         maybe_intermediate_mpt_key_padding = None;
                         delta_mpt = match self
@@ -437,8 +437,8 @@ impl StateManager {
                         return Ok(None);
                     }
                 }
-                Some(snapshot_got) => {
-                    snapshot = snapshot_got;
+                Some(guarded_snapshot) => {
+                    snapshot = guarded_snapshot;
                     maybe_intermediate_mpt_key_padding =
                         parent_state_index.maybe_intermediate_mpt_key_padding;
                     maybe_intermediate_mpt =
@@ -479,7 +479,7 @@ impl StateManager {
             }
         };
         Self::get_state_trees_internal(
-            snapshot,
+            snapshot.into().1,
             snapshot_epoch_id,
             snapshot_merkle_root,
             maybe_intermediate_mpt,
@@ -538,7 +538,9 @@ impl StateManagerTrait for StateManager {
                     .storage_manager
                     .wait_for_snapshot(&NULL_EPOCH)
                     .unwrap()
-                    .unwrap(),
+                    .unwrap()
+                    .into()
+                    .1,
                 snapshot_epoch_id: NULL_EPOCH,
                 snapshot_merkle_root: MERKLE_NULL_NODE,
                 maybe_intermediate_trie: None,

--- a/core/src/storage/impls/storage_manager/storage_manager.rs
+++ b/core/src/storage/impls/storage_manager/storage_manager.rs
@@ -185,13 +185,25 @@ impl StorageManager {
 
     pub fn wait_for_snapshot(
         &self, snapshot_epoch_id: &EpochId,
-    ) -> Result<Option<SnapshotDb>> {
+    ) -> Result<
+        Option<GuardedValue<RwLockReadGuard<Vec<SnapshotInfo>>, SnapshotDb>>,
+    > {
+        // After a snapshot is returned from this function, it can be deleted,
+        // then getting intermediate mpt for the snapshot can fail,
+        // which is not a nice error to state queries from clients.
+        //
+        // maintain_snapshots_pivot_chain_confirmed() can not delete snapshot
+        // while the current_snapshots are read locked.
+        let guard = self.current_snapshots.read();
         match self
             .snapshot_manager
             .get_snapshot_by_epoch_id(snapshot_epoch_id)?
         {
-            Some(snapshot_db) => Ok(Some(snapshot_db)),
+            Some(snapshot_db) => {
+                Ok(Some(GuardedValue::new(guard, snapshot_db)))
+            }
             None => {
+                drop(guard);
                 // Wait for in progress snapshot.
                 if let Some(in_progress_snapshot_task) = self
                     .in_progress_snapshotting_tasks
@@ -199,15 +211,24 @@ impl StorageManager {
                     .get(snapshot_epoch_id)
                     .cloned()
                 {
-                    // Snapshot error is thrown-out when the snapshot is first
-                    // requested here.
+                    // Snapshotting error is thrown-out when the snapshot is
+                    // first requested here.
                     if let Some(result) =
                         in_progress_snapshot_task.write().join()
                     {
                         result?;
                     }
-                    self.snapshot_manager
+                    let guard = self.current_snapshots.read();
+                    match self
+                        .snapshot_manager
                         .get_snapshot_by_epoch_id(snapshot_epoch_id)
+                    {
+                        Err(e) => Err(e),
+                        Ok(None) => Ok(None),
+                        Ok(Some(snapshot_db)) => {
+                            Ok(Some(GuardedValue::new(guard, snapshot_db)))
+                        }
+                    }
                 } else {
                     Ok(None)
                 }
@@ -557,6 +578,7 @@ impl StorageManager {
             (maybe_intermediate_delta_mpt, None),
         );
 
+        drop(snapshot_associated_mpts_locked);
         self.snapshot_info_map_by_epoch
             .write()
             .insert(snapshot_epoch_id.clone(), new_snapshot_info.clone());
@@ -1119,11 +1141,12 @@ use crate::{
                 KvdbSqliteStatements,
             },
         },
+        utils::guarded_value::GuardedValue,
         KeyValueDbTrait, KvdbSqlite, StorageConfiguration,
     },
 };
 use fallible_iterator::FallibleIterator;
-use parking_lot::{Mutex, RwLock};
+use parking_lot::{Mutex, RwLock, RwLockReadGuard};
 use primitives::{EpochId, MERKLE_NULL_NODE, NULL_EPOCH};
 use rlp::{Decodable, DecoderError, Encodable, Rlp};
 use sqlite::Statement;


### PR DESCRIPTION
Rpc call to get state will not fail because of DeltaMPTEntryNotFound. Full node execution works fine without the lock.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/976)
<!-- Reviewable:end -->
