### PR TITLE
Fix some catch up issues.

### DIFF
--- a/core/src/sync/message/capability.rs
+++ b/core/src/sync/message/capability.rs
@@ -88,6 +88,13 @@ impl DynamicCapabilitySet {
             None => return false,
         }
     }
+
+    /// Return `None` is the capability slot has not been set.
+    pub fn contains_exact(&self, cap: DynamicCapability) -> Option<bool> {
+        self.caps[cap.code() as usize]
+            .as_ref()
+            .map(|cur_cap| cur_cap == &cap)
+    }
 }
 
 #[derive(Debug, RlpDecodableWrapper, RlpEncodableWrapper)]

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -771,7 +771,7 @@ impl SynchronizationProtocolHandler {
                         true, /* ignore_db */
                     );
                 }
-                *latest_requested += 1;
+                *latest_requested = from;
                 continue;
             } else if best_peer_epoch == 0 {
                 // We have recovered all epochs from db, and there is no peer to

--- a/core/src/sync/synchronization_state.rs
+++ b/core/src/sync/synchronization_state.rs
@@ -184,15 +184,21 @@ impl SynchronizationState {
             }
             for (_, state_lock) in &*peers {
                 let state = state_lock.read();
-                if state
+                match state
                     .capabilities
-                    .contains(DynamicCapability::NormalPhase(true))
+                    .contains_exact(DynamicCapability::NormalPhase(true))
                 {
-                    peer_best_epoches.push(state.best_epoch);
-                } else if state.best_epoch != 0 {
-                    // Note `best_epoch` is initialized according to Status,
-                    // so if it's 0, the peer is just newly started
-                    fresh_start = false;
+                    Some(true) => peer_best_epoches.push(state.best_epoch),
+                    Some(false) => {
+                        if state.best_epoch != 0 {
+                            // Note `best_epoch` is initialized according to
+                            // Status, so if it's 0,
+                            // the peer is just newly started
+                            fresh_start = false;
+                        }
+                    }
+                    // Do not know about the peer state yet.
+                    None => {}
                 }
             }
         };


### PR DESCRIPTION
`DynamicCapability::NormalPhase` is updated later than the connection establishment, so it's possible that its NormalPhase peer is regarded as in catch-up phase, and the node may enter exit catch-up mode unexpectedly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1438)
<!-- Reviewable:end -->
