### PR TITLE
Restore in progress snapshotting at last shutdown.

### DIFF
--- a/core/src/alliance_tree_graph/consensus/consensus_inner/consensus_new_block_handler.rs
+++ b/core/src/alliance_tree_graph/consensus/consensus_inner/consensus_new_block_handler.rs
@@ -642,6 +642,7 @@ impl ConsensusNewBlockHandler {
                 inner.get_epoch_start_block_number(pivot_arena_index),
                 None,  /* reward_info */
                 false, /* debug_record */
+                false, /* force_recompute */
             ));
         }
     }
@@ -752,6 +753,7 @@ impl ConsensusNewBlockHandler {
                     inner.get_epoch_start_block_number(pivot_arena_index),
                     None,  /* reward_info */
                     false, /* debug_record */
+                    true,  /* force_recompute */
                 ));
             }
         }

--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -108,13 +108,14 @@ pub struct EpochExecutionTask {
     pub reward_info: Option<RewardExecutionInfo>,
     pub on_local_pivot: bool,
     pub debug_record: Arc<Mutex<Option<ComputeEpochDebugRecord>>>,
+    pub force_recompute: bool,
 }
 
 impl EpochExecutionTask {
     pub fn new(
         epoch_hash: H256, epoch_block_hashes: Vec<H256>,
         start_block_number: u64, reward_info: Option<RewardExecutionInfo>,
-        on_local_pivot: bool, debug_record: bool,
+        on_local_pivot: bool, debug_record: bool, force_recompute: bool,
     ) -> Self
     {
         Self {
@@ -129,6 +130,7 @@ impl EpochExecutionTask {
             } else {
                 Arc::new(Mutex::new(None))
             },
+            force_recompute,
         }
     }
 }
@@ -315,8 +317,9 @@ impl ConsensusExecutor {
             inner.get_epoch_block_hashes(epoch_arena_index),
             inner.get_epoch_start_block_number(epoch_arena_index),
             self.get_reward_execution_info(inner, epoch_arena_index),
-            true,
-            false,
+            true,  /* on_local_pivot */
+            false, /* debug_record */
+            false, /* force_compute */
         );
         Some(execution_task)
     }
@@ -736,8 +739,9 @@ impl ConsensusExecutor {
                     inner.get_epoch_block_hashes(epoch_arena_index),
                     inner.get_epoch_start_block_number(epoch_arena_index),
                     reward_execution_info,
-                    false,
-                    false,
+                    false, /* on_local_pivot */
+                    false, /* debug_record */
+                    false, /* force_recompute */
                 ));
                 last_state_height += 1;
             }
@@ -754,8 +758,9 @@ impl ConsensusExecutor {
                 inner.get_epoch_block_hashes(epoch_arena_index),
                 inner.get_epoch_start_block_number(epoch_arena_index),
                 reward_execution_info,
-                false,
-                false,
+                false, /* on_local_pivot */
+                false, /* debug_record */
+                false, /* force_recompute */
             ));
         }
 
@@ -845,6 +850,7 @@ impl ConsensusExecutionHandler {
             &task.reward_info,
             task.on_local_pivot,
             &mut *task.debug_record.lock(),
+            task.force_recompute,
         );
     }
 
@@ -884,6 +890,7 @@ impl ConsensusExecutionHandler {
         reward_execution_info: &Option<RewardExecutionInfo>,
         on_local_pivot: bool,
         debug_record: &mut Option<ComputeEpochDebugRecord>,
+        force_recompute: bool,
     )
     {
         // FIXME: Question: where to calculate if we should make a snapshot?
@@ -891,7 +898,8 @@ impl ConsensusExecutionHandler {
         // FIXME: a new state.
 
         // Check if the state has been computed
-        if debug_record.is_none()
+        if !force_recompute
+            && debug_record.is_none()
             && self.data_man.epoch_executed_and_recovered(
                 &epoch_hash,
                 &epoch_block_hashes,

--- a/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
+++ b/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
@@ -630,8 +630,9 @@ impl ConsensusNewBlockHandler {
             epoch_block_hashes.clone(),
             inner.get_epoch_start_block_number(epoch_arena_index),
             reward_execution_info,
-            false,
-            true,
+            false, /* on_local_pivot */
+            true,  /* debug_record */
+            false, /* force_recompute */
         );
         let debug_record_data = task.debug_record.clone();
         {
@@ -1649,8 +1650,9 @@ impl ConsensusNewBlockHandler {
                     inner.get_epoch_block_hashes(epoch_arena_index),
                     inner.get_epoch_start_block_number(epoch_arena_index),
                     reward_execution_info,
-                    true,
-                    false,
+                    true,  /* on_local_pivot */
+                    false, /* debug_record */
+                    false, /* force_recompute */
                 ));
 
                 // send to PubSub
@@ -1942,6 +1944,7 @@ impl ConsensusNewBlockHandler {
                         .get_reward_execution_info(inner, pivot_arena_index),
                     true,  /* on_local_pivot */
                     false, /* debug_record */
+                    true,  /* force_recompute */
                 ));
             }
         }


### PR DESCRIPTION
Tested with crafted crash when a freshly made snapshot is first needed. In the test the snapshot is removed, and in the next run it's verified that the snapshotting process is triggered again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/993)
<!-- Reviewable:end -->
