### PR TITLE
Make heartbeat timeout configurable.

### DIFF
--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -141,6 +141,7 @@ build_config! {
         (expire_block_gc_period_s, (u64), 900)
         (headers_request_timeout_ms, (u64), 10_000)
         (heartbeat_period_interval_ms, (u64), 30_000)
+        (heartbeat_timeout_ms, (u64), 180_000)
         (inflight_pending_tx_index_maintain_timeout_ms, (u64), 30_000)
         (max_allowed_timeout_in_observing_period, (u64), 10)
         (max_download_state_peers, (usize), 8)
@@ -512,6 +513,9 @@ impl Configuration {
                 .raw_conf
                 .max_allowed_timeout_in_observing_period,
             demote_peer_for_timeout: self.raw_conf.demote_peer_for_timeout,
+            heartbeat_timeout: Duration::from_millis(
+                self.raw_conf.heartbeat_timeout_ms,
+            ),
         }
     }
 

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -255,6 +255,7 @@ pub struct ProtocolConfiguration {
     pub send_tx_period: Duration,
     pub check_request_period: Duration,
     pub heartbeat_period_interval: Duration,
+    pub heartbeat_timeout: Duration,
     pub block_cache_gc_period: Duration,
     pub expire_block_gc_period: Duration,
     pub headers_request_timeout: Duration,
@@ -1588,9 +1589,9 @@ impl NetworkProtocolHandler for SynchronizationProtocolHandler {
                 self.update_total_weight_delta_heartbeat();
             }
             CHECK_PEER_HEARTBEAT_TIMER => {
-                let timeout = Duration::from_secs(180);
-                let timeout_peers =
-                    self.syn.get_heartbeat_timeout_peers(timeout);
+                let timeout_peers = self.syn.get_heartbeat_timeout_peers(
+                    self.protocol_config.heartbeat_timeout,
+                );
                 for peer in timeout_peers {
                     io.disconnect_peer(
                         peer,


### PR DESCRIPTION
We can use a long timeout to prevent the python mini node to be disconnected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1206)
<!-- Reviewable:end -->
