### PR TITLE
Decrease the max number of unprocessed blocks.

### DIFF
--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -151,7 +151,7 @@ build_config! {
         (max_outgoing_peers, (usize), 16)
         (max_outgoing_peers_archive, (usize), 0)
         (max_peers_tx_propagation, (usize), 128)
-        (max_unprocessed_block_count, (usize), (512))
+        (max_unprocessed_block_count, (usize), (128))
         (min_peers_tx_propagation, (usize), 8)
         (received_tx_index_maintain_timeout_ms, (u64), 300_000)
         (request_block_with_public, (bool), false)

--- a/run/default.toml
+++ b/run/default.toml
@@ -208,6 +208,14 @@ jsonrpc_local_http_port=12539
 #
 # max_peers_tx_propagation = 128
 
+# Maximum number of cached received blocks waiting to be processed.
+# Note that our block size is limited by its rlp encoded size (200KB), but the memory size of a
+# decoded block is usually about 4x the rlp size, so this default value 128 will take about 1GB memory.
+# On the other hand, the sync module can consume about 5 blocks per second per core, so this value can cache
+# about 10-second work for a quad-core host (assuming 2 cores for sync and 2 core for consensus).
+#
+# max_unprocessed_block_count = 128
+
 # Minimum number of peers to broadcast transaction digests.
 #
 # min_peers_tx_propagation = 8


### PR DESCRIPTION
The previous default value is set assuming 200 KB block size, but the
memory usage of decoded blocks are much higher (about 4 times in our
tests and about 30 times in the extreme cases).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1257)
<!-- Reviewable:end -->
