### PR TITLE
When node IP changed, evict itself before insertion

### DIFF
--- a/network/src/ip/node_limit.rs
+++ b/network/src/ip/node_limit.rs
@@ -153,8 +153,10 @@ impl NodeIpLimit {
     /// The returned result indicates whether insertion is allowed,
     /// and possible evictee before insertion.
     ///
-    /// When subnet quota is not enough before insertion, someone in the
-    /// same subnet may be evicted.
+    /// When subnet quota is not enough before insertion:
+    /// 1. If node IP changed and still in the same subnet,
+    /// just evict the node itself.
+    /// 2. Otherwise, someone in the subnet of `ip` may be evicted.
     ///
     /// There are 2 cases that insertion is not allowed:
     /// 1. Node already exists and ip not changed;
@@ -178,10 +180,22 @@ impl NodeIpLimit {
             return ValidateInsertResult::OccupyIp(old_id.clone());
         }
 
+        // quota enough
         if self.is_quota_allowed(ip) {
             return ValidateInsertResult::QuotaEnough;
         }
 
+        // Node ip changed, but still in the same subnet.
+        // So, just evict the node itself.
+        if let Some(cur_ip) = self.node_index.get(&id) {
+            let cur_subnet = self.subnet_type.subnet(cur_ip);
+            let new_subnet = self.subnet_type.subnet(ip);
+            if cur_subnet == new_subnet {
+                return ValidateInsertResult::Evict(id.clone());
+            }
+        }
+
+        // quota not enough, try to evict one.
         if let Some(evictee) = self.select_evictee(ip, db) {
             return ValidateInsertResult::Evict(evictee);
         }

--- a/network/src/ip/node_limit.rs
+++ b/network/src/ip/node_limit.rs
@@ -169,7 +169,8 @@ impl NodeIpLimit {
         }
 
         // node exists and ip not changed.
-        if let Some(cur_ip) = self.node_index.get(&id) {
+        let maybe_cur_ip = self.node_index.get(&id);
+        if let Some(cur_ip) = maybe_cur_ip {
             if cur_ip == ip {
                 return ValidateInsertResult::AlreadyExists;
             }
@@ -187,7 +188,7 @@ impl NodeIpLimit {
 
         // Node ip changed, but still in the same subnet.
         // So, just evict the node itself.
-        if let Some(cur_ip) = self.node_index.get(&id) {
+        if let Some(cur_ip) = maybe_cur_ip {
             let cur_subnet = self.subnet_type.subnet(cur_ip);
             let new_subnet = self.subnet_type.subnet(ip);
             if cur_subnet == new_subnet {


### PR DESCRIPTION
Before node insertion into database, NodeIpLimit will update the node ID and IP indices. If the quota of a subnet is not enough, and the new/old IPs of node are both in the same subnet, then just evict the node itself instead of other nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1326)
<!-- Reviewable:end -->
