### PR TITLE
Fix CI regression for sqlite dependency in storage bench.

### DIFF
--- a/core/benchmark/storage/Cargo.toml
+++ b/core/benchmark/storage/Cargo.toml
@@ -44,6 +44,8 @@ serde_json = "1.0"
 [patch.crates-io]
 parity-snappy = { path = "parity-snappy/rust-snappy" }
 bzip2-sys = { git = "https://github.com/alexcrichton/bzip2-rs.git", commit = "a8ee5cb4" }
+sqlite3-sys = { git = "https://github.com/Conflux-Chain/sqlite3-sys.git", rev = "1de8e5998f7c2d919336660b8ef4e8f52ac43844" }
+
 
 [patch.'https://github.com/paritytech/rust-secp256k1']
 # There was a package name change, bit it's not possible to redirect eth-secp256k1 to "parity-secp256k1"


### PR DESCRIPTION
Jenkins is failing because we did not change the `sqlite3-sys` configuration in storage benchmark, and we have uninstalled sqlite3 from Jenkins.

The reason PR #1497 succeeded even after uninstalling sqlite3 is that its CI rerun does not trigger compiling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1504)
<!-- Reviewable:end -->
