### PR TITLE
Add chain_id params into p2p Status message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Improvements
 
+- Add chain_id field into p2p Status message so that peers can disconnect peers from another Conflux chain, e.g. testnet.
+
 # 0.5.0
 
 ## Improvements

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -960,11 +960,12 @@ impl SynchronizationProtocolHandler {
 
     fn produce_status_message(&self) -> Status {
         let best_info = self.graph.consensus.best_info();
-
+        let chain_id = self.graph.consensus.get_config().chain_id.clone();
         let terminal_hashes = best_info.bounded_terminal_block_hashes.clone();
 
         Status {
             protocol_version: SYNCHRONIZATION_PROTOCOL_VERSION,
+            chain_id,
             genesis_hash: self.graph.data_man.true_genesis.hash(),
             best_epoch: best_info.best_epoch_number,
             terminal_block_hashes: terminal_hashes,

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -194,7 +194,7 @@ impl Encodable for Action {
 }
 
 /// The parameters needed to determine the chain_id based on epoch_number.
-#[derive(Clone)]
+#[derive(Clone, Debug, Eq, RlpEncodable, RlpDecodable, PartialEq)]
 pub struct ChainIdParams {
     /// Preconfigured chain_id.
     pub chain_id: u64,

--- a/tests/conflux/messages.py
+++ b/tests/conflux/messages.py
@@ -119,10 +119,15 @@ class Disconnect(rlp.Serializable):
     def deserialize(cls, serial):
         return cls(int(serial[0]), str(serial[1:]))
 
+class ChainIdParams(rlp.Serializable):
+    fields = [
+        ("chain_id", big_endian_int),
+    ]
 
 class Status(rlp.Serializable):
     fields = [
         ("protocol_version", big_endian_int),
+        ("chain_id", ChainIdParams),
         ("genesis_hash", hash32),
         ("best_epoch", big_endian_int),
         ("terminal_block_hashes", CountableList(hash32)),

--- a/tests/test_framework/mininode.py
+++ b/tests/test_framework/mininode.py
@@ -42,9 +42,13 @@ class P2PConnection(asyncore.dispatcher):
     sub-classed and the on_message() callback overridden."""
 
     def __init__(self):
+        self.chain_id = None
         assert not network_thread_running()
 
         super().__init__(map=mininode_socket_map)
+
+    def set_chain_id(self, chain_id):
+        self.chain_id = chain_id
 
     def peer_connect(self, dstaddr, dstport):
         self.dstaddr = dstaddr
@@ -327,7 +331,9 @@ class P2PInterface(P2PConnection):
     # Message receiving methods
 
     def send_status(self):
-        status = Status(self.protocol_version, self.genesis.block_header.hash, 0, [self.best_block_hash])
+        status = Status(
+            self.protocol_version, ChainIdParams(self.chain_id),
+            self.genesis.block_header.hash, 0, [self.best_block_hash])
         self.send_protocol_msg(status)
 
     def on_protocol_packet(self, protocol, payload):

--- a/tests/test_framework/test_node.py
+++ b/tests/test_framework/test_node.py
@@ -20,6 +20,7 @@ import urllib.parse
 import eth_utils
 
 from conflux.utils import get_nodeid, sha3, encode_int32
+from conflux.config import DEFAULT_PY_TEST_CHAIN_ID
 from .authproxy import JSONRPCException
 from .util import *
 
@@ -36,7 +37,8 @@ class ErrorMatch(Enum):
 
 class TestNode:
     def __init__(self, index, datadir, rpchost, confluxd, rpc_timeout=None, remote=False, ip=None, user=None,
-                 rpcport=None, auto_recovery=False, recovery_timeout=30):
+                 rpcport=None, auto_recovery=False, recovery_timeout=30, chain_id=DEFAULT_PY_TEST_CHAIN_ID):
+        self.chain_id = chain_id
         self.index = index
         self.datadir = datadir
         self.stdout_dir = os.path.join(self.datadir, "stdout")
@@ -353,6 +355,8 @@ class TestNode:
             kwargs['dstport'] = int(self.port)
         if 'dstaddr' not in kwargs:
             kwargs['dstaddr'] = self.ip
+
+        p2p_conn.set_chain_id(self.chain_id)
 
         # if self.ip is not None:
         #     kwargs['dstaddr'] = self.ip


### PR DESCRIPTION
 so that peers can disconnect peers from another Conflux chain, e.g. testnet.

This change is not at all urgent because most of the time the genesis hashes from different chains are different.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1334)
<!-- Reviewable:end -->
