### PR TITLE
Get rid of recompute_anticone_weight and past_era_weight

### DIFF
--- a/client/src/rpc/types/consensus_graph_states.rs
+++ b/client/src/rpc/types/consensus_graph_states.rs
@@ -2,7 +2,7 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use crate::rpc::types::{H256, U256};
+use crate::rpc::types::H256;
 use cfxcore::state_exposer::ConsensusGraphStates as PrimitiveConsensusGraphStates;
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -11,7 +11,6 @@ pub struct ConsensusGraphBlockState {
     pub block_hash: H256,
     pub best_block_hash: H256,
     pub block_status: u8,
-    pub past_era_weight: U256,
     pub era_block_hash: H256,
     pub adaptive: bool,
 }
@@ -44,7 +43,6 @@ impl ConsensusGraphStates {
                 block_hash: block_state.block_hash.into(),
                 best_block_hash: block_state.best_block_hash.into(),
                 block_status: block_state.block_status as u8,
-                past_era_weight: U256::from(block_state.past_era_weight),
                 era_block_hash: block_state.era_block_hash.into(),
                 adaptive: block_state.adaptive,
             })

--- a/core/src/alliance_tree_graph/consensus/mod.rs
+++ b/core/src/alliance_tree_graph/consensus/mod.rs
@@ -686,7 +686,6 @@ impl ConsensusGraphTrait for TreeGraphConsensus {
                             block_hash: *hash,
                             best_block_hash: inner.best_block_hash(),
                             block_status: local_info.get_status(),
-                            past_era_weight: 0.into(),
                             era_block_hash,
                             adaptive: false,
                         },

--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -7,7 +7,10 @@ use crate::{
     block_data_manager::{
         block_data_types::EpochExecutionCommitment, BlockDataManager,
     },
-    consensus::ConsensusGraphInner,
+    consensus::{
+        consensus_inner::consensus_new_block_handler::ConsensusNewBlockHandler,
+        ConsensusGraphInner,
+    },
     executive::{Executed, ExecutionError, Executive, InternalContractMap},
     machine::new_machine_with_builtin,
     parameters::{consensus::*, consensus_internal::*},
@@ -360,11 +363,11 @@ impl ConsensusExecutor {
                 let anticone_cutoff_epoch_anticone_set_ref_opt = inner
                     .anticone_cache
                     .get(anticone_penalty_cutoff_epoch_arena_index);
-                let anticone_cutoff_epoch_anticone_set_opt;
+                let anticone_cutoff_epoch_anticone_set;
                 if let Some(r) = anticone_cutoff_epoch_anticone_set_ref_opt {
-                    anticone_cutoff_epoch_anticone_set_opt = Some(r.clone());
+                    anticone_cutoff_epoch_anticone_set = r.clone();
                 } else {
-                    anticone_cutoff_epoch_anticone_set_opt = None;
+                    anticone_cutoff_epoch_anticone_set = ConsensusNewBlockHandler::compute_anticone_hashset_bruteforce(inner, anticone_penalty_cutoff_epoch_arena_index);
                 }
                 let ordered_epoch_blocks = inner.get_or_compute_ordered_executable_epoch_blocks(pivot_arena_index);
                 for index in ordered_epoch_blocks.iter() {
@@ -392,52 +395,42 @@ impl ConsensusExecutor {
                     if !no_reward {
                         let block_consensus_node_anticone_opt =
                             inner.anticone_cache.get(*index);
-                        if block_consensus_node_anticone_opt.is_none()
-                            || anticone_cutoff_epoch_anticone_set_opt.is_none()
-                        {
-                            anticone_difficulty = U512::from(U256::from(
-                                inner.recompute_anticone_weight(
-                                    *index,
-                                    anticone_penalty_cutoff_epoch_arena_index,
-                                ),
-                            ));
+                        let block_consensus_node_anticone = if let Some(r) = block_consensus_node_anticone_opt {
+                            r.clone()
                         } else {
-                            let block_consensus_node_anticone: HashSet<usize> =
-                                block_consensus_node_anticone_opt
-                                    .unwrap()
-                                    .iter()
-                                    .filter(|idx| {
-                                        inner.is_same_era(
-                                            **idx,
-                                            pivot_arena_index,
-                                        )
-                                    })
-                                    .map(|idx| *idx)
-                                    .collect();
-                            let anticone_cutoff_epoch_anticone_set: HashSet<
-                                usize,
-                            > = anticone_cutoff_epoch_anticone_set_opt
-                                .as_ref()
-                                .unwrap()
+                            ConsensusNewBlockHandler::compute_anticone_hashset_bruteforce(inner, *index)
+                        };
+
+                        let block_consensus_node_anticone_sameera : HashSet<usize> =
+                            block_consensus_node_anticone
                                 .iter()
                                 .filter(|idx| {
-                                    inner.is_same_era(**idx, pivot_arena_index)
+                                    inner.is_same_era(
+                                        **idx,
+                                        pivot_arena_index,
+                                    )
                                 })
                                 .map(|idx| *idx)
                                 .collect();
-                            let anticone_set = block_consensus_node_anticone
-                                .difference(&anticone_cutoff_epoch_anticone_set)
-                                .cloned()
-                                .collect::<HashSet<_>>();
-                            for a_index in anticone_set {
-                                // TODO: Maybe consider to use base difficulty
-                                // Check with the spec!
-                                anticone_difficulty +=
-                                    U512::from(U256::from(inner.block_weight(
-                                        a_index
-                                    )));
-                            }
-                        };
+                        let anticone_cutoff_epoch_anticone_set_sameera : HashSet<usize> = anticone_cutoff_epoch_anticone_set
+                            .iter()
+                            .filter(|idx| {
+                                inner.is_same_era(**idx, pivot_arena_index)
+                            })
+                            .map(|idx| *idx)
+                            .collect();
+                        let anticone_set = block_consensus_node_anticone_sameera
+                            .difference(&anticone_cutoff_epoch_anticone_set_sameera)
+                            .cloned()
+                            .collect::<HashSet<_>>();
+                        for a_index in anticone_set {
+                            // TODO: Maybe consider to use base difficulty
+                            // Check with the spec!
+                            anticone_difficulty +=
+                                U512::from(U256::from(inner.block_weight(
+                                    a_index
+                                )));
+                        }
 
                         // TODO: check the clear definition of anticone penalty,
                         // normally and around the time of difficulty

--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -401,7 +401,7 @@ impl ConsensusExecutor {
                             ConsensusNewBlockHandler::compute_anticone_hashset_bruteforce(inner, *index)
                         };
 
-                        let block_consensus_node_anticone_sameera : HashSet<usize> =
+                        let block_consensus_node_anticone_same_era: HashSet<usize> =
                             block_consensus_node_anticone
                                 .iter()
                                 .filter(|idx| {
@@ -412,15 +412,15 @@ impl ConsensusExecutor {
                                 })
                                 .map(|idx| *idx)
                                 .collect();
-                        let anticone_cutoff_epoch_anticone_set_sameera : HashSet<usize> = anticone_cutoff_epoch_anticone_set
+                        let anticone_cutoff_epoch_anticone_set_same_era: HashSet<usize> = anticone_cutoff_epoch_anticone_set
                             .iter()
                             .filter(|idx| {
                                 inner.is_same_era(**idx, pivot_arena_index)
                             })
                             .map(|idx| *idx)
                             .collect();
-                        let anticone_set = block_consensus_node_anticone_sameera
-                            .difference(&anticone_cutoff_epoch_anticone_set_sameera)
+                        let anticone_set = block_consensus_node_anticone_same_era
+                            .difference(&anticone_cutoff_epoch_anticone_set_same_era)
                             .cloned()
                             .collect::<HashSet<_>>();
                         for a_index in anticone_set {

--- a/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
+++ b/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
@@ -378,6 +378,18 @@ impl ConsensusNewBlockHandler {
         anticone
     }
 
+    pub fn compute_anticone_hashset_bruteforce(
+        inner: &ConsensusGraphInner, me: usize,
+    ) -> HashSet<usize> {
+        let s =
+            ConsensusNewBlockHandler::compute_anticone_bruteforce(inner, me);
+        let mut ret = HashSet::new();
+        for index in s.iter() {
+            ret.insert(index as usize);
+        }
+        ret
+    }
+
     /// Note that this function is not a pure computation function. It has the
     /// sideeffect of updating all existing anticone set in the anticone
     /// cache
@@ -1058,24 +1070,6 @@ impl ConsensusNewBlockHandler {
 
         // Because the following computation relies on all previous blocks being
         // active, We have to delay it till now
-        let era_genesis = inner.get_era_genesis_block_with_parent(parent);
-        let blockset =
-            inner.exchange_or_compute_blockset_in_own_view_of_epoch(me, None);
-        let weight_era_in_my_epoch =
-            inner.total_weight_in_own_epoch(&blockset, era_genesis);
-        inner.exchange_or_compute_blockset_in_own_view_of_epoch(
-            me,
-            Some(blockset),
-        );
-        let past_era_weight = if parent != era_genesis {
-            inner.arena[parent].past_era_weight
-                + inner.block_weight(parent)
-                + weight_era_in_my_epoch
-        } else {
-            inner.block_weight(parent) + weight_era_in_my_epoch
-        };
-        inner.arena[me].past_era_weight = past_era_weight;
-
         let mut timer_longest_difficulty = 0;
         let mut longest_referee = parent;
         if parent != NULL {
@@ -1179,8 +1173,8 @@ impl ConsensusNewBlockHandler {
         }
 
         debug!(
-            "Finish preactivation block {} index = {} past_era_weight={}",
-            inner.arena[me].hash, me, inner.arena[me].past_era_weight
+            "Finish preactivation block {} index = {}",
+            inner.arena[me].hash, me
         );
         let block_status = if pending {
             BlockStatus::Pending
@@ -1967,7 +1961,6 @@ impl ConsensusNewBlockHandler {
                     block_hash: inner.arena[me].hash,
                     best_block_hash: inner.best_block_hash(),
                     block_status: block_info.get_status(),
-                    past_era_weight: inner.arena[me].past_era_weight(),
                     era_block_hash,
                     adaptive: inner.arena[me].adaptive(),
                 },

--- a/core/src/consensus/consensus_inner/mod.rs
+++ b/core/src/consensus/consensus_inner/mod.rs
@@ -457,8 +457,6 @@ pub struct ConsensusGraphNode {
     is_timer: bool,
     /// The total weight of its past set in the era (exclude itself)
     past_num_blocks: u64,
-    /// The total weight of its past set in its own era (exclude itself)
-    past_era_weight: i128,
     adaptive: bool,
 
     /// The genesis arena index of the era that `self` is in.
@@ -476,8 +474,6 @@ pub struct ConsensusGraphNode {
 }
 
 impl ConsensusGraphNode {
-    pub fn past_era_weight(&self) -> i128 { self.past_era_weight }
-
     pub fn past_num_blocks(&self) -> u64 { self.past_num_blocks }
 
     pub fn adaptive(&self) -> bool { self.adaptive }
@@ -1419,7 +1415,6 @@ impl ConsensusGraphInner {
             is_heavy: true,
             difficulty: *block_header.difficulty(),
             past_num_blocks: 0,
-            past_era_weight: 0, // will be updated later below
             is_timer: false,
             // Block header contains an adaptive field, we will verify with our
             // own computation
@@ -1540,7 +1535,6 @@ impl ConsensusGraphInner {
             is_heavy,
             difficulty: *block_header.difficulty(),
             past_num_blocks: 0,
-            past_era_weight: 0, // will be updated later
             is_timer,
             // Block header contains an adaptive field, we will verify with our
             // own computation
@@ -1753,71 +1747,6 @@ impl ConsensusGraphInner {
             epoch_blocks.push(block);
         }
         epoch_blocks
-    }
-
-    fn recompute_anticone_weight(
-        &self, me: usize, pivot_block_arena_index: usize,
-    ) -> i128 {
-        assert!(self.is_same_era(me, pivot_block_arena_index));
-        // We need to compute the future size of me under the view of epoch
-        // height pivot_index
-        let mut visited = BitSet::new();
-        let mut queue = VecDeque::new();
-        queue.push_back(pivot_block_arena_index);
-        visited.add(pivot_block_arena_index as u32);
-        let last_pivot = self.arena[me].data.last_pivot_in_past;
-        while let Some(index) = queue.pop_front() {
-            let parent = self.arena[index].parent;
-            if self.arena[parent].data.epoch_number > last_pivot
-                && !visited.contains(parent as u32)
-            {
-                queue.push_back(parent);
-                visited.add(parent as u32);
-            }
-            for referee in &self.arena[index].referees {
-                if self.arena[*referee].data.epoch_number > last_pivot
-                    && !visited.contains(*referee as u32)
-                {
-                    queue.push_back(*referee);
-                    visited.add(*referee as u32);
-                }
-            }
-        }
-        queue.push_back(me);
-        let mut visited2 = BitSet::new();
-        visited2.add(me as u32);
-        while let Some(index) = queue.pop_front() {
-            for child in &self.arena[index].children {
-                if visited.contains(*child as u32)
-                    && !visited2.contains(*child as u32)
-                {
-                    queue.push_back(*child);
-                    visited2.add(*child as u32);
-                }
-            }
-            for referrer in &self.arena[index].referrers {
-                if visited.contains(*referrer as u32)
-                    && !visited2.contains(*referrer as u32)
-                {
-                    queue.push_back(*referrer);
-                    visited2.add(*referrer as u32);
-                }
-            }
-        }
-        let mut total_weight = self.arena[pivot_block_arena_index]
-            .past_era_weight
-            - self.arena[me].past_era_weight
-            + self.block_weight(pivot_block_arena_index);
-        for index in visited2.iter() {
-            if self.is_same_era(index as usize, pivot_block_arena_index) {
-                total_weight -= self.block_weight(index as usize);
-            }
-        }
-        debug!(
-            "recompute_anticone_weight: me={} upper={} total_weight={}",
-            me, pivot_block_arena_index, total_weight
-        );
-        total_weight
     }
 
     /// Compute the expected difficulty of a new block given its parent.

--- a/core/src/state_exposer/consensus_graph_exposer.rs
+++ b/core/src/state_exposer/consensus_graph_exposer.rs
@@ -10,7 +10,6 @@ pub struct ConsensusGraphBlockState {
     pub block_hash: H256,
     pub best_block_hash: H256,
     pub block_status: BlockStatus,
-    pub past_era_weight: i128,
     pub era_block_hash: H256,
     pub adaptive: bool,
 }

--- a/tests/conflux_tracing.py
+++ b/tests/conflux_tracing.py
@@ -125,7 +125,6 @@ class ConsensusBlockStatus(object):
         self.hash = json_data['blockHash']
         self.best_block_hash = json_data['bestBlockHash']
         self.block_status = BlockStatus(json_data['blockStatus'])
-        self.past_era_weight = json_data['pastEraWeight']
         self.era_block_hash = json_data['eraBlockHash']
         self.adaptive = json_data['adaptive']
 
@@ -138,7 +137,6 @@ class ConsensusBlockStatus(object):
                 self.era_block_hash != other.era_block_hash:
             return False
         return self.hash == other.hash and \
-            self.past_era_weight == other.past_era_weight and \
             self.block_status == other.block_status and \
             self.adaptive == other.adaptive
 
@@ -147,13 +145,11 @@ class ConsensusBlockStatus(object):
                 hash={}, \
                 best_block_hash={}, \
                 block_status={}, \
-                past_era_weight={}, \
                 era_block={}, \
                 adaptive={})".format(
             self.hash,
             self.best_block_hash,
             self.block_status,
-            self.past_era_weight,
             self.era_block_hash,
             self.adaptive)
 
@@ -206,8 +202,6 @@ class ConsensusSnapshot(object):
                 assert block.era_block_hash == verified_block.era_block_hash or \
                     block.era_block_hash == DEFAULT_HASH, "peer[{}] block[{}] era_block_hash[{}], expect [{}]".format(
                         self.peer_id, block.hash, block.era_block_hash, verified_block.era_block_hash)
-                assert block.past_era_weight == verified_block.past_era_weight, "peer[{}] block[{}] past_era_weight[{}], expect [{}]".format(
-                    self.peer_id, block.hash, block.past_era_weight, verified_block.past_era_weight)
         elif block.hash in self.block_status_unverified:
             unverified_block = self.block_status_unverified[block.hash]
             if unverified_block.block_status == BlockStatus.Pending:
@@ -222,8 +216,6 @@ class ConsensusSnapshot(object):
                         block.era_block_hash == DEFAULT_HASH or \
                         unverified_block.era_block_hash == DEFAULT_HASH, "peer[{}] block[{}] era_block_hash[{}], expect [{}]".format(
                             self.peer_id, block.hash, block.era_block_hash, unverified_block.era_block_hash)
-                    assert block.past_era_weight == unverified_block.past_era_weight, "peer[{}] block[{}] past_era_weight[{}], expect [{}]".format(
-                        self.peer_id, block.hash, block.past_era_weight, unverified_block.past_era_weight)
         else:
             self.block_status_unverified[block.hash] = block
 

--- a/tests/tg_archive_tests/health_check.py
+++ b/tests/tg_archive_tests/health_check.py
@@ -132,7 +132,6 @@ class ConsensusBlockStatus(object):
         self.hash = json_data['blockHash']
         self.best_block_hash = json_data['bestBlockHash']
         self.block_status = BlockStatus(json_data['blockStatus'])
-        self.past_era_weight = json_data['pastEraWeight']
         self.era_block_hash = json_data['eraBlockHash']
         self.adaptive = json_data['adaptive']
 
@@ -145,7 +144,6 @@ class ConsensusBlockStatus(object):
                 self.era_block_hash != other.era_block_hash:
             return False
         return self.hash == other.hash and \
-            self.past_era_weight == other.past_era_weight and \
             self.block_status == other.block_status and \
             self.adaptive == other.adaptive
 
@@ -154,13 +152,11 @@ class ConsensusBlockStatus(object):
                 hash={}, \
                 best_block_hash={}, \
                 block_status={}, \
-                past_era_weight={}, \
                 era_block={}, \
                 adaptive={})".format(
             self.hash,
             self.best_block_hash,
             self.block_status,
-            self.past_era_weight,
             self.era_block,
             self.adaptive)
 
@@ -205,8 +201,6 @@ class ConsensusSnapshot(object):
                 assert block.era_block_hash == verified_block.era_block_hash or \
                     block.era_block_hash == DEFAULT_HASH, "peer[{}] block[{}] era_block_hash[{}], expect [{}]".format(
                         self.peer_id, block.hash, block.era_block_hash, verified_block.era_block_hash)
-                assert block.past_era_weight == verified_block.past_era_weight, "peer[{}] block[{}] past_era_weight[{}], expect [{}]".format(
-                    self.peer_id, block.hash, block.past_era_weight, verified_block.past_era_weight)
         elif block.hash in self.block_status_unverified:
             unverified_block = self.block_status_unverified[block.hash]
             if unverified_block.block_status == BlockStatus.Pending:
@@ -221,8 +215,6 @@ class ConsensusSnapshot(object):
                         block.era_block_hash == DEFAULT_HASH or \
                         unverified_block.era_block_hash == DEFAULT_HASH, "peer[{}] block[{}] era_block_hash[{}], expect [{}]".format(
                             self.peer_id, block.hash, block.era_block_hash, unverified_block.era_block_hash)
-                    assert block.past_era_weight == unverified_block.past_era_weight, "peer[{}] block[{}] past_era_weight[{}], expect [{}]".format(
-                        self.peer_id, block.hash, block.past_era_weight, unverified_block.past_era_weight)
         else:
             self.block_status_unverified[block.hash] = block
 


### PR DESCRIPTION
The fast pass benefit is minimum and it gives us a lot of trouble in extreme corner cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1095)
<!-- Reviewable:end -->
