### PR TITLE
 Reuse open snapshot db for better performance and limit the number of snapshots to open to prevent attack.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "cfxcore"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "app_dirs",
  "blockgen",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "conflux"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "app_dirs",
  "blockgen",

--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -198,6 +198,7 @@ build_config! {
         (storage_delta_mpts_cache_start_size, (u32), storage::defaults::DEFAULT_DELTA_MPTS_CACHE_START_SIZE)
         (storage_delta_mpts_node_map_vec_size, (u32), storage::defaults::MAX_CACHED_TRIE_NODES_R_LFU_COUNTER)
         (storage_delta_mpts_slab_idle_size, (u32), storage::defaults::DEFAULT_DELTA_MPTS_SLAB_IDLE_SIZE)
+        (storage_max_open_snapshots, (u16), storage::defaults::DEFAULT_MAX_OPEN_SNAPSHOTS)
 
         // General/Unclassified section.
         (enable_optimistic_execution, (bool), true)
@@ -433,6 +434,7 @@ impl Configuration {
             delta_mpts_slab_idle_size: self
                 .raw_conf
                 .storage_delta_mpts_slab_idle_size,
+            max_open_snapshots: self.raw_conf.storage_max_open_snapshots,
             path_delta_mpts_dir: self.raw_conf.conflux_data_dir.clone()
                 + StorageConfiguration::DELTA_MPTS_DIR,
             path_snapshot_dir: self.raw_conf.conflux_data_dir.clone()

--- a/core/examples/snapshot_merge_test.rs
+++ b/core/examples/snapshot_merge_test.rs
@@ -166,7 +166,10 @@ fn main() -> Result<(), Error> {
     );
     storage_manager.register_new_snapshot(snapshot_info2.clone())?;
     let snapshot2 = snapshot_db_manager
-        .get_snapshot_by_epoch_id(&snapshot2_epoch)?
+        .get_snapshot_by_epoch_id(
+            &snapshot2_epoch,
+            /* try_open = */ false,
+        )?
         .expect("exists");
     for (addr, account) in &accounts_map {
         let value: Option<Box<[u8]>> = snapshot2.get(addr.as_bytes())?;
@@ -373,9 +376,10 @@ fn add_accounts(
 
     let root = manager
         // TODO consider snapshot.
-        .get_state_no_commit(StateIndex::new_for_readonly(
-            &epoch_id, state_root,
-        ))?
+        .get_state_no_commit(
+            StateIndex::new_for_readonly(&epoch_id, state_root),
+            /* try_open = */ false,
+        )?
         .unwrap()
         .get_state_root()?
         .state_root

--- a/core/src/block_data_manager/mod.rs
+++ b/core/src/block_data_manager/mod.rs
@@ -424,10 +424,13 @@ impl BlockDataManager {
     pub fn true_genesis_state_root(&self) -> StateRootWithAuxInfo {
         let true_genesis_hash = self.true_genesis.hash();
         self.storage_manager
-            .get_state_no_commit(StateIndex::new_for_readonly(
-                &true_genesis_hash,
-                &StateRootWithAuxInfo::genesis(&true_genesis_hash),
-            ))
+            .get_state_no_commit(
+                StateIndex::new_for_readonly(
+                    &true_genesis_hash,
+                    &StateRootWithAuxInfo::genesis(&true_genesis_hash),
+                ),
+                /* try_open = */ false,
+            )
             .unwrap()
             .unwrap()
             .get_state_root()

--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -653,10 +653,10 @@ impl ConsensusExecutor {
             // The state is computed and is retrievable from storage.
             if let Some(maybe_cached_state_result) =
                 maybe_state_index.map(|state_readonly_index| {
-                    self.handler
-                        .data_man
-                        .storage_manager
-                        .get_state_no_commit(state_readonly_index)
+                    self.handler.data_man.storage_manager.get_state_no_commit(
+                        state_readonly_index,
+                        /* try_open = */ false,
+                    )
                 })
             {
                 if let Ok(Some(_)) = maybe_cached_state_result {
@@ -1557,13 +1557,17 @@ impl ConsensusExecutionHandler {
             StateDb::new(
                 self.data_man
                     .storage_manager
-                    .get_state_no_commit(state_index.unwrap())
+                    .get_state_no_commit(
+                        state_index.unwrap(),
+                        /* try_open = */ true,
+                    )
                     // FIXME: propogate error
                     .expect("No DB Error")
                     // Safe because the state exists.
                     .expect("State Exists"),
             ),
             self.vm.clone(),
+            // FIXME: 0 as block number?
             0, /* block_number */
         );
         drop(state_availability_boundary);

--- a/core/src/light_protocol/common/ledger_info.rs
+++ b/core/src/light_protocol/common/ledger_info.rs
@@ -134,7 +134,7 @@ impl LedgerInfo {
             self.consensus
                 .get_data_manager()
                 .storage_manager
-                .get_state_no_commit(state_index)
+                .get_state_no_commit(state_index, /* try_open = */ true)
         });
 
         match state {

--- a/core/src/storage/impls/errors.rs
+++ b/core/src/storage/impls/errors.rs
@@ -94,6 +94,11 @@ error_chain! {
             display("Snapshot file not found."),
         }
 
+        SnapshotAlreadyExists {
+            description("Attempting to create or modify a Snapshot which already exists."),
+            display("Attempting to create or modify a Snapshot which already exists."),
+        }
+
         SnapshotMPTTrieNodeNotFound {
             description("Trie node not found when loading Snapshot MPT."),
             display("Trie node not found when loading Snapshot MPT."),
@@ -146,6 +151,11 @@ error_chain! {
         MpscError {
             description("Error from std::sync::mpsc."),
             display("Error from std::sync::mpsc."),
+        }
+
+        SemaphoreTryAcquireError {
+            description("tokio::sync::Semaphore::try_acquire(): the semaphore is unavailable."),
+            display("tokio::sync::Semaphore::try_acquire(): the semaphore is unavailable."),
         }
     }
 }

--- a/core/src/storage/impls/mod.rs
+++ b/core/src/storage/impls/mod.rs
@@ -27,6 +27,9 @@ pub mod defaults {
         DeltaMptsNodeMemoryManager::START_CAPACITY;
     pub const DEFAULT_DELTA_MPTS_SLAB_IDLE_SIZE: u32 =
         DeltaMptsNodeMemoryManager::MAX_DIRTY_AND_TEMPORARY_TRIE_NODES;
+    /// Limit the number of open snapshots to set an upper limit on open files
+    /// in Storage subsystem.
+    pub const DEFAULT_MAX_OPEN_SNAPSHOTS: u16 = 10;
     pub const MAX_CACHED_TRIE_NODES_R_LFU_COUNTER: u32 =
         DeltaMptsNodeMemoryManager::MAX_CACHED_TRIE_NODES_R_LFU_COUNTER;
 

--- a/core/src/storage/impls/state.rs
+++ b/core/src/storage/impls/state.rs
@@ -7,7 +7,7 @@ pub type ChildrenMerkleMap =
 
 pub struct State {
     manager: Arc<StateManager>,
-    snapshot_db: SnapshotDb,
+    snapshot_db: Arc<SnapshotDb>,
     snapshot_epoch_id: EpochId,
     snapshot_merkle_root: MerkleHash,
     maybe_intermediate_trie: Option<Arc<DeltaMpt>>,
@@ -419,7 +419,7 @@ impl StateTrait for State {
         };
 
         // Retrieve key/value pairs from snapshot
-        let mut kv_iterator = self.snapshot_db.snapshot_kv_iterator();
+        let mut kv_iterator = self.snapshot_db.snapshot_kv_iterator()?;
         let lower_bound_incl = access_key_prefix.to_key_bytes();
         let mut upper_bound_excl_value = lower_bound_incl.clone();
         let upper_bound_excl = if lower_bound_incl.len() == 0 {

--- a/core/src/storage/impls/state_manager.rs
+++ b/core/src/storage/impls/state_manager.rs
@@ -7,7 +7,7 @@ pub type SnapshotDbManager = SnapshotDbManagerSqlite;
 pub type SnapshotDb = <SnapshotDbManager as SnapshotDbManagerTrait>::SnapshotDb;
 
 pub struct StateTrees {
-    pub snapshot_db: SnapshotDb,
+    pub snapshot_db: Arc<SnapshotDb>,
     pub snapshot_epoch_id: EpochId,
     pub snapshot_merkle_root: MerkleHash,
     /// None means that the intermediate_trie is empty, or in a special
@@ -117,7 +117,7 @@ impl StateManager {
     /// it's calculated for the state_trees.
     #[inline]
     pub fn get_state_trees_internal(
-        snapshot_db: SnapshotDb, snapshot_epoch_id: &EpochId,
+        snapshot_db: Arc<SnapshotDb>, snapshot_epoch_id: &EpochId,
         snapshot_merkle_root: MerkleHash,
         maybe_intermediate_trie: Option<Arc<DeltaMpt>>,
         maybe_intermediate_trie_key_padding: Option<&DeltaMptKeyPadding>,
@@ -177,7 +177,7 @@ impl StateManager {
     }
 
     pub fn get_state_trees(
-        &self, state_index: &StateIndex,
+        &self, state_index: &StateIndex, try_open: bool,
     ) -> Result<Option<StateTrees>> {
         let maybe_intermediate_mpt;
         let maybe_intermediate_mpt_key_padding;
@@ -186,14 +186,16 @@ impl StateManager {
 
         match self
             .storage_manager
-            .wait_for_snapshot(&state_index.snapshot_epoch_id)?
+            .wait_for_snapshot(&state_index.snapshot_epoch_id, try_open)?
         {
             None => {
                 // This is the special scenario when the snapshot isn't
                 // available but the snapshot at the intermediate epoch exists.
-                if let Some(guarded_snapshot) = self
-                    .storage_manager
-                    .wait_for_snapshot(&state_index.intermediate_epoch_id)?
+                if let Some(guarded_snapshot) =
+                    self.storage_manager.wait_for_snapshot(
+                        &state_index.intermediate_epoch_id,
+                        try_open,
+                    )?
                 {
                     snapshot = guarded_snapshot;
                     maybe_intermediate_mpt = None;
@@ -273,7 +275,7 @@ impl StateManager {
     }
 
     pub fn get_state_trees_for_next_epoch(
-        &self, parent_state_index: &StateIndex,
+        &self, parent_state_index: &StateIndex, try_open: bool,
     ) -> Result<Option<StateTrees>> {
         let maybe_height = parent_state_index.maybe_height.map(|x| x + 1);
 
@@ -301,7 +303,10 @@ impl StateManager {
 
             snapshot_epoch_id = parent_state_index.intermediate_epoch_id;
             intermediate_epoch_id = parent_state_index.epoch_id;
-            match self.storage_manager.wait_for_snapshot(snapshot_epoch_id)? {
+            match self
+                .storage_manager
+                .wait_for_snapshot(snapshot_epoch_id, try_open)?
+            {
                 None => {
                     // This is the special scenario when the snapshot isn't
                     // available but the snapshot at the intermediate epoch
@@ -315,10 +320,10 @@ impl StateManager {
                     // See validate_blame_states().
                     snapshot_merkle_root =
                         *parent_state_index.snapshot_epoch_id;
-                    match self
-                        .storage_manager
-                        .wait_for_snapshot(parent_state_index.epoch_id)?
-                    {
+                    match self.storage_manager.wait_for_snapshot(
+                        parent_state_index.epoch_id,
+                        try_open,
+                    )? {
                         None => {
                             warn!(
                                 "get_state_trees_for_next_epoch, shift snapshot, special case, \
@@ -406,14 +411,17 @@ impl StateManager {
             intermediate_epoch_id = parent_state_index.intermediate_epoch_id;
             intermediate_trie_root_merkle =
                 *parent_state_index.intermediate_trie_root_merkle;
-            match self.storage_manager.wait_for_snapshot(snapshot_epoch_id)? {
+            match self
+                .storage_manager
+                .wait_for_snapshot(snapshot_epoch_id, try_open)?
+            {
                 None => {
                     // This is the special scenario when the snapshot isn't
                     // available but the snapshot at the intermediate epoch
                     // exists.
                     if let Some(guarded_snapshot) = self
                         .storage_manager
-                        .wait_for_snapshot(&intermediate_epoch_id)?
+                        .wait_for_snapshot(&intermediate_epoch_id, try_open)?
                     {
                         snapshot = guarded_snapshot;
                         maybe_intermediate_mpt = None;
@@ -524,9 +532,9 @@ impl StateManager {
 
 impl StateManagerTrait for StateManager {
     fn get_state_no_commit(
-        &self, state_index: StateIndex,
+        &self, state_index: StateIndex, try_open: bool,
     ) -> Result<Option<State>> {
-        let maybe_state_trees = self.get_state_trees(&state_index)?;
+        let maybe_state_trees = self.get_state_trees(&state_index, try_open)?;
         match maybe_state_trees {
             None => Ok(None),
             Some(state_trees) => Ok(Some(State::new(
@@ -544,7 +552,7 @@ impl StateManagerTrait for StateManager {
             StateTrees {
                 snapshot_db: self
                     .storage_manager
-                    .wait_for_snapshot(&NULL_EPOCH)
+                    .wait_for_snapshot(&NULL_EPOCH, /* try_open = */ false)
                     .unwrap()
                     .unwrap()
                     .into()
@@ -586,8 +594,10 @@ impl StateManagerTrait for StateManager {
     fn get_state_for_next_epoch(
         &self, parent_epoch_id: StateIndex,
     ) -> Result<Option<State>> {
-        let maybe_state_trees =
-            self.get_state_trees_for_next_epoch(&parent_epoch_id)?;
+        let maybe_state_trees = self.get_state_trees_for_next_epoch(
+            &parent_epoch_id,
+            /* try_open = */ false,
+        )?;
         match maybe_state_trees {
             None => Ok(None),
             Some(state_trees) => Ok(Some(State::new(

--- a/core/src/storage/impls/storage_db/snapshot_db_manager_sqlite.rs
+++ b/core/src/storage/impls/storage_db/snapshot_db_manager_sqlite.rs
@@ -7,13 +7,24 @@ pub struct SnapshotDbManagerSqlite {
     // FIXME: add an command line option to assert that this method made
     // successfully cow_copy and print error messages if it fails.
     force_cow: bool,
-    open_ref_count_and_to_destroy: Arc<Mutex<HashMap<String, (u32, bool)>>>,
+    already_open_snapshots: AlreadyOpenSnapshots<SnapshotDbSqlite>,
+    /// Set a limit on the number of open snapshots. When the limit is reached,
+    /// consensus initiated open should wait, other non-critical opens such as
+    /// rpc initiated opens should simply abort when the limit is reached.
+    open_snapshot_semaphore: Arc<Semaphore>,
+    open_create_delete_lock: Mutex<()>,
 }
+
+// The map from path to the already open snapshots.
+// when the mapped snapshot is None, the snapshot is open exclusively for write,
+// when the mapped snapshot is Some(), the snapshot can be shared by other
+// readers.
+pub type AlreadyOpenSnapshots<T> = Arc<RwLock<HashMap<String, Option<Arc<T>>>>>;
 
 impl SnapshotDbManagerSqlite {
     const SNAPSHOT_DB_SQLITE_DIR_PREFIX: &'static str = "sqlite_";
 
-    pub fn new(snapshot_path: String) -> Result<Self> {
+    pub fn new(snapshot_path: String, max_open_snapshots: u16) -> Result<Self> {
         let snapshot_dir = Path::new(snapshot_path.as_str());
         if !snapshot_dir.exists() {
             fs::create_dir_all(snapshot_dir)?;
@@ -22,34 +33,134 @@ impl SnapshotDbManagerSqlite {
         Ok(Self {
             snapshot_path,
             force_cow: false,
-            open_ref_count_and_to_destroy: Default::default(),
+            already_open_snapshots: Default::default(),
+            open_snapshot_semaphore: Arc::new(Semaphore::new(
+                max_open_snapshots as usize,
+            )),
+            open_create_delete_lock: Default::default(),
         })
     }
 
-    pub fn update_ref_count_open(
-        ref_count: &Arc<Mutex<HashMap<String, (u32, bool)>>>, path: &str,
-    ) -> Arc<Mutex<HashMap<String, (u32, bool)>>> {
-        ref_count
-            .lock()
-            .entry(path.to_string())
-            .or_insert((0, false))
-            .0 += 1;
-        ref_count.clone()
+    fn open_snapshot_readonly(
+        &self, snapshot_path: &str, try_open: bool,
+    ) -> Result<Option<Arc<SnapshotDbSqlite>>> {
+        if let Some(already_open) =
+            self.already_open_snapshots.read().get(snapshot_path)
+        {
+            return Ok(already_open.clone());
+        }
+        let file_exists = Path::new(&snapshot_path).exists();
+        if file_exists {
+            let semaphore_permit = if try_open {
+                self.open_snapshot_semaphore
+                    .try_acquire()
+                    // Unfortunately we have to use map_error because the
+                    // TryAcquireError isn't public.
+                    .map_err(|_err| ErrorKind::SemaphoreTryAcquireError)?
+            } else {
+                executor::block_on(self.open_snapshot_semaphore.acquire())
+            };
+
+            // To serialize simultaneous opens.
+            let _open_lock = self.open_create_delete_lock.lock();
+            if let Some(already_open) =
+                self.already_open_snapshots.read().get(snapshot_path)
+            {
+                return Ok(already_open.clone());
+            }
+
+            let snapshot_db = Arc::new(SnapshotDbSqlite::open(
+                snapshot_path,
+                /* readonly = */ true,
+                &self.already_open_snapshots,
+                &self.open_snapshot_semaphore,
+            )?);
+
+            semaphore_permit.forget();
+            self.already_open_snapshots
+                .write()
+                .insert(snapshot_path.into(), Some(snapshot_db.clone()));
+
+            return Ok(Some(snapshot_db));
+        } else {
+            return Ok(None);
+        }
     }
 
-    pub fn update_ref_count_and_destroy_close(
-        ref_count: &Arc<Mutex<HashMap<String, (u32, bool)>>>, path: &str,
-    ) {
-        let ref_count_locked = &mut *ref_count.lock();
-        // Unwrap is safe because it's guaranteed to exist.
-        let entry = ref_count_locked.get_mut(path).unwrap();
-        entry.0 -= 1;
-        if entry.0 == 0 {
-            // Destroy at close.
-            if ref_count_locked.remove(path).unwrap().1 {
-                Self::fs_remove_snapshot(path).ok();
-            }
+    fn open_snapshot_write(
+        &self, snapshot_path: &str, create: bool,
+    ) -> Result<SnapshotDbSqlite> {
+        if self
+            .already_open_snapshots
+            .read()
+            .get(snapshot_path)
+            .is_some()
+        {
+            bail!(ErrorKind::SnapshotAlreadyExists)
         }
+
+        let semaphore_permit =
+            executor::block_on(self.open_snapshot_semaphore.acquire());
+        // When an open happens around the same time, we should make sure that
+        // the open returns None.
+        let mut _open_lock = self.open_create_delete_lock.lock();
+
+        // Simultaneous creation fails here.
+        if self
+            .already_open_snapshots
+            .read()
+            .get(snapshot_path)
+            .is_some()
+        {
+            bail!(ErrorKind::SnapshotAlreadyExists)
+        }
+
+        let snapshot_db = if create {
+            SnapshotDbSqlite::create(
+                snapshot_path,
+                &self.already_open_snapshots,
+                &self.open_snapshot_semaphore,
+            )
+        } else {
+            let file_exists = Path::new(&snapshot_path).exists();
+            if file_exists {
+                SnapshotDbSqlite::open(
+                    snapshot_path,
+                    /* readonly = */ false,
+                    &self.already_open_snapshots,
+                    &self.open_snapshot_semaphore,
+                )
+            } else {
+                bail!(ErrorKind::SnapshotNotFound);
+            }
+        }?;
+
+        semaphore_permit.forget();
+        self.already_open_snapshots
+            .write()
+            .insert(snapshot_path.to_string(), None);
+        Ok(snapshot_db)
+    }
+
+    pub fn on_close(
+        already_open_snapshots: &AlreadyOpenSnapshots<SnapshotDbSqlite>,
+        open_semaphore: &Arc<Semaphore>, path: &str, remove_on_close: bool,
+    )
+    {
+        // Destroy at close.
+        if remove_on_close {
+            // When removal fails, we can not raise the error because this
+            // function is called within a destructor.
+            //
+            // It's fine to just ignore the error because Conflux doesn't remove
+            // then immediate create a snapshot, or open the snapshot for
+            // modification.
+            //
+            // Conflux will remove orphan storage upon restart.
+            Self::fs_remove_snapshot(path).ok();
+        }
+        already_open_snapshots.write().remove(path);
+        open_semaphore.add_permits(1);
     }
 
     fn fs_remove_snapshot(path: &str) -> Result<()> {
@@ -185,14 +296,14 @@ impl SnapshotDbManagerSqlite {
     ) -> Result<MerkleHash>
     {
         let snapshot_path = self.get_snapshot_db_path(old_snapshot_epoch_id);
-        let maybe_old_snapshot_db = SnapshotDbSqlite::open(
+        let maybe_old_snapshot_db = Self::open_snapshot_readonly(
+            self,
             &snapshot_path,
-            /* readonly = */ true,
-            &self.open_ref_count_and_to_destroy,
+            /* try_open = */ false,
         )?;
-        let mut old_snapshot_db = maybe_old_snapshot_db
+        let old_snapshot_db = maybe_old_snapshot_db
             .ok_or(Error::from(ErrorKind::SnapshotNotFound))?;
-        temp_snapshot_db.copy_and_merge(&mut old_snapshot_db)
+        temp_snapshot_db.copy_and_merge(&old_snapshot_db)
     }
 
     fn rename_snapshot_db(old_path: &str, new_path: &str) -> Result<()> {
@@ -255,7 +366,8 @@ impl SnapshotDbManagerTrait for SnapshotDbManagerSqlite {
                     // direct merge the first snapshot
                     snapshot_db = Self::SnapshotDb::create(
                         &temp_db_path,
-                        &self.open_ref_count_and_to_destroy,
+                        &self.already_open_snapshots,
+                        &self.open_snapshot_semaphore,
                     )?;
                     snapshot_db.dump_delta_mpt(&delta_mpt)?;
                     snapshot_db.direct_merge()?
@@ -268,12 +380,10 @@ impl SnapshotDbManagerTrait for SnapshotDbManagerSqlite {
                         .is_ok()
                     {
                         // Open the copied database.
-                        snapshot_db = Self::SnapshotDb::open(
+                        snapshot_db = self.open_snapshot_write(
                             &temp_db_path,
-                            /* readonly = */ false,
-                            &self.open_ref_count_and_to_destroy,
-                        )?
-                        .ok_or(Error::from(ErrorKind::SnapshotNotFound))?;
+                            /* create = */ false,
+                        )?;
 
                         // Drop copied old snapshot delta mpt dump
                         snapshot_db.drop_delta_mpt_dump()?;
@@ -282,9 +392,9 @@ impl SnapshotDbManagerTrait for SnapshotDbManagerSqlite {
                         snapshot_db.dump_delta_mpt(&delta_mpt)?;
                         snapshot_db.direct_merge()?
                     } else {
-                        snapshot_db = Self::SnapshotDb::create(
+                        snapshot_db = self.open_snapshot_write(
                             &temp_db_path,
-                            &self.open_ref_count_and_to_destroy,
+                            /* create = */ true,
                         )?;
                         snapshot_db.dump_delta_mpt(&delta_mpt)?;
                         self.copy_and_merge(
@@ -307,26 +417,32 @@ impl SnapshotDbManagerTrait for SnapshotDbManagerSqlite {
     }
 
     fn get_snapshot_by_epoch_id(
-        &self, snapshot_epoch_id: &EpochId,
-    ) -> Result<Option<Self::SnapshotDb>> {
+        &self, snapshot_epoch_id: &EpochId, try_open: bool,
+    ) -> Result<Option<Arc<Self::SnapshotDb>>> {
         if snapshot_epoch_id.eq(&NULL_EPOCH) {
-            return Ok(Some(Self::SnapshotDb::get_null_snapshot()));
+            return Ok(Some(Arc::new(Self::SnapshotDb::get_null_snapshot())));
         } else {
             let path = self.get_snapshot_db_path(snapshot_epoch_id);
-            Self::SnapshotDb::open(
-                &path,
-                /* readonly = */ true,
-                &self.open_ref_count_and_to_destroy,
-            )
+            self.open_snapshot_readonly(&path, try_open)
         }
     }
 
     fn destroy_snapshot(&self, snapshot_epoch_id: &EpochId) -> Result<()> {
         let path = self.get_snapshot_db_path(snapshot_epoch_id);
-        match self.open_ref_count_and_to_destroy.lock().get_mut(&path) {
-            Some(ref_count_and_to_destroy) => {
-                ref_count_and_to_destroy.1 = true;
+        match self.already_open_snapshots.read().get(&path) {
+            Some(Some(snapshot)) => {
+                snapshot.set_remove_on_last_close();
                 Ok(())
+            }
+            Some(None) => {
+                // This should not happen because Conflux always write on a
+                // snapshot db under a temporary name. All completed snapshots
+                // are readonly.
+                if cfg!(debug_assertions) {
+                    unreachable!("Try to destroy a snapshot being open exclusively for write.");
+                } else {
+                    unsafe { unreachable_unchecked() };
+                }
             }
             None => {
                 if snapshot_epoch_id.ne(&NULL_EPOCH) {
@@ -345,10 +461,7 @@ impl SnapshotDbManagerTrait for SnapshotDbManagerSqlite {
             snapshot_epoch_id,
             merkle_root,
         );
-        Self::SnapshotDb::create(
-            &temp_db_path,
-            &self.open_ref_count_and_to_destroy,
-        )
+        self.open_snapshot_write(&temp_db_path, /* create = */ true)
     }
 
     fn finalize_full_sync_snapshot(
@@ -371,7 +484,12 @@ use crate::storage::{
     storage_db::{SnapshotDbManagerTrait, SnapshotDbTrait, SnapshotInfo},
 };
 use fs_extra::dir::CopyOptions;
+use futures::executor;
 use parity_bytes::ToPretty;
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 use primitives::{EpochId, MerkleHash, MERKLE_NULL_NODE, NULL_EPOCH};
-use std::{collections::HashMap, fs, path::Path, process::Command, sync::Arc};
+use std::{
+    collections::HashMap, fs, hint::unreachable_unchecked, path::Path,
+    process::Command, sync::Arc,
+};
+use tokio::sync::Semaphore;

--- a/core/src/storage/mod.rs
+++ b/core/src/storage/mod.rs
@@ -38,6 +38,7 @@ pub struct StorageConfiguration {
     pub delta_mpts_cache_size: u32,
     pub delta_mpts_node_map_vec_size: u32,
     pub delta_mpts_slab_idle_size: u32,
+    pub max_open_snapshots: u16,
     pub path_delta_mpts_dir: String,
     pub path_storage_dir: String,
     pub path_snapshot_dir: String,
@@ -70,6 +71,7 @@ impl StorageConfiguration {
                 defaults::MAX_CACHED_TRIE_NODES_R_LFU_COUNTER,
             delta_mpts_slab_idle_size:
                 defaults::DEFAULT_DELTA_MPTS_SLAB_IDLE_SIZE,
+            max_open_snapshots: defaults::DEFAULT_MAX_OPEN_SNAPSHOTS,
             path_delta_mpts_dir: conflux_data_dir.clone()
                 + StorageConfiguration::DELTA_MPTS_DIR,
             path_snapshot_dir: conflux_data_dir.clone()

--- a/core/src/storage/snapshot_manager.rs
+++ b/core/src/storage/snapshot_manager.rs
@@ -7,10 +7,10 @@ pub trait SnapshotManagerTrait: GetSnapshotDbManager {
     // FIXME: add check_make_register_snapshot_background into trait
 
     fn get_snapshot_by_epoch_id(
-        &self, epoch_id: &EpochId,
-    ) -> Result<Option<Self::SnapshotDb>> {
+        &self, epoch_id: &EpochId, try_open: bool,
+    ) -> Result<Option<Arc<Self::SnapshotDb>>> {
         self.get_snapshot_db_manager()
-            .get_snapshot_by_epoch_id(epoch_id)
+            .get_snapshot_by_epoch_id(epoch_id, try_open)
     }
 
     fn remove_old_pivot_snapshot(
@@ -36,3 +36,4 @@ use super::{
     storage_db::{snapshot_db::*, snapshot_db_manager::*},
 };
 use primitives::EpochId;
+use std::sync::Arc;

--- a/core/src/storage/state_manager.rs
+++ b/core/src/storage/state_manager.rs
@@ -71,8 +71,11 @@ pub struct StateIndex<'a> {
 pub trait StateManagerTrait {
     /// At the boundary of snapshot, getting a state for new epoch will switch
     /// to new Delta MPT, but it's unnecessary getting a no-commit state.
+    ///
+    /// With try_open == true, the call fails immediately when the max number of
+    /// snapshot open is reached.
     fn get_state_no_commit(
-        &self, epoch_id: StateIndex,
+        &self, epoch_id: StateIndex, try_open: bool,
     ) -> Result<Option<State>>;
     fn get_state_for_next_epoch(
         &self, parent_epoch_id: StateIndex,

--- a/core/src/storage/storage_db/snapshot_db_manager.rs
+++ b/core/src/storage/storage_db/snapshot_db_manager.rs
@@ -60,8 +60,8 @@ pub trait SnapshotDbManagerTrait {
         delta_mpt: DeltaMptIterator, in_progress_snapshot_info: SnapshotInfo,
     ) -> Result<SnapshotInfo>;
     fn get_snapshot_by_epoch_id(
-        &self, epoch_id: &EpochId,
-    ) -> Result<Option<Self::SnapshotDb>>;
+        &self, epoch_id: &EpochId, try_open: bool,
+    ) -> Result<Option<Arc<Self::SnapshotDb>>>;
     fn destroy_snapshot(&self, snapshot_epoch_id: &EpochId) -> Result<()>;
 
     fn new_temp_snapshot_for_full_sync(
@@ -78,4 +78,4 @@ use super::{
     snapshot_db::*,
 };
 use primitives::{EpochId, MerkleHash};
-use std::{collections::HashMap, fs};
+use std::{collections::HashMap, fs, sync::Arc};

--- a/core/src/storage/tests/mod.rs
+++ b/core/src/storage/tests/mod.rs
@@ -86,6 +86,7 @@ impl FakeStateManager {
                     delta_mpts_cache_start_size: 1_000_000,
                     delta_mpts_node_map_vec_size: 20_000_000,
                     delta_mpts_slab_idle_size: 200_000,
+                    max_open_snapshots: defaults::DEFAULT_MAX_OPEN_SNAPSHOTS,
                     path_delta_mpts_dir: unit_test_data_dir.clone()
                         + StorageConfiguration::DELTA_MPTS_DIR,
                     path_snapshot_dir: unit_test_data_dir.clone()
@@ -206,7 +207,8 @@ pub fn print_mpt_key(key: &[u8]) {
 
 #[cfg(test)]
 use crate::storage::{
-    impls::state_manager::StateManager, ConsensusParam, StorageConfiguration,
+    defaults, impls::state_manager::StateManager, ConsensusParam,
+    StorageConfiguration,
 };
 use crate::storage::{
     impls::{errors::*, merkle_patricia_trie::CompressedPathRaw},

--- a/core/src/storage/tests/snapshot.rs
+++ b/core/src/storage/tests/snapshot.rs
@@ -213,10 +213,10 @@ fn test_mpt_node_path_to_from_db_key() {
     let state_root_with_aux_info = state.commit(epoch_id).unwrap();
 
     let state = state_manager
-        .get_state_no_commit(StateIndex::new_for_readonly(
-            &epoch_id,
-            &state_root_with_aux_info,
-        ))
+        .get_state_no_commit(
+            StateIndex::new_for_readonly(&epoch_id, &state_root_with_aux_info),
+            /* try_open = */ false,
+        )
         .unwrap()
         .unwrap();
 

--- a/core/src/storage/tests/state.rs
+++ b/core/src/storage/tests/state.rs
@@ -16,9 +16,10 @@ fn test_empty_genesis_block() {
     }
 
     state_manager
-        .get_state_trees(&StateIndex::new_for_test_only_delta_mpt(
-            &genesis_epoch_id,
-        ))
+        .get_state_trees(
+            &StateIndex::new_for_test_only_delta_mpt(&genesis_epoch_id),
+            /* try_open = */ false,
+        )
         .unwrap();
 }
 

--- a/core/src/sync/state/storage.rs
+++ b/core/src/sync/state/storage.rs
@@ -260,9 +260,10 @@ impl RangedManifest {
         let snapshot_db_manager =
             storage_manager.get_storage_manager().get_snapshot_manager();
 
-        let mut snapshot_db = match snapshot_db_manager
-            .get_snapshot_by_epoch_id(snapshot_epoch_id)?
-        {
+        let snapshot_db = match snapshot_db_manager.get_snapshot_by_epoch_id(
+            snapshot_epoch_id,
+            /* try_open = */ true,
+        )? {
             Some(db) => db,
             None => {
                 debug!(
@@ -272,7 +273,7 @@ impl RangedManifest {
                 return Ok(None);
             }
         };
-        let mut snapshot_mpt = snapshot_db.open_snapshot_mpt_owned()?;
+        let mut snapshot_mpt = snapshot_db.open_snapshot_mpt_shared()?;
         let merkle_root = snapshot_mpt.merkle_root;
         let mut slicer = match start_key {
             Some(ref key) => MptSlicer::new_from_key(&mut snapshot_mpt, key)?,
@@ -383,9 +384,10 @@ impl Chunk {
         let snapshot_db_manager =
             storage_manager.get_storage_manager().get_snapshot_manager();
 
-        let mut snapshot_db = match snapshot_db_manager
-            .get_snapshot_by_epoch_id(snapshot_epoch_id)?
-        {
+        let snapshot_db = match snapshot_db_manager.get_snapshot_by_epoch_id(
+            snapshot_epoch_id,
+            /* try_open = */ true,
+        )? {
             Some(db) => db,
             None => {
                 debug!(
@@ -395,7 +397,7 @@ impl Chunk {
             }
         };
 
-        let mut kv_iterator = snapshot_db.snapshot_kv_iterator();
+        let mut kv_iterator = snapshot_db.snapshot_kv_iterator()?;
         let lower_bound_incl =
             chunk_key.lower_bound_incl.clone().unwrap_or_default();
         let upper_bound_excl =

--- a/core/src/transaction_pool/mod.rs
+++ b/core/src/transaction_pool/mod.rs
@@ -155,10 +155,13 @@ impl TransactionPool {
             best_executed_state: Mutex::new(Arc::new(StateDb::new(
                 data_man
                     .storage_manager
-                    .get_state_no_commit(StateIndex::new_for_readonly(
-                        &genesis_hash,
-                        &data_man.true_genesis_state_root(),
-                    ))
+                    .get_state_no_commit(
+                        StateIndex::new_for_readonly(
+                            &genesis_hash,
+                            &data_man.true_genesis_state_root(),
+                        ),
+                        /* try_open = */ false,
+                    )
                     // Safe because we don't expect any error at program start.
                     .expect(&concat!(file!(), ":", line!(), ":", column!()))
                     // Safe because true genesis state is available at program
@@ -579,7 +582,10 @@ impl TransactionPool {
         let best_executed_state = Arc::new(StateDb::new(
             self.data_man
                 .storage_manager
-                .get_state_no_commit(best_executed_epoch)?
+                .get_state_no_commit(
+                    best_executed_epoch,
+                    /* try_open = */ false,
+                )?
                 // Safe because the state is guaranteed to be available.
                 .unwrap(),
         ));


### PR DESCRIPTION
This is the first PR in a series. The TODO will be addressed in a later PR.

TODO: Implement iterate for a snapshot db opened in shared mode, then remove try_clone_connection().


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1237)
<!-- Reviewable:end -->
