### PR TITLE
Disable tx index recording by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ the pool will not be able to tell whether they mined a block or not.
 - Improve the stratum protocol to make it more consistent with the convention.
 Now the stratum protocol can correctly work with an external miner.
 
+- Disable transaction index recording by default. This will reduce the disk usage 
+for miners. If you want to serve transaction-related RPCs, you should set `record_tx_index=true`
+in the configuration file manually.
+
 # 0.5.0
 
 ## Improvements

--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -222,7 +222,7 @@ build_config! {
         (future_block_buffer_capacity, (usize), 32768)
         (get_logs_filter_max_limit, (Option<usize>), None)
         (max_trans_count_received_in_catch_up, (u64), 60_000)
-        (record_tx_index, (bool), true)
+        (record_tx_index, (bool), false)
         (target_block_gas_limit, (u64), DEFAULT_TARGET_BLOCK_GAS_LIMIT)
 
         // TreeGraph Section.

--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -33,7 +33,7 @@ pub const COL_MISC: u32 = 0;
 pub const COL_BLOCKS: u32 = 1;
 /// Column for Transaction Index
 pub const COL_TX_INDEX: u32 = 2;
-/// Column for Transaction Index
+/// Column for Epoch Sets
 pub const COL_EPOCH_NUMBER: u32 = 3;
 /// Number of columns in DB
 pub const NUM_COLUMNS: u32 = 4;

--- a/run/default.toml
+++ b/run/default.toml
@@ -122,6 +122,7 @@ log_conf="log.yaml"
 # the node will not start rpc services. By default, the `jsonrpc_local_http_port` is set,
 # so as to support the Conflux CLI subcommands. What's provided here is the recommended
 # value if you want to start rpc services for other front-end applications.
+# Note that to serve transaction-related RPCs, `record_tx_index` should also be set to `true`.
 #
 # jsonrpc_ws_port=12535
 # jsonrpc_tcp_port=12536
@@ -329,7 +330,7 @@ jsonrpc_local_http_port=12539
 # Whether to record transaction indices.
 # This only needs to be enabled if you want to answer transaction-related RPCs.
 #
-# record_tx_index = true
+# record_tx_index = false
 
 # Time to keep transactions in in-memory transaction cache.
 #

--- a/tests/conflux/config.py
+++ b/tests/conflux/config.py
@@ -44,4 +44,5 @@ small_local_test_conf = dict(
     storage_delta_mpts_cache_start_size = 200_000,
     storage_delta_mpts_slab_idle_size = 2_000_000,
     subnet_quota = 0,
+    record_tx_index = "true",
 )

--- a/tests/conflux/config.py
+++ b/tests/conflux/config.py
@@ -25,6 +25,7 @@ default_conflux_conf = dict(
     storage_delta_mpts_cache_start_size = 2_000_000,
     storage_delta_mpts_slab_idle_size = 2_000_000,
     tx_pool_size = 500_000,
+    record_tx_index = "true",
 )
 
 production_conf = default_conflux_conf


### PR DESCRIPTION
Recording tx index is only needed to serve tx-related RPCs, and will not
be used by miners. The tx indices take close to 40% of `blockchain_db`
for archive nodes and more for full nodes, and it will not be removed
in making checkpoints, so it's better disabled by default. 
Those RPC providers should enable it manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1427)
<!-- Reviewable:end -->
