### PR TITLE
Add storage benchmark code to test TPS of random transactions

### DIFF
--- a/core/src/storage/tests/mod.rs
+++ b/core/src/storage/tests/mod.rs
@@ -129,6 +129,29 @@ impl DerefMut for FakeStateManager {
 
 #[cfg(test)]
 pub fn new_state_manager_for_unit_test() -> FakeStateManager {
+    const WITH_LOGGER: bool = false;
+    if WITH_LOGGER {
+        log4rs::init_config(
+            log4rs::config::Config::builder()
+                .appender(
+                    log4rs::config::Appender::builder().build(
+                        "stdout",
+                        Box::new(
+                            log4rs::append::console::ConsoleAppender::builder()
+                                .build(),
+                        ),
+                    ),
+                )
+                .build(
+                    log4rs::config::Root::builder()
+                        .appender("stdout")
+                        .build(log::LevelFilter::Debug),
+                )
+                .unwrap(),
+        )
+        .ok();
+    }
+
     FakeStateManager::new("./conflux_unit_test_data_dir/".to_string()).unwrap()
 }
 


### PR DESCRIPTION
from around 10 million accounts.

To run the benchmark, modify TEST_NUMBER_OF_KEYS and parameters to create the FakeStateManager.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1344)
<!-- Reviewable:end -->
