### PR TITLE
make ESTIMATED_MAX_BLOCK_SIZE_IN_TRANSACTION_COUNT more conservative

### DIFF
--- a/core/src/parameters.rs
+++ b/core/src/parameters.rs
@@ -147,8 +147,8 @@ pub mod block {
     // peak with only simple payment, which is good enough for now.
     pub const MAX_BLOCK_SIZE_IN_BYTES: usize = 200 * 1024;
     // The maximum number of transactions to be packed in a block given
-    // `MAX_BLOCK_SIZE_IN_BYTES`, assuming 100-Byte transactions.
-    pub const ESTIMATED_MAX_BLOCK_SIZE_IN_TRANSACTION_COUNT: usize = 2048;
+    // `MAX_BLOCK_SIZE_IN_BYTES`, assuming 50-byte transactions.
+    pub const ESTIMATED_MAX_BLOCK_SIZE_IN_TRANSACTION_COUNT: usize = 4096;
     // The maximum number of referees allowed for each block
     pub const REFEREE_DEFAULT_BOUND: usize = 200;
     // The maximal length of custom data in block header


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1134)
<!-- Reviewable:end -->
