### PR TITLE
Bug fix in #1182.

### DIFF
--- a/core/src/storage/impls/merkle_patricia_trie/compressed_path.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/compressed_path.rs
@@ -168,11 +168,13 @@ impl CompressedPathRaw {
             path_mask,
             byte_array_memory_manager: Default::default(),
         };
-        // 0xf* -> no second nibble
-        // 0x0* -> has second nibble
-        // 0xf0 -> 0x0f -> &= 0xf0
-        // 0x00 -> 0xff -> &= 0xff
-        *ret.last_byte_mut() &= !Self::first_nibble(path_mask);
+        if path_size > 0 {
+            // 0xf* -> no second nibble
+            // 0x0* -> has second nibble
+            // 0xf0 -> 0x0f -> &= 0xf0
+            // 0x00 -> 0xff -> &= 0xff
+            *ret.last_byte_mut() &= !Self::first_nibble(path_mask);
+        }
 
         ret
     }


### PR DESCRIPTION
The bug is caused in #1182 when I merged two cases for CompressedPathRaw creation, however new_and_apply_mask assumes that the length of the compressed path is at least one, thus the bug.

I didn't modify the changelog because it's the bug introduced and fixed within the same version.

The bug triggers only in debug test mode. I'm thinking about running debug tests periodically as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1228)
<!-- Reviewable:end -->
