### PR TITLE
Fix incorrect behavior of require() in vm operations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## Bug Fixes
 
+
 - Make sure all internal account exists at genesis block, otherwise some
 readonly operation may crash.
+
+- Fix incorrect usages of require() in vm operations. In most cases creation of
+basic account in its absense is undesired, especially when the address is a
+contract. When a user account is to be created, the address space is checked.
 
 ## Improvements
 

--- a/core/src/state/account_entry.rs
+++ b/core/src/state/account_entry.rs
@@ -171,6 +171,7 @@ impl OverlayAccount {
         }
     }
 
+    #[cfg(test)]
     pub fn new_contract(
         address: &Address, balance: U256, nonce: U256, reset_storage: bool,
     ) -> Self {

--- a/core/src/statedb/error.rs
+++ b/core/src/statedb/error.rs
@@ -18,7 +18,7 @@ error_chain! {
     errors {
         IncompleteDatabase(address: Address) {
             description("incomplete database")
-            display("incomplete database: address={}", address)
+            display("incomplete database: address={:?}", address)
         }
     }
 }

--- a/core/src/storage/impls/merkle_patricia_trie/mpt_merger.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/mpt_merger.rs
@@ -40,8 +40,7 @@ impl<'a> MptMerger<'a> {
         }
     }
 
-    // This is test only.
-    #[allow(unused)]
+    #[cfg(test)]
     pub fn merge(
         &mut self, inserter: &DumpedDeltaMptIterator,
     ) -> Result<MerkleHash> {
@@ -182,8 +181,11 @@ impl GetRwMpt for MergeMptsInRequest<'_> {
 use super::{
     super::{super::storage_db::snapshot_mpt::*, errors::*},
     mpt_cursor::*,
-    KVInserter,
 };
-use crate::storage::tests::DumpedDeltaMptIterator;
 use fallible_iterator::FallibleIterator;
 use primitives::MerkleHash;
+
+#[cfg(test)]
+use super::KVInserter;
+#[cfg(test)]
+use crate::storage::tests::DumpedDeltaMptIterator;

--- a/tests/secondary_reward_test.py
+++ b/tests/secondary_reward_test.py
@@ -12,8 +12,8 @@ class StorageMaintenanceTest(ConfluxTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
-        self.mining_author = "0x00000000000000000000000000000000000000aa"
-        self.conf_parameters = {"mining_author": "\"00000000000000000000000000000000000000aa\""}
+        self.mining_author = "0x10000000000000000000000000000000000000aa"
+        self.conf_parameters = {"mining_author": "\"10000000000000000000000000000000000000aa\""}
         self.gasPrice = 1
 
     def setup_network(self):


### PR DESCRIPTION
In most cases creation of basic account in its absense is undesired, especially when the address should be a contract. When a user account is to be created, the address space is checked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1356)
<!-- Reviewable:end -->
