### PR TITLE
Fix chunk request issues.

### DIFF
--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -154,7 +154,7 @@ build_config! {
         (heartbeat_timeout_ms, (u64), 180_000)
         (inflight_pending_tx_index_maintain_timeout_ms, (u64), 30_000)
         (max_allowed_timeout_in_observing_period, (u64), 10)
-        (max_download_state_peers, (usize), 8)
+        (max_downloading_chunks, (usize), 8)
         (max_handshakes, (usize), 64)
         (max_incoming_peers, (usize), 64)
         (max_inflight_request_count, (u64), 64)
@@ -535,7 +535,7 @@ impl Configuration {
             future_block_buffer_capacity: self
                 .raw_conf
                 .future_block_buffer_capacity,
-            max_download_state_peers: self.raw_conf.max_download_state_peers,
+            max_downloading_chunks: self.raw_conf.max_downloading_chunks,
             test_mode: self.is_test_mode(),
             dev_mode: self.is_dev_mode(),
             throttling_config_file: self.raw_conf.throttling_conf.clone(),
@@ -571,7 +571,7 @@ impl Configuration {
 
     pub fn state_sync_config(&self) -> StateSyncConfiguration {
         StateSyncConfiguration {
-            max_download_peers: self.raw_conf.max_download_state_peers,
+            max_downloading_chunks: self.raw_conf.max_downloading_chunks,
             candidate_request_timeout: Duration::from_millis(
                 self.raw_conf.snapshot_candidate_request_timeout_ms,
             ),

--- a/core/src/light_protocol/error.rs
+++ b/core/src/light_protocol/error.rs
@@ -150,7 +150,7 @@ error_chain! {
 
 pub fn handle(io: &dyn NetworkContext, peer: &NodeId, msg_id: MsgId, e: Error) {
     warn!(
-        "Error while handling message, peer={}, msg_id={:?}, error={:?}",
+        "Error while handling message, peer={}, msg_id={:?}, error={}",
         peer, msg_id, e
     );
 

--- a/core/src/parameters.rs
+++ b/core/src/parameters.rs
@@ -131,7 +131,7 @@ pub mod sync {
             Duration::from_millis(50);
     }
     //const REQUEST_WAITING_TIME_BACKOFF: u32 = 2;
-    pub const DEFAULT_CHUNK_SIZE: u64 = 1 * 1024 * 1024;
+    pub const DEFAULT_CHUNK_SIZE: u64 = 256 * 1024;
 
     /// The batch size of old-era blocks garbage-collected from database for
     /// each BLOCK_CACHE_GC_TIMER timer trigger.

--- a/core/src/sync/state/snapshot_chunk_response.rs
+++ b/core/src/sync/state/snapshot_chunk_response.rs
@@ -33,8 +33,14 @@ impl Handleable for SnapshotChunkResponse {
             &ctx.manager.request_manager,
         )?;
 
+        debug!(
+            "handle_snapshot_chunk_response key={:?} chunk_len={}",
+            request.chunk_key,
+            self.chunk.keys.len()
+        );
+
         if let Err(e) = self.chunk.validate(&request.chunk_key) {
-            debug!("failed to validate the snapshot chunk, error = {:?}", e);
+            debug!("failed to validate the snapshot chunk, error = {}", e);
             // TODO: is the "other" peer guaranteed to have the chunk?
             // How did we pass the peer list?
             ctx.manager

--- a/core/src/sync/state/snapshot_chunk_sync.rs
+++ b/core/src/sync/state/snapshot_chunk_sync.rs
@@ -430,15 +430,7 @@ impl SnapshotChunkSync {
         inner.bloom_blame_vec = response.bloom_blame_vec;
 
         // request snapshot chunks from peers concurrently
-        let chosen_peers = PeerFilter::new(msgid::GET_SNAPSHOT_CHUNK)
-            .choose_from(inner.sync_candidate_manager.active_peers())
-            .select_n(self.config.max_download_peers, &ctx.manager.syn);
-
-        for peer in chosen_peers {
-            if self.request_chunk(ctx, &mut inner, &peer).is_none() {
-                break;
-            }
-        }
+        self.request_chunks(ctx, inner);
 
         debug!("sync state progress: {:?}", *inner);
         Ok(())
@@ -448,7 +440,27 @@ impl SnapshotChunkSync {
         inner.request_manifest(ctx.io, ctx.manager);
     }
 
-    fn request_chunk(
+    /// Request multiple chunks from random peers.
+    fn request_chunks(&self, ctx: &Context, inner: &mut Inner) {
+        if inner.downloading_chunks.len() > self.config.max_download_peers {
+            // This should not happen.
+            error!("downloading_chunks > max_download_peers");
+            return;
+        }
+        let chosen_peers = PeerFilter::new(msgid::GET_SNAPSHOT_CHUNK)
+            .choose_from(inner.sync_candidate_manager.active_peers())
+            .select_n(
+                self.config.max_download_peers - inner.downloading_chunks.len(),
+                &ctx.manager.syn,
+            );
+        for peer in chosen_peers {
+            if self.request_chunk_from_peer(ctx, inner, &peer).is_none() {
+                break;
+            }
+        }
+    }
+
+    fn request_chunk_from_peer(
         &self, ctx: &Context, inner: &mut Inner, peer: &NodeId,
     ) -> Option<ChunkKey> {
         let chunk_key = inner.pending_chunks.pop_front()?;
@@ -482,12 +494,6 @@ impl SnapshotChunkSync {
         &self, ctx: &Context, chunk_key: ChunkKey, chunk: Chunk,
     ) -> StorageResult<()> {
         let mut inner = self.inner.write();
-        debug!(
-            "handle_snapshot_chunk_response key={:?} chunk_len={}",
-            chunk_key,
-            chunk.keys.len()
-        );
-
         // status mismatch
         let download_start_time = match inner.status {
             Status::DownloadingChunks(t) => {
@@ -503,13 +509,16 @@ impl SnapshotChunkSync {
             }
         };
 
-        // maybe received a out-of-date snapshot chunk, e.g. new era started
+        // There are two possible reasons:
+        // 1. received a out-of-date snapshot chunk, e.g. new era started.
+        // 2. Duplicated chunks received, and it has been processed.
         if inner.downloading_chunks.remove(&chunk_key).is_none() {
             info!("Snapshot chunk received, but not in downloading queue");
             // FIXME Handle out-of-date chunks
             inner
                 .sync_candidate_manager
                 .note_state_sync_failure(&ctx.node_id);
+            self.request_chunks(ctx, &mut inner);
             return Ok(());
         }
 
@@ -517,7 +526,7 @@ impl SnapshotChunkSync {
         inner.restorer.append(chunk_key, chunk);
 
         // continue to request remaining chunks
-        self.request_chunk(ctx, &mut inner, &ctx.node_id);
+        self.request_chunks(ctx, &mut inner);
 
         // begin to restore if all chunks downloaded
         if inner.downloading_chunks.is_empty() {
@@ -900,8 +909,17 @@ impl SnapshotChunkSync {
     )
     {
         let mut inner = self.inner.write();
-        self.check_timeout(&mut *inner);
+        self.check_timeout(
+            &mut *inner,
+            &Context {
+                // node_id is not used here
+                node_id: Default::default(),
+                io,
+                manager: sync_handler,
+            },
+        );
         if inner.sync_candidate_manager.is_inactive() {
+            warn!("current sync candidate becomes inactive: {:?}", inner);
             inner.status = Status::Inactive;
             inner.current_sync_candidate = Default::default();
             inner.trusted_blame_block = Default::default();
@@ -972,7 +990,7 @@ impl SnapshotChunkSync {
         }
     }
 
-    fn check_timeout(&self, inner: &mut Inner) {
+    fn check_timeout(&self, inner: &mut Inner, ctx: &Context) {
         inner
             .sync_candidate_manager
             .check_timeout(&self.config.candidate_request_timeout);
@@ -998,6 +1016,7 @@ impl SnapshotChunkSync {
             inner.downloading_chunks.remove(&timeout_key);
             inner.pending_chunks.push_back(timeout_key);
         }
+        self.request_chunks(ctx, inner);
     }
 }
 

--- a/core/src/sync/state/snapshot_chunk_sync.rs
+++ b/core/src/sync/state/snapshot_chunk_sync.rs
@@ -442,15 +442,16 @@ impl SnapshotChunkSync {
 
     /// Request multiple chunks from random peers.
     fn request_chunks(&self, ctx: &Context, inner: &mut Inner) {
-        if inner.downloading_chunks.len() > self.config.max_download_peers {
+        if inner.downloading_chunks.len() > self.config.max_downloading_chunks {
             // This should not happen.
-            error!("downloading_chunks > max_download_peers");
+            error!("downloading_chunks > max_downloading_chunks");
             return;
         }
         let chosen_peers = PeerFilter::new(msgid::GET_SNAPSHOT_CHUNK)
             .choose_from(inner.sync_candidate_manager.active_peers())
             .select_n(
-                self.config.max_download_peers - inner.downloading_chunks.len(),
+                self.config.max_downloading_chunks
+                    - inner.downloading_chunks.len(),
                 &ctx.manager.syn,
             );
         for peer in chosen_peers {
@@ -1021,7 +1022,7 @@ impl SnapshotChunkSync {
 }
 
 pub struct StateSyncConfiguration {
-    pub max_download_peers: usize,
+    pub max_downloading_chunks: usize,
     pub candidate_request_timeout: Duration,
     pub chunk_request_timeout: Duration,
     pub manifest_request_timeout: Duration,

--- a/core/src/sync/state/storage.rs
+++ b/core/src/sync/state/storage.rs
@@ -182,7 +182,7 @@ impl RangedManifest {
             // chunks in manifest should not be empty
             if self.chunk_boundaries.is_empty() {
                 return Err(ErrorKind::InvalidSnapshotManifest(
-                    "empty chunks".into(),
+                    "empty snapshot manifest".into(),
                 )
                 .into());
             }
@@ -348,6 +348,10 @@ impl Chunk {
     pub fn validate(&self, key: &ChunkKey) -> Result<(), Error> {
         // chunk should not be empty
         if self.keys.is_empty() {
+            // TODO: Now this may happen if the requested peer has opened
+            // maximal number of snapshots and cannot give a
+            // response temporarily, we should differentiate this
+            // from dishonest behaviors.
             return Err(
                 ErrorKind::InvalidSnapshotChunk("empty chunk".into()).into()
             );
@@ -390,9 +394,8 @@ impl Chunk {
         )? {
             Some(db) => db,
             None => {
-                debug!(
-                    "failed to load chunk, cannot find snapshot by checkpoint"
-                );
+                debug!("failed to load chunk, cannot find snapshot by checkpoint {:?}",
+                       snapshot_epoch_id);
                 return Ok(None);
             }
         };

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -527,7 +527,7 @@ impl SynchronizationProtocolHandler {
         &self, io: &dyn NetworkContext, peer: &NodeId, msg_id: MsgId, e: Error,
     ) {
         warn!(
-            "Error while handling message, peer={}, msgid={:?}, error={:?}",
+            "Error while handling message, peer={}, msgid={:?}, error={}",
             peer, msg_id, e
         );
 

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -363,7 +363,7 @@ pub struct ProtocolConfiguration {
     pub min_peers_tx_propagation: usize,
     pub max_peers_tx_propagation: usize,
     pub future_block_buffer_capacity: usize,
-    pub max_download_state_peers: usize,
+    pub max_downloading_chunks: usize,
     pub test_mode: bool,
     pub dev_mode: bool,
     pub throttling_config_file: Option<String>,

--- a/run/default.toml
+++ b/run/default.toml
@@ -330,7 +330,7 @@ jsonrpc_local_http_port=12539
 #
 # tx_cache_index_maintain_timeout_ms = 300_000
 
-# Maximum number of transactions allowed in the ransaction pool.
+# Maximum number of transactions allowed in the transaction pool.
 #
 # tx_pool_size = 500_000
 


### PR DESCRIPTION
The problem is that we start with `max_downloading_peers`, but if a response is invalid for some reason, we will not request the next one, so eventually we may stop requesting chunks although they are not all received.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1404)
<!-- Reviewable:end -->
