### PR TITLE
Use bzip2-sys-0.1.8 to avoid CI fail

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ deadlock_detection = ["parking_lot/deadlock_detection"]
 #"bzip2-sys:0.1.6"={git = "https://github.com/alexcrichton/bzip2-rs.git"}
 
 [patch.crates-io]
-bzip2-sys = {git = "https://github.com/alexcrichton/bzip2-rs.git"}
+bzip2-sys = {git = "https://github.com/alexcrichton/bzip2-rs.git", commit = "461d6691" }
 
 [profile.test]
 debug-assertions = true


### PR DESCRIPTION
The crate `bzip2-sys` has been updated recently and it seems to make CI fail.

```
11:05:53 error: multiple packages link to native library `bzip2`, but a native library can be linked only once
11:05:53 
11:05:53 package `bzip2-sys v0.1.6`
11:05:53     ... which is depended on by `bzip2 v0.3.3`
11:05:53     ... which is depended on by `zip v0.5.4`
11:05:53     ... which is depended on by `cfxcore v0.6.0 (/var/lib/jenkins/workspace/conflux-rust-github/core)`
11:05:53     ... which is depended on by `storage_bench v0.1.0 (/var/lib/jenkins/workspace/conflux-rust-github/core/benchmark/storage)`
11:05:53 links to native library `bzip2`
11:05:53 
11:05:53 package `bzip2-sys v0.1.9+1.0.8 (https://github.com/alexcrichton/bzip2-rs.git#ea8fc591)`
11:05:53     ... which is depended on by `librocksdb_sys v0.1.0 (https://github.com/Conflux-Chain/rust-rocksdb.git?rev=6d96482ddb51c1779af615767fd1967da9d98377#6d96482d)`
11:05:53     ... which is depended on by `rocksdb v0.3.0 (https://github.com/Conflux-Chain/rust-rocksdb.git?rev=6d96482ddb51c1779af615767fd1967da9d98377#6d96482d)`
11:05:53     ... which is depended on by `kvdb-rocksdb v0.1.6 (/var/lib/jenkins/workspace/conflux-rust-github/db/src/kvdb-rocksdb)`
11:05:53     ... which is depended on by `cfxcore v0.6.0 (/var/lib/jenkins/workspace/conflux-rust-github/core)`
11:05:53     ... which is depended on by `storage_bench v0.1.0 (/var/lib/jenkins/workspace/conflux-rust-github/core/benchmark/storage)`
11:05:53 also links to native library `bzip2`
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1492)
<!-- Reviewable:end -->
