### PR TITLE
Link sqlite3 statically.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3601,8 +3601,7 @@ dependencies = [
 [[package]]
 name = "sqlite3-sys"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fec807a1534bd13eeaaec396175d67c79bdc68df55e18a452726ec62a8fb08"
+source = "git+https://github.com/Conflux-Chain/sqlite3-sys.git?rev=1de8e5998f7c2d919336660b8ef4e8f52ac43844#1de8e5998f7c2d919336660b8ef4e8f52ac43844"
 dependencies = [
  "libc",
  "sqlite3-src",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,8 @@ deadlock_detection = ["parking_lot/deadlock_detection"]
 #"bzip2-sys:0.1.6"={git = "https://github.com/alexcrichton/bzip2-rs.git"}
 
 [patch.crates-io]
-bzip2-sys = {git = "https://github.com/alexcrichton/bzip2-rs.git", commit = "461d6691" }
+bzip2-sys = { git = "https://github.com/alexcrichton/bzip2-rs.git", commit = "461d6691" }
+sqlite3-sys = { git = "https://github.com/Conflux-Chain/sqlite3-sys.git", rev = "1de8e5998f7c2d919336660b8ef4e8f52ac43844" }
 
 [profile.test]
 debug-assertions = true


### PR DESCRIPTION
We need `bundled` feature of `sqlite3-sys` to link it statically, which is not exposed by the crate `sqlite`, so we have to fork `sqlite3-sys` and change the feature used.

We want to link `sqlite3` and `openssl` statically so that the compiled executable binary can run on any Linux distribution without installing any dependency. The problems with dynamic link include

* The default installed version of `sqlite3` on CentOS 7 has 3.7.17, but we need at least `3.8` to support `WITHOUT ROWID`.

* The dynamic link library file name of `openssl` on Ubuntu 18.04 is `libssl.so.1.1`, while on CentOS 7 is `libssl.so.10`, so the binary compiled on one platform cannot run on the other.

BTW, we need a compiled `openssl` library for static link, and the following instructions will work:
```bash
$ wget https://www.openssl.org/source/openssl-1.1.1g.tar.gz
$ tar xfvz openssl-1.1.1g.tar.gz
$ cd openssl-1.1.1g
$ ./config -fPIC && make
$ export OPENSSL_DIR=`pwd`
$ export OPENSSL_LIB_DIR=`pwd`
$ export OPENSSL_STATIC=yes

# Enter conflux-rust and build
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1497)
<!-- Reviewable:end -->
