### PR TITLE
Add statistic sync_graph.inserted_block_headers.

### DIFF
--- a/core/src/statistics/mod.rs
+++ b/core/src/statistics/mod.rs
@@ -31,28 +31,27 @@ impl Statistics {
     }
 
     pub fn inc_sync_graph_inserted_block_count(&self) {
-        let mut inner = self.inner.write();
-        inner.sync_graph.inserted_block_count += 1;
+        self.inner.write().sync_graph.inserted_block_count += 1;
+    }
+
+    pub fn inc_sync_graph_inserted_header_count(&self) {
+        self.inner.write().sync_graph.inserted_header_count += 1;
     }
 
     pub fn inc_consensus_graph_processed_block_count(&self) {
-        let mut inner = self.inner.write();
-        inner.consensus_graph.processed_block_count += 1;
+        self.inner.write().consensus_graph.processed_block_count += 1;
     }
 
     pub fn inc_consensus_graph_activated_block_count(&self) {
-        let mut inner = self.inner.write();
-        inner.consensus_graph.activated_block_count += 1;
+        self.inner.write().consensus_graph.activated_block_count += 1;
     }
 
     pub fn set_consensus_graph_inserted_block_count(&self, count: usize) {
-        let mut inner = self.inner.write();
-        inner.consensus_graph.inserted_block_count = count;
+        self.inner.write().consensus_graph.inserted_block_count = count;
     }
 
     pub fn get_consensus_graph_processed_block_count(&self) -> usize {
-        let inner = self.inner.read();
-        inner.consensus_graph.processed_block_count
+        self.inner.read().consensus_graph.processed_block_count
     }
 
     pub fn clear_sync_and_consensus_graph_statistics(&self) {

--- a/core/src/sync/message/get_compact_blocks.rs
+++ b/core/src/sync/message/get_compact_blocks.rs
@@ -79,7 +79,7 @@ impl Handleable for GetCompactBlocks {
                     blocks.push(block.as_ref().clone());
                 }
             } else {
-                warn!(
+                debug!(
                     "Peer {} requested non-existent compact block {}",
                     ctx.node_id, hash
                 );

--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -65,17 +65,22 @@ pub struct SyncGraphConfig {
 #[derive(Debug)]
 pub struct SyncGraphStatistics {
     pub inserted_block_count: usize,
+    pub inserted_header_count: usize,
 }
 
 impl SyncGraphStatistics {
     pub fn new() -> SyncGraphStatistics {
         SyncGraphStatistics {
             // Already counted genesis block
+            inserted_header_count: 1,
             inserted_block_count: 1,
         }
     }
 
-    pub fn clear(&mut self) { self.inserted_block_count = 1; }
+    pub fn clear(&mut self) {
+        self.inserted_header_count = 1;
+        self.inserted_block_count = 1;
+    }
 }
 
 #[derive(DeriveMallocSizeOf)]


### PR DESCRIPTION
This gives us more progress information in the header sync phase. 
Currently, if we only sync not-graph-ready headers in the header sync phase for a period, nothing is making progress.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1471)
<!-- Reviewable:end -->
