### PR TITLE
Improve JsonRpc error returning mechanism and fix incorrect rpc error code return

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -9,6 +9,8 @@ use jsonrpc_http_server as http;
 use jsonrpc_tcp_server as tcp;
 
 #[macro_use]
+extern crate error_chain;
+#[macro_use]
 extern crate log;
 #[macro_use]
 extern crate serde_derive;

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -9,7 +9,9 @@ use crate::{
     },
     tcp::{self, Server as TcpServer, ServerBuilder as TcpServerBuilder},
 };
-use jsonrpc_core::{Error as RpcError, MetaIoHandler, Result as RpcResult};
+use jsonrpc_core::{
+    Error as JsonRpcError, MetaIoHandler, Result as JsonRpcResult,
+};
 use std::{
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     sync::Arc,
@@ -25,6 +27,61 @@ mod interceptor;
 pub mod metadata;
 mod traits;
 mod types;
+
+mod error {
+    use crate::rpc::helpers::errors::codes::EXCEPTION_ERROR;
+    use cfxcore::storage::Error as StorageError;
+    use jsonrpc_core::{Error as JsonRpcError, Result as JsonRpcResult};
+    use primitives::filter::FilterError;
+    use rlp::DecoderError;
+
+    error_chain! {
+        links {
+        }
+
+        foreign_links {
+            FilterError(FilterError);
+            Storage(StorageError);
+            Decoder(DecoderError);
+        }
+
+        errors {
+            JsonRpcError(e: JsonRpcError) {
+                description("JsonRpcError directly constructed to return to Rpc peer.")
+                display("JsonRpcError directly constructed to return to Rpc peer. Error: {}", e)
+            }
+        }
+    }
+
+    impl From<JsonRpcError> for Error {
+        fn from(j: JsonRpcError) -> Self { ErrorKind::JsonRpcError(j).into() }
+    }
+
+    impl From<Error> for JsonRpcError {
+        fn from(e: Error) -> Self {
+            match e.0 {
+                ErrorKind::JsonRpcError(j) => j,
+                _ => JsonRpcError {
+                    code: jsonrpc_core::ErrorCode::ServerError(EXCEPTION_ERROR),
+                    message: format!("Error processing request: {}", e),
+                    data: None,
+                },
+            }
+        }
+    }
+
+    pub fn into_jsonrpc_result<T>(r: Result<T>) -> JsonRpcResult<T> {
+        match r {
+            Ok(t) => Ok(t),
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+
+pub use error::{
+    into_jsonrpc_result, Error as RpcError,
+    ErrorKind::JsonRpcError as JsonRpcErrorKind, Result as RpcResult,
+};
 
 use self::{
     impls::{
@@ -237,8 +294,9 @@ impl ThrottleInterceptor {
     }
 }
 
+// FIXME: check if we use RpcResult?
 impl RpcInterceptor for ThrottleInterceptor {
-    fn before(&self, name: &String) -> RpcResult<()> {
+    fn before(&self, name: &String) -> JsonRpcResult<()> {
         let bucket = match self.manager.get(name) {
             Some(bucket) => bucket,
             None => return Ok(()),
@@ -250,14 +308,14 @@ impl RpcInterceptor for ThrottleInterceptor {
             ThrottleResult::Success => Ok(()),
             ThrottleResult::Throttled(wait_time) => {
                 debug!("RPC {} throttled in {:?}", name, wait_time);
-                Err(RpcError::invalid_params(format!(
+                bail!(JsonRpcError::invalid_params(format!(
                     "throttled in {:?}",
                     wait_time
                 )))
             }
             ThrottleResult::AlreadyThrottled => {
                 debug!("RPC {} already throttled", name);
-                Err(RpcError::invalid_params(
+                bail!(JsonRpcError::invalid_params(
                     "already throttled, please try again later",
                 ))
             }

--- a/client/src/rpc/helpers/errors.rs
+++ b/client/src/rpc/helpers/errors.rs
@@ -24,41 +24,116 @@ use crate::rpc::types::Bytes;
 use jsonrpc_core::{Error, ErrorCode, Value};
 
 pub mod codes {
-    // NOTE [ToDr] Codes from [-32099, -32000]
-    pub const UNSUPPORTED_REQUEST: i64 = -32000;
-    pub const NO_WORK: i64 = -32001;
-    pub const NO_AUTHOR: i64 = -32002;
-    pub const NO_NEW_WORK: i64 = -32003;
-    pub const NO_WORK_REQUIRED: i64 = -32004;
-    pub const CANNOT_SUBMIT_WORK: i64 = -32005;
-    pub const CANNOT_SUBMIT_BLOCK: i64 = -32006;
-    pub const UNKNOWN_ERROR: i64 = -32009;
-    pub const TRANSACTION_ERROR: i64 = -32010;
-    pub const EXECUTION_ERROR: i64 = -32015;
+    /// JsonRPC spec reserved from and including -32768 to -32000 for
+    /// pre-defined errors. The reminder of the space is available for
+    /// application defined errors.
+    ///
+    /// -32000 to -32099 is defined for "(JsonRPC) Server Error".
+    ///
+    /// We use the same error code number as in Parity Ethereum wherever
+    /// possible. Since the error code is almost used up by Parity, we
+    /// further reserve [-31999, -31000] for Conflux's extra server error
+    /// codes, in the range of "application defined errors" as defined by
+    /// JsonRPC.
+
+    /// When the number on the right is -32100, check the next variable below.
+    ///
+    /// Please use the number on the right for new error code, then decrease it
+    /// by 1.
+    ///
+    /// Do not recycle deprecated error codes.
+    const NEXT_SERVER_ERROR_CODE: i64 = -32073;
+    /// When the above number is equal to -32100, take the number below on the
+    /// right for new error code, then increase it by 1.
+    const CFX_EXTRA_SERVER_ERROR_CODE: i64 = -31999;
+
+    /// We reserve [-30999, 30000] for application error code. i.e. Error code
+    /// which is defined specifically for a particular rpc.
+    const CFX_EXTRA_APP_ERROR_CODE: i64 = -30999;
+
+    /* Rpc functional related error codes. */
+    /// The request is not supported (yet) at this version.
+    pub const UNSUPPORTED: i64 = -32000;
+    /// The requested feature is deprecated.
+    pub const DEPRECATED: i64 = -32070;
+    /// The requested feature is experimental.
+    pub const EXPERIMENTAL: i64 = -32071;
+    /// The node is not able to serve the request due to configuration. e.g. Not
+    /// mining, light node, not archive node.
+    pub const INCAPABLE: i64 = -32703;
+
+    /* Rpc usage related error codes */
+    /// When there are too many rpc requests. We limt the number of allowed rpc
+    /// requests for attack prevention.
+    pub const REQUEST_REJECTED_TOO_MANY_REQUESTS: i64 = -32072;
+    /// When the request is considered too much for the rpc function.
+    /// The consideration is set individually per rpc. It can be data too large,
+    /// or it can be that some performance/security related parameter is outside
+    /// the accepted range.
+    ///
+    /// This is mostly an application error but it's generic enough to define it
+    /// here.
+    pub const REQUEST_REJECTED_LIMIT_DATA: i64 = -32041;
+
+    /* Conflux node status related error codes
+     *
+     * When the node is not well-connected to the Conflux network, or when an
+     * ongoing attack is detected, the rpc server should stop providing
+     * on-chain information, and instead return a relevant error code.
+     */
+    /// No connection to trusted peers.
+    pub const NO_TRUSTED_PEERS: i64 = -32074;
+    /// No peers are currently connected or there is insufficient amount of
+    /// peers connected.
+    pub const NO_PEERS: i64 = -32066;
+    pub const CONFLUX_PIVOT_CHAIN_UNSTABLE: i64 = -32075;
+    /// The node see a suspicious total mining power or block rate.
+    /// It's likely that the node is under attack or the whole Conflux network
+    /// enters an abnormal state.
+    pub const SUSPICIOUS_MINING_RATE: i64 = -32076;
+
+    /* Other server error codes */
+    /// Any exception happened while processing the transaction. Mostly likely
+    /// there is an internal error within the server state.
+    ///
+    /// When the server can detect an error with the request itself, it should
+    /// return another error code such as invalid params, or for example
+    /// CALL_EXECUTION_ERROR.
     pub const EXCEPTION_ERROR: i64 = -32016;
-    pub const DATABASE_ERROR: i64 = -32017;
+    /// The error can be given to a request about a previous related request
+    /// which we can not associate with.
+    ///
+    /// In Parity it was used for rpc check_request(). In parity's comment:
+    /// "Checks the progress of a previously posted request (transaction/sign).
+    /// Should be given a valid send_transaction ID."
+    pub const PREVIOUS_REQUEST_NOT_FOUND: i64 = -32042;
+
+    // FIXME: Used in Parity for all Transaction related errors.
+    // FIXME: We may process it as general invalid_params with error message?
+    // FIXME: How do rpc clients handle errors from send_raw_transaction?
+
+    /* Wallet/secret-store/signing related. */
+    // FIXME: why didn't we use this error code?
     #[cfg(any(test, feature = "accounts"))]
     pub const ACCOUNT_LOCKED: i64 = -32020;
+    // FIXME: why didn't we use this error code?
     #[cfg(any(test, feature = "accounts"))]
     pub const PASSWORD_INVALID: i64 = -32021;
+    // FIXME: why didn't we use this error code?
     pub const ACCOUNT_ERROR: i64 = -32023;
-    pub const PRIVATE_ERROR: i64 = -32024;
-    pub const REQUEST_REJECTED: i64 = -32040;
-    pub const REQUEST_REJECTED_LIMIT: i64 = -32041;
-    pub const REQUEST_NOT_FOUND: i64 = -32042;
-    pub const ENCRYPTION_ERROR: i64 = -32055;
+    /// Encoding error happened in signing structured data. Related to EIP712.
     pub const ENCODING_ERROR: i64 = -32058;
-    pub const FETCH_ERROR: i64 = -32060;
-    pub const NO_LIGHT_PEERS: i64 = -32065;
-    pub const NO_PEERS: i64 = -32066;
-    pub const DEPRECATED: i64 = -32070;
-    pub const EXPERIMENTAL_RPC: i64 = -32071;
-    pub const CANNOT_RESTART: i64 = -32080;
+
+    /* Other application error codes */
+    /// Call() execution error. This is clearly an application level error code,
+    /// but we keep the error code to be ethereum rpc client compatible.
+    pub const CALL_EXECUTION_ERROR: i64 = -32015;
+
 }
 
 pub fn unimplemented(details: Option<String>) -> Error {
     Error {
-        code: ErrorCode::ServerError(codes::UNSUPPORTED_REQUEST),
+        code: ErrorCode::ServerError(codes::UNSUPPORTED),
         message: "This request is not implemented yet. Please create an issue on Github repo.".into(),
         data: details.map(Value::String),
     }
@@ -67,15 +142,15 @@ pub fn unimplemented(details: Option<String>) -> Error {
 pub fn invalid_params<T: fmt::Debug>(param: &str, details: T) -> Error {
     Error {
         code: ErrorCode::InvalidParams,
-        message: format!("Couldn't parse parameters: {}", param),
+        message: format!("Invalid parameters: {}", param),
         data: Some(Value::String(format!("{:?}", details))),
     }
 }
 
-pub fn execution_error(message: String, output: Vec<u8>) -> Error {
+pub fn call_execution_error(message: String, output: Vec<u8>) -> Error {
     let output_bytes = Bytes::new(output);
     Error {
-        code: ErrorCode::ServerError(codes::EXECUTION_ERROR),
+        code: ErrorCode::ServerError(codes::CALL_EXECUTION_ERROR),
         message,
         data: Some(Value::String(
             serde_json::to_string(&output_bytes)

--- a/client/src/rpc/helpers/errors.rs
+++ b/client/src/rpc/helpers/errors.rs
@@ -158,3 +158,13 @@ pub fn call_execution_error(message: String, output: Vec<u8>) -> Error {
         )),
     }
 }
+
+pub fn request_rejected_too_many_request_error(
+    details: Option<String>,
+) -> Error {
+    Error {
+        code: ErrorCode::ServerError(codes::REQUEST_REJECTED_TOO_MANY_REQUESTS),
+        message: "Request rejected.".into(),
+        data: details.map(Value::String),
+    }
+}

--- a/client/src/rpc/helpers/errors.rs
+++ b/client/src/rpc/helpers/errors.rs
@@ -23,7 +23,7 @@ use std::fmt;
 use crate::rpc::types::Bytes;
 use jsonrpc_core::{Error, ErrorCode, Value};
 
-mod codes {
+pub mod codes {
     // NOTE [ToDr] Codes from [-32099, -32000]
     pub const UNSUPPORTED_REQUEST: i64 = -32000;
     pub const NO_WORK: i64 = -32001;

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -3,7 +3,7 @@
 // See http://www.gnu.org/licenses/
 
 use crate::rpc::{
-    helpers::errors::execution_error,
+    helpers::errors::{call_execution_error, invalid_params},
     impls::common::RpcImpl as CommonImpl,
     traits::{cfx::Cfx, debug::LocalRpc, test::TestRpc},
     types::{
@@ -15,6 +15,7 @@ use crate::rpc::{
         Transaction as RpcTransaction, H160 as RpcH160, H256 as RpcH256,
         H520 as RpcH520, U128 as RpcU128, U256 as RpcU256, U64 as RpcU64,
     },
+    RpcResult,
 };
 use blockgen::BlockGenerator;
 use cfx_types::{H160, H256, U256};
@@ -25,7 +26,7 @@ use cfxcore::{
     SharedSynchronizationService, SharedTransactionPool,
 };
 use delegate::delegate;
-use jsonrpc_core::{BoxFuture, Error as RpcError, Result as RpcResult};
+use jsonrpc_core::{BoxFuture, Error as JsonRpcError, Result as JsonRpcResult};
 use network::{
     node_table::{Node, NodeId},
     throttling, SessionDetails, UpdateNodeOperation,
@@ -89,10 +90,9 @@ impl RpcImpl {
             .downcast_ref::<ConsensusGraph>()
             .expect("downcast should succeed");
 
-        consensus_graph
-            .get_code(address, epoch_number.into())
-            .map(Bytes::new)
-            .map_err(RpcError::invalid_params)
+        Ok(Bytes::new(
+            consensus_graph.get_code(address, epoch_number.into())?,
+        ))
     }
 
     fn balance(
@@ -111,10 +111,7 @@ impl RpcImpl {
             .downcast_ref::<ConsensusGraph>()
             .expect("downcast should succeed");
 
-        consensus_graph
-            .get_balance(address, num.into())
-            .map(|x| x.into())
-            .map_err(RpcError::invalid_params)
+        Ok(consensus_graph.get_balance(address, num.into())?.into())
     }
 
     fn admin(
@@ -133,9 +130,7 @@ impl RpcImpl {
             .downcast_ref::<ConsensusGraph>()
             .expect("downcast should succeed");
 
-        cg.get_admin(address, num.into())
-            .map(|x| x.into())
-            .map_err(RpcError::invalid_params)
+        Ok(cg.get_admin(address, num.into())?.into())
     }
 
     fn sponsor_info(
@@ -154,9 +149,9 @@ impl RpcImpl {
             .downcast_ref::<ConsensusGraph>()
             .expect("downcast should succeed");
 
-        cg.get_sponsor_info(address, num.into())
-            .map(|x| RpcSponsorInfo::new(x))
-            .map_err(RpcError::invalid_params)
+        Ok(RpcSponsorInfo::new(
+            cg.get_sponsor_info(address, num.into())?,
+        ))
     }
 
     fn staking_balance(
@@ -175,10 +170,9 @@ impl RpcImpl {
             .downcast_ref::<ConsensusGraph>()
             .expect("downcast should succeed");
 
-        consensus_graph
-            .get_staking_balance(address, num.into())
-            .map(|x| x.into())
-            .map_err(RpcError::invalid_params)
+        Ok(consensus_graph
+            .get_staking_balance(address, num.into())?
+            .into())
     }
 
     fn collateral_for_storage(
@@ -197,10 +191,9 @@ impl RpcImpl {
             .downcast_ref::<ConsensusGraph>()
             .expect("downcast should succeed");
 
-        consensus_graph
-            .get_collateral_for_storage(address, num.into())
-            .map(|x| x.into())
-            .map_err(RpcError::invalid_params)
+        Ok(consensus_graph
+            .get_collateral_for_storage(address, num.into())?
+            .into())
     }
 
     /// Return account related states of the given account
@@ -220,10 +213,9 @@ impl RpcImpl {
             .downcast_ref::<ConsensusGraph>()
             .expect("downcast should succeed");
 
-        consensus_graph
-            .get_account(address, epoch_num.into())
-            .map(|acc| RpcAccount::new(acc))
-            .map_err(RpcError::invalid_params)
+        Ok(RpcAccount::new(
+            consensus_graph.get_account(address, epoch_num.into())?,
+        ))
     }
 
     /// Returns interest rate of the given epoch
@@ -237,10 +229,9 @@ impl RpcImpl {
             .downcast_ref::<ConsensusGraph>()
             .expect("downcast should succeed");
 
-        consensus_graph
-            .get_annual_interest_rate(epoch_num.into())
-            .map(|x| x.into())
-            .map_err(RpcError::invalid_params)
+        Ok(consensus_graph
+            .get_annual_interest_rate(epoch_num.into())?
+            .into())
     }
 
     /// Returns accumulate interest rate of the given epoch
@@ -254,17 +245,17 @@ impl RpcImpl {
             .downcast_ref::<ConsensusGraph>()
             .expect("downcast should succeed");
 
-        consensus_graph
-            .get_accumulate_interest_rate(epoch_num.into())
-            .map(|x| x.into())
-            .map_err(RpcError::invalid_params)
+        Ok(consensus_graph
+            .get_accumulate_interest_rate(epoch_num.into())?
+            .into())
     }
 
     fn send_raw_transaction(&self, raw: Bytes) -> RpcResult<RpcH256> {
         info!("RPC Request: cfx_sendRawTransaction bytes={:?}", raw);
 
+        // FIXME: input parse error.
         let tx = Rlp::new(&raw.into_vec()).as_val().map_err(|err| {
-            RpcError::invalid_params(format!("Error: {:?}", err))
+            invalid_params("raw", format!("Error: {:?}", err))
         })?;
 
         self.send_transaction_with_signature(tx)
@@ -290,10 +281,9 @@ impl RpcImpl {
             .downcast_ref::<ConsensusGraph>()
             .expect("downcast should succeed");
 
-        consensus_graph
-            .get_storage(address, position, epoch_num.into())
-            .map(|x| x.map(Into::into))
-            .map_err(RpcError::invalid_params)
+        Ok(consensus_graph
+            .get_storage(address, position, epoch_num.into())?
+            .map(Into::into))
     }
 
     fn send_transaction_with_signature(
@@ -301,12 +291,14 @@ impl RpcImpl {
     ) -> RpcResult<RpcH256> {
         if let Call(H160(r)) = &tx.transaction.action {
             let type_bits = r[0] & 0xf0;
+            // FIXME: this check should be a separate call.
             if !(type_bits == 0x0 || type_bits == 0x10 || type_bits == 0x80) {
-                return Err(RpcError::invalid_params("Sending transactions to invalid address. The first four bits must be 0x0 (built-in/reserved), 0x1 (user-account), or 0x8 (contract)."));
+                bail!(invalid_params("tx", "Sending transactions to invalid address. The first four bits must be 0x0 (built-in/reserved), 0x1 (user-account), or 0x8 (contract)."));
             }
         }
         let (signed_trans, failed_trans) =
             self.tx_pool.insert_new_transactions(vec![tx]);
+        // FIXME: how is it possible?
         if signed_trans.len() + failed_trans.len() > 1 {
             // This should never happen
             error!("insert_new_transactions failed, invalid length of returned result vector {}", signed_trans.len() + failed_trans.len());
@@ -314,10 +306,12 @@ impl RpcImpl {
         } else if signed_trans.len() + failed_trans.len() == 0 {
             // For tx in transactions_pubkey_cache, we simply ignore them
             debug!("insert_new_transactions ignores inserted transactions");
-            Err(RpcError::invalid_params(String::from("tx already exist")))
+            // FIXME: this is not invalid params
+            bail!(invalid_params("tx", String::from("tx already exist")))
         } else if signed_trans.is_empty() {
             let tx_err = failed_trans.iter().next().expect("Not empty").1;
-            Err(RpcError::invalid_params(tx_err))
+            // FIXME: this is not invalid params
+            bail!(invalid_params("tx", tx_err))
         } else {
             let tx_hash = signed_trans[0].hash();
             self.sync.append_received_transactions(signed_trans);
@@ -325,6 +319,7 @@ impl RpcImpl {
         }
     }
 
+    // FIXME: understand this rpc..
     fn prepare_transaction(
         &self, mut tx: SendTxRequest, password: Option<String>,
     ) -> RpcResult<TransactionWithSignature> {
@@ -344,10 +339,10 @@ impl RpcImpl {
                     .into_primitive(),
                 )
                 .map_err(|e| {
-                    RpcError::invalid_params(format!(
-                        "failed to send transaction: {:?}",
-                        e
-                    ))
+                    invalid_params(
+                        "tx",
+                        format!("failed to send transaction: {:?}", e),
+                    )
                 })?;
             tx.nonce.replace(nonce.into());
             debug!("after loading nonce in latest state, tx = {:?}", tx);
@@ -358,10 +353,10 @@ impl RpcImpl {
         let tx =
             tx.sign_with(epoch_height, chain_id, password)
                 .map_err(|e| {
-                    RpcError::invalid_params(format!(
-                        "failed to send transaction: {:?}",
-                        e
-                    ))
+                    invalid_params(
+                        "tx",
+                        format!("failed to send transaction: {:?}", e),
+                    )
                 })?;
 
         Ok(tx)
@@ -393,10 +388,9 @@ impl RpcImpl {
             .downcast_ref::<ConsensusGraph>()
             .expect("downcast should succeed");
 
-        consensus_graph
-            .get_storage_root(address, epoch_num.into())
-            .map(|maybe_hash| maybe_hash.map(Into::into))
-            .map_err(RpcError::invalid_params)
+        Ok(consensus_graph
+            .get_storage_root(address, epoch_num.into())?
+            .map(Into::into))
     }
 
     fn send_usable_genesis_accounts(
@@ -408,9 +402,10 @@ impl RpcImpl {
         );
         match self.maybe_txgen.as_ref() {
             None => {
-                let mut rpc_error = RpcError::method_not_found();
+                // FIXME: method_not_found
+                let mut rpc_error = JsonRpcError::method_not_found();
                 rpc_error.message = "send_usable_genesis_accounts only allowed in test or dev mode with txgen set.".into();
-                Err(rpc_error)
+                bail!(rpc_error)
             }
             Some(txgen) => {
                 txgen.set_genesis_accounts_start_index(account_start_index);
@@ -464,7 +459,8 @@ impl RpcImpl {
             .consensus
             .get_data_manager()
             .block_header_by_hash(&epoch_hash)
-            .ok_or(RpcError::internal_error())?;
+            // FIXME: server error, client should request another server.
+            .ok_or("Inconsistent state")?;
         let epoch_number = epoch_block_header.height();
         if epoch_number > consensus_graph.best_executed_state_epoch_number() {
             // The receipt is only visible to optimistic execution.
@@ -476,18 +472,21 @@ impl RpcImpl {
             .consensus
             .get_data_manager()
             .block_by_hash(&address.block_hash, true)
-            .ok_or(RpcError::internal_error())?;
+            // FIXME: server error, client should request another server.
+            .ok_or("Inconsistent state")?;
         let transaction = block
             .transactions
             .get(address.index)
-            .ok_or(RpcError::internal_error())?
+            // FIXME: server error, client should request another server.
+            .ok_or("Inconsistent state")?
             .as_ref()
             .clone();
         let receipt = execution_result
             .block_receipts
             .receipts
             .get(address.index)
-            .ok_or(RpcError::internal_error())?
+            // FIXME: server error, client should request another server.
+            .ok_or("Inconsistent state")?
             .clone();
         let prior_gas_used = if address.index == 0 {
             U256::zero()
@@ -496,7 +495,8 @@ impl RpcImpl {
                 .block_receipts
                 .receipts
                 .get(address.index - 1)
-                .ok_or(RpcError::internal_error())?
+                // FIXME: server error, client should request another server.
+                .ok_or("Inconsistent state")?
                 .clone();
             prior_receipt.gas_used
         };
@@ -542,41 +542,38 @@ impl RpcImpl {
             "RPC Request: generate_fixed_block({:?}, {:?}, {:?}, {:?})",
             parent_hash, referee, num_txs, difficulty
         );
-        match self.block_gen.generate_fixed_block(
+        Ok(self.block_gen.generate_fixed_block(
             parent_hash,
             referee,
             num_txs,
             difficulty.unwrap_or(0),
             adaptive,
-        ) {
-            Ok(hash) => Ok(hash),
-            Err(e) => Err(RpcError::invalid_params(e)),
-        }
+        )?)
     }
 
     fn generate_one_block(
         &self, num_txs: usize, block_size_limit: usize,
     ) -> RpcResult<H256> {
         info!("RPC Request: generate_one_block()");
-        let hash =
-            self.block_gen
-                .generate_block(num_txs, block_size_limit, vec![]);
-        Ok(hash)
+        Ok(self
+            .block_gen
+            .generate_block(num_txs, block_size_limit, vec![]))
     }
 
     fn generate_one_block_with_direct_txgen(
         &self, num_txs: usize, mut block_size_limit: usize,
         num_txs_simple: usize, num_txs_erc20: usize,
-    ) -> RpcResult<()>
+    ) -> RpcResult<H256>
     {
         info!("RPC Request: generate_one_block_with_direct_txgen()");
 
         let block_gen = &self.block_gen;
         match self.maybe_direct_txgen.as_ref() {
             None => {
-                let mut rpc_error = RpcError::method_not_found();
+                // FIXME: create helper function.
+                let mut rpc_error = JsonRpcError::method_not_found();
                 rpc_error.message = "generate_one_block_with_direct_txgen only allowed in test or dev mode.".into();
-                Err(rpc_error)
+                bail!(rpc_error)
             }
             Some(direct_txgen) => {
                 let generated_transactions =
@@ -586,12 +583,11 @@ impl RpcImpl {
                         num_txs_erc20,
                     );
 
-                block_gen.generate_block(
+                Ok(block_gen.generate_block(
                     num_txs,
                     block_size_limit,
                     generated_transactions,
-                );
-                Ok(())
+                ))
             }
         }
     }
@@ -605,15 +601,12 @@ impl RpcImpl {
 
         let transactions = self.decode_raw_txs(raw_txs, 0)?;
 
-        match self.block_gen.generate_custom_block_with_parent(
+        Ok(self.block_gen.generate_custom_block_with_parent(
             parent_hash,
             referee,
             transactions,
             adaptive.unwrap_or(false),
-        ) {
-            Ok(hash) => Ok(hash),
-            Err(e) => Err(RpcError::invalid_params(e)),
-        }
+        )?)
     }
 
     fn generate_block_with_nonce_and_timestamp(
@@ -622,17 +615,14 @@ impl RpcImpl {
     ) -> RpcResult<H256>
     {
         let transactions = self.decode_raw_txs(raw, 0)?;
-        match self.block_gen.generate_block_with_nonce_and_timestamp(
+        Ok(self.block_gen.generate_block_with_nonce_and_timestamp(
             parent,
             referees,
             transactions,
             nonce,
             timestamp,
             adaptive,
-        ) {
-            Ok(hash) => Ok(hash),
-            Err(e) => Err(RpcError::invalid_params(e)),
-        }
+        )?)
     }
 
     fn decode_raw_txs(
@@ -640,7 +630,7 @@ impl RpcImpl {
     ) -> RpcResult<Vec<Arc<SignedTransaction>>> {
         let txs: Vec<TransactionWithSignature> =
             Rlp::new(&raw_txs.into_vec()).as_list().map_err(|err| {
-                RpcError::invalid_params(format!("Decode error: {:?}", err))
+                invalid_params("raw_txs", format!("Decode error: {:?}", err))
             })?;
 
         let mut transactions = Vec::new();
@@ -656,10 +646,10 @@ impl RpcImpl {
                     transactions.push(Arc::new(signed_tx));
                 }
                 Err(e) => {
-                    return Err(RpcError::invalid_params(format!(
-                        "Recover public error: {:?}",
-                        e
-                    )));
+                    bail!(invalid_params(
+                        &format!("raw_txs, tx {:?}", tx),
+                        format!("Recover public error: {:?}", e),
+                    ));
                 }
             }
         }
@@ -710,11 +700,12 @@ impl RpcImpl {
             }
         }
 
-        consensus_graph
-            .logs(filter)
-            .map_err(|e| format!("{}", e))
-            .map_err(RpcError::invalid_params)
-            .map(|logs| logs.iter().cloned().map(RpcLog::from).collect())
+        Ok(consensus_graph
+            .logs(filter)?
+            .iter()
+            .cloned()
+            .map(RpcLog::from)
+            .collect())
     }
 
     fn call(
@@ -754,18 +745,14 @@ impl RpcImpl {
 
         let best_epoch_height = consensus_graph.best_epoch_number();
         let chain_id = consensus_graph.best_chain_id();
-        let signed_tx = sign_call(best_epoch_height, chain_id, request)
-            .map_err(|err| {
-                RpcError::invalid_params(format!("Sign tx error: {:?}", err))
-            })?;
+        let signed_tx = sign_call(best_epoch_height, chain_id, request);
         trace!("call tx {:?}", signed_tx);
-        let executed = consensus_graph
-            .call_virtual(&signed_tx, epoch.into())
-            .map_err(RpcError::invalid_params)?;
+        let executed =
+            consensus_graph.call_virtual(&signed_tx, epoch.into())?;
         match executed.exception {
             None => Ok(executed),
             Some(exception) => {
-                Err(execution_error(exception.to_string(), executed.output))
+                bail!(execution_error(exception.to_string(), executed.output))
             }
         }
     }
@@ -801,16 +788,17 @@ impl RpcImpl {
         let status = consensus_graph
             .data_man
             .local_block_info_from_db(&block_hash)
-            .ok_or(RpcError::invalid_params("No block status"))?
+            // FIXME: invalid_params?
+            .ok_or(invalid_params("block_hash", "No block status"))?
             .get_status();
         let state_valid = consensus_graph
             .inner
             .read()
             .block_node(&block_hash)
-            .ok_or(RpcError::invalid_params("No block in consensus"))?
+            .ok_or(invalid_params("block_hash", "No block in consensus"))?
             .data
             .state_valid
-            .ok_or(RpcError::invalid_params("No state_valid"))?;
+            .ok_or(invalid_params("block_hash", "No state_valid"))?;
         Ok((status.to_db_status(), state_valid))
     }
 
@@ -839,53 +827,50 @@ impl CfxHandler {
     }
 }
 
-// Use the #[into] attribute to convert from RpcResult to BoxFuture
-// automatically.
+// To convert from RpcResult to BoxFuture by delegate! macro automatically.
 use crate::common::delegate_convert;
 impl Cfx for CfxHandler {
     delegate! {
         to self.common {
-            fn best_block_hash(&self) -> RpcResult<RpcH256>;
-            fn block_by_epoch_number(&self, epoch_num: EpochNumber, include_txs: bool) -> RpcResult<RpcBlock>;
-            fn block_by_hash_with_pivot_assumption(&self, block_hash: RpcH256, pivot_hash: RpcH256, epoch_number: RpcU64) -> RpcResult<RpcBlock>;
-            fn block_by_hash(&self, hash: RpcH256, include_txs: bool) -> RpcResult<Option<RpcBlock>>;
-            fn blocks_by_epoch(&self, num: EpochNumber) -> RpcResult<Vec<RpcH256>>;
-            fn skipped_blocks_by_epoch(&self, num: EpochNumber) -> RpcResult<Vec<RpcH256>>;
-            fn epoch_number(&self, epoch_num: Option<EpochNumber>) -> RpcResult<RpcU256>;
-            fn gas_price(&self) -> RpcResult<RpcU256>;
-            fn next_nonce(&self, address: RpcH160, num: Option<BlockHashOrEpochNumber>) -> RpcResult<RpcU256>;
+            fn best_block_hash(&self) -> JsonRpcResult<RpcH256>;
+            fn block_by_epoch_number(
+                &self, epoch_num: EpochNumber, include_txs: bool) -> JsonRpcResult<RpcBlock>;
+            fn block_by_hash_with_pivot_assumption(
+                &self, block_hash: RpcH256, pivot_hash: RpcH256, epoch_number: RpcU64)
+                -> JsonRpcResult<RpcBlock>;
+            fn block_by_hash(&self, hash: RpcH256, include_txs: bool)
+                -> JsonRpcResult<Option<RpcBlock>>;
+            fn blocks_by_epoch(&self, num: EpochNumber) -> JsonRpcResult<Vec<RpcH256>>;
+            fn skipped_blocks_by_epoch(&self, num: EpochNumber) -> JsonRpcResult<Vec<RpcH256>>;
+            fn epoch_number(&self, epoch_num: Option<EpochNumber>) -> JsonRpcResult<RpcU256>;
+            fn gas_price(&self) -> JsonRpcResult<RpcU256>;
+            fn next_nonce(&self, address: RpcH160, num: Option<BlockHashOrEpochNumber>)
+                -> JsonRpcResult<RpcU256>;
         }
 
         to self.rpc_impl {
-            #[into]
             fn code(&self, addr: RpcH160, epoch_number: Option<EpochNumber>) -> BoxFuture<Bytes>;
-            #[into]
             fn account(&self, address: RpcH160, num: Option<EpochNumber>) -> BoxFuture<RpcAccount>;
-            fn interest_rate(&self, num: Option<EpochNumber>) -> RpcResult<RpcU256>;
-            fn accumulate_interest_rate(&self, num: Option<EpochNumber>) -> RpcResult<RpcU256>;
-            #[into]
+            fn interest_rate(&self, num: Option<EpochNumber>) -> JsonRpcResult<RpcU256>;
+            fn accumulate_interest_rate(&self, num: Option<EpochNumber>) -> JsonRpcResult<RpcU256>;
             fn admin(&self, address: RpcH160, num: Option<EpochNumber>) -> BoxFuture<RpcH160>;
-            #[into]
-            fn sponsor_info(&self, address: RpcH160, num: Option<EpochNumber>) -> BoxFuture<RpcSponsorInfo>;
-            #[into]
+            fn sponsor_info(&self, address: RpcH160, num: Option<EpochNumber>)
+                -> BoxFuture<RpcSponsorInfo>;
             fn balance(&self, address: RpcH160, num: Option<EpochNumber>) -> BoxFuture<RpcU256>;
-            #[into]
-            fn staking_balance(&self, address: RpcH160, num: Option<EpochNumber>) -> BoxFuture<RpcU256>;
-            #[into]
-            fn collateral_for_storage(&self, address: RpcH160, num: Option<EpochNumber>) -> BoxFuture<RpcU256>;
-            fn call(&self, request: CallRequest, epoch: Option<EpochNumber>) -> RpcResult<Bytes>;
+            fn staking_balance(&self, address: RpcH160, num: Option<EpochNumber>)
+                -> BoxFuture<RpcU256>;
+            fn collateral_for_storage(&self, address: RpcH160, num: Option<EpochNumber>)
+                -> BoxFuture<RpcU256>;
+            fn call(&self, request: CallRequest, epoch: Option<EpochNumber>)
+                -> JsonRpcResult<Bytes>;
             fn estimate_gas_and_collateral(
                 &self, request: CallRequest, epoch_number: Option<EpochNumber>)
-                -> RpcResult<EstimateGasAndCollateralResponse>;
-            #[into]
+                -> JsonRpcResult<EstimateGasAndCollateralResponse>;
             fn get_logs(&self, filter: RpcFilter) -> BoxFuture<Vec<RpcLog>>;
-            fn send_raw_transaction(&self, raw: Bytes) -> RpcResult<RpcH256>;
-            #[into]
+            fn send_raw_transaction(&self, raw: Bytes) -> JsonRpcResult<RpcH256>;
             fn storage_at(&self, addr: RpcH160, pos: RpcH256, epoch_number: Option<EpochNumber>)
                 -> BoxFuture<Option<RpcH256>>;
-            #[into]
             fn transaction_by_hash(&self, hash: RpcH256) -> BoxFuture<Option<RpcTransaction>>;
-            #[into]
             fn transaction_receipt(&self, tx_hash: RpcH256) -> BoxFuture<Option<RpcReceipt>>;
         }
     }
@@ -906,33 +891,44 @@ impl TestRpcImpl {
 impl TestRpc for TestRpcImpl {
     delegate! {
         to self.common {
-            fn add_latency(&self, id: NodeId, latency_ms: f64) -> RpcResult<()>;
-            fn add_peer(&self, node_id: NodeId, address: SocketAddr) -> RpcResult<()>;
-            fn chain(&self) -> RpcResult<Vec<RpcBlock>>;
-            fn drop_peer(&self, node_id: NodeId, address: SocketAddr) -> RpcResult<()>;
-            fn get_block_count(&self) -> RpcResult<u64>;
-            fn get_goodput(&self) -> RpcResult<String>;
-            fn get_nodeid(&self, challenge: Vec<u8>) -> RpcResult<Vec<u8>>;
-            fn get_peer_info(&self) -> RpcResult<Vec<PeerInfo>>;
-            fn get_status(&self) -> RpcResult<RpcStatus>;
-            fn say_hello(&self) -> RpcResult<String>;
-            fn stop(&self) -> RpcResult<()>;
-            fn save_node_db(&self) -> RpcResult<()>;
+            fn add_latency(&self, id: NodeId, latency_ms: f64) -> JsonRpcResult<()>;
+            fn add_peer(&self, node_id: NodeId, address: SocketAddr) -> JsonRpcResult<()>;
+            fn chain(&self) -> JsonRpcResult<Vec<RpcBlock>>;
+            fn drop_peer(&self, node_id: NodeId, address: SocketAddr) -> JsonRpcResult<()>;
+            fn get_block_count(&self) -> JsonRpcResult<u64>;
+            fn get_goodput(&self) -> JsonRpcResult<String>;
+            fn get_nodeid(&self, challenge: Vec<u8>) -> JsonRpcResult<Vec<u8>>;
+            fn get_peer_info(&self) -> JsonRpcResult<Vec<PeerInfo>>;
+            fn get_status(&self) -> JsonRpcResult<RpcStatus>;
+            fn say_hello(&self) -> JsonRpcResult<String>;
+            fn stop(&self) -> JsonRpcResult<()>;
+            fn save_node_db(&self) -> JsonRpcResult<()>;
         }
 
         to self.rpc_impl {
-            fn expire_block_gc(&self, timeout: u64) -> RpcResult<()>;
-            fn generate_block_with_blame_info(&self, num_txs: usize, block_size_limit: usize, blame_info: BlameInfo) -> RpcResult<H256>;
-            fn generate_block_with_fake_txs(&self, raw_txs_without_data: Bytes, adaptive: Option<bool>, tx_data_len: Option<usize>) -> RpcResult<H256>;
-            fn generate_custom_block(&self, parent_hash: H256, referee: Vec<H256>, raw_txs: Bytes, adaptive: Option<bool>) -> RpcResult<H256>;
-            fn generate_fixed_block(&self, parent_hash: H256, referee: Vec<H256>, num_txs: usize, adaptive: bool, difficulty: Option<u64>) -> RpcResult<H256>;
-            fn generate_one_block_with_direct_txgen(&self, num_txs: usize, block_size_limit: usize, num_txs_simple: usize, num_txs_erc20: usize) -> RpcResult<()>;
-            fn generate_one_block(&self, num_txs: usize, block_size_limit: usize) -> RpcResult<H256>;
-            fn generate_block_with_nonce_and_timestamp(&self, parent: H256, referees: Vec<H256>, raw: Bytes, nonce: u64, timestamp: u64, adaptive: bool) -> RpcResult<H256>;
-            fn generate_empty_blocks(&self, num_blocks: usize) -> RpcResult<Vec<H256>>;
-            fn get_block_status(&self, block_hash: H256) -> RpcResult<(u8, bool)>;
-            fn send_usable_genesis_accounts(& self, account_start_index: usize) -> RpcResult<Bytes>;
-            fn set_db_crash(&self, crash_probability: f64, crash_exit_code: i32) -> RpcResult<()>;
+            fn expire_block_gc(&self, timeout: u64) -> JsonRpcResult<()>;
+            fn generate_block_with_blame_info(
+                &self, num_txs: usize, block_size_limit: usize, blame_info: BlameInfo) -> JsonRpcResult<H256>;
+            fn generate_block_with_fake_txs(
+                &self, raw_txs_without_data: Bytes, adaptive: Option<bool>, tx_data_len: Option<usize>)
+                -> JsonRpcResult<H256>;
+            fn generate_custom_block(
+                &self, parent_hash: H256, referee: Vec<H256>, raw_txs: Bytes, adaptive: Option<bool>)
+                -> JsonRpcResult<H256>;
+            fn generate_fixed_block(
+                &self, parent_hash: H256, referee: Vec<H256>, num_txs: usize, adaptive: bool, difficulty: Option<u64>)
+                -> JsonRpcResult<H256>;
+            fn generate_one_block_with_direct_txgen(
+                &self, num_txs: usize, block_size_limit: usize, num_txs_simple: usize, num_txs_erc20: usize)
+                -> JsonRpcResult<H256>;
+            fn generate_one_block(&self, num_txs: usize, block_size_limit: usize) -> JsonRpcResult<H256>;
+            fn generate_block_with_nonce_and_timestamp(
+                &self, parent: H256, referees: Vec<H256>, raw: Bytes, nonce: u64, timestamp: u64, adaptive: bool)
+                -> JsonRpcResult<H256>;
+            fn generate_empty_blocks(&self, num_blocks: usize) -> JsonRpcResult<Vec<H256>>;
+            fn get_block_status(&self, block_hash: H256) -> JsonRpcResult<(u8, bool)>;
+            fn send_usable_genesis_accounts(& self, account_start_index: usize) -> JsonRpcResult<Bytes>;
+            fn set_db_crash(&self, crash_probability: f64, crash_exit_code: i32) -> JsonRpcResult<()>;
         }
     }
 }
@@ -951,30 +947,36 @@ impl LocalRpcImpl {
 impl LocalRpc for LocalRpcImpl {
     delegate! {
         to self.common {
-            fn clear_tx_pool(&self) -> RpcResult<()>;
-            fn net_node(&self, id: NodeId) -> RpcResult<Option<(String, Node)>>;
-            fn net_disconnect_node(&self, id: NodeId, op: Option<UpdateNodeOperation>) -> RpcResult<bool>;
-            fn net_sessions(&self, node_id: Option<NodeId>) -> RpcResult<Vec<SessionDetails>>;
-            fn net_throttling(&self) -> RpcResult<throttling::Service>;
-            fn tx_inspect(&self, hash: RpcH256) -> RpcResult<BTreeMap<String, String>>;
-            fn txpool_content(&self) -> RpcResult<BTreeMap<String, BTreeMap<String, BTreeMap<usize, Vec<RpcTransaction>>>>>;
-            fn txpool_inspect(&self) -> RpcResult<BTreeMap<String, BTreeMap<String, BTreeMap<usize, Vec<String>>>>>;
-            fn txpool_status(&self) -> RpcResult<BTreeMap<String, usize>>;
-            fn accounts(&self) -> RpcResult<Vec<RpcH160>>;
-            fn new_account(&self, password: String) -> RpcResult<RpcH160>;
-            fn unlock_account(&self, address: RpcH160, password: String, duration: Option<RpcU128>) -> RpcResult<bool>;
-            fn lock_account(&self, address: RpcH160) -> RpcResult<bool>;
-            fn sign(&self, data: Bytes, address: RpcH160, password: Option<String>) -> RpcResult<RpcH520>;
+            fn clear_tx_pool(&self) -> JsonRpcResult<()>;
+            fn net_node(&self, id: NodeId) -> JsonRpcResult<Option<(String, Node)>>;
+            fn net_disconnect_node(&self, id: NodeId, op: Option<UpdateNodeOperation>)
+                -> JsonRpcResult<bool>;
+            fn net_sessions(&self, node_id: Option<NodeId>) -> JsonRpcResult<Vec<SessionDetails>>;
+            fn net_throttling(&self) -> JsonRpcResult<throttling::Service>;
+            fn tx_inspect(&self, hash: RpcH256) -> JsonRpcResult<BTreeMap<String, String>>;
+            fn txpool_content(&self) -> JsonRpcResult<
+                BTreeMap<String, BTreeMap<String, BTreeMap<usize, Vec<RpcTransaction>>>>>;
+            fn txpool_inspect(&self) -> JsonRpcResult<
+                BTreeMap<String, BTreeMap<String, BTreeMap<usize, Vec<String>>>>>;
+            fn txpool_status(&self) -> JsonRpcResult<BTreeMap<String, usize>>;
+            fn accounts(&self) -> JsonRpcResult<Vec<RpcH160>>;
+            fn new_account(&self, password: String) -> JsonRpcResult<RpcH160>;
+            fn unlock_account(
+                &self, address: RpcH160, password: String, duration: Option<RpcU128>)
+                -> JsonRpcResult<bool>;
+            fn lock_account(&self, address: RpcH160) -> JsonRpcResult<bool>;
+            fn sign(&self, data: Bytes, address: RpcH160, password: Option<String>)
+                -> JsonRpcResult<RpcH520>;
         }
 
         to self.rpc_impl {
-            fn current_sync_phase(&self) -> RpcResult<String>;
-            fn consensus_graph_state(&self) -> RpcResult<ConsensusGraphStates>;
-            fn sync_graph_state(&self) -> RpcResult<SyncGraphStates>;
-            #[into]
-            fn send_transaction(&self, tx: SendTxRequest, password: Option<String>) -> BoxFuture<RpcH256>;
-            #[into]
-            fn storage_root(&self, address: RpcH160, epoch_num: Option<EpochNumber>) -> BoxFuture<Option<RpcH256>>;
+            fn current_sync_phase(&self) -> JsonRpcResult<String>;
+            fn consensus_graph_state(&self) -> JsonRpcResult<ConsensusGraphStates>;
+            fn sync_graph_state(&self) -> JsonRpcResult<SyncGraphStates>;
+            fn send_transaction(
+                &self, tx: SendTxRequest, password: Option<String>) -> BoxFuture<RpcH256>;
+            fn storage_root(&self, address: RpcH160, epoch_num: Option<EpochNumber>)
+                -> BoxFuture<Option<RpcH256>>;
         }
     }
 }

--- a/client/src/rpc/impls/light.rs
+++ b/client/src/rpc/impls/light.rs
@@ -451,6 +451,8 @@ impl CfxHandler {
     }
 }
 
+// To convert from RpcResult to BoxFuture by delegate! macro automatically.
+use crate::common::delegate_convert;
 impl Cfx for CfxHandler {
     delegate! {
         to self.common {
@@ -526,7 +528,7 @@ impl TestRpc for TestRpcImpl {
         fn generate_block_with_fake_txs(&self, raw_txs_without_data: Bytes, adaptive: Option<bool>, tx_data_len: Option<usize>) -> RpcResult<H256>;
         fn generate_custom_block(&self, parent_hash: H256, referee: Vec<H256>, raw_txs: Bytes, adaptive: Option<bool>) -> RpcResult<H256>;
         fn generate_fixed_block(&self, parent_hash: H256, referee: Vec<H256>, num_txs: usize, adaptive: bool, difficulty: Option<u64>) -> RpcResult<H256>;
-        fn generate_one_block_with_direct_txgen(&self, num_txs: usize, block_size_limit: usize, num_txs_simple: usize, num_txs_erc20: usize) -> RpcResult<()>;
+        fn generate_one_block_with_direct_txgen(&self, num_txs: usize, block_size_limit: usize, num_txs_simple: usize, num_txs_erc20: usize) -> RpcResult<H256>;
         fn generate_block_with_nonce_and_timestamp(&self, parent: H256, referees: Vec<H256>, raw: Bytes, nonce: u64, timestamp: u64, adaptive: bool) -> RpcResult<H256>;
         fn generate_one_block(&self, num_txs: usize, block_size_limit: usize) -> RpcResult<H256>;
         fn generate_empty_blocks(&self, num_blocks: usize) -> RpcResult<Vec<H256>>;

--- a/client/src/rpc/impls/light.rs
+++ b/client/src/rpc/impls/light.rs
@@ -97,7 +97,7 @@ impl RpcImpl {
 
     fn admin(
         &self, address: RpcH160, num: Option<EpochNumber>,
-    ) -> BoxFuture<RpcH160> {
+    ) -> BoxFuture<Option<RpcH160>> {
         let address: H160 = address.into();
         let epoch = num.unwrap_or(EpochNumber::LatestState).into();
 
@@ -115,9 +115,7 @@ impl RpcImpl {
                 .await
                 .map_err(RpcError::invalid_params)?;
 
-            Ok(account
-                .map(|account| account.admin.into())
-                .unwrap_or_default())
+            Ok(account.map(|account| account.admin.into()))
         };
 
         Box::new(fut.boxed().compat())
@@ -472,7 +470,8 @@ impl Cfx for CfxHandler {
             fn balance(&self, address: RpcH160, num: Option<EpochNumber>) -> BoxFuture<RpcU256>;
             fn staking_balance(&self, address: RpcH160, num: Option<EpochNumber>) -> BoxFuture<RpcU256>;
             fn collateral_for_storage(&self, address: RpcH160, num: Option<EpochNumber>) -> BoxFuture<RpcU256>;
-            fn admin(&self, address: RpcH160, num: Option<EpochNumber>) -> BoxFuture<RpcH160>;
+            fn admin(&self, address: RpcH160, num: Option<EpochNumber>)
+                -> BoxFuture<Option<RpcH160>>;
             fn sponsor_info(&self, address: RpcH160, num: Option<EpochNumber>) -> BoxFuture<RpcSponsorInfo>;
             fn call(&self, request: CallRequest, epoch: Option<EpochNumber>) -> RpcResult<Bytes>;
             fn code(&self, address: RpcH160, epoch_num: Option<EpochNumber>) -> BoxFuture<Bytes>;

--- a/client/src/rpc/traits/cfx.rs
+++ b/client/src/rpc/traits/cfx.rs
@@ -9,7 +9,7 @@ use super::super::types::{
     H160 as RpcH160, H256 as RpcH256, U256 as RpcU256, U64 as RpcU64,
 };
 use crate::rpc::types::BlockHashOrEpochNumber;
-use jsonrpc_core::{BoxFuture, Result as RpcResult};
+use jsonrpc_core::{BoxFuture, Result as JsonRpcResult};
 use jsonrpc_derive::rpc;
 
 /// Cfx rpc interface.
@@ -17,29 +17,29 @@ use jsonrpc_derive::rpc;
 pub trait Cfx {
     //        /// Returns protocol version encoded as a string (quotes are
     // necessary).        #[rpc(name = "cfx_protocolVersion")]
-    //        fn protocol_version(&self) -> RpcResult<String>;
+    //        fn protocol_version(&self) -> JsonRpcResult<String>;
     //
     /// Returns the number of hashes per second that the node is mining with.
     //        #[rpc(name = "cfx_hashrate")]
-    //        fn hashrate(&self) -> RpcResult<RpcU256>;
+    //        fn hashrate(&self) -> JsonRpcResult<RpcU256>;
 
     //        /// Returns block author.
     //        #[rpc(name = "cfx_coinbase")]
-    //        fn author(&self) -> RpcResult<RpcH160>;
+    //        fn author(&self) -> JsonRpcResult<RpcH160>;
 
     //        /// Returns true if client is actively mining new blocks.
     //        #[rpc(name = "cfx_mining")]
-    //        fn is_mining(&self) -> RpcResult<bool>;
+    //        fn is_mining(&self) -> JsonRpcResult<bool>;
 
     /// Returns current gas price.
     #[rpc(name = "cfx_gasPrice")]
-    fn gas_price(&self) -> RpcResult<RpcU256>;
+    fn gas_price(&self) -> JsonRpcResult<RpcU256>;
 
     /// Returns highest epoch number.
     #[rpc(name = "cfx_epochNumber")]
     fn epoch_number(
         &self, epoch_number: Option<EpochNumber>,
-    ) -> RpcResult<RpcU256>;
+    ) -> JsonRpcResult<RpcU256>;
 
     /// Returns balance of the given account.
     #[rpc(name = "cfx_getBalance")]
@@ -87,30 +87,30 @@ pub trait Cfx {
     #[rpc(name = "cfx_getBlockByHash")]
     fn block_by_hash(
         &self, block_hash: RpcH256, include_txs: bool,
-    ) -> RpcResult<Option<Block>>;
+    ) -> JsonRpcResult<Option<Block>>;
 
     /// Returns block with given hash and pivot chain assumption.
     #[rpc(name = "cfx_getBlockByHashWithPivotAssumption")]
     fn block_by_hash_with_pivot_assumption(
         &self, block_hash: RpcH256, pivot_hash: RpcH256, epoch_number: RpcU64,
-    ) -> RpcResult<Block>;
+    ) -> JsonRpcResult<Block>;
 
     /// Returns block with given epoch number.
     #[rpc(name = "cfx_getBlockByEpochNumber")]
     fn block_by_epoch_number(
         &self, epoch_number: EpochNumber, include_txs: bool,
-    ) -> RpcResult<Block>;
+    ) -> JsonRpcResult<Block>;
 
     /// Returns best block hash.
     #[rpc(name = "cfx_getBestBlockHash")]
-    fn best_block_hash(&self) -> RpcResult<RpcH256>;
+    fn best_block_hash(&self) -> JsonRpcResult<RpcH256>;
 
     /// Returns the nonce should be filled in next sending transaction from
     /// given address at given time (epoch number).
     #[rpc(name = "cfx_getNextNonce")]
     fn next_nonce(
         &self, addr: RpcH160, epoch_number: Option<BlockHashOrEpochNumber>,
-    ) -> RpcResult<RpcU256>;
+    ) -> JsonRpcResult<RpcU256>;
 
     //        /// Returns the number of transactions in a block with given hash.
     //        #[rpc(name = "cfx_getBlockTransactionCountByHash")]
@@ -124,17 +124,17 @@ pub trait Cfx {
 
     /// Sends signed transaction, returning its hash.
     #[rpc(name = "cfx_sendRawTransaction")]
-    fn send_raw_transaction(&self, raw_tx: Bytes) -> RpcResult<RpcH256>;
+    fn send_raw_transaction(&self, raw_tx: Bytes) -> JsonRpcResult<RpcH256>;
 
     //        /// @alias of `cfx_sendRawTransaction`.
     //        #[rpc(name = "cfx_submitTransaction")]
-    //        fn submit_transaction(&self, Bytes) -> RpcResult<RpcH256>;
+    //        fn submit_transaction(&self, Bytes) -> JsonRpcResult<RpcH256>;
 
     /// Call contract, returning the output data.
     #[rpc(name = "cfx_call")]
     fn call(
         &self, tx: CallRequest, epoch_number: Option<EpochNumber>,
-    ) -> RpcResult<Bytes>;
+    ) -> JsonRpcResult<Bytes>;
 
     /// Returns logs matching the filter provided.
     #[rpc(name = "cfx_getLogs")]
@@ -150,17 +150,17 @@ pub trait Cfx {
     #[rpc(name = "cfx_estimateGasAndCollateral")]
     fn estimate_gas_and_collateral(
         &self, request: CallRequest, epoch_number: Option<EpochNumber>,
-    ) -> RpcResult<EstimateGasAndCollateralResponse>;
+    ) -> JsonRpcResult<EstimateGasAndCollateralResponse>;
 
     #[rpc(name = "cfx_getBlocksByEpoch")]
     fn blocks_by_epoch(
         &self, epoch_number: EpochNumber,
-    ) -> RpcResult<Vec<RpcH256>>;
+    ) -> JsonRpcResult<Vec<RpcH256>>;
 
     #[rpc(name = "cfx_getSkippedBlocksByEpoch")]
     fn skipped_blocks_by_epoch(
         &self, epoch_number: EpochNumber,
-    ) -> RpcResult<Vec<RpcH256>>;
+    ) -> JsonRpcResult<Vec<RpcH256>>;
 
     #[rpc(name = "cfx_getTransactionReceipt")]
     fn transaction_receipt(
@@ -177,13 +177,13 @@ pub trait Cfx {
     #[rpc(name = "cfx_getInterestRate")]
     fn interest_rate(
         &self, epoch_number: Option<EpochNumber>,
-    ) -> RpcResult<RpcU256>;
+    ) -> JsonRpcResult<RpcU256>;
 
     /// Returns accumulate interest rate of the given epoch
     #[rpc(name = "cfx_getAccumulateInterestRate")]
     fn accumulate_interest_rate(
         &self, epoch_number: Option<EpochNumber>,
-    ) -> RpcResult<RpcU256>;
+    ) -> JsonRpcResult<RpcU256>;
 
     //        /// Returns transaction at given block hash and index.
     //        #[rpc(name = "cfx_getTransactionByBlockHashAndIndex")]

--- a/client/src/rpc/traits/cfx.rs
+++ b/client/src/rpc/traits/cfx.rs
@@ -51,7 +51,7 @@ pub trait Cfx {
     #[rpc(name = "cfx_getAdmin")]
     fn admin(
         &self, addr: RpcH160, epoch_number: Option<EpochNumber>,
-    ) -> BoxFuture<RpcH160>;
+    ) -> BoxFuture<Option<RpcH160>>;
 
     /// Returns sponsor information of the given contract
     #[rpc(name = "cfx_getSponsorInfo")]

--- a/client/src/rpc/traits/debug.rs
+++ b/client/src/rpc/traits/debug.rs
@@ -8,7 +8,7 @@ use super::super::types::{
     H520 as RpcH520, U128 as RpcU128,
 };
 use crate::rpc::types::SendTxRequest;
-use jsonrpc_core::{BoxFuture, Result as RpcResult};
+use jsonrpc_core::{BoxFuture, Result as JsonRpcResult};
 use jsonrpc_derive::rpc;
 use network::{
     node_table::{Node, NodeId},
@@ -19,22 +19,24 @@ use std::collections::BTreeMap;
 #[rpc(server)]
 pub trait LocalRpc {
     #[rpc(name = "txpool_status")]
-    fn txpool_status(&self) -> RpcResult<BTreeMap<String, usize>>;
+    fn txpool_status(&self) -> JsonRpcResult<BTreeMap<String, usize>>;
 
     #[rpc(name = "tx_inspect")]
-    fn tx_inspect(&self, hash: RpcH256) -> RpcResult<BTreeMap<String, String>>;
+    fn tx_inspect(
+        &self, hash: RpcH256,
+    ) -> JsonRpcResult<BTreeMap<String, String>>;
 
     #[rpc(name = "txpool_inspect")]
     fn txpool_inspect(
         &self,
-    ) -> RpcResult<
+    ) -> JsonRpcResult<
         BTreeMap<String, BTreeMap<String, BTreeMap<usize, Vec<String>>>>,
     >;
 
     #[rpc(name = "txpool_content")]
     fn txpool_content(
         &self,
-    ) -> RpcResult<
+    ) -> JsonRpcResult<
         BTreeMap<
             String,
             BTreeMap<String, BTreeMap<usize, Vec<RpcTransaction>>>,
@@ -42,32 +44,34 @@ pub trait LocalRpc {
     >;
 
     #[rpc(name = "clear_tx_pool")]
-    fn clear_tx_pool(&self) -> RpcResult<()>;
+    fn clear_tx_pool(&self) -> JsonRpcResult<()>;
 
     #[rpc(name = "net_throttling")]
-    fn net_throttling(&self) -> RpcResult<throttling::Service>;
+    fn net_throttling(&self) -> JsonRpcResult<throttling::Service>;
 
     #[rpc(name = "net_node")]
-    fn net_node(&self, node_id: NodeId) -> RpcResult<Option<(String, Node)>>;
+    fn net_node(
+        &self, node_id: NodeId,
+    ) -> JsonRpcResult<Option<(String, Node)>>;
 
     #[rpc(name = "net_disconnect_node")]
     fn net_disconnect_node(
         &self, id: NodeId, op: Option<UpdateNodeOperation>,
-    ) -> RpcResult<bool>;
+    ) -> JsonRpcResult<bool>;
 
     #[rpc(name = "net_sessions")]
     fn net_sessions(
         &self, node_id: Option<NodeId>,
-    ) -> RpcResult<Vec<SessionDetails>>;
+    ) -> JsonRpcResult<Vec<SessionDetails>>;
 
     #[rpc(name = "current_sync_phase")]
-    fn current_sync_phase(&self) -> RpcResult<String>;
+    fn current_sync_phase(&self) -> JsonRpcResult<String>;
 
     #[rpc(name = "consensus_graph_state")]
-    fn consensus_graph_state(&self) -> RpcResult<ConsensusGraphStates>;
+    fn consensus_graph_state(&self) -> JsonRpcResult<ConsensusGraphStates>;
 
     #[rpc(name = "sync_graph_state")]
-    fn sync_graph_state(&self) -> RpcResult<SyncGraphStates>;
+    fn sync_graph_state(&self) -> JsonRpcResult<SyncGraphStates>;
 
     #[rpc(name = "send_transaction")]
     fn send_transaction(
@@ -76,26 +80,26 @@ pub trait LocalRpc {
 
     /// Returns accounts list.
     #[rpc(name = "accounts")]
-    fn accounts(&self) -> RpcResult<Vec<RpcH160>>;
+    fn accounts(&self) -> JsonRpcResult<Vec<RpcH160>>;
 
     /// Create a new account
     #[rpc(name = "new_account")]
-    fn new_account(&self, password: String) -> RpcResult<RpcH160>;
+    fn new_account(&self, password: String) -> JsonRpcResult<RpcH160>;
 
     /// Unlock an account
     #[rpc(name = "unlock_account")]
     fn unlock_account(
         &self, address: RpcH160, password: String, duration: Option<RpcU128>,
-    ) -> RpcResult<bool>;
+    ) -> JsonRpcResult<bool>;
 
     /// Lock an account
     #[rpc(name = "lock_account")]
-    fn lock_account(&self, address: RpcH160) -> RpcResult<bool>;
+    fn lock_account(&self, address: RpcH160) -> JsonRpcResult<bool>;
 
     #[rpc(name = "sign")]
     fn sign(
         &self, data: RpcBytes, address: RpcH160, password: Option<String>,
-    ) -> RpcResult<RpcH520>;
+    ) -> JsonRpcResult<RpcH520>;
 
     #[rpc(name = "get_storage_root")]
     fn storage_root(

--- a/client/src/rpc/traits/test.rs
+++ b/client/src/rpc/traits/test.rs
@@ -64,7 +64,7 @@ pub trait TestRpc {
     fn generate_one_block_with_direct_txgen(
         &self, num_txs: usize, block_size_limit: usize, num_txs_simple: usize,
         num_txs_erc20: usize,
-    ) -> RpcResult<()>;
+    ) -> RpcResult<H256>;
 
     #[rpc(name = "test_generatecustomblock")]
     fn generate_custom_block(

--- a/client/src/rpc/types/call_request.rs
+++ b/client/src/rpc/types/call_request.rs
@@ -35,6 +35,7 @@ pub struct CallRequest {
 pub struct EstimateGasAndCollateralResponse {
     /// The amount of gas used in the execution.
     pub gas_used: U256,
+    // TODO: U64
     /// The number of bytes collateralized in the execution.
     pub storage_collateralized: U256,
 }

--- a/client/src/rpc/types/call_request.rs
+++ b/client/src/rpc/types/call_request.rs
@@ -4,7 +4,6 @@
 
 use crate::rpc::types::Bytes;
 use cfx_types::{H160, U256};
-use keylib::Error;
 use primitives::{
     transaction::Action, SignedTransaction, Transaction as PrimitiveTransaction,
 };
@@ -42,12 +41,12 @@ pub struct EstimateGasAndCollateralResponse {
 
 pub fn sign_call(
     epoch_height: u64, chain_id: u64, request: CallRequest,
-) -> Result<SignedTransaction, Error> {
+) -> SignedTransaction {
     let max_gas = U256::from(500_000_000);
     let gas = min(request.gas.unwrap_or(max_gas), max_gas);
     let from = request.from.unwrap_or_else(|| H160::random());
 
-    Ok(PrimitiveTransaction {
+    PrimitiveTransaction {
         nonce: request.nonce.unwrap_or_default(),
         action: request.to.map_or(Action::Create, Action::Call),
         gas,
@@ -58,7 +57,7 @@ pub fn sign_call(
         chain_id,
         data: request.data.unwrap_or_default().into_vec(),
     }
-    .fake_sign(from))
+    .fake_sign(from)
 }
 
 #[cfg(test)]

--- a/client/src/rpc/types/sync_graph_states.rs
+++ b/client/src/rpc/types/sync_graph_states.rs
@@ -11,6 +11,7 @@ pub struct SyncGraphBlockState {
     pub block_hash: H256,
     pub parent: H256,
     pub referees: Vec<H256>,
+    // TODO(yanpei): change into U64
     pub nonce: u64,
     pub timestamp: u64,
     pub adaptive: bool,

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -557,14 +557,10 @@ impl ConsensusGraph {
     pub fn get_sponsor_info(
         &self, address: H160, epoch_number: EpochNumber,
     ) -> Result<SponsorInfo, String> {
-        let state_db = self.get_state_db_by_epoch_number(epoch_number)?;
-        Ok(if let Ok(maybe_acc) = state_db.get_account(&address) {
-            maybe_acc
-                .map_or(Default::default(), |acc| acc.sponsor_info)
-                .into()
-        } else {
-            Default::default()
-        })
+        Ok(self
+            .get_account(address, epoch_number)?
+            .map(|account| account.sponsor_info.clone())
+            .unwrap_or_default())
     }
 
     /// Get the current bank balance of an address

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -493,17 +493,11 @@ impl ConsensusGraph {
 
     pub fn get_account(
         &self, address: H160, epoch_number: EpochNumber,
-    ) -> Result<Account, String> {
+    ) -> Result<Option<Account>, String> {
         let state_db = self.get_state_db_by_epoch_number(epoch_number)?;
-        if let Ok(maybe_acc) = state_db.get_account(&address) {
-            Ok(maybe_acc.unwrap_or(Account::new_empty_with_balance(
-                &address,
-                &U256::zero(), /* balance */
-                &U256::zero(), /* nonce */
-            )))
-        } else {
-            Err("db error occurred".into())
-        }
+        state_db
+            .get_account(&address)
+            .or_else(|_| Err("db error occurred".into()))
     }
 
     /// Get the current balance of an address
@@ -550,17 +544,13 @@ impl ConsensusGraph {
         }
     }
 
-    // FIXME: H160::zero or Option<H160>
-    /// Get the current admin of a contract
+    /// Get the current admin of a contract.
     pub fn get_admin(
         &self, address: H160, epoch_number: EpochNumber,
-    ) -> Result<H160, String> {
-        let state_db = self.get_state_db_by_epoch_number(epoch_number)?;
-        Ok(if let Ok(maybe_acc) = state_db.get_account(&address) {
-            maybe_acc.map_or(H160::zero(), |acc| acc.admin).into()
-        } else {
-            H160::zero()
-        })
+    ) -> Result<Option<H160>, String> {
+        Ok(self
+            .get_account(address, epoch_number)?
+            .map(|account| account.admin))
     }
 
     /// Get the current sponsor of a contract

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -550,6 +550,7 @@ impl ConsensusGraph {
         }
     }
 
+    // FIXME: H160::zero or Option<H160>
     /// Get the current admin of a contract
     pub fn get_admin(
         &self, address: H160, epoch_number: EpochNumber,

--- a/tests/throttle_test.py
+++ b/tests/throttle_test.py
@@ -44,21 +44,24 @@ class ThrottleRpcTests(ConfluxTestFramework):
             client.epoch_number()
             assert "should be throttled"
         except ReceivedErrorResponseError as e:
-            assert e.response.message.startswith("throttled in ")
+            assert e.response.code == -32072
+            assert e.response.data.startswith("throttled in ")
 
-        # allow to tolerate 1 time even throttled
+    # allow to tolerate 1 time even throttled
         try:
             client.epoch_number()
             assert "should be throttled"
         except ReceivedErrorResponseError as e:
-            assert e.response.message.startswith("throttled in ")
+            assert e.response.code == -32072
+            assert e.response.data.startswith("throttled in ")
 
         # already throttled
         try:
             client.epoch_number()
             assert "should be throttled"
         except ReceivedErrorResponseError as e:
-            assert e.response.message == "already throttled, please try again later"
+            assert e.response.code == -32072
+            assert e.response.data == "already throttled, please try again later"
 
     def test_recharged(self, client):
         # allow 5 times
@@ -70,14 +73,16 @@ class ThrottleRpcTests(ConfluxTestFramework):
             client.best_block_hash()
             assert "should be throttled"
         except ReceivedErrorResponseError as e:
-            assert e.response.message.startswith("throttled in ")
+            assert e.response.code == -32072
+            assert e.response.data.startswith("throttled in ")
 
         # do not tolerate once throttled
         try:
             client.best_block_hash()
             assert "should be throttled"
         except ReceivedErrorResponseError as e:
-            assert e.response.message == "already throttled, please try again later"
+            assert e.response.code == -32072
+            assert e.response.data == "already throttled, please try again later"
 
         # sleep 1 second to recharge tokens
         time.sleep(1)
@@ -91,7 +96,8 @@ class ThrottleRpcTests(ConfluxTestFramework):
             client.best_block_hash()
             assert "should be throttled"
         except ReceivedErrorResponseError as e:
-            assert e.response.message.startswith("throttled in ")
+            assert e.response.code == -32072
+            assert e.response.data.startswith("throttled in ")
 
 if __name__ == "__main__":
     ThrottleRpcTests().main()

--- a/util/delegate/src/lib.rs
+++ b/util/delegate/src/lib.rs
@@ -249,7 +249,7 @@ fn parse_attributes<'a>(
         .collect();
 
     drop(map);
-    (attrs, name, into.unwrap_or(false))
+    (attrs, name, into.unwrap_or(true))
 }
 
 /// Returns true if there are any `inline` attributes in the input.


### PR DESCRIPTION
Add an error chain layer to automatically convert exceptions into JsonRpc return type.
Classified all rpc error codes and left commented for further investigations.
Also fixed a few incorrect JsonRpc error codes.
[TODO] Fix incorrect JsonRpc error codes from consensus_graph.
[TODO] light.rs not touched.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1180)
<!-- Reviewable:end -->
