### PR TITLE
Use Path instead of string for storage directories.

### DIFF
--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -18,8 +18,8 @@ use cfxcore::{
     consensus_internal_parameters::*,
     consensus_parameters::*,
     storage::{
-        self, defaults::DEFAULT_DEBUG_SNAPSHOT_CHECKER_THREADS, ConsensusParam,
-        StorageConfiguration,
+        self, defaults::DEFAULT_DEBUG_SNAPSHOT_CHECKER_THREADS, storage_dir,
+        ConsensusParam, StorageConfiguration,
     },
     sync::{ProtocolConfiguration, StateSyncConfiguration, SyncGraphConfig},
     sync_parameters::*,
@@ -452,6 +452,7 @@ impl Configuration {
     }
 
     pub fn storage_config(&self) -> StorageConfiguration {
+        let conflux_data_path = Path::new(&self.raw_conf.conflux_data_dir);
         StorageConfiguration {
             consensus_param: ConsensusParam {
                 snapshot_epoch_count: if self.is_test_mode() {
@@ -476,14 +477,14 @@ impl Configuration {
                 .raw_conf
                 .storage_delta_mpts_slab_idle_size,
             max_open_snapshots: self.raw_conf.storage_max_open_snapshots,
-            path_delta_mpts_dir: self.raw_conf.conflux_data_dir.clone()
-                + StorageConfiguration::DELTA_MPTS_DIR,
-            path_snapshot_dir: self.raw_conf.conflux_data_dir.clone()
-                + StorageConfiguration::SNAPSHOT_DIR,
-            path_snapshot_info_db: self.raw_conf.conflux_data_dir.clone()
-                + StorageConfiguration::SNAPSHOT_INFO_DB_PATH,
-            path_storage_dir: self.raw_conf.conflux_data_dir.clone()
-                + StorageConfiguration::STORAGE_DIR,
+            path_delta_mpts_dir: conflux_data_path
+                .join(&*storage_dir::DELTA_MPTS_DIR),
+            path_snapshot_dir: conflux_data_path
+                .join(&*storage_dir::SNAPSHOT_DIR),
+            path_snapshot_info_db: conflux_data_path
+                .join(&*storage_dir::SNAPSHOT_INFO_DB_PATH),
+            path_storage_dir: conflux_data_path
+                .join(&*storage_dir::STORAGE_DIR),
         }
     }
 

--- a/core/src/storage/impls/storage_manager/storage_manager.rs
+++ b/core/src/storage/impls/storage_manager/storage_manager.rs
@@ -95,7 +95,7 @@ impl StorageManager {
         storage_conf: StorageConfiguration,
     ) -> Result<Arc<Self>>
     {
-        let storage_dir = Path::new(storage_conf.path_storage_dir.as_str());
+        let storage_dir = storage_conf.path_storage_dir.as_path();
         println!(
             "new StorageManager within storage_dir {}",
             storage_dir.display()
@@ -105,7 +105,7 @@ impl StorageManager {
         }
 
         let (_, snapshot_info_db) = KvdbSqlite::open_or_create(
-            storage_conf.path_snapshot_info_db.clone(),
+            &storage_conf.path_snapshot_info_db,
             SNAPSHOT_KVDB_STATEMENTS.clone(),
         )?;
 
@@ -1227,7 +1227,7 @@ lazy_static! {
         KvdbSqliteStatements::make_statements(
             &["value"],
             &["BLOB"],
-            StorageConfiguration::SNAPSHOT_INFO_DB_NAME,
+            &storage_dir::SNAPSHOT_INFO_DB_NAME,
             false
         )
         .unwrap()
@@ -1272,6 +1272,7 @@ use crate::{
         storage_db::{
             key_value_db::KeyValueDbIterableTrait, SnapshotMptTraitRead,
         },
+        storage_dir,
         utils::guarded_value::GuardedValue,
         KeyValueDbTrait, KvdbSqlite, StorageConfiguration,
     },
@@ -1285,7 +1286,6 @@ use std::{
     cell::Cell,
     collections::{HashMap, HashSet},
     fs,
-    path::Path,
     sync::{
         mpsc::{channel, Sender},
         Arc, Weak,

--- a/core/src/storage/mod.rs
+++ b/core/src/storage/mod.rs
@@ -18,6 +18,22 @@ pub mod tests;
 
 mod impls;
 
+pub mod storage_dir {
+    use std::path::PathBuf;
+    lazy_static! {
+        pub static ref DELTA_MPTS_DIR: PathBuf =
+            ["storage_db", "delta_mpts"].iter().collect::<PathBuf>();
+        pub static ref SNAPSHOT_DIR: PathBuf =
+            ["storage_db", "snapshot"].iter().collect::<PathBuf>();
+        pub static ref SNAPSHOT_INFO_DB_NAME: &'static str = "snapshot_info";
+        pub static ref SNAPSHOT_INFO_DB_PATH: PathBuf =
+            ["storage_db", "snapshot_info_db"]
+                .iter()
+                .collect::<PathBuf>();
+        pub static ref STORAGE_DIR: PathBuf = "storage_db".into();
+    }
+}
+
 /// Consensus parameter is only configurable in test mode.
 #[derive(Debug, Clone)]
 pub struct ConsensusParam {
@@ -39,23 +55,15 @@ pub struct StorageConfiguration {
     pub delta_mpts_node_map_vec_size: u32,
     pub delta_mpts_slab_idle_size: u32,
     pub max_open_snapshots: u16,
-    pub path_delta_mpts_dir: String,
-    pub path_storage_dir: String,
-    pub path_snapshot_dir: String,
-    pub path_snapshot_info_db: String,
-}
-
-impl StorageConfiguration {
-    pub const DELTA_MPTS_DIR: &'static str = "storage_db/delta_mpts/";
-    pub const SNAPSHOT_DIR: &'static str = "storage_db/snapshot/";
-    pub const SNAPSHOT_INFO_DB_NAME: &'static str = "snapshot_info";
-    pub const SNAPSHOT_INFO_DB_PATH: &'static str =
-        "storage_db/snapshot_info_db";
-    pub const STORAGE_DIR: &'static str = "storage_db/";
+    pub path_delta_mpts_dir: PathBuf,
+    pub path_storage_dir: PathBuf,
+    pub path_snapshot_dir: PathBuf,
+    pub path_snapshot_info_db: PathBuf,
 }
 
 impl StorageConfiguration {
     pub fn new_default(conflux_data_dir: String) -> Self {
+        let conflux_data_path = Path::new(&conflux_data_dir);
         StorageConfiguration {
             consensus_param: ConsensusParam {
                 snapshot_epoch_count: SNAPSHOT_EPOCHS_CAPACITY,
@@ -72,14 +80,14 @@ impl StorageConfiguration {
             delta_mpts_slab_idle_size:
                 defaults::DEFAULT_DELTA_MPTS_SLAB_IDLE_SIZE,
             max_open_snapshots: defaults::DEFAULT_MAX_OPEN_SNAPSHOTS,
-            path_delta_mpts_dir: conflux_data_dir.clone()
-                + StorageConfiguration::DELTA_MPTS_DIR,
-            path_snapshot_dir: conflux_data_dir.clone()
-                + StorageConfiguration::SNAPSHOT_DIR,
-            path_snapshot_info_db: conflux_data_dir.clone()
-                + StorageConfiguration::SNAPSHOT_INFO_DB_PATH,
-            path_storage_dir: conflux_data_dir.clone()
-                + StorageConfiguration::STORAGE_DIR,
+            path_delta_mpts_dir: conflux_data_path
+                .join(&*storage_dir::DELTA_MPTS_DIR),
+            path_snapshot_dir: conflux_data_path
+                .join(&*storage_dir::SNAPSHOT_DIR),
+            path_snapshot_info_db: conflux_data_path
+                .join(&*storage_dir::SNAPSHOT_INFO_DB_PATH),
+            path_storage_dir: conflux_data_path
+                .join(&*storage_dir::STORAGE_DIR),
         }
     }
 }
@@ -111,3 +119,4 @@ pub use self::{
 #[cfg(test)]
 pub use self::tests::new_state_manager_for_unit_test as new_storage_manager_for_testing;
 use crate::parameters::consensus::SNAPSHOT_EPOCHS_CAPACITY;
+use std::path::{Path, PathBuf};

--- a/core/src/storage/storage_db/delta_db_manager.rs
+++ b/core/src/storage/storage_db/delta_db_manager.rs
@@ -21,9 +21,9 @@ pub trait DeltaDbTrait:
 pub trait DeltaDbManagerTrait {
     type DeltaDb: DeltaDbTrait;
 
-    fn get_delta_db_dir(&self) -> String;
+    fn get_delta_db_dir(&self) -> &Path;
     fn get_delta_db_name(&self, snapshot_epoch_id: &EpochId) -> String;
-    fn get_delta_db_path(&self, delta_db_name: &str) -> String;
+    fn get_delta_db_path(&self, delta_db_name: &str) -> PathBuf;
 
     // Scan delta db dir, remove extra files and return the list of missing
     // snapshots for which the delta db is missing.
@@ -107,4 +107,8 @@ use crate::storage::{
     storage_db::{key_value_db::*, SnapshotInfo},
 };
 use primitives::EpochId;
-use std::{collections::HashMap, fs};
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+};

--- a/core/src/storage/storage_db/snapshot_db.rs
+++ b/core/src/storage/storage_db/snapshot_db.rs
@@ -82,7 +82,7 @@ pub trait SnapshotDbTrait:
     /// SnapshotDbManager on destructor. SnapshotDb itself does not take
     /// care of the update on these data.
     fn open(
-        snapshot_path: &str, readonly: bool,
+        snapshot_path: &Path, readonly: bool,
         already_open_snapshots: &AlreadyOpenSnapshots<Self>,
         open_semaphore: &Arc<Semaphore>,
     ) -> Result<Self>;
@@ -91,7 +91,7 @@ pub trait SnapshotDbTrait:
     /// SnapshotDbManager on destructor. SnapshotDb itself does not take
     /// care of the update on these data.
     fn create(
-        snapshot_path: &str,
+        snapshot_path: &Path,
         already_open_snapshots: &AlreadyOpenSnapshots<Self>,
         open_semaphore: &Arc<Semaphore>,
     ) -> Result<Self>;
@@ -139,5 +139,5 @@ use crate::storage::{
 use derivative::Derivative;
 use primitives::{EpochId, MerkleHash, MERKLE_NULL_NODE, NULL_EPOCH};
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 use tokio::sync::Semaphore;

--- a/core/src/storage/storage_db/snapshot_db_manager.rs
+++ b/core/src/storage/storage_db/snapshot_db_manager.rs
@@ -6,9 +6,9 @@
 pub trait SnapshotDbManagerTrait {
     type SnapshotDb: SnapshotDbTrait<ValueType = Box<[u8]>>;
 
-    fn get_snapshot_dir(&self) -> String;
+    fn get_snapshot_dir(&self) -> &Path;
     fn get_snapshot_db_name(&self, snapshot_epoch_id: &EpochId) -> String;
-    fn get_snapshot_db_path(&self, snapshot_epoch_id: &EpochId) -> String;
+    fn get_snapshot_db_path(&self, snapshot_epoch_id: &EpochId) -> PathBuf;
 
     // Scan snapshot dir, remove extra files and return the list of missing
     // snapshots.
@@ -78,4 +78,9 @@ use super::{
     snapshot_db::*,
 };
 use primitives::{EpochId, MerkleHash};
-use std::{collections::HashMap, fs, sync::Arc};
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+    sync::Arc,
+};

--- a/core/src/storage/tests/mod.rs
+++ b/core/src/storage/tests/mod.rs
@@ -231,7 +231,7 @@ pub fn print_mpt_key(key: &[u8]) {
 
 #[cfg(test)]
 use crate::storage::{
-    defaults, impls::state_manager::StateManager, ConsensusParam,
+    defaults, impls::state_manager::StateManager, storage_dir, ConsensusParam,
     StorageConfiguration,
 };
 use crate::storage::{

--- a/core/src/storage/tests/mod.rs
+++ b/core/src/storage/tests/mod.rs
@@ -74,6 +74,7 @@ impl FakeStateManager {
         if unit_test_data_dir == "" {
             Err(ErrorKind::FailedToCreateUnitTestDataDir.into())
         } else {
+            let unit_test_data_path = Path::new(&unit_test_data_dir);
             Ok(FakeStateManager {
                 data_dir: unit_test_data_dir.clone(),
                 state_manager: Some(StateManager::new(StorageConfiguration {
@@ -87,14 +88,14 @@ impl FakeStateManager {
                     delta_mpts_node_map_vec_size: 20_000_000,
                     delta_mpts_slab_idle_size: 200_000,
                     max_open_snapshots: defaults::DEFAULT_MAX_OPEN_SNAPSHOTS,
-                    path_delta_mpts_dir: unit_test_data_dir.clone()
-                        + StorageConfiguration::DELTA_MPTS_DIR,
-                    path_snapshot_dir: unit_test_data_dir.clone()
-                        + StorageConfiguration::SNAPSHOT_DIR,
-                    path_snapshot_info_db: unit_test_data_dir.clone()
-                        + StorageConfiguration::SNAPSHOT_INFO_DB_PATH,
-                    path_storage_dir: unit_test_data_dir.clone()
-                        + StorageConfiguration::STORAGE_DIR,
+                    path_delta_mpts_dir: unit_test_data_path
+                        .join(&*storage_dir::DELTA_MPTS_DIR),
+                    path_snapshot_dir: unit_test_data_path
+                        .join(&*storage_dir::SNAPSHOT_DIR),
+                    path_snapshot_info_db: unit_test_data_path
+                        .join(&*storage_dir::SNAPSHOT_INFO_DB_PATH),
+                    path_storage_dir: unit_test_data_path
+                        .join(&*storage_dir::STORAGE_DIR),
                 })?),
             })
         }

--- a/core/src/storage/tests/snapshot/verifier.rs
+++ b/core/src/storage/tests/snapshot/verifier.rs
@@ -317,7 +317,7 @@ impl SnapshotDbTrait for Arc<Mutex<FakeSnapshotDb>> {
     fn get_null_snapshot() -> Self { unreachable!() }
 
     fn open(
-        _snapshot_path: &str, _readonly: bool,
+        _snapshot_path: &Path, _readonly: bool,
         _already_open_snapshots: &AlreadyOpenSnapshots<Self>,
         _open_semaphore: &Arc<Semaphore>,
     ) -> Result<Self>
@@ -326,7 +326,7 @@ impl SnapshotDbTrait for Arc<Mutex<FakeSnapshotDb>> {
     }
 
     fn create(
-        _snapshot_path: &str,
+        _snapshot_path: &Path,
         _already_open_snapshots: &AlreadyOpenSnapshots<Self>,
         _open_semaphore: &Arc<Semaphore>,
     ) -> Result<Self>
@@ -351,13 +351,13 @@ struct FakeSnapshotDbManager {
 impl SnapshotDbManagerTrait for FakeSnapshotDbManager {
     type SnapshotDb = Arc<Mutex<FakeSnapshotDb>>;
 
-    fn get_snapshot_dir(&self) -> String { unreachable!() }
+    fn get_snapshot_dir(&self) -> &Path { unreachable!() }
 
     fn get_snapshot_db_name(&self, _snapshot_epoch_id: &EpochId) -> String {
         unreachable!()
     }
 
-    fn get_snapshot_db_path(&self, _snapshot_epoch_id: &EpochId) -> String {
+    fn get_snapshot_db_path(&self, _snapshot_epoch_id: &EpochId) -> PathBuf {
         unreachable!()
     }
 
@@ -600,6 +600,7 @@ use rand::Rng;
 use std::{
     cmp::{max, min},
     collections::HashMap,
+    path::{Path, PathBuf},
     sync::Arc,
 };
 use tokio::sync::Semaphore;


### PR DESCRIPTION
Some user on Windows reported logs like 

```
2020-05-09T17:07:49.223877+08:00 WARN  Socket IO Worker #3  cfxcore::sto - Failed to create sqlite db for ./storage_db/snapshot/sqlite_full_sync_temp_...\shard_00, remove all temporary files ["./storage_db/snapshot/sqlite_full_sync_temp_...\\shard_00-wal", "./storage_db/snapshot/sqlite_full_sync_temp_...\\shard_00-shm"]
2020-05-09T17:07:49.225871700+08:00 DEBUG Socket IO Worker #3  cfxcore::syn - failed to handle sync protocol message, peer = 0x24ca…9f33, id = 26, name = SnapshotManifestResponse, request_id = None, error_kind = Storage(Io(Os { code: 3, kind: NotFound, message: "系统找不到指定的路径。" }))
2020-05-09T17:07:49.227866300+08:00 WARN  Socket IO Worker #3  cfxcore::syn - Error while handling message, peer=0x24ca…9f33, msgid=26, error=系统找不到指定的路径。 (os error 3)
```

This is possibly caused by the hardcoded slash in the data path. Always using `join` for this may eliminate this kind of errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1420)
<!-- Reviewable:end -->
