### PR TITLE
Fix nodes wrongly exiting catch-up mode when there are no peers.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2055,7 +2055,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=95938bfb97fb01e496904c955280525abf23466c#95938bfb97fb01e496904c955280525abf23466c"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=6d96482ddb51c1779af615767fd1967da9d98377#6d96482ddb51c1779af615767fd1967da9d98377"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -2071,7 +2071,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=95938bfb97fb01e496904c955280525abf23466c#95938bfb97fb01e496904c955280525abf23466c"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=6d96482ddb51c1779af615767fd1967da9d98377#6d96482ddb51c1779af615767fd1967da9d98377"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -3293,7 +3293,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=95938bfb97fb01e496904c955280525abf23466c#95938bfb97fb01e496904c955280525abf23466c"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=6d96482ddb51c1779af615767fd1967da9d98377#6d96482ddb51c1779af615767fd1967da9d98377"
 dependencies = [
  "crc",
  "libc",

--- a/core/src/sync/synchronization_state.rs
+++ b/core/src/sync/synchronization_state.rs
@@ -176,7 +176,13 @@ impl SynchronizationState {
         let mut fresh_start = true;
         let mut peer_best_epoches = Vec::new();
         {
-            for (_, state_lock) in &*self.peers.read() {
+            let peers = self.peers.read();
+            if peers.is_empty() {
+                // We do not have peers, so just assume that this is not a fresh
+                // start and do not enter NormalPhase.
+                fresh_start = false;
+            }
+            for (_, state_lock) in &*peers {
                 let state = state_lock.read();
                 if state
                     .capabilities


### PR DESCRIPTION
This closes #1400.

We need to allow nodes to go back to catch-up mode to fully fix this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1401)
<!-- Reviewable:end -->
