### PR TITLE
Compress debug string of state boundary and snapshot info.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,6 +582,7 @@ dependencies = [
  "clap",
  "criterion 0.2.11",
  "db",
+ "derivative 2.0.2",
  "error-chain",
  "fallible-iterator",
  "fs_extra",
@@ -1261,6 +1262,17 @@ dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
  "syn 0.15.44",
+]
+
+[[package]]
+name = "derivative"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b94d2eb97732ec84b4e25eaf37db890e317b80e921f168c82cb5282473f8151"
+dependencies = [
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.16",
 ]
 
 [[package]]
@@ -3300,7 +3312,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be601e38e20a6f3d01049d85801cb9b7a34a8da7a0da70df507bbde7735058c8"
 dependencies = [
- "derivative",
+ "derivative 1.0.4",
  "num_enum_derive",
 ]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -95,6 +95,7 @@ threadpool = "1.0"
 unexpected = { git = "https://github.com/Conflux-Chain/conflux-parity-deps.git" }
 zip = "*"
 tokio-timer = "0.2.13"
+derivative = "2.0.2"
 
 [dev-dependencies]
 criterion = "0.2"

--- a/core/src/block_data_manager/mod.rs
+++ b/core/src/block_data_manager/mod.rs
@@ -38,6 +38,7 @@ use crate::block_data_manager::{
     db_manager::DBManager, tx_data_manager::TransactionDataManager,
 };
 pub use block_data_types::*;
+use derivative::Derivative;
 use std::{hash::Hash, path::Path, time::Duration};
 
 use crate::parameters::consensus_internal::REWARD_EPOCH_COUNT;
@@ -50,10 +51,13 @@ lazy_static! {
 pub const NULLU64: u64 = !0;
 
 /// FIXME: move it to another module.
-#[derive(Debug, Clone)]
+#[derive(Derivative, Clone)]
+#[derivative(Debug)]
 pub struct StateAvailabilityBoundary {
     /// This is the hash of blocks in pivot chain based on current graph.
+    #[derivative(Debug = "ignore")]
     pub pivot_chain: Vec<H256>,
+
     pub synced_state_height: u64,
     /// This is the lower boundary height of available state.
     pub lower_bound: u64,

--- a/core/src/storage/storage_db/snapshot_db.rs
+++ b/core/src/storage/storage_db/snapshot_db.rs
@@ -2,7 +2,8 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Default, Derivative)]
+#[derivative(Debug)]
 pub struct SnapshotInfo {
     // FIXME: update serve_one_step_sync at maintenance.
     pub serve_one_step_sync: bool,
@@ -13,6 +14,7 @@ pub struct SnapshotInfo {
     pub parent_snapshot_epoch_id: EpochId,
     // the last element of pivot_chain_parts is the epoch id of the snapshot
     // itself.
+    #[derivative(Debug = "ignore")]
     pub pivot_chain_parts: Vec<EpochId>,
 }
 
@@ -120,6 +122,7 @@ use super::{
 use crate::storage::storage_db::{
     KeyValueDbTraitRead, SnapshotMptTraitRead, SnapshotMptTraitRw,
 };
+use derivative::Derivative;
 use parking_lot::Mutex;
 use primitives::{EpochId, MerkleHash, MERKLE_NULL_NODE, NULL_EPOCH};
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};


### PR DESCRIPTION
The included `pivot_chain_part` can be very large, so we should avoid printing it in logs or RPC responses.

This closes #1021.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1054)
<!-- Reviewable:end -->
