### PR TITLE
Decrease the number of cached trie nodes.

### DIFF
--- a/core/src/storage/impls/delta_mpt/node_memory_manager.rs
+++ b/core/src/storage/impls/delta_mpt/node_memory_manager.rs
@@ -75,7 +75,7 @@ impl<
     /// 12B*4x LRU) * number of nodes + 200M * 4B NodeRef. 5GB + extra 800M
     /// ~ 20_000_000 nodes.
     // TODO(yz): Need to calculate a factor in LRU (currently made up to 4).
-    pub const MAX_CACHED_TRIE_NODES_DISK_HYBRID: u32 = 20_000_000;
+    pub const MAX_CACHED_TRIE_NODES_DISK_HYBRID: u32 = 10_000_000;
     pub const MAX_CACHED_TRIE_NODES_R_LFU_COUNTER: u32 = (Self::R_LFU_FACTOR
         * Self::MAX_CACHED_TRIE_NODES_DISK_HYBRID as f64)
         as u32;
@@ -83,7 +83,7 @@ impl<
     /// introduces copies for committing.
     // TODO(yz): log the dirty size to monitor if other component produces too
     // many.
-    pub const MAX_DIRTY_AND_TEMPORARY_TRIE_NODES: u32 = 2_000_000;
+    pub const MAX_DIRTY_AND_TEMPORARY_TRIE_NODES: u32 = 1_000_000;
     /// If we do not swap out any node onto disk, the maximum tolerable nodes is
     /// about 27.6M, where there is about 4.6M leaf nodes. The total memory
     /// consumption is about (27.6 * 192 - 4.6 * 64) MB ~= 5GB. It can hold new


### PR DESCRIPTION
Leave some free memory for now.
Set a better value after thorough benchmarks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1258)
<!-- Reviewable:end -->
