### PR TITLE
Fix a key format conversion bug in delete_all

### DIFF
--- a/core/src/storage/impls/delta_mpt/cow_node_ref.rs
+++ b/core/src/storage/impls/delta_mpt/cow_node_ref.rs
@@ -154,7 +154,7 @@ impl CowNodeRef {
 impl Drop for CowNodeRef {
     /// Assert that the CowNodeRef doesn't own something.
     fn drop(&mut self) {
-        assert_eq!(false, self.owned);
+        debug_assert_eq!(false, self.owned);
     }
 }
 

--- a/core/src/storage/impls/delta_mpt/mem_optimized_trie_node.rs
+++ b/core/src/storage/impls/delta_mpt/mem_optimized_trie_node.rs
@@ -55,7 +55,7 @@ pub struct MemOptimizedTrieNode<CacheAlgoDataT: CacheAlgoDataTrait> {
     pub(super) children_table: ChildrenTableDeltaMpt,
     // Rust automatically moves the value_size field in order to minimize the
     // total size of the struct.
-    /// We limit the maximum value length by u16. If it proves insufficient,
+    /// We limit the maximum value length by u32. If it proves insufficient,
     /// manage the length and content separately.
     value_size: u32,
     value: MaybeInPlaceByteArray,

--- a/core/src/storage/impls/state.rs
+++ b/core/src/storage/impls/state.rs
@@ -486,7 +486,7 @@ impl StateTrait for State {
         // No need to check v.len() because there are no tombStone values in
         // snapshot.
         for (k, v) in snapshot_kvs {
-            let storage_key = StorageKey::from_delta_mpt_key(&k);
+            let storage_key = StorageKey::from_key_bytes(&k);
             self.delete(storage_key)?;
             if !deleted_keys.contains(&k) {
                 result.push((k, v));


### PR DESCRIPTION
The bug is caused by incorrect conversion of DeltaMptKey to SnapshotMptKey from SnapshotMptKey itself.

Other small fixes:
- Change assert into debug assert in CowNodeDef drop method to improve error reporting.
- A comment update in MemOptimizedTrieNode.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1385)
<!-- Reviewable:end -->
