### PR TITLE
Make estimateGasAndCollateral work for "reverted" transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,6 +548,7 @@ dependencies = [
 name = "cfxkey"
 version = "0.3.0"
 dependencies = [
+ "cfx-types",
  "edit-distance",
  "ethereum-types",
  "lazy_static",
@@ -568,6 +569,7 @@ dependencies = [
 name = "cfxstore"
 version = "0.2.1"
 dependencies = [
+ "cfx-types",
  "cfxkey",
  "dir",
  "ethereum-types",

--- a/accounts/cfxkey/Cargo.toml
+++ b/accounts/cfxkey/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.3.0"
 authors = ["Conflux Foundation"]
 
 [dependencies]
+cfx-types = { path = "../../cfx_types" }
 edit-distance = "2.0"
 parity-crypto = "0.4.0"
 parity-secp256k1 = "0.7.0"

--- a/accounts/cfxkey/src/keypair.rs
+++ b/accounts/cfxkey/src/keypair.rs
@@ -15,6 +15,7 @@
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::{Address, Error, Public, Secret, SECP256K1};
+use cfx_types::address_util::AddressUtil;
 use parity_crypto::Keccak256 as _;
 use secp256k1::key;
 use std::fmt;
@@ -25,8 +26,7 @@ pub fn public_to_address(public: &Public) -> Address {
     result.as_bytes_mut().copy_from_slice(&hash[12..]);
     // In Conflux, we reserve the first four bits to indicate the type of the
     // address. For user address, the first four bits will be 0x1.
-    result.as_bytes_mut()[0] &= 0x0f;
-    result.as_bytes_mut()[0] |= 0x10;
+    result.set_user_account_type_bits();
     result
 }
 

--- a/accounts/cfxkey/src/lib.rs
+++ b/accounts/cfxkey/src/lib.rs
@@ -16,6 +16,7 @@
 
 // #![warn(missing_docs)]
 
+extern crate cfx_types;
 extern crate edit_distance;
 extern crate ethereum_types;
 extern crate parity_crypto;

--- a/accounts/cfxstore/Cargo.toml
+++ b/accounts/cfxstore/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 log = "0.4"
 libc = "0.2"
 rand = "0.7"
+cfx-types = { path = "../../cfx_types" }
 cfxkey = { path = "../cfxkey" }
 serde = "1.0"
 serde_json = "1.0"

--- a/accounts/cfxstore/src/account/safe_account.rs
+++ b/accounts/cfxstore/src/account/safe_account.rs
@@ -20,6 +20,7 @@
 
 use super::crypto::Crypto;
 use account::Version;
+use cfx_types::address_util::AddressUtil;
 use cfxkey::{
     self, crypto::ecdh::agree, sign, Address, KeyPair, Message, Password,
     Public, Secret, Signature,
@@ -140,8 +141,7 @@ impl SafeAccount {
         let meta_plain = json::VaultKeyMeta::load(&meta_plain)
             .map_err(|e| Error::Custom(format!("{:?}", e)))?;
 
-        let type_bits = meta_plain.address.at(0) & 0xf0;
-        if type_bits != 0x10 {
+        if !meta_plain.address.is_user_account_address() {
             warn!("Trying to import a non-user type account address. Are you trying to import an Ethkey for Conflux? Note that the address scheme between Ethereum and Conflux are different.");
             return Err(Error::Custom(format!(
                 "Import non-user type address. Address: {:?}",

--- a/accounts/cfxstore/src/json/hash.rs
+++ b/accounts/cfxstore/src/json/hash.rs
@@ -15,12 +15,13 @@
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::Error;
+use cfx_types::address_util::AddressUtil;
 use rustc_hex::{FromHex, ToHex};
 use serde::{
     de::{Error as SerdeError, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::{fmt, ops, str};
+use std::{cmp::Ordering, fmt, ops, str};
 
 macro_rules! impl_hash {
     ($name:ident, $size:expr) => {
@@ -132,3 +133,24 @@ macro_rules! impl_hash {
 impl_hash!(H128, 16);
 impl_hash!(H160, 20);
 impl_hash!(H256, 32);
+
+// FIXME: find a better hash type.
+impl PartialOrd for H160 {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+impl Eq for H160 {}
+
+impl Ord for H160 {
+    fn cmp(&self, other: &Self) -> Ordering { self.0.cmp(&other.0) }
+}
+
+impl AddressUtil for H160 {
+    #[inline]
+    fn type_byte(&self) -> &u8 { &self.0[0] }
+
+    #[inline]
+    fn type_byte_mut(&mut self) -> &mut u8 { &mut self.0[0] }
+}

--- a/accounts/cfxstore/src/lib.rs
+++ b/accounts/cfxstore/src/lib.rs
@@ -43,6 +43,7 @@ extern crate serde_derive;
 #[cfg(test)]
 #[macro_use]
 extern crate matches;
+extern crate cfx_types;
 
 pub mod accounts_dir;
 pub mod cfxkey;

--- a/cfx_types/src/lib.rs
+++ b/cfx_types/src/lib.rs
@@ -8,7 +8,6 @@ pub use ethereum_types::{
     Address, BigEndianHash, Bloom, BloomInput, Public, Secret, Signature, H128,
     H160, H256, H512, H520, H64, U128, U256, U512, U64,
 };
-use std::collections::BTreeMap;
 
 /// The KECCAK hash of an empty bloom filter (0x00 * 256)
 pub const KECCAK_EMPTY_BLOOM: H256 = H256([
@@ -28,38 +27,95 @@ pub fn hexstr_to_h256(hex_str: &str) -> H256 {
     H256::from(bytes)
 }
 
-pub trait AddressUtil {
-    fn type_bits(&self) -> u8;
+pub mod address_util {
+    use super::Address;
+    use std::collections::BTreeMap;
 
-    fn is_valid<T>(&self, builtin_map: &BTreeMap<Address, T>) -> bool;
+    pub const TYPE_BITS_BUILTIN: u8 = 0x00;
+    pub const TYPE_BITS_CONTRACT: u8 = 0x80;
+    pub const TYPE_BITS_USER_ACCOUNT: u8 = 0x10;
 
-    fn is_contract(&self) -> bool;
+    pub trait AddressUtil: Sized + Ord {
+        fn type_byte(&self) -> &u8;
 
-    fn is_payment(&self) -> bool;
+        fn type_byte_mut(&mut self) -> &mut u8;
 
-    fn is_builtin<T>(&self, builtin_map: &BTreeMap<Address, T>) -> bool;
+        #[inline]
+        fn address_type_bits(&self) -> u8 { self.type_byte() & 0xf0 }
 
-    fn converted_to_contract(&mut self);
-}
+        #[inline]
+        fn set_address_type_bits(&mut self, type_bits: u8) {
+            let type_byte = self.type_byte_mut();
+            *type_byte &= 0x0f;
+            *type_byte |= type_bits;
+        }
 
-impl AddressUtil for Address {
-    fn type_bits(&self) -> u8 { self.as_fixed_bytes()[0] & 0xf0 }
+        #[inline]
+        fn is_valid_address<T>(&self, builtin_map: &BTreeMap<Self, T>) -> bool {
+            self.is_contract_address()
+                || self.is_user_account_address()
+                || self.is_builtin_address(builtin_map)
+        }
 
-    fn is_valid<T>(&self, builtin_map: &BTreeMap<Address, T>) -> bool {
-        self.is_contract() || self.is_payment() || self.is_builtin(builtin_map)
+        #[inline]
+        fn is_contract_address(&self) -> bool {
+            self.address_type_bits() == TYPE_BITS_CONTRACT
+        }
+
+        #[inline]
+        fn is_user_account_address(&self) -> bool {
+            self.address_type_bits() == TYPE_BITS_USER_ACCOUNT
+        }
+
+        #[inline]
+        fn is_builtin_address<T>(
+            &self, builtin_map: &BTreeMap<Self, T>,
+        ) -> bool {
+            self.address_type_bits() == TYPE_BITS_BUILTIN
+                && builtin_map.contains_key(self)
+        }
+
+        #[inline]
+        fn set_contract_type_bits(&mut self) {
+            self.set_address_type_bits(TYPE_BITS_CONTRACT);
+        }
+
+        #[inline]
+        fn set_user_account_type_bits(&mut self) {
+            self.set_address_type_bits(TYPE_BITS_USER_ACCOUNT);
+        }
     }
 
-    /// Should keep this consistent with `converted_to_contract()`.
-    fn is_contract(&self) -> bool { self.type_bits() == 0x80 }
+    impl AddressUtil for Address {
+        #[inline]
+        fn type_byte(&self) -> &u8 { &self.as_fixed_bytes()[0] }
 
-    fn is_payment(&self) -> bool { self.type_bits() == 0x10 }
-
-    fn is_builtin<T>(&self, builtin_map: &BTreeMap<Address, T>) -> bool {
-        self.type_bits() == 0x0 && builtin_map.contains_key(&self)
+        #[inline]
+        fn type_byte_mut(&mut self) -> &mut u8 {
+            &mut self.as_fixed_bytes_mut()[0]
+        }
     }
 
-    fn converted_to_contract(&mut self) {
-        self.as_bytes_mut()[0] &= 0x0f;
-        self.as_bytes_mut()[0] |= 0x80;
+    #[cfg(test)]
+    mod tests {
+        use super::{Address, AddressUtil};
+
+        #[test]
+        fn test_set_type_bits() {
+            let mut address = Address::default();
+
+            address.set_contract_type_bits();
+            assert!(address.is_contract_address());
+            assert!(!address.is_user_account_address());
+
+            address.set_user_account_type_bits();
+            assert!(address.is_user_account_address());
+
+            for types in 0..16 {
+                let type_bits = types << 4;
+                address.set_address_type_bits(type_bits);
+                assert_eq!(address.address_type_bits(), type_bits);
+            }
+        }
     }
 }

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -22,7 +22,6 @@ use blockgen::BlockGenerator;
 use cfx_types::{AddressUtil, H160, H256, U256};
 use cfxcore::{
     block_data_manager::BlockExecutionResultWithEpoch,
-    executive::Executed,
     machine::{new_machine_with_builtin, Machine},
     state_exposer::STATE_EXPOSER,
     test_context::*,
@@ -725,45 +724,7 @@ impl RpcImpl {
     fn call(
         &self, request: CallRequest, epoch: Option<EpochNumber>,
     ) -> RpcResult<Bytes> {
-        let success_executed = self.exec_transaction(request, epoch)?;
-        Ok(Bytes::new(success_executed.output))
-    }
-
-    fn estimate_gas_and_collateral(
-        &self, request: CallRequest, epoch: Option<EpochNumber>,
-    ) -> RpcResult<EstimateGasAndCollateralResponse> {
-        // FIXME: what's the definition of "exception" for the execution of this
-        // FIXME: transaction? How can a transaction fail to execute? Is it
-        // FIXME: possible that a transaction execution fail but still legal? We
-        // FIXME: can not refuse to estimate gas for a legal transaction. The
-        // FIXME: transaction must have no side effect in order to be illegal.
-        let success_executed = self.exec_transaction(request, epoch)?;
-        let mut storage_collateralized = 0;
-        for storage_change in &success_executed.storage_collateralized {
-            storage_collateralized += storage_change.amount;
-        }
-        let response = EstimateGasAndCollateralResponse {
-            gas_used: success_executed.gas_used.into(),
-            storage_collateralized: storage_collateralized.into(),
-        };
-        Ok(response)
-    }
-
-    fn exec_transaction(
-        &self, request: CallRequest, epoch: Option<EpochNumber>,
-    ) -> RpcResult<Executed> {
-        let consensus_graph = self
-            .consensus
-            .as_any()
-            .downcast_ref::<ConsensusGraph>()
-            .expect("downcast should succeed");
-        let epoch = epoch.unwrap_or(EpochNumber::LatestState);
-
-        let best_epoch_height = consensus_graph.best_epoch_number();
-        let chain_id = consensus_graph.best_chain_id();
-        let signed_tx = sign_call(best_epoch_height, chain_id, request);
-        trace!("call tx {:?}", signed_tx);
-        match consensus_graph.call_virtual(&signed_tx, epoch.into())? {
+        match self.exec_transaction(request, epoch)? {
             ExecutionOutcome::NotExecutedToReconsiderPacking(e) => {
                 bail!(call_execution_error(
                     "Transaction can not be executed".into(),
@@ -783,8 +744,60 @@ impl RpcImpl {
                     format! {"{:?}", e}.into_bytes()
                 ))
             }
-            ExecutionOutcome::Finished(executed) => Ok(executed),
+            ExecutionOutcome::Finished(executed) => Ok(executed.output.into()),
         }
+    }
+
+    fn estimate_gas_and_collateral(
+        &self, request: CallRequest, epoch: Option<EpochNumber>,
+    ) -> RpcResult<EstimateGasAndCollateralResponse> {
+        let executed = match self.exec_transaction(request, epoch)? {
+            ExecutionOutcome::NotExecutedToReconsiderPacking(e) => {
+                bail!(call_execution_error(
+                    "Can not estimate: transaction can not be executed".into(),
+                    format! {"{:?}", e}.into_bytes()
+                ))
+            }
+            ExecutionOutcome::ExecutionErrorBumpNonce(
+                ExecutionError::VmError(vm::Error::Reverted),
+                executed,
+            ) => executed,
+            ExecutionOutcome::ExecutionErrorBumpNonce(e, _) => {
+                bail!(call_execution_error(
+                    "Can not estimate: transaction execution failed, \
+                     all gas will be charged"
+                        .into(),
+                    format! {"{:?}", e}.into_bytes()
+                ))
+            }
+            ExecutionOutcome::Finished(executed) => executed,
+        };
+        let mut storage_collateralized = 0;
+        for storage_change in &executed.storage_collateralized {
+            storage_collateralized += storage_change.amount;
+        }
+        let response = EstimateGasAndCollateralResponse {
+            gas_used: executed.gas_used.into(),
+            storage_collateralized: storage_collateralized.into(),
+        };
+        Ok(response)
+    }
+
+    fn exec_transaction(
+        &self, request: CallRequest, epoch: Option<EpochNumber>,
+    ) -> RpcResult<ExecutionOutcome> {
+        let consensus_graph = self
+            .consensus
+            .as_any()
+            .downcast_ref::<ConsensusGraph>()
+            .expect("downcast should succeed");
+        let epoch = epoch.unwrap_or(EpochNumber::LatestState);
+
+        let best_epoch_height = consensus_graph.best_epoch_number();
+        let chain_id = consensus_graph.best_chain_id();
+        let signed_tx = sign_call(best_epoch_height, chain_id, request);
+        trace!("call tx {:?}", signed_tx);
+        consensus_graph.call_virtual(&signed_tx, epoch.into())
     }
 
     fn current_sync_phase(&self) -> RpcResult<String> {

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -19,7 +19,7 @@ use crate::rpc::{
     RpcResult,
 };
 use blockgen::BlockGenerator;
-use cfx_types::{AddressUtil, H160, H256, U256};
+use cfx_types::{H160, H256, U256};
 use cfxcore::{
     block_data_manager::BlockExecutionResultWithEpoch,
     machine::{new_machine_with_builtin, Machine},
@@ -305,7 +305,7 @@ impl RpcImpl {
         &self, tx: TransactionWithSignature,
     ) -> RpcResult<RpcH256> {
         if let Call(address) = &tx.transaction.action {
-            if !address.is_valid(self.machine.builtins()) {
+            if !address.is_valid_address(self.machine.builtins()) {
                 bail!(invalid_params("tx", "Sending transactions to invalid address. The first four bits must be 0x0 (built-in/reserved), 0x1 (user-account), or 0x8 (contract)."));
             }
         }
@@ -872,6 +872,7 @@ impl CfxHandler {
 
 // To convert from RpcResult to BoxFuture by delegate! macro automatically.
 use crate::common::delegate_convert;
+use cfx_types::address_util::AddressUtil;
 use cfxcore::executive::{ExecutionError, ExecutionOutcome};
 
 impl Cfx for CfxHandler {

--- a/client/src/rpc/types/call_request.rs
+++ b/client/src/rpc/types/call_request.rs
@@ -45,6 +45,7 @@ pub fn sign_call(
 ) -> SignedTransaction {
     let max_gas = U256::from(500_000_000);
     let gas = min(request.gas.unwrap_or(max_gas), max_gas);
+    // FIXME: the from address must be a simple account.
     let from = request.from.unwrap_or_else(|| H160::random());
 
     PrimitiveTransaction {

--- a/client/src/rpc/types/call_request.rs
+++ b/client/src/rpc/types/call_request.rs
@@ -3,7 +3,7 @@
 // See http://www.gnu.org/licenses/
 
 use crate::rpc::types::Bytes;
-use cfx_types::{H160, U256};
+use cfx_types::{address_util::AddressUtil, Address, H160, U256};
 use primitives::{
     transaction::Action, SignedTransaction, Transaction as PrimitiveTransaction,
 };
@@ -35,7 +35,6 @@ pub struct CallRequest {
 pub struct EstimateGasAndCollateralResponse {
     /// The amount of gas used in the execution.
     pub gas_used: U256,
-    // TODO: U64
     /// The number of bytes collateralized in the execution.
     pub storage_collateralized: U256,
 }
@@ -45,8 +44,11 @@ pub fn sign_call(
 ) -> SignedTransaction {
     let max_gas = U256::from(500_000_000);
     let gas = min(request.gas.unwrap_or(max_gas), max_gas);
-    // FIXME: the from address must be a simple account.
-    let from = request.from.unwrap_or_else(|| H160::random());
+    let from = request.from.unwrap_or_else(|| {
+        let mut address = Address::random();
+        address.set_user_account_type_bits();
+        address
+    });
 
     PrimitiveTransaction {
         nonce: request.nonce.unwrap_or_default(),

--- a/core/src/executive/executive.rs
+++ b/core/src/executive/executive.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     vm_factory::VmFactory,
 };
-use cfx_types::{Address, AddressUtil, H256, U256, U512};
+use cfx_types::{address_util::AddressUtil, Address, H256, U256, U512};
 use primitives::{
     receipt::StorageChange, transaction::Action, SignedTransaction,
 };
@@ -53,8 +53,8 @@ pub fn contract_address(
             // the address. For contract address, the bits will be
             // set to 0x8.
             let mut h = Address::from(keccak(&buffer[..]));
-            h.converted_to_contract();
-            (h, None)
+            h.set_contract_type_bits();
+            (h, Some(code_hash))
         }
         CreateContractAddress::FromSenderSaltAndCodeHash(salt) => {
             let code_hash = keccak(code);
@@ -66,7 +66,7 @@ pub fn contract_address(
             // In Conflux, we use the first bit to indicate the type of the
             // address. For contract address, the bits will be set to 0x8.
             let mut h = Address::from(keccak(&buffer[..]));
-            h.converted_to_contract();
+            h.set_contract_type_bits();
             (h, Some(code_hash))
         }
     }

--- a/core/src/executive/executive.rs
+++ b/core/src/executive/executive.rs
@@ -1673,7 +1673,7 @@ impl<'a> Executive<'a> {
                 if r.apply_state {
                     Ok(ExecutionOutcome::Finished(executed))
                 } else {
-                    // Transaction reverted for unspecified reason.
+                    // Transaction reverted by vm instruction.
                     Ok(ExecutionOutcome::ExecutionErrorBumpNonce(
                         ExecutionError::VmError(vm::Error::Reverted),
                         executed,

--- a/core/src/transaction_pool/transaction_pool_inner.rs
+++ b/core/src/transaction_pool/transaction_pool_inner.rs
@@ -5,7 +5,9 @@ use super::{
     nonce_pool::{InsertResult, NoncePool, TxWithReadyInfo},
 };
 use crate::statedb::Result as StateDbResult;
-use cfx_types::{Address, AddressUtil, BigEndianHash, H256, H512, U256, U512};
+use cfx_types::{
+    address_util::AddressUtil, Address, BigEndianHash, H256, H512, U256, U512,
+};
 use malloc_size_of_derive::MallocSizeOf as DeriveMallocSizeOf;
 use metrics::{
     register_meter_with_group, Counter, CounterUsize, Meter, MeterTimer,
@@ -723,7 +725,7 @@ impl TransactionPoolInner {
         // Compute sponsored_gas for `transaction`
         if let Action::Call(callee) = transaction.action {
             // FIXME: This is a quick fix for performance issue.
-            if callee.is_contract() {
+            if callee.is_contract_address() {
                 if let Ok(Some(sponsor_info)) =
                     self.get_sponsor_info_from_storage(&callee, account_cache)
                 {


### PR DESCRIPTION
Reverted is a special vm error code. For a reverted transaction we will charge only for used gas, therefore estimateGas should not give an error.

In call_virtual and estimateGasAndCollateral, when using a random sender address, make sure the sender address is a user address. And use AddressUtil wherever it applies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1273)
<!-- Reviewable:end -->
