### PR TITLE
Demote peers for invalid status.

### DIFF
--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -543,7 +543,7 @@ impl SynchronizationProtocolHandler {
                 op = Some(UpdateNodeOperation::Demotion)
             }
             ErrorKind::InvalidStatus(_) => {
-                op = Some(UpdateNodeOperation::Failure)
+                op = Some(UpdateNodeOperation::Demotion)
             }
             ErrorKind::InvalidMessageFormat => {
                 // TODO: Shall we blacklist a node when the message format is


### PR DESCRIPTION
This may only happen if genesis hash or chain id does not match. In both
cases, we do not want to keep connecting this peer actively. We also should
not blacklist this peer because we just run different versions of
data now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1370)
<!-- Reviewable:end -->
