### PR TITLE
Handle Interrupted properly in network.

### DIFF
--- a/network/src/connection.rs
+++ b/network/src/connection.rs
@@ -212,13 +212,14 @@ impl<Socket: GenericSocket> GenericConnection<Socket> {
                     }
                     self.recv_buf.extend_from_slice(&buf[0..size]);
                 }
-                Err(e) => {
-                    if e.kind() != io::ErrorKind::WouldBlock {
+                Err(e) => match e.kind() {
+                    io::ErrorKind::Interrupted => continue,
+                    io::ErrorKind::WouldBlock => break,
+                    _ => {
                         debug!("Failed to read socket data, token = {}, err = {:?}", self.token, e);
                         return Err(e);
                     }
-                    break;
-                }
+                },
             }
         }
 


### PR DESCRIPTION
As the document says:

> An error of the [`ErrorKind::Interrupted`] kind is non-fatal and the read
> operation should be retried if there is nothing else to do.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/984)
<!-- Reviewable:end -->
