### PR TITLE
Fix multiple sessions from the same node id.

### DIFF
--- a/network/src/service.rs
+++ b/network/src/service.rs
@@ -1049,7 +1049,11 @@ impl NetworkServiceInner {
                 let data = sess.readable(io, self);
                 match data {
                     Ok(session_data) => {
-                        token_to_disconnect = session_data.token_to_disconnect;
+                        if session_data.token_to_disconnect.is_some() {
+                            debug!("session_readable: set token_to_disconnect to {:?}", token_to_disconnect);
+                            token_to_disconnect =
+                                session_data.token_to_disconnect;
+                        }
                         match session_data.session_data {
                             SessionData::Ready => {
                                 handshake_done = true;

--- a/network/src/service.rs
+++ b/network/src/service.rs
@@ -1050,7 +1050,7 @@ impl NetworkServiceInner {
                 match data {
                     Ok(session_data) => {
                         if session_data.token_to_disconnect.is_some() {
-                            debug!("session_readable: set token_to_disconnect to {:?}", token_to_disconnect);
+                            debug!("session_readable: set token_to_disconnect to {:?}", session_data.token_to_disconnect);
                             token_to_disconnect =
                                 session_data.token_to_disconnect;
                         }


### PR DESCRIPTION
The buggy log is like this:

> 2020-05-05T19:27:23.203765923+08:00 DEBUG network_eventloop    network::ses - SessionManager.update_ingress_node_id: enter
> 2020-05-05T19:27:23.204542935+08:00 DEBUG network_eventloop    network::ses - SessionManager.update_ingress_node_id: leave on node_id already exists
> 2020-05-05T19:27:23.204565663+08:00 DEBUG network_eventloop    network::ses - SessionManager.update_ingress_node_id: leave
> 2020-05-05T19:27:23.204615349+08:00 DEBUG network_eventloop    network::ses - Received valid endpoint NodeEntry ...
> 2020-05-05T19:27:23.204668252+08:00 DEBUG network_eventloop    network::nod - NodeTable Some("./net_config/trusted_nodes.json") add_node Node ...
> 2020-05-05T19:27:23.204812569+08:00 DEBUG network_eventloop    network::ser - session handshaked, token = 68
> 2020-05-05T19:27:23.204828043+08:00 INFO  network_eventloop    cfxcore::lig - on_peer_connected: peer=...
> 2020-05-05T19:27:23.204843224+08:00 DEBUG network_eventloop    network::ser - session handshaked, token = 68
> 2020-05-05T19:27:23.204856608+08:00 INFO  network_eventloop    cfxcore::syn - Peer connected: peer=...

Since "node_id already exists" is logged, the old session should be killed by `kill_connection_by_token`. `token_to_disconnect` is overwritten by `None` may be the reason why the old session still exists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1405)
<!-- Reviewable:end -->
