### PR TITLE
Fix full node sync issues.

### DIFF
--- a/core/src/sync/state/snapshot_chunk_request.rs
+++ b/core/src/sync/state/snapshot_chunk_request.rs
@@ -92,9 +92,7 @@ impl Request for SnapshotChunkRequest {
 
     fn is_empty(&self) -> bool { false }
 
-    fn resend(&self) -> Option<Box<dyn Request>> {
-        Some(Box::new(self.clone()))
-    }
+    fn resend(&self) -> Option<Box<dyn Request>> { None }
 
     fn required_capability(&self) -> Option<DynamicCapability> { None }
 }

--- a/core/src/sync/state/snapshot_chunk_sync.rs
+++ b/core/src/sync/state/snapshot_chunk_sync.rs
@@ -912,9 +912,7 @@ impl SnapshotChunkSync {
                 manager: sync_handler,
             },
         );
-        // We are requesting candidates and all `pending_peers` timeout,
-        // or we are syncing states for a candidate and all `active_peers`
-        // timeout.
+
         // If we moves into the next era, we should force state_sync to change
         // the candidates to states with in the new stable era. If the
         // era stays the same and a new snapshot becomes available, we

--- a/core/src/sync/state/snapshot_chunk_sync.rs
+++ b/core/src/sync/state/snapshot_chunk_sync.rs
@@ -249,11 +249,13 @@ impl Debug for Inner {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
-            "(status = {:?}, download = {}/{}/{})",
+            "(status = {:?}, download = {}/{}/{}, pending_peers: {}, active_peers: {})",
             self.status,
             self.pending_chunks.len(),
             self.downloading_chunks.len(),
             self.num_downloaded,
+            self.sync_candidate_manager.pending_peers().len(),
+            self.sync_candidate_manager.active_peers().len(),
         )
     }
 }

--- a/core/src/sync/state/snapshot_manifest_request.rs
+++ b/core/src/sync/state/snapshot_manifest_request.rs
@@ -291,9 +291,7 @@ impl Request for SnapshotManifestRequest {
 
     fn is_empty(&self) -> bool { false }
 
-    fn resend(&self) -> Option<Box<dyn Request>> {
-        Some(Box::new(self.clone()))
-    }
+    fn resend(&self) -> Option<Box<dyn Request>> { None }
 
     fn required_capability(&self) -> Option<DynamicCapability> { None }
 }

--- a/core/src/sync/state/state_sync_candidate_manager.rs
+++ b/core/src/sync/state/state_sync_candidate_manager.rs
@@ -150,7 +150,7 @@ impl StateSyncCandidateManager {
 
     /// `peer` cannot support the active candidate now
     pub fn note_state_sync_failure(&mut self, peer: &NodeId) {
-        if self.pending_peers.remove(peer) {}
+        self.pending_peers.remove(peer);
         self.active_peers.remove(peer);
         if let Some(active_candidate) = self.active_candidate.clone() {
             if let Some(peers) = self

--- a/core/src/sync/state/state_sync_candidate_manager.rs
+++ b/core/src/sync/state/state_sync_candidate_manager.rs
@@ -86,11 +86,11 @@ impl StateSyncCandidateManager {
         &mut self, peer: &NodeId,
         supported_candidates: &Vec<SnapshotSyncCandidate>,
         requested_candidates: &Vec<SnapshotSyncCandidate>,
-    ) -> Option<SnapshotSyncCandidate>
+    )
     {
         if !self.pending_peers.remove(peer) {
             debug!("Receive response from unexpected peer {:?}, possibly from old requests", peer);
-            return None;
+            return;
         }
         let mut requested_candidates_set: HashSet<&SnapshotSyncCandidate> =
             requested_candidates.iter().collect();
@@ -125,17 +125,6 @@ impl StateSyncCandidateManager {
                 }
             }
         }
-
-        // TODO We can choose an active candidate before receiving all the
-        // response
-        if self.pending_peers.is_empty() {
-            self.set_active_candidate();
-            // Here we return None only if all requested peers cannot serve the
-            // candidates TODO ask about new state candidates or new
-            // peers when active_candidate is None
-            return self.get_active_candidate();
-        }
-        None
     }
 
     pub fn on_peer_disconnected(&mut self, peer: &NodeId) {
@@ -153,17 +142,15 @@ impl StateSyncCandidateManager {
 
     pub fn active_peers(&self) -> &HashSet<NodeId> { &self.active_peers }
 
+    pub fn pending_peers(&self) -> &HashSet<NodeId> { &self.pending_peers }
+
     pub fn get_active_candidate(&self) -> Option<SnapshotSyncCandidate> {
         self.active_candidate.map(|i| self.candidates[i].clone())
     }
 
     /// `peer` cannot support the active candidate now
     pub fn note_state_sync_failure(&mut self, peer: &NodeId) {
-        self.pending_peers.remove(peer);
-        if self.pending_peers.is_empty() {
-            // Rely on periodic phase checks to start state sync
-            self.set_active_candidate();
-        }
+        if self.pending_peers.remove(peer) {}
         self.active_peers.remove(peer);
         if let Some(active_candidate) = self.active_candidate.clone() {
             if let Some(peers) = self
@@ -208,7 +195,6 @@ impl StateSyncCandidateManager {
             && self.start_time.elapsed() > *candidate_timeout
         {
             self.pending_peers.clear();
-            self.set_active_candidate();
         }
     }
 

--- a/core/src/sync/state/state_sync_candidate_request.rs
+++ b/core/src/sync/state/state_sync_candidate_request.rs
@@ -103,9 +103,7 @@ impl Request for StateSyncCandidateRequest {
 
     fn is_empty(&self) -> bool { false }
 
-    fn resend(&self) -> Option<Box<dyn Request>> {
-        Some(Box::new(self.clone()))
-    }
+    fn resend(&self) -> Option<Box<dyn Request>> { None }
 
     fn required_capability(&self) -> Option<DynamicCapability> { None }
 }

--- a/core/src/sync/state/state_sync_candidate_response.rs
+++ b/core/src/sync/state/state_sync_candidate_response.rs
@@ -12,7 +12,7 @@ use crate::{
 use network::service::ProtocolVersion;
 use rlp_derive::{RlpDecodable, RlpEncodable};
 
-#[derive(RlpEncodable, RlpDecodable)]
+#[derive(RlpEncodable, RlpDecodable, Debug)]
 pub struct StateSyncCandidateResponse {
     pub request_id: RequestId,
     pub supported_candidates: Vec<SnapshotSyncCandidate>,
@@ -30,6 +30,7 @@ impl Handleable for StateSyncCandidateResponse {
             ctx.io,
             &ctx.manager.request_manager,
         )?;
+        debug!("Receive StateSyncCandidateResponse={:?}", self);
         ctx.manager.state_sync.handle_snapshot_candidate_response(
             &ctx.node_id,
             &self.supported_candidates,

--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -1324,8 +1324,6 @@ impl SynchronizationGraph {
                 }
             }
 
-            // FIXME: for full node in `CatchUpRecoverBlockHeaderFromDB` phase,
-            // we may only have header in db
             if let Some(block_header_arc) =
                 self.data_man.block_header_by_hash(&hash)
             {

--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -1623,6 +1623,13 @@ impl SynchronizationGraph {
                     || self
                         .verification_config
                         .verify_header_params(header)
+                        .or_else(|e| {
+                            warn!(
+                                "Invalid header: err={} header={:?}",
+                                e, header
+                            );
+                            Err(e)
+                        })
                         .is_err())
         } else {
             if !bench_mode && !self.is_consortium() {

--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -1326,11 +1326,14 @@ impl SynchronizationGraph {
 
             // FIXME: for full node in `CatchUpRecoverBlockHeaderFromDB` phase,
             // we may only have header in db
-            if let Some(mut block) = self.data_man.block_from_db(&hash) {
+            if let Some(block_header_arc) =
+                self.data_man.block_header_by_hash(&hash)
+            {
+                let mut block_header = block_header_arc.as_ref().clone();
                 // Only construct synchronization graph if is not header_only.
                 // Construct both sync and consensus graph if is header_only.
                 let (insert_result, _) = self.insert_block_header(
-                    &mut block.block_header,
+                    &mut block_header,
                     true,        /* need_to_verify */
                     false,       /* bench_mode */
                     header_only, /* insert_to_consensus */
@@ -1338,17 +1341,24 @@ impl SynchronizationGraph {
                 );
                 assert!(!insert_result.is_invalid());
 
-                let parent = block.block_header.parent_hash().clone();
-                let referees = block.block_header.referee_hashes().clone();
+                let parent = block_header.parent_hash().clone();
+                let referees = block_header.referee_hashes().clone();
 
                 // Construct consensus graph if is not header_only.
                 if !header_only {
-                    let result = self.insert_block(
-                        block, true,  /* need_to_verify */
-                        false, /* persistent */
-                        true,  /* recover_from_db */
-                    );
-                    assert!(result.is_valid());
+                    if let Some(block) =
+                        self.data_man.block_by_hash(&hash, false)
+                    {
+                        let result = self.insert_block(
+                            block.as_ref().clone(),
+                            true,  /* need_to_verify */
+                            false, /* persistent */
+                            true,  /* recover_from_db */
+                        );
+                        assert!(result.is_valid());
+                    } else {
+                        missed_hashes.insert(hash);
+                    }
                 }
 
                 if !visited_blocks.contains(&parent) {

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -1387,11 +1387,17 @@ impl SynchronizationProtocolHandler {
             .ok();
     }
 
-    /// If we are in `SyncHeaders` phase, we should insert graph-ready block
-    /// headers to sync graph directly
+    /// If we are in `SyncHeaders` or `CatchUpCheckpoint` phase, we should
+    /// insert graph-ready block headers to sync graph directly.
+    /// For `CatchUpCheckpoint`, this is needed to move the target checkpoint,
+    /// and avoid being blocked on a stale checkpoint that no peers can serve.
     pub fn insert_header_to_consensus(&self) -> bool {
         let current_phase = self.phase_manager.get_current_phase();
-        current_phase.phase_type() == SyncPhaseType::CatchUpSyncBlockHeader
+        matches!(
+            current_phase.phase_type(),
+            SyncPhaseType::CatchUpSyncBlockHeader
+                | SyncPhaseType::CatchUpCheckpoint
+        )
     }
 
     pub fn propagate_new_transactions(&self, io: &dyn NetworkContext) {


### PR DESCRIPTION
1. Allow headers to be inserted into Consensus during `CatchUpCheckpoint` phase, so if all peers forward their checkpoints, we can switch to sync the new checkpoint. Keeping syncing the old checkpoint is not an option because the peers may have removed it.

2. During `CatchUpRecoverBlockHeaderFromDB` phase, we only read headers from DB. Otherwise full nodes cannot recover any data if it crashes during `CatchUpSyncBlockHeader` phase. 

3. Fix the state-sync related issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1475)
<!-- Reviewable:end -->
