### PR TITLE
Do not demote inactive peer.

### DIFF
--- a/core/src/sync/message/status.rs
+++ b/core/src/sync/message/status.rs
@@ -35,7 +35,7 @@ impl Handleable for Status {
             bail!(ErrorKind::InvalidStatus("genesis hash mismatches".into()));
         }
 
-        let mut latest: HashSet<H256> =
+        let latest: HashSet<H256> =
             self.terminal_block_hashes.iter().cloned().collect();
 
         if let Ok(peer_info) = ctx.manager.syn.get_peer_info(&ctx.peer) {
@@ -71,10 +71,6 @@ impl Handleable for Status {
                 warn!("Unexpected Status message from peer={}", ctx.peer);
                 return Err(ErrorKind::UnknownPeer.into());
             }
-
-            latest.extend(
-                ctx.manager.graph.initial_missed_block_hashes.lock().drain(),
-            );
 
             let throttling =
                 match ctx.manager.protocol_config.throttling_config_file {

--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -1255,7 +1255,7 @@ impl SynchronizationGraph {
         // Remember the hashes of blocks that belong to the current genesis
         // era but are missed in db. The missed blocks will be fetched from
         // peers.
-        let mut missed_hashes = self.initial_missed_block_hashes.lock();
+        let mut missed_hashes = HashSet::new();
         while let Some(hash) = queue.pop_front() {
             if hash == genesis_hash {
                 // Genesis block is already in consensus graph.
@@ -1321,7 +1321,8 @@ impl SynchronizationGraph {
             }
         }
 
-        debug!("Initial missed blocks {:?}", *missed_hashes);
+        debug!("Initial missed blocks {:?}", missed_hashes);
+        *self.initial_missed_block_hashes.lock() = missed_hashes;
 
         // Resolve out-of-era dependencies for graph-unready blocks.
         self.resolve_outside_dependencies(

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -568,7 +568,7 @@ impl SynchronizationProtocolHandler {
             if missing_hashes.is_empty() {
                 return;
             }
-            to_request = missing_hashes.iter().cloned().collect::<Vec<H256>>();
+            to_request = missing_hashes.drain().collect::<Vec<H256>>();
             missing_hashes.clear();
         }
         let chosen_peer =

--- a/network/src/session.rs
+++ b/network/src/session.rs
@@ -568,7 +568,7 @@ impl Session {
         } else if self.had_hello.is_none() {
             // should receive HELLO packet timely after session created
             if self.sent_hello.elapsed() > Duration::from_secs(300) {
-                return (true, Some(UpdateNodeOperation::Demotion));
+                return (true, Some(UpdateNodeOperation::Failure));
             }
         }
 


### PR DESCRIPTION
Also do not lock `initial_missed_block_hashes` during `recover_from_db`
to avoid blocking other threads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1149)
<!-- Reviewable:end -->
