### PR TITLE
Fix light node log filtering test

### DIFF
--- a/tests/light/log_filtering_test.py
+++ b/tests/light/log_filtering_test.py
@@ -137,18 +137,20 @@ class LogFilteringTest(ConfluxTestFramework):
     def number_to_topic(self, number):
         return "0x" + ("%x" % number).zfill(64)
 
-    def deploy_contract(self, sender, priv_key, data_hex, epoch_height = 0):
-        tx = self.rpc[FULLNODE0].new_contract_tx(receiver="", data_hex=data_hex, sender=sender, priv_key=priv_key, epoch_height = epoch_height, storage_limit=20000)
+    def deploy_contract(self, sender, priv_key, data_hex):
+        tx = self.rpc[FULLNODE0].new_contract_tx(receiver="", data_hex=data_hex, sender=sender, priv_key=priv_key, storage_limit=1000)
         assert_equal(self.rpc[FULLNODE0].send_tx(tx, True), tx.hash_hex())
         receipt = self.rpc[FULLNODE0].get_transaction_receipt(tx.hash_hex())
+        assert_equal(receipt["outcomeStatus"], 0)
         address = receipt["contractCreated"]
         assert_is_hex_string(address)
         return receipt, address
 
     def call_contract(self, sender, priv_key, contract, data_hex):
-        tx = self.rpc[FULLNODE0].new_contract_tx(receiver=contract, data_hex=data_hex, sender=sender, priv_key=priv_key)
+        tx = self.rpc[FULLNODE0].new_contract_tx(receiver=contract, data_hex=data_hex, sender=sender, priv_key=priv_key, storage_limit=1000)
         assert_equal(self.rpc[FULLNODE0].send_tx(tx, True), tx.hash_hex())
         receipt = self.rpc[FULLNODE0].get_transaction_receipt(tx.hash_hex())
+        assert_equal(receipt["outcomeStatus"], 0)
         return receipt
 
 if __name__ == "__main__":

--- a/tests/log_filtering_test.py
+++ b/tests/log_filtering_test.py
@@ -153,6 +153,7 @@ class LogFilteringTest(ConfluxTestFramework):
         tx = self.rpc.new_contract_tx(receiver="", data_hex=data_hex, sender=sender, priv_key=priv_key, storage_limit=253)
         assert_equal(self.rpc.send_tx(tx, True), tx.hash_hex())
         receipt = self.rpc.get_transaction_receipt(tx.hash_hex())
+        assert_equal(receipt["outcomeStatus"], 0)
         address = receipt["contractCreated"]
         c1 = self.rpc.get_collateral_for_storage(sender)
         assert_equal(c1 - c0, 253 * 10 ** 18 // 1024)
@@ -164,6 +165,7 @@ class LogFilteringTest(ConfluxTestFramework):
         tx = self.rpc.new_contract_tx(receiver=contract, data_hex=data_hex, sender=sender, priv_key=priv_key, storage_limit=storage_limit)
         assert_equal(self.rpc.send_tx(tx, True), tx.hash_hex())
         receipt = self.rpc.get_transaction_receipt(tx.hash_hex())
+        assert_equal(receipt["outcomeStatus"], 0)
         c1 = self.rpc.get_collateral_for_storage(sender)
         assert_equal(c1 - c0, storage_limit * 10 ** 18 // 1024)
         return receipt


### PR DESCRIPTION
Storage limit was not properly set for contract calls, so we were comparing empty results.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1517)
<!-- Reviewable:end -->
