### PR TITLE
Fix that the state restoration starts before all chunks downloaded.

### DIFF
--- a/network/src/service.rs
+++ b/network/src/service.rs
@@ -1228,7 +1228,7 @@ impl NetworkServiceInner {
                 }
                 deregister = remote || sess.done();
                 failure_id = sess.id().cloned();
-                info!(
+                debug!(
                     "kill connection, deregister = {}, reason = {:?}, session = {:?}, op = {:?}",
                     deregister, reason, *sess, op
                 );
@@ -1303,7 +1303,7 @@ impl NetworkServiceInner {
             deregister = remote || sess.done();
             token = sess.token();
             assert_eq!(sess.id().unwrap().clone(), node_id.clone());
-            info!(
+            debug!(
                 "kill connection, deregister = {}, reason = {:?}, session = {:?}, op = {:?}",
                 deregister, reason, *sess, op
             );


### PR DESCRIPTION
`downloading_chunks.is_empty()` does not mean all chunks are downloaded now.
It was true long ago because for every received chunk we will add another one to `dowdloading_chunks`.

Also, since we have called `note_state_sync_failure` in `check_timeout`, we do not need to do it again after receiving a timeout response. Calling it for the response may interfere with resumed state sync and make inaccurate marks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1460)
<!-- Reviewable:end -->
