### PR TITLE
Change txgen and special_txgen to Option.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,15 +127,6 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
-dependencies = [
- "nodrop",
-]
-
-[[package]]
-name = "arrayvec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
@@ -317,7 +308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.1",
+ "arrayvec",
  "constant_time_eq",
 ]
 
@@ -1265,7 +1256,7 @@ version = "0.1.2"
 source = "git+https://github.com/Conflux-Chain/conflux-parity-deps.git#8581500f4d47525eb9e3bd8599ece591f4d599ce"
 dependencies = [
  "app_dirs",
- "ethereum-types 0.6.0",
+ "ethereum-types 0.7.0",
  "home 0.3.4",
 ]
 
@@ -1408,12 +1399,12 @@ dependencies = [
 
 [[package]]
 name = "ethbloom"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3932e82d64d347a045208924002930dc105a138995ccdc1479d0f05f0359f17c"
+checksum = "bd0584482a6433370908dee84ea13992c2cf39c569600e4dbfafe520bb3b90d1"
 dependencies = [
  "crunchy",
- "fixed-hash 0.3.2",
+ "fixed-hash 0.4.0",
  "impl-rlp",
  "impl-serde 0.2.3",
  "tiny-keccak",
@@ -1455,16 +1446,16 @@ checksum = "e957efe1e627f8ec4e253660615fd9fe3736e10026197740b8b4b26c812be2e9"
 
 [[package]]
 name = "ethereum-types"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d1bc682337e2c5ec98930853674dd2b4bd5d0d246933a9e98e5280f7c76c5f"
+checksum = "4a5a7777cb75d9ee2b8d3752634b15e4e4e70d2ef81a227e9d157acfa18592b1"
 dependencies = [
- "ethbloom 0.6.4",
- "fixed-hash 0.3.2",
+ "ethbloom 0.7.0",
+ "fixed-hash 0.4.0",
  "impl-rlp",
  "impl-serde 0.2.3",
- "primitive-types 0.3.0",
- "uint 0.7.1",
+ "primitive-types 0.5.1",
+ "uint",
 ]
 
 [[package]]
@@ -1478,7 +1469,7 @@ dependencies = [
  "impl-rlp",
  "impl-serde 0.2.3",
  "primitive-types 0.6.2",
- "uint 0.8.2",
+ "uint",
 ]
 
 [[package]]
@@ -1570,19 +1561,6 @@ name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
-
-[[package]]
-name = "fixed-hash"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a683d1234507e4f3bf2736eeddf0de1dc65996dc0164d57eba0a74bcf29489"
-dependencies = [
- "byteorder",
- "heapsize",
- "rand 0.5.6",
- "rustc-hex 2.1.0",
- "static_assertions 0.2.5",
-]
 
 [[package]]
 name = "fixed-hash"
@@ -2227,15 +2205,6 @@ dependencies = [
  "tokio-timer 0.1.2",
  "xml-rs",
  "xmltree",
-]
-
-[[package]]
-name = "impl-codec"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2050d823639fbeae26b2b5ba09aca8907793117324858070ade0673c49f793b"
-dependencies = [
- "parity-codec",
 ]
 
 [[package]]
@@ -3229,12 +3198,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d77f3db4bce033f4d04db08079b2ef1c3d02b44e86f25d08886fafa7756ffa"
 
 [[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-
-[[package]]
 name = "nom"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3480,16 +3443,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c276d76c5333b8c2579e02d49a06733a55b8282d2d9b13e8d53b6406bd7e30a"
 
 [[package]]
-name = "parity-codec"
-version = "3.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b9df1283109f542d8852cd6b30e9341acc2137481eb6157d2e62af68b0afec9"
-dependencies = [
- "arrayvec 0.4.12",
- "serde",
-]
-
-[[package]]
 name = "parity-crypto"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3577,7 +3530,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f747c06d9f3b2ad387ac881b9667298c81b1243aa9833f086e05996937c35507"
 dependencies = [
- "arrayvec 0.5.1",
+ "arrayvec",
  "bitvec 0.15.2",
  "byte-slice-cast",
  "serde",
@@ -3589,7 +3542,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fca4f82fccae37e8bbdaeb949a4a218a1bbc485d11598f193d2a908042e5fc1"
 dependencies = [
- "arrayvec 0.5.1",
+ "arrayvec",
  "cc",
  "cfg-if",
  "rand 0.7.3",
@@ -3779,26 +3732,15 @@ checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 
 [[package]]
 name = "primitive-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2288eb2a39386c4bc817974cc413afe173010dc80e470fcb1e9a35580869f024"
-dependencies = [
- "fixed-hash 0.3.2",
- "impl-codec 0.2.0",
- "impl-rlp",
- "impl-serde 0.2.3",
- "uint 0.7.1",
-]
-
-[[package]]
-name = "primitive-types"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83ef7b3b965c0eadcb6838f34f827e1dfb2939bdd5ebd43f9647e009b12b0371"
 dependencies = [
  "fixed-hash 0.4.0",
- "impl-codec 0.4.2",
- "uint 0.8.2",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde 0.2.3",
+ "uint",
 ]
 
 [[package]]
@@ -3808,10 +3750,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4336f4f5d5524fa60bcbd6fe626f9223d8142a50e7053e979acdf0da41ab975"
 dependencies = [
  "fixed-hash 0.5.2",
- "impl-codec 0.4.2",
+ "impl-codec",
  "impl-rlp",
  "impl-serde 0.3.0",
- "uint 0.8.2",
+ "uint",
 ]
 
 [[package]]
@@ -5730,18 +5672,6 @@ name = "ucd-util"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ccdc2daea7cf8bc50cd8710d170a9d816678e54943829c5082bb1594312cf8e"
-
-[[package]]
-name = "uint"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2143cded94692b156c356508d92888acc824db5bffc0b4089732264c6fcf86d4"
-dependencies = [
- "byteorder",
- "crunchy",
- "heapsize",
- "rustc-hex 2.1.0",
-]
 
 [[package]]
 name = "uint"

--- a/client/benches/benchmark.rs
+++ b/client/benches/benchmark.rs
@@ -28,7 +28,7 @@ fn txgen_benchmark(c: &mut Criterion) {
     let handler = ArchiveClient::start(conf, exit).unwrap();
     c.bench_function("Randomly generate 1 transaction", move |b| {
         b.iter(|| {
-            handler.txgen.generate_transaction();
+            handler.txgen.unwrap().generate_transaction();
         });
     });
 }

--- a/client/benches/benchmark.rs
+++ b/client/benches/benchmark.rs
@@ -28,7 +28,7 @@ fn txgen_benchmark(c: &mut Criterion) {
     let handler = ArchiveClient::start(conf, exit).unwrap();
     c.bench_function("Randomly generate 1 transaction", move |b| {
         b.iter(|| {
-            handler.txgen.unwrap().generate_transaction();
+            handler.txgen.as_ref().unwrap().generate_transaction();
         });
     });
 }

--- a/client/src/full/mod.rs
+++ b/client/src/full/mod.rs
@@ -49,7 +49,7 @@ pub struct FullClientHandle {
     pub consensus: Arc<ConsensusGraph>,
     pub txpool: Arc<TransactionPool>,
     pub sync: Arc<SynchronizationService>,
-    pub txgen: Arc<TransactionGenerator>,
+    pub txgen: Option<Arc<TransactionGenerator>>,
     pub txgen_join_handle: Option<thread::JoinHandle<()>>,
     pub blockgen: Arc<BlockGenerator>,
     pub secret_store: Arc<SecretStore>,
@@ -232,22 +232,27 @@ impl FullClient {
             DataPropagation::register(dp, network.clone())?;
         }
 
-        let txgen = Arc::new(TransactionGenerator::new(
-            consensus.clone(),
-            txpool.clone(),
-            sync.clone(),
-            secret_store.clone(),
-            network.net_key_pair().ok(),
-        ));
+        // txgen is only needed in testing or debugging
+        let (txgen, special_txgen) = if conf.is_test_or_dev_mode() {
+            let txgen = Arc::new(TransactionGenerator::new(
+                consensus.clone(),
+                txpool.clone(),
+                sync.clone(),
+                secret_store.clone(),
+                network.net_key_pair().ok(),
+            ));
 
-        let special_txgen =
-            Arc::new(Mutex::new(SpecialTransactionGenerator::new(
-                network.net_key_pair().unwrap(),
-                &public_to_address(secret_store.get_keypair(0).public()),
-                U256::from_dec_str("10000000000000000").unwrap(),
-                U256::from_dec_str("10000000000000000").unwrap(),
-            )));
-
+            let special_txgen =
+                Arc::new(Mutex::new(SpecialTransactionGenerator::new(
+                    network.net_key_pair().unwrap(),
+                    &public_to_address(secret_store.get_keypair(0).public()),
+                    U256::from_dec_str("10000000000000000").unwrap(),
+                    U256::from_dec_str("10000000000000000").unwrap(),
+                )));
+            (Some(txgen), Some(special_txgen))
+        } else {
+            (None, None)
+        };
         let maybe_author: Option<Address> = conf.raw_conf.mining_author.clone().map(|hex_str| Address::from_str(hex_str.as_str()).expect("mining-author should be 40-digit hex string without 0x prefix"));
         let blockgen = Arc::new(BlockGenerator::new(
             sync_graph,
@@ -286,7 +291,10 @@ impl FullClient {
 
         let tx_conf = conf.tx_gen_config();
         let txgen_handle = if tx_conf.generate_tx {
-            let txgen_clone = txgen.clone();
+            if !conf.is_test_or_dev_mode() {
+                panic!("generate_tx is only allowed in test or dev mode");
+            }
+            let txgen_clone = txgen.clone().unwrap();
             let t = if conf.is_test_mode() {
                 match conf.raw_conf.genesis_secrets {
                     Some(ref _file) => {

--- a/client/src/rpc/impls/alliance.rs
+++ b/client/src/rpc/impls/alliance.rs
@@ -42,7 +42,6 @@ use parking_lot::RwLock;
 use primitives::TransactionWithSignature;
 use rlp::Rlp;
 use std::{collections::BTreeMap, net::SocketAddr, sync::Arc};
-use txgen::SharedTransactionGenerator;
 
 pub struct RpcImpl {
     //config: RpcImplConfiguration,
@@ -60,8 +59,7 @@ impl RpcImpl {
     pub fn new(
         _consensus: SharedConsensusGraph, sync: SharedSynchronizationService,
         block_gen: Arc<TGBlockGenerator>, tx_pool: SharedTransactionPool,
-        _tx_gen: SharedTransactionGenerator, _config: RpcImplConfiguration,
-        executor: Arc<Executor>,
+        _config: RpcImplConfiguration, executor: Arc<Executor>,
         admin_transaction: Arc<RwLock<Option<SignedTransaction>>>,
     ) -> Self
     {


### PR DESCRIPTION
The initialization of `special_txgen` requires `secret_store` to be not empty, which is not satisfied if we set `genesis_accounts` to initialize the genesis state with only addresses.

Since transaction generation is only needed for testing, and `genesis_accounts` is only used for production (not `test` or `dev` mode), it's reasonable to make `txgen` and `special_txgen` optional, and only set in `test` or `dev` mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/996)
<!-- Reviewable:end -->
