### PR TITLE
Prioritize blocks based on the parent's epoch number for the processing…

### DIFF
--- a/core/src/channel.rs
+++ b/core/src/channel.rs
@@ -6,7 +6,7 @@ use crate::UniqueId;
 use cfx_types::H256;
 use parking_lot::RwLock;
 use std::{collections::BTreeMap, sync::Arc};
-use tokio::sync::mpsc;
+use tokio::sync::mpsc::{self, error::TryRecvError};
 
 pub struct Receiver<T> {
     pub id: u64,
@@ -15,6 +15,10 @@ pub struct Receiver<T> {
 
 impl<T> Receiver<T> {
     pub async fn recv(&mut self) -> Option<T> { self.receiver.recv().await }
+
+    pub fn try_recv(&mut self) -> Result<T, TryRecvError> {
+        self.receiver.try_recv()
+    }
 
     pub fn recv_blocking(&mut self) -> Option<T> {
         futures::executor::block_on(self.receiver.recv())

--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -28,12 +28,13 @@ use primitives::{
 use slab::Slab;
 use std::{
     cmp::max,
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{BinaryHeap, HashMap, HashSet, VecDeque},
     mem, panic,
     sync::Arc,
-    thread,
+    thread::{self, sleep},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
+use tokio::sync::mpsc::error::TryRecvError;
 use unexpected::{Mismatch, OutOfBounds};
 
 lazy_static! {
@@ -1075,17 +1076,68 @@ impl SynchronizationGraph {
         // `ConsensusGraph`
         thread::Builder::new()
             .name("Consensus Worker".into())
-            .spawn(move || loop {
-                match consensus_receiver.recv_blocking() {
-                    Some((hash, ignore_body)) => {
+            .spawn(move || {
+                // The Consensus Worker will prioritize blocks based on its parent epoch number while respecting the topological order. This has the following two benefits:
+                //
+                // 1. It will almost make sure that the self mined block being processed first
+                //
+                // 2. In case of a DoS attack that a malicious player releases a large chunk of old blocks. This strategy will make the consensus to process the meaningful blocks first.
+                let mut priority_queue: BinaryHeap<(u64, H256, bool)> = BinaryHeap::new();
+                let mut reverse_map : HashMap<H256, Vec<H256>> = HashMap::new();
+                let mut counter_map = HashMap::new();
+
+                'outer: loop {
+                    'inner: loop {
+                        match consensus_receiver.try_recv() {
+                            Ok((hash, ignore_body)) => {
+                                let header = data_man.block_header_by_hash(&hash).expect("Header must exist before sending to the consensus worker!");
+                                let mut cnt: usize = 0;
+                                let parent_hash = header.parent_hash();
+                                if let Some(v) = reverse_map.get_mut(parent_hash) {
+                                    v.push(hash.clone());
+                                    cnt += 1;
+                                }
+                                for referee in header.referee_hashes() {
+                                    if let Some(v) = reverse_map.get_mut(referee) {
+                                        v.push(hash.clone());
+                                        cnt += 1;
+                                    }
+                                }
+                                reverse_map.insert(hash.clone(), Vec::new());
+                                if cnt == 0 {
+                                    let epoch_number = consensus.get_block_epoch_number(parent_hash).unwrap_or(0);
+                                    priority_queue.push((epoch_number, hash, ignore_body));
+                                } else {
+                                    counter_map.insert(hash, (cnt, ignore_body));
+                                }
+                            },
+                            Err(TryRecvError::Empty) => break 'inner,
+                            Err(TryRecvError::Closed) => break 'outer,
+                        }
+                    }
+                    if let Some((_, hash, ignore_body)) = priority_queue.pop() {
                         CONSENSUS_WORKER_QUEUE.dequeue(1);
+                        let referers = reverse_map.remove(&hash).unwrap();
+                        for referer in referers {
+                            let cnt_tuple = counter_map.get_mut(&referer).unwrap();
+                            cnt_tuple.0 -= 1;
+                            if cnt_tuple.0 == 0 {
+                                let ignore_body = cnt_tuple.1;
+                                counter_map.remove(&referer);
+                                let header = data_man.block_header_by_hash(&hash).expect("Header must exist before sending to the consensus worker!");
+                                let parent_hash = header.parent_hash();
+                                let epoch_number = consensus.get_block_epoch_number(parent_hash).unwrap_or(0);
+                                priority_queue.push((epoch_number, referer, ignore_body));
+                            }
+                        }
                         consensus.on_new_block(
                             &hash,
                             ignore_body,
                             true, /* update_best_info */
                         )
+                    } else {
+                        sleep(Duration::from_millis(30));
                     }
-                    _ => break,
                 }
             })
             .expect("Cannot fail");

--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -1124,9 +1124,9 @@ impl SynchronizationGraph {
                             if cnt_tuple.0 == 0 {
                                 let ignore_body = cnt_tuple.1;
                                 counter_map.remove(&referer);
-                                let header = data_man.block_header_by_hash(&hash).expect("Header must exist before sending to the consensus worker!");
-                                let parent_hash = header.parent_hash();
-                                let epoch_number = consensus.get_block_epoch_number(parent_hash).unwrap_or(0);
+                                let header_referrer = data_man.block_header_by_hash(&referer).expect("Header must exist before sending to the consensus worker!");
+                                let parent_referrer = header_referrer.parent_hash();
+                                let epoch_number = consensus.get_block_epoch_number(parent_referrer).unwrap_or(0);
                                 priority_queue.push((epoch_number, referer, ignore_body));
                             }
                         }

--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -31,7 +31,7 @@ use std::{
     collections::{BinaryHeap, HashMap, HashSet, VecDeque},
     mem, panic,
     sync::Arc,
-    thread::{self, sleep},
+    thread::{self, yield_now},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use tokio::sync::mpsc::error::TryRecvError;
@@ -1136,7 +1136,7 @@ impl SynchronizationGraph {
                             true, /* update_best_info */
                         )
                     } else {
-                        sleep(Duration::from_millis(30));
+                        yield_now();
                     }
                 }
             })

--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -1117,17 +1117,17 @@ impl SynchronizationGraph {
                     }
                     if let Some((_, hash, ignore_body)) = priority_queue.pop() {
                         CONSENSUS_WORKER_QUEUE.dequeue(1);
-                        let referers = reverse_map.remove(&hash).unwrap();
-                        for referer in referers {
-                            let cnt_tuple = counter_map.get_mut(&referer).unwrap();
+                        let successors = reverse_map.remove(&hash).unwrap();
+                        for succ in successors {
+                            let cnt_tuple = counter_map.get_mut(&succ).unwrap();
                             cnt_tuple.0 -= 1;
                             if cnt_tuple.0 == 0 {
                                 let ignore_body = cnt_tuple.1;
-                                counter_map.remove(&referer);
-                                let header_referrer = data_man.block_header_by_hash(&referer).expect("Header must exist before sending to the consensus worker!");
-                                let parent_referrer = header_referrer.parent_hash();
-                                let epoch_number = consensus.get_block_epoch_number(parent_referrer).unwrap_or(0);
-                                priority_queue.push((epoch_number, referer, ignore_body));
+                                counter_map.remove(&succ);
+                                let header_succ = data_man.block_header_by_hash(&succ).expect("Header must exist before sending to the consensus worker!");
+                                let parent_succ = header_succ.parent_hash();
+                                let epoch_number = consensus.get_block_epoch_number(parent_succ).unwrap_or(0);
+                                priority_queue.push((epoch_number, succ, ignore_body));
                             }
                         }
                         consensus.on_new_block(


### PR DESCRIPTION
… of consensus

This enables better behavior in the case of DoS attacks and will almost always prioritize self-mined blocks first.

This closes #1088

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1144)
<!-- Reviewable:end -->
