### PR TITLE
Change storage-limit defaut in CLI to 0, fix CLI version

### DIFF
--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -1,4 +1,4 @@
-name: conflux
+name: Conflux 0.6.0
 about: Conflux client.
 author: The Conflux Team
 
@@ -166,7 +166,6 @@ args:
         long: tg_archive
     - full:
         long: full
-        hidden: true
 subcommands:
     - account:
         about: Manage accounts
@@ -559,7 +558,7 @@ subcommands:
                             - rpc-args:
                                 multiple: true
                                 use_delimiter: true
-                                default_value: tx:map(from;to;gasPrice;gas;value;data;nonce),password:password
+                                default_value: tx:map(from;to;gasPrice;gas;value;data;nonce;storageLimit),password:password
                                 hidden: true
                             - from:
                                 help: Transaction from address
@@ -600,6 +599,12 @@ subcommands:
                                 long: nonce
                                 takes_value: true
                                 value_name: HEX
+                            - storageLimit:
+                                help: Storage limit for the transaction
+                                long: storage-limit
+                                takes_value: true
+                                value_name: HEX
+                                default_value: "0x0"
                     - account:
                         about: Account related subcommands
                         setting: SubcommandRequiredElseHelp


### PR DESCRIPTION
Because standard usage for CLI is mostly send/receive. Put default to zero for now.

This closes #1362. This closes #1359

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1366)
<!-- Reviewable:end -->
