### PR TITLE
Fix wrong epoch hash in db for receipts.

### DIFF
--- a/client/src/rpc/impls/pubsub.rs
+++ b/client/src/rpc/impls/pubsub.rs
@@ -322,7 +322,8 @@ impl ChainNotificationHandler {
 
         for iter in 0..NUM_POLLS {
             match self.data_man.block_execution_result_by_hash_with_epoch(
-                &block, &pivot, true, /* update_cache */
+                &block, &pivot, false, /* update_pivot_assumption */
+                true,  /* update_cache */
             ) {
                 Some(res) => return Some(res.block_receipts.clone()),
                 None => {

--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -1356,7 +1356,8 @@ impl ConsensusExecutionHandler {
                 .block_execution_result_by_hash_with_epoch(
                     &block_hash,
                     &reward_epoch_hash,
-                    true, /* update_cache */
+                    false, /* update_pivot_assumption */
+                    true,  /* update_cache */
                 ) {
                 Some(block_exec_result) => block_exec_result.block_receipts,
                 None => {

--- a/core/src/consensus/consensus_inner/mod.rs
+++ b/core/src/consensus/consensus_inner/mod.rs
@@ -2161,6 +2161,7 @@ impl ConsensusGraphInner {
                     self.data_man.block_execution_result_by_hash_with_epoch(
                         hash,
                         &epoch,
+                        false, /* update_pivot_assumption */
                         update_cache,
                     )?;
                 Some(BlockExecutionResultWithEpoch(epoch, execution_result))

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -801,7 +801,9 @@ impl ConsensusGraph {
         if let Some(block_log_bloom) = self
             .data_man
             .block_execution_result_by_hash_with_epoch(
-                block_hash, epoch_hash, false, /* update_cache */
+                block_hash, epoch_hash,
+                false, /* update_pivot_assumption */
+                false, /* update_cache */
             )
             .map(|r| r.bloom)
         {

--- a/core/src/light_protocol/common/ledger_info.rs
+++ b/core/src/light_protocol/common/ledger_info.rs
@@ -185,7 +185,8 @@ impl LedgerInfo {
                 self.consensus
                     .get_data_manager()
                     .block_execution_result_by_hash_with_epoch(
-                        &h, &pivot, false, /* update_cache */
+                        &h, &pivot, false, /* update_pivot_assumption */
+                        false, /* update_cache */
                     )
                     .map(|res| (*res.block_receipts).clone())
                     .ok_or(ErrorKind::InternalError.into())
@@ -209,7 +210,8 @@ impl LedgerInfo {
                 self.consensus
                     .get_data_manager()
                     .block_execution_result_by_hash_with_epoch(
-                        &h, &pivot, false, /* update_cache */
+                        &h, &pivot, false, /* update_pivot_assumption */
+                        false, /* update_cache */
                     )
                     .map(|res| res.bloom)
                     .ok_or(ErrorKind::InternalError.into())

--- a/core/src/sync/state/snapshot_manifest_request.rs
+++ b/core/src/sync/state/snapshot_manifest_request.rs
@@ -125,6 +125,7 @@ impl SnapshotManifestRequest {
                                 .block_execution_result_by_hash_with_epoch(
                                     hash,
                                     &epoch_hash,
+                                    false, /* update_pivot_assumption */
                                     false, /* update_cache */
                                 ) {
                                 Some(block_execution_result) => {


### PR DESCRIPTION
In the old implementation, if

1. Block A is on pivot chain and executed.
2. Pivot chain switches, and Block A is referred and executed in the epoch of block B.
3. Pivot chain switches back where A is on pivot chain.

Our receipts for Block A in db will still be the one that it's executed in
the epoch of block B.

This bugfix is just a patch, we should refactor/optimize this receipt
storage to make it more clear and efficient. The current implemenration may
need to insert TransactionIndex and BlockExecutionResult duplicatedly
due to pivot chain switch, especially when optimistic execution is
enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1421)
<!-- Reviewable:end -->
