### PR TITLE
Fix constant duplicate transaction packing

### DIFF
--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -760,6 +760,12 @@ impl RpcImpl {
         &self, request: CallRequest, epoch: Option<EpochNumber>,
     ) -> RpcResult<Bytes> {
         match self.exec_transaction(request, epoch)? {
+            ExecutionOutcome::NotExecutedOldNonce(expected, got) => {
+                bail!(call_execution_error(
+                    "Can not estimate: transaction can not be executed".into(),
+                    format! {"nonce is too old expected {:?} got {:?}", expected, got}.into_bytes()
+                ))
+            }
             ExecutionOutcome::NotExecutedToReconsiderPacking(e) => {
                 bail!(call_execution_error(
                     "Transaction can not be executed".into(),
@@ -787,6 +793,12 @@ impl RpcImpl {
         &self, request: CallRequest, epoch: Option<EpochNumber>,
     ) -> RpcResult<EstimateGasAndCollateralResponse> {
         let executed = match self.exec_transaction(request, epoch)? {
+            ExecutionOutcome::NotExecutedOldNonce(expected, got) => {
+                bail!(call_execution_error(
+                    "Can not estimate: transaction can not be executed".into(),
+                    format! {"nonce is too old expected {:?} got {:?}", expected, got}.into_bytes()
+                ))
+            }
             ExecutionOutcome::NotExecutedToReconsiderPacking(e) => {
                 bail!(call_execution_error(
                     "Can not estimate: transaction can not be executed".into(),

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -762,7 +762,7 @@ impl RpcImpl {
         match self.exec_transaction(request, epoch)? {
             ExecutionOutcome::NotExecutedOldNonce(expected, got) => {
                 bail!(call_execution_error(
-                    "Can not estimate: transaction can not be executed".into(),
+                    "Transaction can not be executed".into(),
                     format! {"nonce is too old expected {:?} got {:?}", expected, got}.into_bytes()
                 ))
             }

--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -1130,6 +1130,7 @@ impl ConsensusExecutionHandler {
                             expected,
                             got
                         );
+                        gas_fee = U256::zero();
                     }
                     ExecutionOutcome::NotExecutedToReconsiderPacking(e) => {
                         tx_outcome_status =

--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -1120,6 +1120,17 @@ impl ConsensusExecutionHandler {
                 let mut gas_sponsor_paid = false;
                 let mut storage_sponsor_paid = false;
                 match r {
+                    ExecutionOutcome::NotExecutedOldNonce(expected, got) => {
+                        tx_outcome_status =
+                            TRANSACTION_OUTCOME_EXCEPTION_WITHOUT_NONCE_BUMPING;
+                        trace!(
+                            "tx not executed due to old nonce: \
+                             transaction={:?}, expected={:?}, got={:?}",
+                            transaction,
+                            expected,
+                            got
+                        );
+                    }
                     ExecutionOutcome::NotExecutedToReconsiderPacking(e) => {
                         tx_outcome_status =
                             TRANSACTION_OUTCOME_EXCEPTION_WITHOUT_NONCE_BUMPING;

--- a/core/src/executive/executed.rs
+++ b/core/src/executive/executed.rs
@@ -100,6 +100,7 @@ pub enum ExecutionError {
 
 #[derive(Debug)]
 pub enum ExecutionOutcome {
+    NotExecutedOldNonce(U256, U256),
     NotExecutedToReconsiderPacking(ToRepackError),
     ExecutionErrorBumpNonce(ExecutionError, Executed),
     Finished(Executed),

--- a/core/src/executive/executive.rs
+++ b/core/src/executive/executive.rs
@@ -1357,7 +1357,9 @@ impl<'a> Executive<'a> {
         let nonce = self.state.nonce(&sender)?;
 
         // Validate transaction nonce
-        if tx.nonce != nonce {
+        if tx.nonce < nonce {
+            return Ok(ExecutionOutcome::NotExecutedOldNonce(nonce, tx.nonce));
+        } else if tx.nonce > nonce {
             return Ok(ExecutionOutcome::NotExecutedToReconsiderPacking(
                 ToRepackError::InvalidNonce {
                     expected: nonce,

--- a/core/src/transaction_pool/transaction_pool_inner.rs
+++ b/core/src/transaction_pool/transaction_pool_inner.rs
@@ -779,7 +779,9 @@ impl TransactionPoolInner {
                 "Transaction {:?} is discarded due to in too distant future",
                 transaction.hash()
             ));
-        } else if transaction.nonce < state_nonce {
+        } else if !packed /* Because we may get slightly out-dated state for transaction pool, we should allow transaction pool to set already past-nonce transactions to packed. */
+            && transaction.nonce < state_nonce
+        {
             trace!(
                 "Transaction {:?} is discarded due to a too stale nonce, self.nonce={}, state_nonce={}",
                 transaction.hash(), transaction.nonce, state_nonce,


### PR DESCRIPTION
Transaction pool may not get the updated account so it may temporarily in an inconsistent state. However, once a transaction with old nonce not being marked as packed, it will always stay in the transaction pool due to the nonce check before the setting pack flag. 

This PR fixes this issue and introduce an additional error type to avoid repackaging old nonce from execution.

This closes #1455.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1458)
<!-- Reviewable:end -->
