### PR TITLE
Fix: cfx_getTransactionByHash RPC won't return a created contract address if the outcome status is not zero

### DIFF
--- a/client/src/rpc/types/receipt.rs
+++ b/client/src/rpc/types/receipt.rs
@@ -48,7 +48,7 @@ impl Receipt {
     ) -> Receipt
     {
         let mut address = None;
-        if Action::Create == transaction.action {
+        if Action::Create == transaction.action && receipt.outcome_status == 0 {
             let (created_address, _) = contract_address(
                 CreateContractAddress::FromSenderAndNonce,
                 &transaction.sender,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1022)
<!-- Reviewable:end -->
