### PR TITLE
Do not insert block header if block is missing in block recovery.

### DIFF
--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -1329,46 +1329,42 @@ impl SynchronizationGraph {
                 }
             }
 
-            if let Some(block_header_arc) =
-                self.data_man.block_header_by_hash(&hash)
-            {
-                let mut block_header = block_header_arc.as_ref().clone();
-                // Only construct synchronization graph if is not header_only.
-                // Construct both sync and consensus graph if is header_only.
-                let (insert_result, _) = self.insert_block_header(
-                    &mut block_header,
-                    true,        /* need_to_verify */
-                    false,       /* bench_mode */
-                    header_only, /* insert_to_consensus */
-                    false,       /* persistent */
-                );
-                assert!(!insert_result.is_invalid());
-
-                let parent = block_header.parent_hash().clone();
-                let referees = block_header.referee_hashes().clone();
-
-                // Construct consensus graph if is not header_only.
-                if !header_only {
-                    if let Some(block) =
-                        self.data_man.block_by_hash(&hash, false)
-                    {
-                        let result = self.insert_block(
+            // Insert headers or full blocks depending on our phase.
+            // Note that if we have headers in db for recover block phase, we
+            // will not insert the headers, so the blocks can be
+            // retrieved later.
+            let get_and_insert = |hash| {
+                if header_only {
+                    self.data_man.block_header_by_hash(hash).map(|header| {
+                        self.insert_block_header(
+                            &mut header.as_ref().clone(),
+                            true,  /* need_to_verify */
+                            false, /* bench_mode */
+                            true,  /* insert_to_consensus */
+                            false, /* persistent */
+                        );
+                        header
+                    })
+                } else {
+                    self.data_man.block_by_hash(hash, false).map(|block| {
+                        self.insert_block(
                             block.as_ref().clone(),
                             true,  /* need_to_verify */
                             false, /* persistent */
                             true,  /* recover_from_db */
                         );
-                        assert!(result.is_valid());
-                    } else {
-                        missed_hashes.insert(hash);
-                    }
+                        Arc::new(block.block_header.clone())
+                    })
                 }
+            };
 
+            if let Some(block_header) = get_and_insert(&hash) {
+                let parent = block_header.parent_hash().clone();
+                let referees = block_header.referee_hashes().clone();
                 if !visited_blocks.contains(&parent) {
                     queue.push_back(parent);
                     visited_blocks.insert(parent);
                 }
-
                 for referee in referees {
                     if !visited_blocks.contains(&referee) {
                         queue.push_back(referee);
@@ -1580,6 +1576,7 @@ impl SynchronizationGraph {
     ) -> (BlockHeaderInsertionResult, Vec<H256>)
     {
         let _timer = MeterTimer::time_func(SYNC_INSERT_HEADER.as_ref());
+        self.statistics.inc_sync_graph_inserted_header_count();
         let inner = &mut *self.inner.write();
         let hash = header.hash();
 

--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -1347,13 +1347,21 @@ impl SynchronizationGraph {
                     })
                 } else {
                     self.data_man.block_by_hash(hash, false).map(|block| {
+                        let mut header = block.block_header.clone();
+                        self.insert_block_header(
+                            &mut header,
+                            true,  /* need_to_verify */
+                            false, /* bench_mode */
+                            false, /* insert_to_consensus */
+                            false, /* persistent */
+                        );
                         self.insert_block(
                             block.as_ref().clone(),
                             true,  /* need_to_verify */
                             false, /* persistent */
                             true,  /* recover_from_db */
                         );
-                        Arc::new(block.block_header.clone())
+                        Arc::new(header)
                     })
                 }
             };


### PR DESCRIPTION
Inserting block header at this time may prevent us from retrieving the
block body later, because we assume that a block with header inserted
has already been requested.

Another solution is to keep track of blocks missing bodies at this time,
but would involve keeping more states and make it more complicated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1511)
<!-- Reviewable:end -->
