### PR TITLE
Fix wrong state boundary after state sync.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,15 +127,6 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
-dependencies = [
- "nodrop",
-]
-
-[[package]]
-name = "arrayvec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
@@ -317,7 +308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.1",
+ "arrayvec",
  "constant_time_eq",
 ]
 
@@ -1265,7 +1256,7 @@ version = "0.1.2"
 source = "git+https://github.com/Conflux-Chain/conflux-parity-deps.git#8581500f4d47525eb9e3bd8599ece591f4d599ce"
 dependencies = [
  "app_dirs",
- "ethereum-types 0.6.0",
+ "ethereum-types 0.7.0",
  "home 0.3.4",
 ]
 
@@ -1408,12 +1399,12 @@ dependencies = [
 
 [[package]]
 name = "ethbloom"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3932e82d64d347a045208924002930dc105a138995ccdc1479d0f05f0359f17c"
+checksum = "bd0584482a6433370908dee84ea13992c2cf39c569600e4dbfafe520bb3b90d1"
 dependencies = [
  "crunchy",
- "fixed-hash 0.3.2",
+ "fixed-hash 0.4.0",
  "impl-rlp",
  "impl-serde 0.2.3",
  "tiny-keccak",
@@ -1455,16 +1446,16 @@ checksum = "e957efe1e627f8ec4e253660615fd9fe3736e10026197740b8b4b26c812be2e9"
 
 [[package]]
 name = "ethereum-types"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d1bc682337e2c5ec98930853674dd2b4bd5d0d246933a9e98e5280f7c76c5f"
+checksum = "4a5a7777cb75d9ee2b8d3752634b15e4e4e70d2ef81a227e9d157acfa18592b1"
 dependencies = [
- "ethbloom 0.6.4",
- "fixed-hash 0.3.2",
+ "ethbloom 0.7.0",
+ "fixed-hash 0.4.0",
  "impl-rlp",
  "impl-serde 0.2.3",
- "primitive-types 0.3.0",
- "uint 0.7.1",
+ "primitive-types 0.5.1",
+ "uint",
 ]
 
 [[package]]
@@ -1478,7 +1469,7 @@ dependencies = [
  "impl-rlp",
  "impl-serde 0.2.3",
  "primitive-types 0.6.2",
- "uint 0.8.2",
+ "uint",
 ]
 
 [[package]]
@@ -1570,19 +1561,6 @@ name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
-
-[[package]]
-name = "fixed-hash"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a683d1234507e4f3bf2736eeddf0de1dc65996dc0164d57eba0a74bcf29489"
-dependencies = [
- "byteorder",
- "heapsize",
- "rand 0.5.6",
- "rustc-hex 2.1.0",
- "static_assertions 0.2.5",
-]
 
 [[package]]
 name = "fixed-hash"
@@ -2227,15 +2205,6 @@ dependencies = [
  "tokio-timer 0.1.2",
  "xml-rs",
  "xmltree",
-]
-
-[[package]]
-name = "impl-codec"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2050d823639fbeae26b2b5ba09aca8907793117324858070ade0673c49f793b"
-dependencies = [
- "parity-codec",
 ]
 
 [[package]]
@@ -3229,12 +3198,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d77f3db4bce033f4d04db08079b2ef1c3d02b44e86f25d08886fafa7756ffa"
 
 [[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-
-[[package]]
 name = "nom"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3480,16 +3443,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c276d76c5333b8c2579e02d49a06733a55b8282d2d9b13e8d53b6406bd7e30a"
 
 [[package]]
-name = "parity-codec"
-version = "3.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b9df1283109f542d8852cd6b30e9341acc2137481eb6157d2e62af68b0afec9"
-dependencies = [
- "arrayvec 0.4.12",
- "serde",
-]
-
-[[package]]
 name = "parity-crypto"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3577,7 +3530,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f747c06d9f3b2ad387ac881b9667298c81b1243aa9833f086e05996937c35507"
 dependencies = [
- "arrayvec 0.5.1",
+ "arrayvec",
  "bitvec 0.15.2",
  "byte-slice-cast",
  "serde",
@@ -3589,7 +3542,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fca4f82fccae37e8bbdaeb949a4a218a1bbc485d11598f193d2a908042e5fc1"
 dependencies = [
- "arrayvec 0.5.1",
+ "arrayvec",
  "cc",
  "cfg-if",
  "rand 0.7.3",
@@ -3779,26 +3732,15 @@ checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 
 [[package]]
 name = "primitive-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2288eb2a39386c4bc817974cc413afe173010dc80e470fcb1e9a35580869f024"
-dependencies = [
- "fixed-hash 0.3.2",
- "impl-codec 0.2.0",
- "impl-rlp",
- "impl-serde 0.2.3",
- "uint 0.7.1",
-]
-
-[[package]]
-name = "primitive-types"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83ef7b3b965c0eadcb6838f34f827e1dfb2939bdd5ebd43f9647e009b12b0371"
 dependencies = [
  "fixed-hash 0.4.0",
- "impl-codec 0.4.2",
- "uint 0.8.2",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde 0.2.3",
+ "uint",
 ]
 
 [[package]]
@@ -3808,10 +3750,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4336f4f5d5524fa60bcbd6fe626f9223d8142a50e7053e979acdf0da41ab975"
 dependencies = [
  "fixed-hash 0.5.2",
- "impl-codec 0.4.2",
+ "impl-codec",
  "impl-rlp",
  "impl-serde 0.3.0",
- "uint 0.8.2",
+ "uint",
 ]
 
 [[package]]
@@ -5730,18 +5672,6 @@ name = "ucd-util"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ccdc2daea7cf8bc50cd8710d170a9d816678e54943829c5082bb1594312cf8e"
-
-[[package]]
-name = "uint"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2143cded94692b156c356508d92888acc824db5bffc0b4089732264c6fcf86d4"
-dependencies = [
- "byteorder",
- "crunchy",
- "heapsize",
- "rustc-hex 2.1.0",
-]
 
 [[package]]
 name = "uint"

--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -132,6 +132,7 @@ build_config! {
         (egress_queue_capacity, (usize), 256)
         (egress_min_throttle, (usize), 10)
         (egress_max_throttle, (usize), 64)
+        (expire_block_gc_period_s, (u64), 900)
         (headers_request_timeout_ms, (u64), 10_000)
         (heartbeat_period_interval_ms, (u64), 30_000)
         (inflight_pending_tx_index_maintain_timeout_ms, (u64), 30_000)
@@ -443,6 +444,9 @@ impl Configuration {
             ),
             block_cache_gc_period: Duration::from_millis(
                 self.raw_conf.block_cache_gc_period_ms,
+            ),
+            expire_block_gc_period: Duration::from_secs(
+                self.raw_conf.expire_block_gc_period_s,
             ),
             headers_request_timeout: Duration::from_millis(
                 self.raw_conf.headers_request_timeout_ms,

--- a/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
+++ b/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
@@ -83,8 +83,16 @@ impl ConsensusNewBlockHandler {
         // chain checkpoint mechanism (`RecoverBlockFromDb` or
         // `Normal`), ensure all blocks on the pivot chain before
         // stable_era_genesis have state_valid computed
-        if will_execute {
-            // Make sure state execution is finished before setting lower_bound
+        if will_execute
+            && new_era_height
+                >= inner
+                    .data_man
+                    .state_availability_boundary
+                    .read()
+                    .lower_bound
+        {
+            // If new_era_genesis should have available state,
+            // make sure state execution is finished before setting lower_bound
             // to the new_checkpoint_era_genesis.
             executor
                 .wait_for_result(inner.arena[new_era_block_arena_index].hash);
@@ -1377,16 +1385,29 @@ impl ConsensusNewBlockHandler {
             }
         }
 
-        if fork_at <= inner.cur_era_stable_height && !self.conf.bench_mode {
+        inner.adjust_difficulty(*inner.pivot_chain.last().expect("not empty"));
+        meter.update_confirmation_risks(inner);
+
+        // Only process blocks in the subtree of stable
+        if (inner.arena[me].height <= inner.cur_era_stable_height
+            || (inner.arena[me].height > inner.cur_era_stable_height
+                && inner.arena
+                    [inner.ancestor_at(me, inner.cur_era_stable_height)]
+                .hash
+                    != inner.cur_era_stable_block_hash))
+            && !self.conf.bench_mode
+        {
             if has_body {
                 self.persist_terminals(inner);
             }
             debug!(
-                "Finish activating block in ConsensusGraph: index={:?} hash={:?}, block is earlier than stable, skip execution.",
+                "Finish activating block in ConsensusGraph: index={:?} hash={:?},\
+                 block is not in the subtree of stable",
                 me, inner.arena[me].hash
             );
             return;
         }
+        fork_at = max(inner.cur_era_stable_height + 1, fork_at);
 
         if pivot_changed {
             if inner.pivot_chain.len() > EPOCH_SET_PERSISTENCE_DELAY as usize {
@@ -1414,9 +1435,6 @@ impl ConsensusNewBlockHandler {
                 }
             }
         }
-
-        inner.adjust_difficulty(*inner.pivot_chain.last().expect("not empty"));
-        meter.update_confirmation_risks(inner);
 
         // Note that after the checkpoint (if happens), the old_pivot_chain_len
         // value will become obsolete

--- a/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
+++ b/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
@@ -1385,9 +1385,6 @@ impl ConsensusNewBlockHandler {
             }
         }
 
-        inner.adjust_difficulty(*inner.pivot_chain.last().expect("not empty"));
-        meter.update_confirmation_risks(inner);
-
         // Only process blocks in the subtree of stable
         if (inner.arena[me].height <= inner.cur_era_stable_height
             || (inner.arena[me].height > inner.cur_era_stable_height
@@ -1408,6 +1405,9 @@ impl ConsensusNewBlockHandler {
             return;
         }
         fork_at = max(inner.cur_era_stable_height + 1, fork_at);
+
+        inner.adjust_difficulty(*inner.pivot_chain.last().expect("not empty"));
+        meter.update_confirmation_risks(inner);
 
         if pivot_changed {
             if inner.pivot_chain.len() > EPOCH_SET_PERSISTENCE_DELAY as usize {

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -260,6 +260,7 @@ pub struct ProtocolConfiguration {
     pub check_request_period: Duration,
     pub heartbeat_period_interval: Duration,
     pub block_cache_gc_period: Duration,
+    pub expire_block_gc_period: Duration,
     pub headers_request_timeout: Duration,
     pub blocks_request_timeout: Duration,
     pub transaction_request_timeout: Duration,
@@ -1486,8 +1487,11 @@ impl NetworkProtocolHandler for SynchronizationProtocolHandler {
             Duration::from_millis(1000),
         )
         .expect("Error registering CHECK_FUTURE_BLOCK_TIMER");
-        io.register_timer(EXPIRE_BLOCK_GC_TIMER, Duration::from_secs(60 * 15))
-            .expect("Error registering EXPIRE_BLOCK_GC_TIMER");
+        io.register_timer(
+            EXPIRE_BLOCK_GC_TIMER,
+            self.protocol_config.expire_block_gc_period,
+        )
+        .expect("Error registering EXPIRE_BLOCK_GC_TIMER");
 
         if self.is_consortium() {
             io.register_timer(

--- a/run/default.toml
+++ b/run/default.toml
@@ -146,6 +146,10 @@ jsonrpc_local_http_port=12539
 #
 # egress_max_throttle = 10
 
+# Time interval to to garbage-collect not block-graph-ready blocks periodically.
+#
+# expire_block_gc_period_s = 900
+
 # Timeout for header-related requests (GetBlockHeaders)
 #
 # headers_request_timeout_ms=10_000

--- a/tests/test_framework/util.py
+++ b/tests/test_framework/util.py
@@ -310,6 +310,7 @@ def initialize_datadir(dirname, n, conf_parameters):
                         "metrics_enabled": "true",
                         # "block_db_type": "\'sqlite\'"
                         "tg_config_path": "\'{}\'".format(os.path.join(datadir, "tg_config/tg_config.conf")),
+                        "expire_block_gc_period_s": "5",
                       }
         for k in conf_parameters:
             local_conf[k] = conf_parameters[k]


### PR DESCRIPTION
If we use `fork_at` to filter out blocks earlier than stable is inaccurate, when we switch from a wrong pivot chain back to the correct one where stable_genesis is on, it's possible that `fork_at` is before stable_height. 

In this case, the new block is not earlier than stable and we should not skip the rest code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1002)
<!-- Reviewable:end -->
