### PR TITLE
modify tx-repalcement rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ another testnet.
 experimental purposes.
 
 - Improve the transaction replacement rule in tx-pool: now a transaction can
- replace one with same sender and nonce by higher gas-price or by same gas-price
-  and larger epoch height.
+replace one with same sender and nonce by higher gas-price or by same gas-price
+and larger epoch height.
 
 
 # 0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ another testnet.
 - Keep network_id the same as chain_id. Setting network_id is only for local
 experimental purposes.
 
+- Improve the transaction replacement rule in tx-pool: now a transaction can
+ replace one with same sender and nonce by higher gas-price or by same gas-price
+  and larger epoch height.
+
 
 # 0.5.0
 

--- a/core/benchmark/storage/src/main.rs
+++ b/core/benchmark/storage/src/main.rs
@@ -1199,7 +1199,7 @@ impl<EthTxT: EthTxTypeTrait> EthTxExtractor<EthTxT> {
     fn verify_tx_then_stream_out(
         &self, tx_verify_request: EthTxNonceVerifierRequest<EthTxT>,
     ) {
-        let thread = (tx_verify_request.sender.low_u64_be() & 7) as usize;
+        let thread = (tx_verify_request.sender.low_u64() & 7) as usize;
 
         self.nonce_verifier.workers[thread]
             .lock()

--- a/core/benchmark/storage/src/main.rs
+++ b/core/benchmark/storage/src/main.rs
@@ -1199,7 +1199,7 @@ impl<EthTxT: EthTxTypeTrait> EthTxExtractor<EthTxT> {
     fn verify_tx_then_stream_out(
         &self, tx_verify_request: EthTxNonceVerifierRequest<EthTxT>,
     ) {
-        let thread = (tx_verify_request.sender.low_u64() & 7) as usize;
+        let thread = (tx_verify_request.sender.low_u64_be() & 7) as usize;
 
         self.nonce_verifier.workers[thread]
             .lock()

--- a/core/src/transaction_pool/nonce_pool.rs
+++ b/core/src/transaction_pool/nonce_pool.rs
@@ -120,7 +120,7 @@ impl NoncePoolNode {
                         tx.clone(),
                     ))
                 } else {
-                    InsertResult::Failed(format!("Tx with same nonce already inserted. To replace it, you need to specify a gas price >= {}", &node.as_ref().unwrap().tx.gas_price))
+                    InsertResult::Failed(format!("Tx with same nonce already inserted. To replace it, you need to specify a gas price > {}", &node.as_ref().unwrap().tx.gas_price))
                 }
             };
             node.as_mut().unwrap().update();
@@ -450,7 +450,7 @@ mod nonce_pool_test {
         }
         for i in 0..10 {
             tx2.push(new_test_tx_with_ready_info(
-                &me, i as usize, 9, 10000, false,
+                &me, i as usize, 10, 10000, false,
             ));
         }
         let mut nonce_pool = NoncePool::new();
@@ -465,7 +465,7 @@ mod nonce_pool_test {
                 Some(tx1[i].clone())
             );
             assert_eq!(nonce_pool.insert(&tx2[i as usize], false /* force */),
-                       InsertResult::Failed(format!("Tx with same nonce already inserted. To replace it, you need to specify a gas price >= {}", &tx1[i as usize].gas_price)));
+                       InsertResult::Failed(format!("Tx with same nonce already inserted. To replace it, you need to specify a gas price > {}", &tx1[i as usize].gas_price)));
             assert_eq!(
                 nonce_pool.insert(&tx2[i as usize], true /* force */),
                 InsertResult::Updated(tx1[i as usize].clone())

--- a/core/src/transaction_pool/nonce_pool.rs
+++ b/core/src/transaction_pool/nonce_pool.rs
@@ -28,7 +28,9 @@ impl TxWithReadyInfo {
         if self.is_already_packed() {
             return true;
         }
-        self.gas_price >= x.gas_price
+        self.gas_price > x.gas_price
+            || self.gas_price == x.gas_price
+                && self.epoch_height > x.epoch_height
     }
 }
 

--- a/core/src/transaction_pool/transaction_pool_inner.rs
+++ b/core/src/transaction_pool/transaction_pool_inner.rs
@@ -917,7 +917,7 @@ mod test_transaction_pool_inner {
 
         assert_eq!(
             deferred_pool.insert(bob_tx2.clone(), false /* force */),
-            InsertResult::Failed(format!("Tx with same nonce already inserted, try to replace it with a higher gas price"))
+            InsertResult::Failed(format!("Tx with same nonce already inserted. To replace it, you need to specify a gas price > {}", bob_tx2_new.gas_price))
         );
 
         assert_eq!(


### PR DESCRIPTION
In the old version of the transaction pool, the sender can replace his tx in the pool by a new one with strictly higher gas_price. This rule makes the user really hard to correct a wrong transaction sent before.

To make it easier, a simple way just replaces 
```this.gas_price > tx.gas_price``` 
by 
```this.gas_price > tx.gas_price || this.gas_price == tx.gas_price && this.epoch_height > tx.epoch_height``` 
in the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1378)
<!-- Reviewable:end -->
