### PR TITLE
Keep network id the same as chain id.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@
 
 - Improve the performance of the consensus layer for unstable TreeGraph scenarios. 
 
-- Add chain_id field into p2p Status message so that peers can disconnect peers from another Conflux chain, e.g. testnet.
+- Add chain_id field into p2p Status message so that peers can disconnect peers
+from another Conflux chain, e.g. testnet.
 
+- Keep network_id the same as chain_id. Setting network_id is only for local
+experimental purposes.
 
 # 0.5.0
 

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -137,15 +137,11 @@ pub struct NetworkConfiguration {
     pub session_ip_limit_config: SessionIpLimitConfig,
 }
 
-impl Default for NetworkConfiguration {
-    fn default() -> Self { NetworkConfiguration::new() }
-}
-
 impl NetworkConfiguration {
-    pub fn new() -> Self {
+    pub fn new(id: u64) -> Self {
         NetworkConfiguration {
             is_consortium: false,
-            id: 1,
+            id,
             config_path: Some("./net_config".to_string()),
             listen_address: None,
             public_address: None,
@@ -174,8 +170,8 @@ impl NetworkConfiguration {
         }
     }
 
-    pub fn new_with_port(port: u16) -> NetworkConfiguration {
-        let mut config = NetworkConfiguration::new();
+    pub fn new_with_port(id: u64, port: u16) -> NetworkConfiguration {
+        let mut config = NetworkConfiguration::new(id);
         config.listen_address = Some(SocketAddr::V4(SocketAddrV4::new(
             Ipv4Addr::new(0, 0, 0, 0),
             port,
@@ -183,8 +179,8 @@ impl NetworkConfiguration {
         config
     }
 
-    pub fn new_local() -> NetworkConfiguration {
-        let mut config = NetworkConfiguration::new();
+    pub fn new_local(id: u64) -> NetworkConfiguration {
+        let mut config = NetworkConfiguration::new(id);
         config.listen_address = Some(SocketAddr::V4(SocketAddrV4::new(
             Ipv4Addr::new(127, 0, 0, 1),
             0,

--- a/tests/test_framework/mininode.py
+++ b/tests/test_framework/mininode.py
@@ -7,6 +7,7 @@ P2PInterface: A high-level interface object for communicating to a node over P2P
 from eth_utils import big_endian_to_int, encode_hex
 
 from conflux import utils
+from conflux.config import DEFAULT_PY_TEST_CHAIN_ID
 from conflux.messages import *
 import asyncore
 from collections import defaultdict
@@ -420,7 +421,7 @@ class P2PInterface(P2PConnection):
         if self.remote:
             ip = get_ip_address()
         endpoint = NodeEndpoint(address=bytes(ip), port=32325, udp_port=32325)
-        hello = Hello(1, [Capability(self.protocol, self.protocol_version)], endpoint)
+        hello = Hello(DEFAULT_PY_TEST_CHAIN_ID, [Capability(self.protocol, self.protocol_version)], endpoint)
 
         self.send_packet(PACKET_HELLO, rlp.encode(hello, Hello))
         self.had_hello = True


### PR DESCRIPTION
Set network id only for local experimental purposes, e.g. when user would like to keep the existing blockchain data but disconnect from the public network.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1343)
<!-- Reviewable:end -->
