### PR TITLE
mpt_node_path_from_db_key bug fix, with unit test.

### DIFF
--- a/core/src/storage/impls/merkle_patricia_trie/compressed_path.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/compressed_path.rs
@@ -192,7 +192,11 @@ impl CompressedPathRaw {
         }
     }
 
-    pub fn first_nibble_mask() -> u8 { Self::BITS_4_7_MASK }
+    #[inline]
+    pub const fn first_nibble_mask() -> u8 { Self::BITS_0_3_MASK }
+
+    #[inline]
+    pub const fn second_nibble_mask() -> u8 { Self::BITS_4_7_MASK }
 
     pub fn from_first_nibble(x: u8) -> u8 { x << 4 }
 
@@ -210,7 +214,7 @@ impl CompressedPathRaw {
         // Need to extend the length.
         if x.end_mask() == 0 {
             new_size = x.path_size() + 1;
-            end_mask = Self::first_nibble_mask();
+            end_mask = Self::second_nibble_mask();
         } else {
             new_size = x.path_size();
             end_mask = 0;

--- a/core/src/storage/impls/merkle_patricia_trie/tests/trie_proof_test.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/tests/trie_proof_test.rs
@@ -15,7 +15,7 @@ fn test_rlp() {
         Some(Box::new([0x03, 0x04, 0x05])),
         CompressedPathRaw::new(
             &[0x00, 0x01, 0x02],
-            CompressedPathRaw::first_nibble_mask(),
+            CompressedPathRaw::second_nibble_mask(),
         ),
     );
     assert_eq!(node1, rlp::decode(&rlp::encode(&node1)).unwrap());

--- a/core/src/storage/impls/merkle_patricia_trie/walk.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/walk.rs
@@ -141,7 +141,7 @@ pub(super) fn walk<
                     // "First half" matched
                     matched_path = CompressedPathRaw::new_and_apply_mask(
                         &path_slice[0..i + 1],
-                        CompressedPathRaw::first_nibble_mask(),
+                        CompressedPathRaw::second_nibble_mask(),
                     );
 
                     key_child_index = CompressedPathRaw::second_nibble(key[i]);

--- a/core/src/storage/impls/state_manager.rs
+++ b/core/src/storage/impls/state_manager.rs
@@ -516,9 +516,9 @@ impl StateManager {
 
 impl StateManagerTrait for StateManager {
     fn get_state_no_commit(
-        &self, epoch_id: StateIndex,
+        &self, state_index: StateIndex,
     ) -> Result<Option<State>> {
-        let maybe_state_trees = self.get_state_trees(&epoch_id)?;
+        let maybe_state_trees = self.get_state_trees(&state_index)?;
         match maybe_state_trees {
             None => Ok(None),
             Some(state_trees) => Ok(Some(State::new(

--- a/core/src/storage/impls/storage_db/snapshot_mpt.rs
+++ b/core/src/storage/impls/storage_db/snapshot_mpt.rs
@@ -48,9 +48,9 @@ pub fn mpt_node_path_from_db_key(db_key: &[u8]) -> Result<CompressedPathRaw> {
     let last_offset = db_key.len() - 1;
     let mut path = CompressedPathRaw::new_zeroed(
         (db_key.len() / 2).try_into()?,
-        // When last_offset is odd, 0xff is passed to first_nibble, otherwise
+        // When last_offset is odd, 0xf0 is set to path_mask, otherwise
         // 0.
-        CompressedPathRaw::first_nibble(0xff * ((last_offset & 1) as u8)),
+        CompressedPathRaw::second_nibble_mask() * ((last_offset & 1) as u8),
     );
     let path_mut = path.path_slice_mut();
 


### PR DESCRIPTION
It's wrong to use CompressedPathRaw::first_nibble() in mpt_node_path_from_db_key, which may cause snapshot mpt merkle root mismatch.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1131)
<!-- Reviewable:end -->
