### PR TITLE
Fix crash caused by using get_ordered_blockset() for non-pivot block …

### DIFF
--- a/core/src/consensus/consensus_inner/mod.rs
+++ b/core/src/consensus/consensus_inner/mod.rs
@@ -1816,7 +1816,10 @@ impl ConsensusGraphInner {
                     &self.arena[parent_arena_index].hash,
                     |h| {
                         let index = self.hash_to_arena_indices.get(h).unwrap();
-                        self.get_ordered_executable_epoch_blocks(*index).len()
+                        let parent = self.arena[*index].parent;
+                        (self.arena[*index].past_num_blocks
+                            - self.arena[parent].past_num_blocks)
+                            as usize
                     },
                 )
             }
@@ -1847,7 +1850,10 @@ impl ConsensusGraphInner {
                 &new_best_hash,
                 |h| {
                     let index = self.hash_to_arena_indices.get(h).unwrap();
-                    self.get_ordered_executable_epoch_blocks(*index).len()
+                    let parent = self.arena[*index].parent;
+                    (self.arena[*index].past_num_blocks
+                        - self.arena[parent].past_num_blocks)
+                        as usize
                 },
             );
         } else {


### PR DESCRIPTION
…in expected_difficulty when checking

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1127)
<!-- Reviewable:end -->
