### PR TITLE
Add a execution state prefetcher to speed up transaction processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,6 +472,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfx-utils"
+version = "0.6.0"
+dependencies = [
+ "log 0.4.8",
+ "parking_lot 0.10.0",
+]
+
+[[package]]
 name = "cfxcore"
 version = "0.6.0"
 dependencies = [
@@ -483,6 +491,7 @@ dependencies = [
  "cfx-bytes",
  "cfx-stratum",
  "cfx-types",
+ "cfx-utils",
  "cfxkey",
  "clap",
  "criterion",

--- a/cfx_utils/Cargo.toml
+++ b/cfx_utils/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+description = "Conflux utilities library"
+homepage = "http://www.conflux-chain.org"
+license = "GPL-3.0"
+name = "cfx-utils"
+version = "0.6.0"
+edition = "2018"
+
+[dependencies]
+log = "0.4"
+parking_lot = "0.10"

--- a/cfx_utils/src/cancellable_task_channel.rs
+++ b/cfx_utils/src/cancellable_task_channel.rs
@@ -1,0 +1,369 @@
+// Copyright 2020 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+pub fn new_cancellable_task_channel<T: CancelByKey>(
+) -> (CancelableTaskSender<T>, CancelableTaskReceiver<T>) {
+    let (sender, receiver) = mpsc::channel();
+    let queue = Arc::<RwLock<VecDeque<Option<T>>>>::default();
+    let task_info = Arc::new(Mutex::new(TaskInfo {
+        maybe_current_task_key: None,
+        current_task_waits: None,
+        pending_tasks_waits: vec![],
+    }));
+    (
+        CancelableTaskSender {
+            sender,
+            task_info: task_info.clone(),
+            queue: queue.clone(),
+        },
+        CancelableTaskReceiver {
+            queue,
+            receiver,
+            task_info,
+        },
+    )
+}
+
+pub trait CancelByKey {
+    type Key: Clone + std::fmt::Debug + PartialEq;
+
+    fn key(&self) -> &Self::Key;
+
+    #[inline]
+    fn matches_key(&self, key: &Self::Key) -> bool {
+        Self::key_matches(self.key(), key)
+    }
+
+    #[inline]
+    fn key_matches(this: &Self::Key, other: &Self::Key) -> bool {
+        this.eq(other)
+    }
+}
+
+#[derive(Clone)]
+pub struct CancelableTaskSender<T: CancelByKey> {
+    sender: mpsc::Sender<bool>,
+    // Use Mutex in combination with Condvar.
+    task_info: Arc<Mutex<TaskInfo<T>>>,
+    queue: Arc<RwLock<VecDeque<Option<T>>>>,
+}
+
+pub struct CancelableTaskReceiver<T: CancelByKey> {
+    queue: Arc<RwLock<VecDeque<Option<T>>>>,
+    task_info: Arc<Mutex<TaskInfo<T>>>,
+    receiver: mpsc::Receiver<bool>,
+}
+
+pub enum StopOr<RecvError> {
+    Stop,
+    RecvError(RecvError),
+}
+
+impl<T: CancelByKey> CancelableTaskSender<T> {
+    pub fn stop(&self) -> Result<(), SendError<bool>> {
+        self.sender.send(false)
+    }
+
+    pub fn send(&self, task: T) -> Result<(), SendError<bool>> {
+        self.queue.write().push_back(Some(task));
+        self.sender.send(true)
+    }
+
+    pub fn current_task(&self) -> MappedMutexGuard<Option<T::Key>> {
+        MutexGuard::map(self.task_info.lock(), |info| {
+            &mut info.maybe_current_task_key
+        })
+    }
+
+    // Return whether the key to remove is the current task.
+    pub fn remove(&self, key: &T::Key) -> bool {
+        debug!("remove task {:?}", key);
+        let is_current_task_removed;
+        // Hold the current task lock because we don't want a pending task
+        // becomes the current task while we are trying to cancel it.
+        let mut task_info_locked = self.task_info.lock();
+        if task_info_locked
+            .maybe_current_task_key
+            .as_ref()
+            .map_or(false, |current_task_key| {
+                T::key_matches(current_task_key, key)
+            })
+        {
+            // It's the current task.
+            is_current_task_removed = true;
+
+            debug!("issue cancellation of current task",);
+            // Search in pending queue because we allow multiple tasks with same
+            // id.
+            self.remove_pending(
+                &mut task_info_locked,
+                key,
+                // There are no waits in pending queue for the current task.
+                /* notify_waits = */
+                false,
+            );
+            // Set the cancellation flag.
+            task_info_locked.maybe_current_task_key = None;
+        } else {
+            is_current_task_removed = false;
+            // Search in pending queue.
+            self.remove_pending(
+                &mut task_info_locked,
+                key,
+                /* notify_waits = */ true,
+            );
+        }
+
+        is_current_task_removed
+    }
+
+    // Return None if the key can not be found.
+    pub fn wait_for(
+        &self, key: &T::Key,
+    ) -> Option<(Arc<Condvar>, MutexGuard<TaskInfo<T>>)> {
+        let mut task_info_locked = self.task_info.lock();
+        if task_info_locked
+            .maybe_current_task_key
+            .as_ref()
+            .map_or(false, |current_key| T::key_matches(current_key, key))
+        {
+            // It's the current task.
+            if task_info_locked.current_task_waits.is_none() {
+                // There are no existing waits.
+                let new_waits = Arc::<Condvar>::default();
+                task_info_locked.current_task_waits = Some(new_waits.clone());
+
+                Some((new_waits, task_info_locked))
+            } else {
+                // There are existing waits.
+                Some((
+                    task_info_locked.current_task_waits.clone().unwrap(),
+                    task_info_locked,
+                ))
+            }
+        } else {
+            // Search in pending waits.
+            let wait = task_info_locked.clone_pending_task_wait(key);
+            if wait.is_some() {
+                Some((wait.unwrap(), task_info_locked))
+            } else {
+                let queue = &*self.queue.read();
+                for pending_task in queue {
+                    if pending_task
+                        .as_ref()
+                        .map_or(false, |task| task.matches_key(key))
+                    {
+                        let cond_var = Arc::<Condvar>::default();
+                        task_info_locked
+                            .pending_tasks_waits
+                            .push((key.clone(), cond_var.clone()));
+
+                        return Some((cond_var, task_info_locked));
+                    }
+                }
+
+                None
+            }
+        }
+    }
+}
+
+impl<T: CancelByKey> CancelableTaskSender<T> {
+    fn notify_pending_task_waits(
+        task_info_locked: &mut TaskInfo<T>, key: &T::Key,
+    ) {
+        task_info_locked.pending_tasks_waits.retain(|task| {
+            if T::key_matches(&task.0, key) {
+                task.1.notify_all();
+                false
+            } else {
+                true
+            }
+        })
+    }
+
+    // Return whether a task is removed.
+    fn remove_pending(
+        &self, task_info_locked: &mut TaskInfo<T>, key: &T::Key,
+        notify_waits: bool,
+    ) -> bool
+    {
+        let queue = &mut *self.queue.write();
+        let mut found = false;
+        // Remove tasks from queue.
+        for maybe_task in queue.iter_mut() {
+            if maybe_task
+                .as_ref()
+                .map_or(false, |task| task.matches_key(key))
+            {
+                found = true;
+                *maybe_task = None
+            }
+        }
+        if notify_waits && found {
+            Self::notify_pending_task_waits(task_info_locked, key);
+        }
+        found
+    }
+}
+
+impl<T: CancelByKey> CancelableTaskReceiver<T> {
+    pub fn try_recv(&self) -> Result<T, StopOr<TryRecvError>> {
+        self.recv_impl(/* try_recv = */ true)
+    }
+
+    pub fn recv(&self) -> Result<T, StopOr<RecvError>> {
+        match self.recv_impl(/* try_recv = */ false) {
+            Ok(t) => Ok(t),
+            Err(StopOr::Stop) => Err(StopOr::Stop),
+            Err(StopOr::RecvError(TryRecvError::Disconnected)) => {
+                Err(StopOr::RecvError(RecvError))
+            }
+            _ => unsafe { unreachable_unchecked() },
+        }
+    }
+}
+
+impl<T: CancelByKey> CancelableTaskReceiver<T> {
+    #[inline]
+    fn recv_task_from_receiver(&self) -> Result<bool, StopOr<TryRecvError>> {
+        match self.receiver.recv() {
+            Ok(true) => Ok(true),
+            Ok(false) => Err(StopOr::Stop),
+            Err(_) => Err(StopOr::RecvError(TryRecvError::Disconnected)),
+        }
+    }
+
+    fn pop_task_from_receiver(
+        &self, try_recv: bool, may_block_indefinitely: bool,
+        task_guard: &mut MutexGuard<TaskInfo<T>>,
+        queue_guard: &mut RwLockWriteGuard<VecDeque<Option<T>>>,
+    ) -> Result<bool, StopOr<TryRecvError>>
+    {
+        match self.receiver.try_recv() {
+            Err(TryRecvError::Disconnected) => {
+                Err(StopOr::RecvError(TryRecvError::Disconnected))
+            }
+            Err(TryRecvError::Empty) => {
+                if try_recv {
+                    debug!("TryRecv: no task available");
+                    Err(StopOr::RecvError(TryRecvError::Empty))
+                } else {
+                    debug!("Recv: no task available, wait for new task");
+                    if may_block_indefinitely {
+                        // Notify all waits of the previous task.
+                        task_guard.set_current_task(None);
+                        // Unblock all locks when we are waiting.
+                        RwLockWriteGuard::unlocked(queue_guard, || {
+                            MutexGuard::unlocked(task_guard, || {
+                                self.recv_task_from_receiver()
+                            })
+                        })
+                    } else {
+                        self.recv_task_from_receiver()
+                    }
+                }
+            }
+            Ok(true) => Ok(true),
+            Ok(false) => Err(StopOr::Stop),
+        }
+    }
+
+    fn recv_impl(&self, try_recv: bool) -> Result<T, StopOr<TryRecvError>> {
+        let mut current_task_guard = self.task_info.lock();
+        let mut queue_locked = self.queue.write();
+        let mut should_pop_recv = true;
+        loop {
+            if should_pop_recv {
+                self.pop_task_from_receiver(
+                    try_recv,
+                    /* may_block_indefinitely = */
+                    queue_locked.is_empty(),
+                    &mut current_task_guard,
+                    &mut queue_locked,
+                )?;
+            }
+            debug!("received new task, check the task queue.");
+            match queue_locked.pop_front() {
+                None => {
+                    // Retry when we already received the new task from
+                    // task_receiver, but task_queue is still empty.
+                    should_pop_recv = false;
+                    debug!("wait for received task to appear in queue");
+                    continue;
+                }
+                Some(None) => {
+                    // Received a task, however it's already cancelled, retry.
+                    should_pop_recv = true;
+                    continue;
+                }
+                Some(Some(task)) => {
+                    // Task received
+
+                    // Notify all waits on the previous task, and set current
+                    // key.
+                    current_task_guard
+                        .set_current_task(Some(task.key().clone()));
+                    break Ok(task);
+                }
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct TaskInfo<T: CancelByKey> {
+    // It is None at the very beginning of the execution, or when the task
+    // execution is canceled.
+    maybe_current_task_key: Option<T::Key>,
+    // Maintained when a task become the current key. All old waiters are
+    // informed about the finish.
+    current_task_waits: Option<Arc<Condvar>>,
+    pending_tasks_waits: Vec<(T::Key, Arc<Condvar>)>,
+}
+
+impl<T: CancelByKey> TaskInfo<T> {
+    pub fn inform_previous_task_finish(&mut self) {
+        let waits = self.current_task_waits.take();
+        if let Some(wait) = waits {
+            wait.notify_all();
+        }
+    }
+
+    fn set_current_task(&mut self, maybe_key: Option<T::Key>) {
+        if self.current_task_waits.is_some() {
+            self.inform_previous_task_finish();
+        }
+        if let Some(key) = maybe_key.as_ref() {
+            for i in 0..self.pending_tasks_waits.len() {
+                if T::key_matches(&self.pending_tasks_waits[i].0, key) {
+                    self.current_task_waits =
+                        Some(self.pending_tasks_waits.swap_remove(i).1);
+                }
+            }
+        }
+        self.maybe_current_task_key = maybe_key;
+    }
+
+    fn clone_pending_task_wait(&self, key: &T::Key) -> Option<Arc<Condvar>> {
+        for wait in &self.pending_tasks_waits {
+            if T::key_matches(&wait.0, key) {
+                return Some(wait.1.clone());
+            }
+        }
+        None
+    }
+}
+
+use parking_lot::{
+    Condvar, MappedMutexGuard, Mutex, MutexGuard, RwLock, RwLockWriteGuard,
+};
+use std::{
+    collections::VecDeque,
+    hint::unreachable_unchecked,
+    sync::{
+        mpsc::{self, RecvError, SendError, TryRecvError},
+        Arc,
+    },
+};

--- a/cfx_utils/src/cancellable_task_channel.rs
+++ b/cfx_utils/src/cancellable_task_channel.rs
@@ -78,7 +78,6 @@ impl<T: CancelByKey> CancelableTaskSender<T> {
 
     // Return whether the key to remove is the current task.
     pub fn remove(&self, key: &T::Key) -> bool {
-        debug!("remove task {:?}", key);
         let is_current_task_removed;
         // Hold the current task lock because we don't want a pending task
         // becomes the current task while we are trying to cancel it.
@@ -93,7 +92,6 @@ impl<T: CancelByKey> CancelableTaskSender<T> {
             // It's the current task.
             is_current_task_removed = true;
 
-            debug!("issue cancellation of current task",);
             // Search in pending queue because we allow multiple tasks with same
             // id.
             self.remove_pending(
@@ -247,10 +245,8 @@ impl<T: CancelByKey> CancelableTaskReceiver<T> {
             }
             Err(TryRecvError::Empty) => {
                 if try_recv {
-                    debug!("TryRecv: no task available");
                     Err(StopOr::RecvError(TryRecvError::Empty))
                 } else {
-                    debug!("Recv: no task available, wait for new task");
                     if may_block_indefinitely {
                         // Notify all waits of the previous task.
                         task_guard.set_current_task(None);
@@ -284,13 +280,11 @@ impl<T: CancelByKey> CancelableTaskReceiver<T> {
                     &mut queue_locked,
                 )?;
             }
-            debug!("received new task, check the task queue.");
             match queue_locked.pop_front() {
                 None => {
                     // Retry when we already received the new task from
                     // task_receiver, but task_queue is still empty.
                     should_pop_recv = false;
-                    debug!("wait for received task to appear in queue");
                     continue;
                 }
                 Some(None) => {

--- a/cfx_utils/src/lib.rs
+++ b/cfx_utils/src/lib.rs
@@ -2,6 +2,7 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
+#[allow(unused)]
 #[macro_use]
 extern crate log;
 extern crate parking_lot;

--- a/cfx_utils/src/lib.rs
+++ b/cfx_utils/src/lib.rs
@@ -2,7 +2,7 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-#[allow(unused)]
+#![allow(unused)]
 #[macro_use]
 extern crate log;
 extern crate parking_lot;

--- a/cfx_utils/src/lib.rs
+++ b/cfx_utils/src/lib.rs
@@ -1,0 +1,9 @@
+// Copyright 2020 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+#[macro_use]
+extern crate log;
+extern crate parking_lot;
+
+pub mod cancellable_task_channel;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,6 +15,7 @@ byteorder = "1.0"
 cfx-stratum = { path = "../blockgen/stratum" }
 cfx-types = { path = "../cfx_types" }
 cfx-bytes = { path = "../cfx_bytes" }
+cfx-utils = { path = "../cfx_utils" }
 clap = "2"
 derivative = "2.0.2"
 db = { path = "../db" }

--- a/core/benchmark/storage/src/main.rs
+++ b/core/benchmark/storage/src/main.rs
@@ -1715,6 +1715,7 @@ impl TxReplayer {
         Ok(state_root_with_aux)
     }
 
+    // FIXME: use and test performance with ExecutionStatePrefetcher
     pub fn add_tx(
         &self, tx: RealizedEthTx, latest_state: &mut StateDb,
         last_state_root: &mut StateRootWithAuxInfo,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,6 +7,7 @@
 #![allow(deprecated)]
 
 extern crate cfx_bytes as bytes;
+extern crate cfx_utils;
 extern crate cfxkey as keylib;
 extern crate core;
 extern crate io;

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -2,6 +2,8 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
+pub mod prefetcher;
+
 use self::account_entry::{AccountEntry, AccountState};
 use crate::{
     bytes::Bytes,
@@ -1010,7 +1012,6 @@ impl State {
     }
 
     /// Return whether or not the address exists.
-    #[allow(unused)]
     pub fn try_load(&self, address: &Address) -> bool {
         if let Ok(true) =
             self.ensure_cached(address, RequireCache::None, |maybe| {

--- a/core/src/state/prefetcher.rs
+++ b/core/src/state/prefetcher.rs
@@ -196,9 +196,11 @@ impl ExecutionStatePrefetcher {
         accounts: &'static [&'static Address],
     ) -> Result<(), SendError<bool>>
     {
-        self.task_sender
-            .lock()
-            .send((task_epoch_id, state, accounts))
+        self.task_sender.lock().send(PrefetchTaskKey(
+            task_epoch_id,
+            state,
+            accounts,
+        ))
     }
 
     // Return false when the task does not exist in the queue. It may already
@@ -244,7 +246,7 @@ impl ExecutionStatePrefetcher {
         let mut current_task_id = 0u64;
         loop {
             match task_receiver.recv() {
-                Ok((task_epoch_id, state, accounts)) => {
+                Ok(PrefetchTaskKey(task_epoch_id, state, accounts)) => {
                     if current_task_id == std::u64::MAX {
                         current_task_id = 1;
                     } else {
@@ -336,23 +338,11 @@ impl Drop for PrefetchTaskHandle<'_> {
     }
 }
 
-pub trait CancelByKey {
-    type Key: Clone + std::fmt::Debug + PartialEq;
-
-    fn key(&self) -> &Self::Key;
-
-    #[inline]
-    fn matches_key(&self, key: &Self::Key) -> bool {
-        Self::key_matches(self.key(), key)
-    }
-
-    #[inline]
-    fn key_matches(this: &Self::Key, other: &Self::Key) -> bool {
-        this.eq(other)
-    }
-}
-
-type PrefetchTaskKey = (EpochId, &'static State, &'static [&'static Address]);
+struct PrefetchTaskKey(
+    pub EpochId,
+    pub &'static State,
+    pub &'static [&'static Address],
+);
 
 impl CancelByKey for PrefetchTaskKey {
     type Key = EpochId;
@@ -361,348 +351,17 @@ impl CancelByKey for PrefetchTaskKey {
     fn key(&self) -> &Self::Key { &self.0 }
 }
 
-#[derive(Clone)]
-pub struct CancelableTaskSender<T: CancelByKey> {
-    sender: mpsc::Sender<bool>,
-    // Use Mutex in combination with Condvar.
-    task_info: Arc<Mutex<TaskInfo<T>>>,
-    queue: Arc<RwLock<VecDeque<Option<T>>>>,
-}
-
-pub struct CancelableTaskReceiver<T: CancelByKey> {
-    queue: Arc<RwLock<VecDeque<Option<T>>>>,
-    task_info: Arc<Mutex<TaskInfo<T>>>,
-    receiver: mpsc::Receiver<bool>,
-}
-
-#[derive(Default)]
-pub struct TaskInfo<T: CancelByKey> {
-    // It is None at the very beginning of the execution, or when the task
-    // execution is canceled.
-    maybe_current_task_key: Option<T::Key>,
-    // Maintained when a task become the current key. All old waiters are
-    // informed about the finish.
-    current_task_waits: Option<Arc<Condvar>>,
-    pending_tasks_waits: Vec<(T::Key, Arc<Condvar>)>,
-}
-
-impl<T: CancelByKey> TaskInfo<T> {
-    pub fn inform_previous_task_finish(&mut self) {
-        let waits = self.current_task_waits.take();
-        if let Some(wait) = waits {
-            wait.notify_all();
-        }
-    }
-
-    fn set_current_task(&mut self, maybe_key: Option<T::Key>) {
-        if self.current_task_waits.is_some() {
-            self.inform_previous_task_finish();
-        }
-        if let Some(key) = maybe_key.as_ref() {
-            for i in 0..self.pending_tasks_waits.len() {
-                if T::key_matches(&self.pending_tasks_waits[i].0, key) {
-                    self.current_task_waits =
-                        Some(self.pending_tasks_waits.swap_remove(i).1);
-                }
-            }
-        }
-        self.maybe_current_task_key = maybe_key;
-    }
-
-    fn clone_pending_task_wait(&self, key: &T::Key) -> Option<Arc<Condvar>> {
-        for wait in &self.pending_tasks_waits {
-            if T::key_matches(&wait.0, key) {
-                return Some(wait.1.clone());
-            }
-        }
-        None
-    }
-}
-
-impl<T: CancelByKey> CancelableTaskSender<T> {
-    pub fn stop(&self) -> Result<(), SendError<bool>> {
-        self.sender.send(false)
-    }
-
-    pub fn send(&self, task: T) -> Result<(), SendError<bool>> {
-        self.queue.write().push_back(Some(task));
-        self.sender.send(true)
-    }
-
-    pub fn current_task(&self) -> MappedMutexGuard<Option<T::Key>> {
-        MutexGuard::map(self.task_info.lock(), |info| {
-            &mut info.maybe_current_task_key
-        })
-    }
-
-    fn notify_pending_task_waits(
-        task_info_locked: &mut TaskInfo<T>, key: &T::Key,
-    ) {
-        task_info_locked.pending_tasks_waits.retain(|task| {
-            if T::key_matches(&task.0, key) {
-                task.1.notify_all();
-                false
-            } else {
-                true
-            }
-        })
-    }
-
-    // Return whether a task is removed.
-    fn remove_pending(
-        &self, task_info_locked: &mut TaskInfo<T>, key: &T::Key,
-        notify_waits: bool,
-    ) -> bool
-    {
-        let queue = &mut *self.queue.write();
-        let mut found = false;
-        // Remove tasks from queue.
-        for maybe_task in queue.iter_mut() {
-            if maybe_task
-                .as_ref()
-                .map_or(false, |task| task.matches_key(key))
-            {
-                found = true;
-                *maybe_task = None
-            }
-        }
-        if notify_waits && found {
-            Self::notify_pending_task_waits(task_info_locked, key);
-        }
-        found
-    }
-
-    // Return whether the key to remove is the current task.
-    pub fn remove(&self, key: &T::Key) -> bool {
-        let is_current_task_removed;
-        // Hold the current task lock because we don't want a pending task
-        // becomes the current task while we are trying to cancel it.
-        let mut task_info_locked = self.task_info.lock();
-        if task_info_locked
-            .maybe_current_task_key
-            .as_ref()
-            .map_or(false, |current_task_key| {
-                T::key_matches(current_task_key, key)
-            })
-        {
-            // It's the current task.
-            is_current_task_removed = true;
-
-            // Search in pending queue because we allow multiple tasks with same
-            // id.
-            self.remove_pending(
-                &mut task_info_locked,
-                key,
-                // There are no waits in pending queue for the current task.
-                /* notify_waits = */
-                false,
-            );
-            // Set the cancellation flag.
-            task_info_locked.maybe_current_task_key = None;
-        } else {
-            is_current_task_removed = false;
-            // Search in pending queue.
-            self.remove_pending(
-                &mut task_info_locked,
-                key,
-                /* notify_waits = */ true,
-            );
-        }
-
-        is_current_task_removed
-    }
-
-    // Return None if the key can not be found.
-    pub fn wait_for(
-        &self, key: &T::Key,
-    ) -> Option<(Arc<Condvar>, MutexGuard<TaskInfo<T>>)> {
-        let mut task_info_locked = self.task_info.lock();
-        if task_info_locked
-            .maybe_current_task_key
-            .as_ref()
-            .map_or(false, |current_key| T::key_matches(current_key, key))
-        {
-            // It's the current task.
-            if task_info_locked.current_task_waits.is_none() {
-                // There are no existing waits.
-                let new_waits = Arc::<Condvar>::default();
-                task_info_locked.current_task_waits = Some(new_waits.clone());
-
-                Some((new_waits, task_info_locked))
-            } else {
-                // There are existing waits.
-                Some((
-                    task_info_locked.current_task_waits.clone().unwrap(),
-                    task_info_locked,
-                ))
-            }
-        } else {
-            // Search in pending waits.
-            let wait = task_info_locked.clone_pending_task_wait(key);
-            if wait.is_some() {
-                Some((wait.unwrap(), task_info_locked))
-            } else {
-                let queue = &*self.queue.read();
-                for pending_task in queue {
-                    if pending_task
-                        .as_ref()
-                        .map_or(false, |task| task.matches_key(key))
-                    {
-                        let cond_var = Arc::<Condvar>::default();
-                        task_info_locked
-                            .pending_tasks_waits
-                            .push((key.clone(), cond_var.clone()));
-
-                        return Some((cond_var, task_info_locked));
-                    }
-                }
-
-                None
-            }
-        }
-    }
-}
-
-pub fn new_cancellable_task_channel<T: CancelByKey>(
-) -> (CancelableTaskSender<T>, CancelableTaskReceiver<T>) {
-    let (sender, receiver) = mpsc::channel();
-    let queue = Arc::<RwLock<VecDeque<Option<T>>>>::default();
-    let task_info = Arc::new(Mutex::new(TaskInfo {
-        maybe_current_task_key: None,
-        current_task_waits: None,
-        pending_tasks_waits: vec![],
-    }));
-    (
-        CancelableTaskSender {
-            sender,
-            task_info: task_info.clone(),
-            queue: queue.clone(),
-        },
-        CancelableTaskReceiver {
-            queue,
-            receiver,
-            task_info,
-        },
-    )
-}
-
-pub enum StopOr<RecvError> {
-    Stop,
-    RecvError(RecvError),
-}
-
-impl<T: CancelByKey> CancelableTaskReceiver<T> {
-    pub fn try_recv(&self) -> Result<T, StopOr<TryRecvError>> {
-        self.recv_impl(/* try_recv = */ true)
-    }
-
-    pub fn recv(&self) -> Result<T, StopOr<RecvError>> {
-        match self.recv_impl(/* try_recv = */ false) {
-            Ok(t) => Ok(t),
-            Err(StopOr::Stop) => Err(StopOr::Stop),
-            Err(StopOr::RecvError(TryRecvError::Disconnected)) => {
-                Err(StopOr::RecvError(RecvError))
-            }
-            _ => unsafe { unreachable_unchecked() },
-        }
-    }
-
-    #[inline]
-    fn recv_task_from_receiver(&self) -> Result<bool, StopOr<TryRecvError>> {
-        match self.receiver.recv() {
-            Ok(true) => Ok(true),
-            Ok(false) => Err(StopOr::Stop),
-            Err(_) => Err(StopOr::RecvError(TryRecvError::Disconnected)),
-        }
-    }
-
-    fn pop_task_from_receiver(
-        &self, try_recv: bool, may_block_indefinitely: bool,
-        task_guard: &mut MutexGuard<TaskInfo<T>>,
-        queue_guard: &mut RwLockWriteGuard<VecDeque<Option<T>>>,
-    ) -> Result<bool, StopOr<TryRecvError>>
-    {
-        match self.receiver.try_recv() {
-            Err(TryRecvError::Disconnected) => {
-                Err(StopOr::RecvError(TryRecvError::Disconnected))
-            }
-            Err(TryRecvError::Empty) => {
-                if try_recv {
-                    Err(StopOr::RecvError(TryRecvError::Empty))
-                } else {
-                    if may_block_indefinitely {
-                        // Notify all waits of the previous task.
-                        task_guard.set_current_task(None);
-                        // Unblock all locks when we are waiting.
-                        RwLockWriteGuard::unlocked(queue_guard, || {
-                            MutexGuard::unlocked(task_guard, || {
-                                self.recv_task_from_receiver()
-                            })
-                        })
-                    } else {
-                        self.recv_task_from_receiver()
-                    }
-                }
-            }
-            Ok(true) => Ok(true),
-            Ok(false) => Err(StopOr::Stop),
-        }
-    }
-
-    fn recv_impl(&self, try_recv: bool) -> Result<T, StopOr<TryRecvError>> {
-        let mut current_task_guard = self.task_info.lock();
-        let mut queue_locked = self.queue.write();
-        let mut should_pop_recv = true;
-        loop {
-            if should_pop_recv {
-                self.pop_task_from_receiver(
-                    try_recv,
-                    /* may_block_indefinitely = */
-                    queue_locked.is_empty(),
-                    &mut current_task_guard,
-                    &mut queue_locked,
-                )?;
-            }
-            match queue_locked.pop_front() {
-                None => {
-                    // Retry when we already received the new task from
-                    // task_receiver, but task_queue is still empty.
-                    should_pop_recv = false;
-                    continue;
-                }
-                Some(None) => {
-                    // Received a task, however it's already cancelled, retry.
-                    should_pop_recv = true;
-                    continue;
-                }
-                Some(Some(task)) => {
-                    // Task received
-
-                    // Notify all waits on the previous task, and set current
-                    // key.
-                    current_task_guard
-                        .set_current_task(Some(task.key().clone()));
-                    break Ok(task);
-                }
-            }
-        }
-    }
-}
-
 use crate::state::State;
 use cfx_types::Address;
-use parking_lot::{
-    Condvar, MappedMutexGuard, Mutex, MutexGuard, RwLock, RwLockWriteGuard,
-};
+use cfx_utils::cancellable_task_channel::*;
+use parking_lot::{Mutex, RwLock};
 use primitives::EpochId;
 use std::{
-    collections::VecDeque,
-    hint::unreachable_unchecked,
     io,
     ptr::null,
     sync::{
         atomic::{AtomicU64, Ordering},
-        mpsc::{self, RecvError, SendError, TryRecvError},
+        mpsc::{self, SendError},
         Arc,
     },
     thread::{self, JoinHandle},

--- a/core/src/state/prefetcher.rs
+++ b/core/src/state/prefetcher.rs
@@ -390,12 +390,12 @@ pub struct TaskInfo<T: CancelByKey> {
 impl<T: CancelByKey> TaskInfo<T> {
     pub fn inform_previous_task_finish(&mut self) {
         let waits = self.current_task_waits.take();
-        for wait in waits {
+        if let Some(wait) = waits {
             wait.notify_all();
         }
     }
 
-    pub fn set_current_task(&mut self, maybe_key: Option<T::Key>) {
+    fn set_current_task(&mut self, maybe_key: Option<T::Key>) {
         if self.current_task_waits.is_some() {
             self.inform_previous_task_finish();
         }

--- a/core/src/state/prefetcher.rs
+++ b/core/src/state/prefetcher.rs
@@ -1,0 +1,525 @@
+// Copyright 2020 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+pub fn prefetch_accounts<'a>(
+    prefetcher: &'a ExecutionStatePrefetcher, task_epoch_id: EpochId,
+    state: &State, account_vec: Vec<&'a Address>,
+) -> PrefetchTaskHandle<'a>
+{
+    // transmute the references so that they can be passed into threads.
+    let state = unsafe { std::mem::transmute::<&State, &'static State>(state) };
+    let accounts = unsafe {
+        std::mem::transmute::<&[&Address], &'static [&'static Address]>(
+            &account_vec,
+        )
+    };
+
+    prefetcher.add_task(task_epoch_id, state, accounts).ok();
+
+    PrefetchTaskHandle {
+        prefetcher: Some(prefetcher),
+        state,
+        task_epoch_id,
+        accounts: account_vec,
+    }
+}
+
+pub struct ExecutionStatePrefetcher {
+    task_sender: Mutex<CancelableTaskSender<PrefetchTaskKey>>,
+    current_task_id: Mutex<Option<(EpochId, u64)>>,
+    current_task_canceled_receiver: Mutex<mpsc::Receiver<()>>,
+    workers: Vec<Arc<PrefetcherThreadWorker>>,
+    worker_join_handles: Vec<JoinHandle<()>>,
+
+    join_handle: Mutex<Option<JoinHandle<()>>>,
+}
+
+struct PrefetcherThreadWorker {
+    task_queue_sender:
+        Mutex<mpsc::Sender<(u64, &'static State, &'static [&'static Address])>>,
+    /// All threads should be processing the same task.
+    /// Abort the current task when the task id changed.
+    cancel_task_id: AtomicU64,
+}
+
+impl PrefetcherThreadWorker {
+    fn new(
+        task_queue_sender: mpsc::Sender<(
+            u64,
+            &'static State,
+            &'static [&'static Address],
+        )>,
+    ) -> Self
+    {
+        Self {
+            task_queue_sender: Mutex::new(task_queue_sender),
+            cancel_task_id: Default::default(),
+        }
+    }
+
+    /// Unsafe because there shouldn't be concurrent calls to this function.
+    /// It also doesn't wait for the task to ffinish.
+    unsafe fn signal_current_task_cancellation(&self, task_id: u64) {
+        self.cancel_task_id.store(task_id, Ordering::Relaxed);
+    }
+
+    fn send_new_task(
+        &self, task_id: u64, state: &'static State,
+        addresses: &'static [&'static Address],
+    )
+    {
+        self.task_queue_sender
+            .lock()
+            .send((task_id, state, addresses))
+            .ok();
+    }
+
+    /// Unsafe because we only want the Prefetcher to stop the thread.
+    unsafe fn stop(&self) {
+        self.task_queue_sender.lock().send((0, &*null(), &[])).ok();
+    }
+
+    fn prefetch_accounts(
+        &self, task_id: u64, state: &'static State,
+        accounts: &'static [&'static Address],
+    )
+    {
+        self.cancel_task_id.store(0, Ordering::Relaxed);
+        for address in accounts {
+            let cancel_task_id = self.cancel_task_id.load(Ordering::Relaxed);
+            if cancel_task_id != 0 {
+                if cancel_task_id == task_id {
+                    break;
+                }
+                self.cancel_task_id.store(0, Ordering::Relaxed);
+            }
+            state.try_load(address);
+        }
+    }
+
+    fn run(
+        &self,
+        task_queue: mpsc::Receiver<(
+            u64,
+            &'static State,
+            &'static [&'static Address],
+        )>,
+        task_finish_signal: mpsc::Sender<()>,
+    )
+    {
+        while let Ok((task_id, state, accounts)) = task_queue.recv() {
+            if task_id == 0 {
+                // Stopped by the Prefetcher.
+                return;
+            } else {
+                self.prefetch_accounts(task_id, state, accounts);
+                task_finish_signal.send(()).expect(
+                    // sender shouln not return error.
+                    &concat!(file!(), ":", line!(), ":", column!()),
+                );
+            }
+        }
+        error!("State prefetcher thread Stopped due to exception.");
+    }
+}
+
+impl ExecutionStatePrefetcher {
+    pub fn new(
+        num_threads: usize,
+    ) -> io::Result<Arc<ExecutionStatePrefetcher>> {
+        let mut thread_finish_signal_receivers =
+            Vec::with_capacity(num_threads);
+        let mut workers = Vec::with_capacity(num_threads);
+        let mut worker_join_handles = Vec::with_capacity(num_threads);
+
+        // Start worker threads.
+        for i in 0..num_threads {
+            let (task_finish_sender, task_finish_receiver) = mpsc::channel();
+            let (task_queue_sender, task_queue_receiver) = mpsc::channel();
+            let worker =
+                Arc::new(PrefetcherThreadWorker::new(task_queue_sender));
+            let worker_to_run = worker.clone();
+            let worker_join_handle = thread::Builder::new()
+                .name(format!("Execution state prefetcher worker thread {}", i))
+                .spawn(move || {
+                    worker_to_run.run(task_queue_receiver, task_finish_sender)
+                })?;
+
+            thread_finish_signal_receivers.push(task_finish_receiver);
+            workers.push(worker);
+            worker_join_handles.push(worker_join_handle);
+        }
+
+        // Start task queue controller.
+        let (task_canceled_sender, task_canceled_receiver) = mpsc::channel();
+        let (task_sender, task_receiver) = new_cancelable_task_channel();
+        let prefetcher = Arc::new(Self {
+            task_sender: Mutex::new(task_sender),
+            workers,
+            current_task_id: Default::default(),
+            current_task_canceled_receiver: Mutex::new(task_canceled_receiver),
+            worker_join_handles,
+            join_handle: Default::default(),
+        });
+
+        let prefetcher_to_run = prefetcher.clone();
+        let prefetcher_join_handle = thread::Builder::new()
+            .name("Execution state prefetcher".into())
+            .spawn(move || {
+                prefetcher_to_run.run(
+                    thread_finish_signal_receivers,
+                    task_canceled_sender,
+                    task_receiver,
+                );
+            })?;
+        *prefetcher.join_handle.lock() = Some(prefetcher_join_handle);
+
+        Ok(prefetcher)
+    }
+
+    pub fn stop(&self) { self.task_sender.lock().stop().ok(); }
+
+    pub fn add_task(
+        &self, task_epoch_id: EpochId, state: &'static State,
+        accounts: &'static [&'static Address],
+    ) -> Result<(), SendError<bool>>
+    {
+        self.task_sender
+            .lock()
+            .send((task_epoch_id, state, accounts))
+    }
+
+    pub fn wait_for_task(&self, task_epoch_id: &EpochId) {
+        self.cancel_task(task_epoch_id, /* cancel = */ false);
+    }
+
+    pub fn cancel_task(&self, task_epoch_id: &EpochId, cancel: bool) {
+        // Hold the current task lock because we don't want a pending task
+        // becomes the current task while we are trying to cancel it.
+        let mut current_task_locked = self.current_task_id.lock();
+        if current_task_locked.as_ref().map_or(false, |current| {
+            PrefetchTaskKey::key_matches(&current.0, task_epoch_id)
+        }) {
+            let current_task_id = current_task_locked.as_ref().unwrap().1;
+            // It's the current task.
+            // Inform the thread about the cancellation.
+            if cancel {
+                unsafe {
+                    for thread in &self.workers {
+                        thread
+                            .signal_current_task_cancellation(current_task_id);
+                    }
+                }
+            }
+            *current_task_locked = None;
+            // Search in pending queue.
+            self.task_sender
+                .lock()
+                .cancel(task_epoch_id, &current_task_locked);
+            drop(current_task_locked);
+            // Wait for the cancelled task to finish.
+            self.current_task_canceled_receiver.lock().recv().expect(
+                // recv shouldn't return error.
+                &concat!(file!(), ":", line!(), ":", column!()),
+            );
+        } else {
+            // Search in pending queue.
+            self.task_sender
+                .lock()
+                .cancel(task_epoch_id, &current_task_locked);
+        }
+    }
+
+    fn wait_for_previous_task(
+        finish_signal_receivers: &mut [mpsc::Receiver<()>],
+    ) {
+        for receiver in finish_signal_receivers {
+            receiver.recv().expect(
+                // recv shouldn't return error.
+                &concat!(file!(), ":", line!(), ":", column!()),
+            );
+        }
+    }
+
+    fn run(
+        &self, mut finish_signal_receivers: Vec<mpsc::Receiver<()>>,
+        task_canceled_sender: mpsc::Sender<()>,
+        task_receiver: CancelableTaskReceiver<PrefetchTaskKey>,
+    )
+    {
+        let mut current_task_id = 0u64;
+        loop {
+            let mut current_task_epoch_id = self.current_task_id.lock();
+
+            match task_receiver.recv(&mut current_task_epoch_id) {
+                Ok((task_epoch_id, state, accounts)) => {
+                    if current_task_id == std::u64::MAX {
+                        current_task_id = 1;
+                    } else {
+                        current_task_id += 1;
+                    }
+                    *current_task_epoch_id =
+                        Some((task_epoch_id, current_task_id));
+                    drop(current_task_epoch_id);
+
+                    // Dispatch tasks to threads.
+                    let num_accounts = accounts.len();
+                    let num_threads = self.workers.len();
+                    for thread_idx in 0..num_threads {
+                        let range_start =
+                            num_accounts * thread_idx / num_threads;
+                        let range_end =
+                            num_accounts * (thread_idx + 1) / num_threads;
+
+                        self.workers[thread_idx].send_new_task(
+                            current_task_id,
+                            state,
+                            &accounts[range_start..range_end],
+                        );
+                    }
+
+                    Self::wait_for_previous_task(&mut finish_signal_receivers);
+                    let mut current_task_id_locked =
+                        self.current_task_id.lock();
+                    // The current task has been canceled while it was being
+                    // processed.
+                    if current_task_id_locked.is_none() {
+                        task_canceled_sender.send(()).expect(
+                            // recv shouldn't return error.
+                            &concat!(file!(), ":", line!(), ":", column!()),
+                        );
+                    } else {
+                        // Clear the current task id so that it can not be
+                        // canceled any more.
+                        *current_task_id_locked = None;
+                    }
+                }
+                Err(StopOr::Stop) => {
+                    // Stop
+                    return;
+                }
+                Err(_) => {
+                    // Exception
+                    break;
+                }
+            }
+        }
+        error!("State prefetcher thread Stopped due to exception.");
+    }
+}
+
+impl Drop for ExecutionStatePrefetcher {
+    fn drop(&mut self) {
+        // Signal the prefetch thread to exit.
+        self.stop();
+
+        // Let workers Stop after current task.
+        for worker in &self.workers {
+            unsafe {
+                worker.stop();
+            }
+        }
+        // Cancel the current task
+        let current_task = self.current_task_id.lock().clone();
+        if let Some(task) = &current_task {
+            self.cancel_task(&task.0, /* cancel = */ true);
+        }
+
+        for join_handle in self.worker_join_handles.split_off(0) {
+            join_handle.join().ok();
+        }
+
+        let self_join_handle = self.join_handle.lock().take().unwrap();
+        self_join_handle.join().ok();
+    }
+}
+
+pub struct PrefetchTaskHandle<'a> {
+    pub prefetcher: Option<&'a ExecutionStatePrefetcher>,
+    pub state: &'a State,
+    pub task_epoch_id: EpochId,
+    pub accounts: Vec<&'a Address>,
+}
+
+impl PrefetchTaskHandle<'_> {
+    pub fn wait_for_task(&self) {
+        match self.prefetcher.as_ref() {
+            None => {}
+            Some(prefetcher) => prefetcher.wait_for_task(&self.task_epoch_id),
+        }
+    }
+}
+
+impl Drop for PrefetchTaskHandle<'_> {
+    fn drop(&mut self) {
+        match self.prefetcher.take() {
+            None => {}
+            Some(prefetcher) => prefetcher
+                .cancel_task(&self.task_epoch_id, /* cancel = */ true),
+        }
+        // To mute the compiler complain about accounts isn't used.
+        self.accounts.clear();
+    }
+}
+
+pub trait CancelByKey {
+    type Key: PartialEq;
+
+    fn key(&self) -> &Self::Key;
+
+    #[inline]
+    fn match_key(&self, key: &Self::Key) -> bool {
+        Self::key_matches(self.key(), key)
+    }
+
+    #[inline]
+    fn key_matches(this: &Self::Key, other: &Self::Key) -> bool {
+        this.eq(other)
+    }
+}
+
+type PrefetchTaskKey = (EpochId, &'static State, &'static [&'static Address]);
+
+impl CancelByKey for PrefetchTaskKey {
+    type Key = EpochId;
+
+    #[inline]
+    fn key(&self) -> &Self::Key { &self.0 }
+}
+
+#[derive(Clone)]
+pub struct CancelableTaskSender<T: CancelByKey> {
+    sender: mpsc::Sender<bool>,
+    queue: Arc<Mutex<VecDeque<Option<T>>>>,
+}
+
+pub struct CancelableTaskReceiver<T> {
+    queue: Arc<Mutex<VecDeque<Option<T>>>>,
+    receiver: mpsc::Receiver<bool>,
+    should_pop_recv: AtomicBool,
+}
+
+impl<T: CancelByKey> CancelableTaskSender<T> {
+    pub fn stop(&self) -> Result<(), SendError<bool>> {
+        self.sender.send(false)
+    }
+
+    pub fn send(&self, task: T) -> Result<(), SendError<bool>> {
+        self.queue.lock().push_back(Some(task));
+        self.sender.send(true)
+    }
+
+    pub fn cancel<'a, O>(
+        &self, key: &T::Key, _current_task_guard: &MutexGuard<'a, O>,
+    ) {
+        let queue = &mut *self.queue.lock();
+        for maybe_task in queue.iter_mut() {
+            if maybe_task
+                .as_ref()
+                .map_or(false, |task| task.match_key(key))
+            {
+                *maybe_task = None
+            }
+        }
+    }
+}
+
+pub fn new_cancelable_task_channel<T: CancelByKey>(
+) -> (CancelableTaskSender<T>, CancelableTaskReceiver<T>) {
+    let (sender, receiver) = mpsc::channel();
+    let queue: Arc<Mutex<VecDeque<Option<T>>>> = Default::default();
+    (
+        CancelableTaskSender {
+            sender,
+            queue: queue.clone(),
+        },
+        CancelableTaskReceiver {
+            queue,
+            receiver,
+            should_pop_recv: AtomicBool::new(true),
+        },
+    )
+}
+
+pub enum StopOr<RecvError> {
+    Stop,
+    RecvError(RecvError),
+}
+
+impl<T> CancelableTaskReceiver<T> {
+    fn pop_recv(&self) {
+        if self.should_pop_recv.load(Ordering::Relaxed) {
+            // Pop the task from task receiver as well.
+            self.receiver.recv().ok();
+        } else {
+            self.should_pop_recv.store(true, Ordering::Relaxed);
+        }
+    }
+
+    pub fn recv<'a, O>(
+        &self, current_task_guard: &mut MutexGuard<'a, O>,
+    ) -> Result<T, StopOr<RecvError>> {
+        loop {
+            let new_task = {
+                let queue = &mut self.queue.lock();
+                loop {
+                    match queue.pop_front() {
+                        Some(None) => {
+                            self.pop_recv();
+                            continue;
+                        }
+                        None => break None,
+                        Some(Some(task)) => break Some(task),
+                    }
+                }
+            };
+            // Wait for new task if task queue is empty.
+            match new_task {
+                None => {
+                    // Retry when we already received the new task from
+                    // task_receiver, but task_queue is still empty.
+                    if !self.should_pop_recv.load(Ordering::Relaxed) {
+                        continue;
+                    }
+                    // Should not block cancel_task when we are waiting for
+                    // new tasks.
+                    match MutexGuard::unlocked(current_task_guard, || {
+                        self.receiver.recv()
+                    }) {
+                        Ok(true) => {
+                            self.should_pop_recv
+                                .store(false, Ordering::Relaxed);
+                            continue;
+                        }
+                        Ok(false) => {
+                            // Received stop signal.
+                            return Err(StopOr::Stop);
+                        }
+                        Err(e) => return Err(StopOr::RecvError(e)),
+                    }
+                }
+                Some(task) => {
+                    self.pop_recv();
+                    return Ok(task);
+                }
+            }
+        }
+    }
+}
+
+use crate::state::State;
+use cfx_types::Address;
+use parking_lot::{Mutex, MutexGuard};
+use primitives::EpochId;
+use std::{
+    collections::VecDeque,
+    io,
+    ptr::null,
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        mpsc::{self, RecvError, SendError},
+        Arc,
+    },
+    thread::{self, JoinHandle},
+};

--- a/core/src/storage/impls/mod.rs
+++ b/core/src/storage/impls/mod.rs
@@ -27,6 +27,7 @@ pub mod defaults {
         DeltaMptsNodeMemoryManager::START_CAPACITY;
     pub const DEFAULT_DELTA_MPTS_SLAB_IDLE_SIZE: u32 =
         DeltaMptsNodeMemoryManager::MAX_DIRTY_AND_TEMPORARY_TRIE_NODES;
+    pub const DEFAULT_EXECUTION_PREFETCH_THREADS: usize = 4;
     /// Limit the number of open snapshots to set an upper limit on open files
     /// in Storage subsystem.
     pub const DEFAULT_MAX_OPEN_SNAPSHOTS: u16 = 10;


### PR DESCRIPTION
The prefetcher mainly helps when the access pattern is random read.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1365)
<!-- Reviewable:end -->
