### PR TITLE
Remove unneeded parameters.

### DIFF
--- a/tests/conflux_tracing.py
+++ b/tests/conflux_tracing.py
@@ -460,7 +460,6 @@ class ConfluxTracing(ConfluxTestFramework):
             "generate_tx_period_us": "100000",
             "enable_state_expose": "true",
             "era_epoch_count": 100,
-            "expire_block_gc_period_s": 5,  # Set it short so it can be triggered in the test
             "dev_snapshot_epoch_count": 50,
             "adaptive_weight_beta": "1",
             "timer_chain_block_difficulty_ratio": "10",

--- a/tests/crash_archive_era150_test.py
+++ b/tests/crash_archive_era150_test.py
@@ -23,8 +23,6 @@ class CrashArchiveNodeTest(ConfluxTestFramework):
         self.conf_parameters["era_epoch_count"] = "150"
         self.conf_parameters["dev_snapshot_epoch_count"] = "50"
         self.conf_parameters["anticone_penalty_ratio"] = "8"
-        # Set it short so it can be triggered in the test
-        self.conf_parameters["expire_block_gc_period_s"] = "5"
 
     def setup_network(self):
         self.add_nodes(self.num_nodes)

--- a/tests/full_node_tests/p2p_era_test.py
+++ b/tests/full_node_tests/p2p_era_test.py
@@ -23,8 +23,6 @@ class P2PTest(ConfluxTestFramework):
         self.conf_parameters["timer_chain_block_difficulty_ratio"] = "3"
         self.conf_parameters["timer_chain_beta"] = "20"
         self.conf_parameters["era_epoch_count"] = "100"
-        # Set it short so it can be triggered in the test
-        self.conf_parameters["expire_block_gc_period_s"] = "5"
         self.conf_parameters["dev_snapshot_epoch_count"] = "50"
         self.conf_parameters["anticone_penalty_ratio"] = "10"
         self.stop_probability = 0.02

--- a/tests/p2p_era_test.py
+++ b/tests/p2p_era_test.py
@@ -21,8 +21,6 @@ class P2PTest(ConfluxTestFramework):
         self.conf_parameters["timer_chain_beta"] = "20"
         self.conf_parameters["era_epoch_count"] = "50"
         self.conf_parameters["anticone_penalty_ratio"] = "10"
-        # Set it short so it can be triggered in the test
-        self.conf_parameters["expire_block_gc_period_s"] = "5"
         self.stop_probability = 0.02
         self.clean_probability = 0.5
 


### PR DESCRIPTION
Now we check graph-ready right when inserting a block, so do not need
expire_block_gc to be triggered to process out-of-era blocks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1239)
<!-- Reviewable:end -->
