### PR TITLE
Fix block number inconsistency in inner constructor

### DIFF
--- a/core/src/block_data_manager/block_data_types.rs
+++ b/core/src/block_data_manager/block_data_types.rs
@@ -7,7 +7,8 @@ use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 use rlp_derive::{RlpDecodable, RlpEncodable};
 use std::sync::Arc;
 
-/// The number of blocks in the past of an epoch.
+/// The start block number of an epoch. It equals to the past executed number of
+/// blocks in the previous epoch + 1. For the true genesis, it equals 0.
 /// Used in evm execution.
 #[derive(Clone, RlpEncodable, RlpDecodable, DeriveMallocSizeOf)]
 pub struct EpochExecutionContext {

--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -461,7 +461,7 @@ impl ConsensusExecutor {
                     epoch_block_anticone_difficulties.push(anticone_difficulty);
                 }
                 RewardExecutionInfo {
-                    past_block_count: inner.arena[pivot_arena_index].past_num_blocks + 1,
+                    past_block_count: inner.arena[pivot_arena_index].past_num_blocks,
                     epoch_blocks,
                     epoch_block_no_reward,
                     epoch_block_anticone_difficulties,

--- a/core/src/consensus/consensus_inner/mod.rs
+++ b/core/src/consensus/consensus_inner/mod.rs
@@ -493,7 +493,7 @@ pub struct ConsensusGraphNode {
     difficulty: U256,
     is_heavy: bool,
     is_timer: bool,
-    /// The total number of executed blocks in its past (including self)
+    /// The total number of *executed* blocks in its past (not including self)
     past_num_blocks: u64,
     adaptive: bool,
 

--- a/core/src/consensus/consensus_inner/mod.rs
+++ b/core/src/consensus/consensus_inner/mod.rs
@@ -610,12 +610,19 @@ impl ConsensusGraphInner {
         inner.arena[inner.cur_era_genesis_block_arena_index]
             .data
             .epoch_number = cur_era_genesis_height;
+        let genesis_epoch_size = inner
+            .data_man
+            .executed_epoch_set_hashes_from_db(cur_era_genesis_height)
+            .expect("Genesis epoch set should be in data manager.")
+            .len();
         inner.arena[inner.cur_era_genesis_block_arena_index].past_num_blocks =
             inner
                 .data_man
                 .get_epoch_execution_context(cur_era_genesis_block_hash)
                 .expect("ExecutionContext for cur_era_genesis exists")
-                .start_block_number;
+                .start_block_number
+                + genesis_epoch_size as u64
+                - 1;
         inner.arena[inner.cur_era_genesis_block_arena_index]
             .data
             .last_pivot_in_past = cur_era_genesis_height;

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -1216,7 +1216,7 @@ impl ConsensusGraphTrait for ConsensusGraph {
                                 StateDb::new(db),
                                 Default::default(), /* vm */
                                 &Spec::new_spec(),
-                                past_num_blocks, /* block_numer */
+                                past_num_blocks + 1, /* block_numer */
                             )
                         })
                         .expect("Best state has been executed");


### PR DESCRIPTION
consensus_inner constructor incorrectly uses start_block_number as past_block_number

This closes #1464 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1473)
<!-- Reviewable:end -->
