### PR TITLE
allow user to set gas limit reasonably higher than gas_used

### DIFF
--- a/core/src/alliance_tree_graph/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/alliance_tree_graph/consensus/consensus_inner/consensus_executor.rs
@@ -731,14 +731,14 @@ impl ConsensusExecutionHandler {
                     Err(ExecutionError::NotEnoughCash {
                         required: _,
                         got: _,
-                        actual_cost,
+                        actual_gas_cost,
                     }) => {
-                        /* We charge `actual_cost`, so increase
+                        /* We charge `actual_gas_cost`, so increase
                          * `cumulative_gas_used` to make
                          * this charged balance distributed to miners.
                          * Note for the case that `balance < tx_fee`, the
                          * amount of remainder is lost forever. */
-                        env.gas_used += actual_cost / transaction.gas_price;
+                        env.gas_used += actual_gas_cost / transaction.gas_price;
                         cumulative_gas_used = env.gas_used;
                     }
                     Err(ExecutionError::InvalidNonce { expected, got }) => {

--- a/core/src/executive/executed.rs
+++ b/core/src/executive/executed.rs
@@ -86,7 +86,7 @@ pub enum ExecutionError {
         /// Actual balance.
         got: U512,
         /// Actual cost. This should be min(tx_fee, balance).
-        actual_cost: U256,
+        actual_gas_cost: U256,
     },
     /// When execution tries to modify the state in static context
     MutableCallInStaticContext,

--- a/core/src/executive/executive.rs
+++ b/core/src/executive/executive.rs
@@ -1502,17 +1502,16 @@ impl<'a> Executive<'a> {
             )
         };
 
-        let refundee = if let Some(r) = refund_receiver {
-            r
+        if let Some(r) = refund_receiver {
+            self.state.add_sponsor_balance_for_gas(&r, &refund_value)?;
         } else {
-            tx.sender()
+            let spec = self.spec;
+            self.state.add_balance(
+                &tx.sender(),
+                &refund_value,
+                substate.to_cleanup_mode(&spec),
+            )?;
         };
-        let spec = self.spec;
-        self.state.add_balance(
-            &refundee,
-            &refund_value,
-            substate.to_cleanup_mode(&spec),
-        )?;
 
         // perform suicides
         for address in &substate.suicides {

--- a/core/src/executive/executive_tests.rs
+++ b/core/src/executive/executive_tests.rs
@@ -970,7 +970,7 @@ fn test_commission_privilege() {
     assert_eq!(state.balance(&address).unwrap(), U256::from(1_000_000));
     assert_eq!(
         state.balance(&sender.address()).unwrap(),
-        U256::from(999_999_999_998_900_000u64)
+        U256::from(999_999_999_998_925_000u64)
     );
 
     state
@@ -1031,7 +1031,7 @@ fn test_commission_privilege() {
     let tx = Transaction {
         nonce: 0.into(),
         gas_price: U256::from(1),
-        gas: U256::from(100_000),
+        gas: U256::from(60_000),
         value: U256::zero(),
         action: Action::Call(address),
         storage_limit: U256::MAX,
@@ -1057,7 +1057,10 @@ fn test_commission_privilege() {
 
     assert_eq!(gas_used, U256::from(58_024));
     assert_eq!(state.nonce(&caller3.address()).unwrap(), U256::from(1));
-    assert_eq!(state.balance(&caller3.address()).unwrap(), U256::from(0));
+    assert_eq!(
+        state.balance(&caller3.address()).unwrap(),
+        U256::from(41_976)
+    );
     assert_eq!(
         state.sponsor_balance_for_gas(&address).unwrap(),
         U256::from(110_000)
@@ -1099,7 +1102,7 @@ fn test_commission_privilege() {
     );
     assert_eq!(
         state.sponsor_balance_for_gas(&address).unwrap(),
-        U256::from(10_000)
+        U256::from(35_000)
     );
 
     // call with commission privilege and not enough commission balance
@@ -1132,10 +1135,13 @@ fn test_commission_privilege() {
 
     assert_eq!(gas_used, U256::from(58_024));
     assert_eq!(state.nonce(&caller2.address()).unwrap(), U256::from(1));
-    assert_eq!(state.balance(&caller2.address()).unwrap(), U256::from(0));
+    assert_eq!(
+        state.balance(&caller2.address()).unwrap(),
+        U256::from(25_000)
+    );
     assert_eq!(
         state.sponsor_balance_for_gas(&address).unwrap(),
-        U256::from(10_000)
+        U256::from(35_000)
     );
 
     // add more commission balance
@@ -1166,7 +1172,10 @@ fn test_commission_privilege() {
     }
     .sign(caller2.secret());
     assert_eq!(tx.sender(), caller2.address());
-    assert_eq!(state.balance(&caller2.address()).unwrap(), U256::from(0));
+    assert_eq!(
+        state.balance(&caller2.address()).unwrap(),
+        U256::from(25_000)
+    );
     let Executed { gas_used, .. } = Executive::new(
         &mut state,
         &env,
@@ -1179,10 +1188,13 @@ fn test_commission_privilege() {
 
     assert_eq!(gas_used, U256::from(58_024));
     assert_eq!(state.nonce(&caller2.address()).unwrap(), U256::from(2));
-    assert_eq!(state.balance(&caller2.address()).unwrap(), U256::from(0));
+    assert_eq!(
+        state.balance(&caller2.address()).unwrap(),
+        U256::from(25_000)
+    );
     assert_eq!(
         state.sponsor_balance_for_gas(&address).unwrap(),
-        U256::from(100_000)
+        U256::from(125_000)
     );
 
     // add commission privilege to caller3
@@ -1206,7 +1218,10 @@ fn test_commission_privilege() {
     }
     .sign(caller3.secret());
     assert_eq!(tx.sender(), caller3.address());
-    assert_eq!(state.balance(&caller3.address()).unwrap(), U256::from(0));
+    assert_eq!(
+        state.balance(&caller3.address()).unwrap(),
+        U256::from(41_976)
+    );
     let Executed { gas_used, .. } = Executive::new(
         &mut state,
         &env,
@@ -1219,10 +1234,13 @@ fn test_commission_privilege() {
 
     assert_eq!(gas_used, U256::from(58_024));
     assert_eq!(state.nonce(&caller3.address()).unwrap(), U256::from(2));
-    assert_eq!(state.balance(&caller3.address()).unwrap(), U256::from(0));
+    assert_eq!(
+        state.balance(&caller3.address()).unwrap(),
+        U256::from(41_976)
+    );
     assert_eq!(
         state.sponsor_balance_for_gas(&address).unwrap(),
-        U256::zero()
+        U256::from(50_000)
     );
 }
 

--- a/core/src/executive/executive_tests.rs
+++ b/core/src/executive/executive_tests.rs
@@ -473,10 +473,10 @@ fn test_not_enough_cash() {
         Err(ExecutionError::NotEnoughCash {
             required,
             got,
-            actual_cost,
+            actual_gas_cost,
         }) if required == U512::from(100_018)
             && got == U512::from(100_017)
-            && correct_cost == actual_cost =>
+            && correct_cost == actual_gas_cost =>
         {
             ()
         }

--- a/tests/admin_control_test.py
+++ b/tests/admin_control_test.py
@@ -169,7 +169,7 @@ class AdminControlTest(ConfluxTestFramework):
             wait=True,
             check_status=True)
         assert_equal(client.get_balance(contract_addr), 10 ** 18)
-        assert_equal(client.get_balance(addr), b0 - 10 ** 18 - gas)
+        assert_equal(client.get_balance(addr), b0 - 10 ** 18 - gas + gas // 4)
         assert_equal(client.get_admin(contract_addr), addr)
 
         # transfer admin (fail)
@@ -204,7 +204,7 @@ class AdminControlTest(ConfluxTestFramework):
             wait=True,
             check_status=True)
         assert_equal(client.get_balance(contract_addr), 0)
-        assert_equal(client.get_balance(addr2), 5999999999900000000)
+        assert_equal(client.get_balance(addr2), 5999999999912500000 + gas // 4)
 
         self.log.info("Pass")
 

--- a/tests/commission_privilege_test.py
+++ b/tests/commission_privilege_test.py
@@ -220,7 +220,7 @@ class CommissionPrivilegeTest(ConfluxTestFramework):
         assert_equal(client.get_sponsor_balance_for_gas(contract_addr), 10 ** 18)
         assert_equal(client.get_sponsor_for_gas(contract_addr), genesis_addr)
         assert_equal(client.get_sponsor_gas_bound(contract_addr), upper_bound)
-        assert_equal(client.get_balance(genesis_addr), b0 - 10 ** 18 - gas)
+        assert_equal(client.get_balance(genesis_addr), b0 - 10 ** 18 - gas + 12500000)
 
         # set privilege for addr1
         b0 = client.get_balance(genesis_addr)
@@ -233,7 +233,7 @@ class CommissionPrivilegeTest(ConfluxTestFramework):
             contract_addr=contract_addr,
             wait=True,
             check_status=True)
-        assert_equal(client.get_balance(genesis_addr), b0 - gas - collateral_per_storage_key)
+        assert_equal(client.get_balance(genesis_addr), b0 - gas + 12500000 - collateral_per_storage_key)
         assert_equal(client.get_collateral_for_storage(genesis_addr), c0 + collateral_per_storage_key)
 
         # addr1 call contract with privilege
@@ -247,8 +247,8 @@ class CommissionPrivilegeTest(ConfluxTestFramework):
             contract_addr=contract_addr,
             wait=True,
             check_status=True)
-        assert_equal(client.get_sponsor_balance_for_gas(contract_addr), sb - gas)
         assert_equal(client.get_balance(addr1), b1)
+        assert_equal(client.get_sponsor_balance_for_gas(contract_addr), sb - gas + 12500000)
 
         # addr1 call contract with privilege and large tx fee
         b1 = client.get_balance(addr1)
@@ -263,7 +263,7 @@ class CommissionPrivilegeTest(ConfluxTestFramework):
             check_status=True,
             gas=upper_bound+ 1)
         assert_equal(client.get_sponsor_balance_for_gas(contract_addr), sb)
-        assert_equal(client.get_balance(addr1), b1 - upper_bound - 1)
+        assert_equal(client.get_balance(addr1), b1 - upper_bound + upper_bound // 4 - 1)
 
         # addr2 call contract without privilege
         b2 = client.get_balance(addr2)
@@ -277,7 +277,7 @@ class CommissionPrivilegeTest(ConfluxTestFramework):
             wait=True,
             check_status=True)
         assert_equal(client.get_sponsor_balance_for_gas(contract_addr), sb)
-        assert_equal(client.get_balance(addr2), b2 - gas)
+        assert_equal(client.get_balance(addr2), b2 - gas + 12500000)
 
         # set privilege for addr2
         b0 = client.get_balance(genesis_addr)
@@ -290,7 +290,7 @@ class CommissionPrivilegeTest(ConfluxTestFramework):
             contract_addr=contract_addr,
             wait=True,
             check_status=True)
-        assert_equal(client.get_balance(genesis_addr), b0 - gas - collateral_per_storage_key)
+        assert_equal(client.get_balance(genesis_addr), b0 - gas + 12500000 - collateral_per_storage_key)
         assert_equal(client.get_collateral_for_storage(genesis_addr), c0 + collateral_per_storage_key)
 
         # now, addr2 call contract with privilege
@@ -304,7 +304,7 @@ class CommissionPrivilegeTest(ConfluxTestFramework):
             contract_addr=contract_addr,
             wait=True,
             check_status=True)
-        assert_equal(client.get_sponsor_balance_for_gas(contract_addr), sb - gas)
+        assert_equal(client.get_sponsor_balance_for_gas(contract_addr), sb - gas + 12500000)
         assert_equal(client.get_balance(addr2), b2)
 
         # remove privilege for addr1
@@ -319,7 +319,7 @@ class CommissionPrivilegeTest(ConfluxTestFramework):
             wait=True,
             check_status=True)
         assert_equal(client.get_collateral_for_storage(genesis_addr), c0 - collateral_per_storage_key)
-        assert_equal(client.get_balance(genesis_addr), b0 - gas + collateral_per_storage_key)
+        assert_equal(client.get_balance(genesis_addr), b0 - gas + 12500000 + collateral_per_storage_key)
 
         # addr1 call contract without privilege
         sb = client.get_sponsor_balance_for_gas(contract_addr)
@@ -333,7 +333,7 @@ class CommissionPrivilegeTest(ConfluxTestFramework):
             wait=True,
             check_status=True)
         assert_equal(client.get_sponsor_balance_for_gas(contract_addr), sb)
-        assert_equal(client.get_balance(addr1), b1 - gas)
+        assert_equal(client.get_balance(addr1), b1 - gas + 12500000)
 
         # new sponsor failed due to small sponsor_balance
         b3 = client.get_balance(addr3)
@@ -380,7 +380,7 @@ class CommissionPrivilegeTest(ConfluxTestFramework):
         assert_equal(client.get_sponsor_balance_for_gas(contract_addr), 10 ** 18)
         assert_equal(client.get_sponsor_gas_bound(contract_addr), upper_bound + 1)
         assert_equal(client.get_sponsor_for_gas(contract_addr), addr3)
-        assert_equal(client.get_balance(addr3), b3 - 10 ** 18 - gas)
+        assert_equal(client.get_balance(addr3), b3 - 10 ** 18 - gas + 12500000)
         assert_equal(client.get_balance(genesis_addr), b0 + sb)
 
         # sponsor the contract for collateral failed due to zero sponsor balance
@@ -409,7 +409,7 @@ class CommissionPrivilegeTest(ConfluxTestFramework):
             wait=True)
         assert_equal(client.get_sponsor_balance_for_collateral(contract_addr), 10 ** 18 - 1)
         assert_equal(client.get_sponsor_for_collateral(contract_addr), addr3)
-        assert_equal(client.get_balance(addr3), b3 - gas - 10 ** 18 + 1)
+        assert_equal(client.get_balance(addr3), b3 - gas + 12500000 - 10 ** 18 + 1)
 
         # addr1 create 2 keys without privilege, and storage limit is 1, should failed
         b1 = client.get_balance(addr1)
@@ -439,7 +439,7 @@ class CommissionPrivilegeTest(ConfluxTestFramework):
             storage_limit=collateral_per_storage_key * 2)
         assert_equal(client.get_collateral_for_storage(contract_addr), 0)
         assert_equal(client.get_collateral_for_storage(addr1), collateral_per_storage_key * 2)
-        assert_equal(client.get_balance(addr1), b1 - gas - collateral_per_storage_key * 2)
+        assert_equal(client.get_balance(addr1), b1 - gas + 12500000 - collateral_per_storage_key * 2)
 
         # remove 1 key create by addr1
         b1 = client.get_balance(addr1)
@@ -453,7 +453,7 @@ class CommissionPrivilegeTest(ConfluxTestFramework):
             storage_limit=collateral_per_storage_key * 2)
         assert_equal(client.get_collateral_for_storage(contract_addr), 0)
         assert_equal(client.get_collateral_for_storage(addr1), collateral_per_storage_key)
-        assert_equal(client.get_balance(addr1), b1 - gas + collateral_per_storage_key)
+        assert_equal(client.get_balance(addr1), b1 - gas + 12500000 + collateral_per_storage_key)
 
         # addr2 create 2 keys with privilege, and storage limit is 1, should succeed
         sbc = client.get_sponsor_balance_for_collateral(contract_addr)
@@ -469,7 +469,7 @@ class CommissionPrivilegeTest(ConfluxTestFramework):
             storage_limit=collateral_per_storage_key)
         assert_equal(client.get_collateral_for_storage(contract_addr), collateral_per_storage_key * 2)
         assert_equal(client.get_sponsor_balance_for_collateral(contract_addr), sbc - collateral_per_storage_key * 2)
-        assert_equal(client.get_sponsor_balance_for_gas(contract_addr), sbg - gas)
+        assert_equal(client.get_sponsor_balance_for_gas(contract_addr), sbg - gas + 12500000)
         assert_equal(client.get_collateral_for_storage(addr2), 0)
         assert_equal(client.get_balance(addr2), b2)
 
@@ -487,7 +487,7 @@ class CommissionPrivilegeTest(ConfluxTestFramework):
             storage_limit=0)
         assert_equal(client.get_collateral_for_storage(contract_addr), collateral_per_storage_key * 15)
         assert_equal(client.get_sponsor_balance_for_collateral(contract_addr), sbc - collateral_per_storage_key * 13)
-        assert_equal(client.get_sponsor_balance_for_gas(contract_addr), sbg - gas)
+        assert_equal(client.get_sponsor_balance_for_gas(contract_addr), sbg - gas + 12500000)
         assert_equal(client.get_collateral_for_storage(addr2), 0)
         assert_equal(client.get_balance(addr2), b2)
 
@@ -529,7 +529,7 @@ class CommissionPrivilegeTest(ConfluxTestFramework):
             storage_limit=collateral_per_storage_key * 2)
         assert_equal(client.get_collateral_for_storage(contract_addr), collateral_per_storage_key * 15)
         assert_equal(client.get_sponsor_balance_for_collateral(contract_addr), sbc)
-        assert_equal(client.get_sponsor_balance_for_gas(contract_addr), sbg - gas)
+        assert_equal(client.get_sponsor_balance_for_gas(contract_addr), sbg - gas + 12500000)
         assert_equal(client.get_collateral_for_storage(addr2), collateral_per_storage_key)
         assert_equal(client.get_balance(addr2), b2 - collateral_per_storage_key)
 
@@ -547,7 +547,7 @@ class CommissionPrivilegeTest(ConfluxTestFramework):
             storage_limit=collateral_per_storage_key)
         assert_equal(client.get_collateral_for_storage(contract_addr), collateral_per_storage_key * 5)
         assert_equal(client.get_sponsor_balance_for_collateral(contract_addr), sbc + collateral_per_storage_key * 10)
-        assert_equal(client.get_sponsor_balance_for_gas(contract_addr), sbg - gas)
+        assert_equal(client.get_sponsor_balance_for_gas(contract_addr), sbg - gas + 12500000)
         assert_equal(client.get_collateral_for_storage(addr2), collateral_per_storage_key)
         assert_equal(client.get_balance(addr2), b2)
 
@@ -564,7 +564,7 @@ class CommissionPrivilegeTest(ConfluxTestFramework):
             wait=True)
         assert_equal(client.get_sponsor_balance_for_collateral(contract_addr), sb * 2)
         assert_equal(client.get_sponsor_for_collateral(contract_addr), addr3)
-        assert_equal(client.get_balance(addr3), b3 - gas - sb)
+        assert_equal(client.get_balance(addr3), b3 - gas + 12500000 - sb)
 
         # genesis sponsor with sponsor balance, should failed
         b0 = client.get_balance(genesis_addr)
@@ -597,7 +597,7 @@ class CommissionPrivilegeTest(ConfluxTestFramework):
         assert_equal(client.get_collateral_for_storage(contract_addr), cfs)
         assert_equal(client.get_sponsor_balance_for_collateral(contract_addr), sb + cfs + 1)
         assert_equal(client.get_sponsor_for_collateral(contract_addr), genesis_addr)
-        assert_equal(client.get_balance(genesis_addr), b0 - gas - sb - cfs - 1)
+        assert_equal(client.get_balance(genesis_addr), b0 - gas + 12500000 - sb - cfs - 1)
         assert_equal(client.get_balance(addr3), b3 + sb + cfs)
 
         self.log.info("Pass")

--- a/tests/contract_bench_test.py
+++ b/tests/contract_bench_test.py
@@ -162,7 +162,7 @@ class ContractBenchTest(SmartContractBenchBase):
         c1 = self.rpc.get_collateral_for_storage(self.sender)
         assert_equal(len(logs), l + 2)
         assert_equal(self.rpc.get_balance(contractAddr), cost)
-        assert_equal(self.rpc.get_balance(self.sender), b0 - cost - fee - (c1 - c0))
+        assert_equal(self.rpc.get_balance(self.sender), b0 - cost - (fee - 2500000) - (c1 - c0))
         contract_id = logs[-1]["topics"][1]
 
         # call getContract
@@ -186,7 +186,7 @@ class ContractBenchTest(SmartContractBenchBase):
         assert_equal(self.rpc.get_balance(contractAddr), 0)
         c2 = self.rpc.get_collateral_for_storage(self.sender)
         assert_equal(c2 - c1, 125000000000000000)
-        assert_equal(self.rpc.get_balance(self.sender), b0 - fee * 2 - (c2 - c0))
+        assert_equal(self.rpc.get_balance(self.sender), b0 - (fee - 2500000) * 2 - (c2 - c0))
         logs = self.rpc.get_logs(self.filter)
         assert_equal(len(logs), l + 3)
 

--- a/tests/transaction_test.py
+++ b/tests/transaction_test.py
@@ -64,16 +64,19 @@ class TransactionTest(DefaultConfluxTestFramework):
                 receiver = privtoaddr(receiver_sk)
                 nonce_map[receiver_sk] = 0
                 balance_map[receiver_sk] = value
+                is_payment = True
             elif rand_n > 0.9 and balance_map[sender_key] > 21000 * 4 * tx_n:
                 value = 0
                 receiver = b''
                 data = bytes([96, 128, 96, 64, 82, 52, 128, 21, 97, 0, 16, 87, 96, 0, 128, 253, 91, 80, 96, 5, 96, 0, 129, 144, 85, 80, 96, 230, 128, 97, 0, 39, 96, 0, 57, 96, 0, 243, 254, 96, 128, 96, 64, 82, 96, 4, 54, 16, 96, 67, 87, 96, 0, 53, 124, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 144, 4, 128, 99, 96, 254, 71, 177, 20, 96, 72, 87, 128, 99, 109, 76, 230, 60, 20, 96, 127, 87, 91, 96, 0, 128, 253, 91, 52, 128, 21, 96, 83, 87, 96, 0, 128, 253, 91, 80, 96, 125, 96, 4, 128, 54, 3, 96, 32, 129, 16, 21, 96, 104, 87, 96, 0, 128, 253, 91, 129, 1, 144, 128, 128, 53, 144, 96, 32, 1, 144, 146, 145, 144, 80, 80, 80, 96, 167, 86, 91, 0, 91, 52, 128, 21, 96, 138, 87, 96, 0, 128, 253, 91, 80, 96, 145, 96, 177, 86, 91, 96, 64, 81, 128, 130, 129, 82, 96, 32, 1, 145, 80, 80, 96, 64, 81, 128, 145, 3, 144, 243, 91, 128, 96, 0, 129, 144, 85, 80, 80, 86, 91, 96, 0, 128, 84, 144, 80, 144, 86, 254, 161, 101, 98, 122, 122, 114, 48, 88, 32, 181, 24, 13, 149, 253, 195, 129, 48, 40, 237, 71, 246, 44, 124, 223, 112, 139, 118, 192, 219, 9, 64, 67, 245, 51, 180, 42, 67, 13, 49, 62, 21, 0, 41])
                 gas = 10000000
+                is_payment = False
             else:
                 value = 1
                 receiver_sk = random.choice(list(balance_map))
                 receiver = privtoaddr(receiver_sk)
                 balance_map[receiver_sk] += value
+                is_payment = True
             # not enough transaction fee (gas_price * gas_limit) should not happen for now
             assert balance_map[sender_key] >= value + gas_price * 21000
             tx = create_transaction(pri_key=sender_key, receiver=receiver, value=value, nonce=nonce,
@@ -82,7 +85,10 @@ class TransactionTest(DefaultConfluxTestFramework):
             self.nodes[r].p2p.send_protocol_msg(Transactions(transactions=[tx]))
             all_txs.append(tx)
             nonce_map[sender_key] = nonce + 1
-            balance_map[sender_key] -= value + gas_price * gas
+            if is_payment:
+                balance_map[sender_key] -= value + gas_price * gas
+            else:
+                balance_map[sender_key] -= value + gas_price * 7500000
             self.log.debug("New tx %s: %s send value %d to %s, sender balance:%d, receiver balance:%d nonce:%d", encode_hex(tx.hash), eth_utils.encode_hex(privtoaddr(sender_key))[-4:],
                           value, eth_utils.encode_hex(privtoaddr(receiver_sk))[-4:], balance_map[sender_key], balance_map[receiver_sk], nonce)
             self.log.debug("Send Transaction %s to node %d", encode_hex(tx.hash), r)

--- a/tests/withdraw_deposit_test.py
+++ b/tests/withdraw_deposit_test.py
@@ -79,7 +79,7 @@ class WithdrawDepositTest(ConfluxTestFramework):
         self.wait_for_tx([tx])
         deposit_time = self.get_block_number(client, tx.hash_hex())
         assert_equal(client.get_staking_balance(addr), 10 ** 18)
-        assert_equal(client.get_balance(addr), 4 * 10 ** 18 - gas)
+        assert_equal(client.get_balance(addr), 4 * 10 ** 18 - gas + 12500000)
 
         # withdraw 5 * 10**17
         balance = client.get_balance(addr)
@@ -93,7 +93,7 @@ class WithdrawDepositTest(ConfluxTestFramework):
         interest = 5 * 10 ** 17 * duration * 252288000 // (total_num_blocks * 100) // total_num_blocks
         service_charge = 5 * 10 ** 17 * (total_num_blocks - duration) * 5 // 10000 // total_num_blocks
         assert_equal(client.get_staking_balance(addr), 5 * 10 ** 17)
-        assert_equal(client.get_balance(addr), balance + 5 * 10 ** 17 + interest - service_charge - gas)
+        assert_equal(client.get_balance(addr), balance + 5 * 10 ** 17 + interest - service_charge - gas + 12500000)
 
         # lock 4 * 10 ** 17 for 1 day
         balance = client.get_balance(addr)
@@ -101,7 +101,7 @@ class WithdrawDepositTest(ConfluxTestFramework):
         tx = client.new_tx(value=0, sender=addr, receiver=self.tx_conf["to"], gas=gas, data=tx_data, priv_key=priv_key)
         client.send_tx(tx)
         self.wait_for_tx([tx])
-        assert_equal(client.get_balance(addr), balance - gas)
+        assert_equal(client.get_balance(addr), balance - gas + 12500000)
         assert_equal(client.get_staking_balance(addr), 5 * 10 ** 17)
 
         # withdraw 5 * 10**17 and it should fail
@@ -132,7 +132,7 @@ class WithdrawDepositTest(ConfluxTestFramework):
         duration = withdraw_time - deposit_time
         interest = 10 ** 17 * duration * 252288000 // (total_num_blocks * 100) // total_num_blocks
         service_charge = 10 ** 17 * (total_num_blocks - duration) * 5 // 10000 // total_num_blocks
-        assert_equal(client.get_balance(addr), balance + 10 ** 17 + interest - service_charge - gas)
+        assert_equal(client.get_balance(addr), balance + 10 ** 17 + interest - service_charge - gas + 12500000)
         assert_equal(client.get_staking_balance(addr), 4 * 10 ** 17)
 
         block_gen_thread.stop()


### PR DESCRIPTION
allow user to set gas limit reasonably higher than gas_used without extra charge.

The current rule is that if gas_left < gas_limit/4, then we only charge gas_used, otherwise, we charge 3/4 of the gas_limit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1079)
<!-- Reviewable:end -->
