### PR TITLE
Fix target difficulty calculation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 - Fix definitions and logics in transaction early execution error checking.
 
+- Use block_count - 1 in target difficulty calculation because the timespan is calculated after the max - min timestamp of blocks.
+
 ## Improvements
 
 - Improve the transaction address check at RPC

--- a/core/src/pow/mod.rs
+++ b/core/src/pow/mod.rs
@@ -93,13 +93,14 @@ impl ProofOfWorkConfig {
     pub fn target_difficulty(
         &self, block_count: u64, timespan: u64, cur_difficulty: &U256,
     ) -> U256 {
-        if timespan == 0 || block_count == 0 || self.test_mode {
+        if timespan == 0 || block_count <= 1 || self.test_mode {
             return self.initial_difficulty.into();
         }
 
         let target = (U512::from(*cur_difficulty)
             * U512::from(self.block_generation_period)
-            * U512::from(block_count))
+            // - 1 for unbiased estimation, like stdvar
+            * U512::from(block_count - 1))
             / (U512::from(timespan) * U512::from(1000000));
         if target.is_zero() {
             return 1.into();


### PR DESCRIPTION
The unbiased estimation of the total mining power in the past interval should minus one from the number of blocks.

The period of block generation follows exponential distribution, and the past mining power is the parameter of the distribution.

Reference: The unbiased estimation formula: https://math.stackexchange.com/questions/1048009/exponential-distribution-unbiased-estimator

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1269)
<!-- Reviewable:end -->
