### PR TITLE
Use u128 as tx pool weight.

### DIFF
--- a/core/src/transaction_pool/mod.rs
+++ b/core/src/transaction_pool/mod.rs
@@ -99,6 +99,8 @@ impl Default for TxPoolConfig {
             capacity: 500_000,
             min_tx_price: 1,
             max_tx_gas: DEFAULT_MAX_TRANSACTION_GAS_LIMIT,
+            // TODO: Set a proper default scaling since tx pool uses u128 as
+            // weight.
             tx_weight_scaling: 1,
             tx_weight_exp: 1,
             target_block_gas_limit: DEFAULT_TARGET_BLOCK_GAS_LIMIT,


### PR DESCRIPTION
And use multiple connections in single_bench and increase default batch size.

Now single_bench can reach more than 15K tps. 

This closes #1224.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1329)
<!-- Reviewable:end -->
