### PR TITLE
Fix another cause of random failure of reorg_test.

### DIFF
--- a/core/src/sync/message/get_compact_blocks_response.rs
+++ b/core/src/sync/message/get_compact_blocks_response.rs
@@ -91,7 +91,7 @@ impl Handleable for GetCompactBlocksResponse {
                 continue;
             }
 
-            debug!("Cmpct block Processing, hash={}", hash);
+            debug!("Cmpct block Processing, hash={:?}", hash);
 
             let missing = {
                 let _timer =

--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -1429,7 +1429,7 @@ impl SynchronizationGraph {
             } else if inner.new_to_be_header_graph_ready(index) {
                 inner.arena[index].graph_status = BLOCK_HEADER_GRAPH_READY;
                 inner.arena[index].last_update_timestamp = now;
-                debug!("BlockIndex {} parent_index {} hash {} is header graph ready", index,
+                debug!("BlockIndex {} parent_index {} hash {:?} is header graph ready", index,
                            inner.arena[index].parent, inner.arena[index].block_header.hash());
 
                 let r = inner.verify_header_graph_ready_block(index);
@@ -1504,7 +1504,7 @@ impl SynchronizationGraph {
                 }
             } else {
                 debug!(
-                    "BlockIndex {} parent_index {} hash {} is not ready",
+                    "BlockIndex {} parent_index {} hash {:?} is not ready",
                     index,
                     inner.arena[index].parent,
                     inner.arena[index].block_header.hash()
@@ -1619,7 +1619,7 @@ impl SynchronizationGraph {
             }
         }
 
-        debug!("insert_block_header() Block = {}, index = {}, need_to_verify = {}, bench_mode = {} insert_to_consensus = {}",
+        debug!("insert_block_header() Block = {:?}, index = {}, need_to_verify = {}, bench_mode = {} insert_to_consensus = {}",
                header.hash(), me, need_to_verify, bench_mode, insert_to_consensus);
 
         // Start to pass influence to descendants

--- a/tests/conflux/config.py
+++ b/tests/conflux/config.py
@@ -27,8 +27,6 @@ production_conf = default_conflux_conf
 
 small_local_test_conf = dict(
     enable_discovery = "false",
-    # TODO: The default is 900, is it a must to set to 5?
-    expire_block_gc_period_s = 5,
     log_file = "'./conflux.log'",
     log_level = '"debug"',
     metrics_output_file = "'./metrics.log'",

--- a/tests/conflux_tracing.py
+++ b/tests/conflux_tracing.py
@@ -460,7 +460,7 @@ class ConfluxTracing(ConfluxTestFramework):
             "generate_tx_period_us": "100000",
             "enable_state_expose": "true",
             "era_epoch_count": 100,
-            "expire_block_gc_period_s": 5,
+            "expire_block_gc_period_s": 5,  # Set it short so it can be triggered in the test
             "dev_snapshot_epoch_count": 50,
             "adaptive_weight_beta": "1",
             "timer_chain_block_difficulty_ratio": "10",

--- a/tests/conflux_tracing.py
+++ b/tests/conflux_tracing.py
@@ -460,6 +460,7 @@ class ConfluxTracing(ConfluxTestFramework):
             "generate_tx_period_us": "100000",
             "enable_state_expose": "true",
             "era_epoch_count": 100,
+            "expire_block_gc_period_s": 5,
             "dev_snapshot_epoch_count": 50,
             "adaptive_weight_beta": "1",
             "timer_chain_block_difficulty_ratio": "10",

--- a/tests/crash_archive_era150_test.py
+++ b/tests/crash_archive_era150_test.py
@@ -23,6 +23,7 @@ class CrashArchiveNodeTest(ConfluxTestFramework):
         self.conf_parameters["era_epoch_count"] = "150"
         self.conf_parameters["dev_snapshot_epoch_count"] = "50"
         self.conf_parameters["anticone_penalty_ratio"] = "8"
+        # Set it short so it can be triggered in the test
         self.conf_parameters["expire_block_gc_period_s"] = "5"
 
     def setup_network(self):

--- a/tests/crash_archive_era150_test.py
+++ b/tests/crash_archive_era150_test.py
@@ -23,6 +23,7 @@ class CrashArchiveNodeTest(ConfluxTestFramework):
         self.conf_parameters["era_epoch_count"] = "150"
         self.conf_parameters["dev_snapshot_epoch_count"] = "50"
         self.conf_parameters["anticone_penalty_ratio"] = "8"
+        self.conf_parameters["expire_block_gc_period_s"] = "5"
 
     def setup_network(self):
         self.add_nodes(self.num_nodes)

--- a/tests/full_node_tests/p2p_era_test.py
+++ b/tests/full_node_tests/p2p_era_test.py
@@ -23,6 +23,7 @@ class P2PTest(ConfluxTestFramework):
         self.conf_parameters["timer_chain_block_difficulty_ratio"] = "3"
         self.conf_parameters["timer_chain_beta"] = "20"
         self.conf_parameters["era_epoch_count"] = "100"
+        self.conf_parameters["expire_block_gc_period_s"] = "5"
         self.conf_parameters["dev_snapshot_epoch_count"] = "50"
         self.conf_parameters["anticone_penalty_ratio"] = "10"
         self.stop_probability = 0.02

--- a/tests/full_node_tests/p2p_era_test.py
+++ b/tests/full_node_tests/p2p_era_test.py
@@ -23,6 +23,7 @@ class P2PTest(ConfluxTestFramework):
         self.conf_parameters["timer_chain_block_difficulty_ratio"] = "3"
         self.conf_parameters["timer_chain_beta"] = "20"
         self.conf_parameters["era_epoch_count"] = "100"
+        # Set it short so it can be triggered in the test
         self.conf_parameters["expire_block_gc_period_s"] = "5"
         self.conf_parameters["dev_snapshot_epoch_count"] = "50"
         self.conf_parameters["anticone_penalty_ratio"] = "10"

--- a/tests/p2p_era_test.py
+++ b/tests/p2p_era_test.py
@@ -21,6 +21,7 @@ class P2PTest(ConfluxTestFramework):
         self.conf_parameters["timer_chain_beta"] = "20"
         self.conf_parameters["era_epoch_count"] = "50"
         self.conf_parameters["anticone_penalty_ratio"] = "10"
+        self.conf_parameters["expire_block_gc_period_s"] = "5"
         self.stop_probability = 0.02
         self.clean_probability = 0.5
 

--- a/tests/p2p_era_test.py
+++ b/tests/p2p_era_test.py
@@ -21,6 +21,7 @@ class P2PTest(ConfluxTestFramework):
         self.conf_parameters["timer_chain_beta"] = "20"
         self.conf_parameters["era_epoch_count"] = "50"
         self.conf_parameters["anticone_penalty_ratio"] = "10"
+        # Set it short so it can be triggered in the test
         self.conf_parameters["expire_block_gc_period_s"] = "5"
         self.stop_probability = 0.02
         self.clean_probability = 0.5


### PR DESCRIPTION
Only use small expire_timeout for tests that involve both era and crash.

`reorg_test` may fail before because when blocks are expired, no new
blocks are generated to trigger requesting them again. And it's possible
to expire blocks in `reorg_test` because it will request the blocks in
the fork chain of another shard one by one., which is relatively slow.

We only need expire_gc to be triggered to mark blocks before era_genesis as
graph-ready, so it's only needed if both checkpoints and crash will
happen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1235)
<!-- Reviewable:end -->
