### PR TITLE
Make sure old-era block data is deleted from disk

### DIFF
--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -964,7 +964,7 @@ impl Cfx for CfxHandler {
         to self.common {
             fn best_block_hash(&self) -> JsonRpcResult<RpcH256>;
             fn block_by_epoch_number(
-                &self, epoch_num: EpochNumber, include_txs: bool) -> JsonRpcResult<RpcBlock>;
+                &self, epoch_num: EpochNumber, include_txs: bool) -> JsonRpcResult<Option<RpcBlock>>;
             fn block_by_hash_with_pivot_assumption(
                 &self, block_hash: RpcH256, pivot_hash: RpcH256, epoch_number: RpcU64)
                 -> JsonRpcResult<RpcBlock>;

--- a/client/src/rpc/impls/common.rs
+++ b/client/src/rpc/impls/common.rs
@@ -132,7 +132,7 @@ impl RpcImpl {
 
     pub fn block_by_epoch_number(
         &self, epoch_num: EpochNumber, include_txs: bool,
-    ) -> RpcResult<RpcBlock> {
+    ) -> RpcResult<Option<RpcBlock>> {
         let consensus_graph = self
             .consensus
             .as_any()
@@ -149,14 +149,12 @@ impl RpcImpl {
             .get_pivot_hash_from_epoch_number(epoch_height)
             .map_err(RpcError::invalid_params)?;
 
-        if let Some(block) = self
+        let maybe_block = self
             .data_man
             .block_by_hash(&pivot_hash, false /* update_cache */)
-        {
-            Ok(RpcBlock::new(&*block, inner, &self.data_man, include_txs))
-        } else {
-            Err(RpcError::internal_error())
-        }
+            .map(|b| RpcBlock::new(&*b, inner, &self.data_man, include_txs));
+
+        Ok(maybe_block)
     }
 
     pub fn confirmation_risk_by_hash(

--- a/client/src/rpc/impls/light.rs
+++ b/client/src/rpc/impls/light.rs
@@ -460,7 +460,7 @@ impl Cfx for CfxHandler {
     delegate! {
         to self.common {
             fn best_block_hash(&self) -> RpcResult<RpcH256>;
-            fn block_by_epoch_number(&self, epoch_num: EpochNumber, include_txs: bool) -> RpcResult<RpcBlock>;
+            fn block_by_epoch_number(&self, epoch_num: EpochNumber, include_txs: bool) -> RpcResult<Option<RpcBlock>>;
             fn block_by_hash_with_pivot_assumption(&self, block_hash: RpcH256, pivot_hash: RpcH256, epoch_number: RpcU64) -> RpcResult<RpcBlock>;
             fn block_by_hash(&self, hash: RpcH256, include_txs: bool) -> RpcResult<Option<RpcBlock>>;
             fn blocks_by_epoch(&self, num: EpochNumber) -> RpcResult<Vec<RpcH256>>;

--- a/client/src/rpc/traits/cfx.rs
+++ b/client/src/rpc/traits/cfx.rs
@@ -107,7 +107,7 @@ pub trait Cfx {
     #[rpc(name = "cfx_getBlockByEpochNumber")]
     fn block_by_epoch_number(
         &self, epoch_number: EpochNumber, include_txs: bool,
-    ) -> JsonRpcResult<Block>;
+    ) -> JsonRpcResult<Option<Block>>;
 
     /// Returns best block hash.
     #[rpc(name = "cfx_getBestBlockHash")]

--- a/core/src/storage/impls/storage_db/kvdb_rocksdb.rs
+++ b/core/src/storage/impls/storage_db/kvdb_rocksdb.rs
@@ -32,6 +32,7 @@ impl KeyValueDbTrait for KvdbRocksdb {
         random_crash_if_enabled("rocksdb delete");
         let mut transaction = self.kvdb.transaction();
         transaction.delete(self.col, key);
+        self.kvdb.write(transaction)?;
         Ok(None)
     }
 

--- a/tests/full_node_remove_old_eras_test.py
+++ b/tests/full_node_remove_old_eras_test.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+import os
+import eth_utils
+import time
+
+from conflux.config import default_config
+from conflux.filter import Filter
+from conflux.rpc import RpcClient
+from conflux.utils import sha3 as keccak, priv_to_addr
+from test_framework.blocktools import create_transaction, encode_hex_0x
+from test_framework.test_framework import ConfluxTestFramework
+from test_framework.util import *
+from test_framework.mininode import *
+
+CONTRACT_PATH = "contracts/EventsTestContract_bytecode.dat"
+CALLED_TOPIC = encode_hex_0x(keccak(b"Called(address,uint32)"))
+
+ARCHIVE_NODE = 0
+FULL_NODE = 1
+
+ERA_EPOCH_COUNT = 100
+
+class FullNodeRemoveOldErasTest(ConfluxTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+
+        # set era and snapshot length
+        self.conf_parameters["era_epoch_count"] = str(ERA_EPOCH_COUNT)
+        self.conf_parameters["dev_snapshot_epoch_count"] = str(ERA_EPOCH_COUNT // 2)
+
+        # set other params so that nodes won't crash
+        self.conf_parameters["adaptive_weight_beta"] = "1"
+        self.conf_parameters["anticone_penalty_ratio"] = "10"
+        self.conf_parameters["generate_tx_period_us"] = "100000"
+        self.conf_parameters["timer_chain_beta"] = "20"
+        self.conf_parameters["timer_chain_block_difficulty_ratio"] = "3"
+
+        # make sure GC is run often
+        self.conf_parameters["block_cache_gc_period_ms"] = "10"
+
+    def setup_network(self):
+        self.add_nodes(self.num_nodes)
+
+        self.start_node(ARCHIVE_NODE, ["--archive"])
+        self.start_node(FULL_NODE, ["--full"], phase_to_wait=None)
+
+        # set up RPC clients
+        self.rpc = [None] * self.num_nodes
+        self.rpc[ARCHIVE_NODE] = RpcClient(self.nodes[ARCHIVE_NODE])
+        self.rpc[FULL_NODE] = RpcClient(self.nodes[FULL_NODE])
+
+        # connect archive nodes, wait for phase changes to complete
+        connect_nodes(self.nodes, ARCHIVE_NODE, FULL_NODE)
+
+        self.nodes[ARCHIVE_NODE].wait_for_phase(["NormalSyncPhase"])
+        self.nodes[FULL_NODE].wait_for_phase(["NormalSyncPhase"])
+
+    def run_test(self):
+        num_block = 10 * ERA_EPOCH_COUNT
+
+        self.log.info(f"generating {num_block} blocks...")
+        self.rpc[ARCHIVE_NODE].generate_blocks(num_block)
+
+        # make sure blocks are synced and GC has enough time
+        sync_blocks(self.nodes)
+        time.sleep(1)
+
+        # under these parameters, checkpoints are formed after 4 eras
+        # we expect full nodes to keep the last 4 eras only
+        self.log.info(f"checking deleted blocks...")
+
+        for epoch in range(0, 6 * ERA_EPOCH_COUNT):
+            archive_block = self.rpc[ARCHIVE_NODE].block_by_epoch(hex(epoch), include_txs=True)
+            assert(archive_block != None)
+
+            full_block = self.rpc[FULL_NODE].block_by_epoch(hex(epoch), include_txs=True)
+            assert_equal(full_block, None)
+
+        self.log.info(f"checking existing blocks...")
+
+        for epoch in range(6 * ERA_EPOCH_COUNT, 10 * ERA_EPOCH_COUNT):
+            archive_block = self.rpc[ARCHIVE_NODE].block_by_epoch(hex(epoch), include_txs=True)
+            assert(archive_block != None)
+
+            full_block = self.rpc[FULL_NODE].block_by_epoch(hex(epoch), include_txs=True)
+            assert_equal(full_block, archive_block)
+
+        self.log.info("Pass")
+
+if __name__ == "__main__":
+    FullNodeRemoveOldErasTest().main()

--- a/tests/full_node_remove_old_eras_test.py
+++ b/tests/full_node_remove_old_eras_test.py
@@ -3,17 +3,9 @@ import os
 import eth_utils
 import time
 
-from conflux.config import default_config
-from conflux.filter import Filter
 from conflux.rpc import RpcClient
-from conflux.utils import sha3 as keccak, priv_to_addr
-from test_framework.blocktools import create_transaction, encode_hex_0x
 from test_framework.test_framework import ConfluxTestFramework
-from test_framework.util import *
-from test_framework.mininode import *
-
-CONTRACT_PATH = "contracts/EventsTestContract_bytecode.dat"
-CALLED_TOPIC = encode_hex_0x(keccak(b"Called(address,uint32)"))
+from test_framework.util import assert_equal, connect_nodes, sync_blocks
 
 ARCHIVE_NODE = 0
 FULL_NODE = 1
@@ -65,8 +57,7 @@ class FullNodeRemoveOldErasTest(ConfluxTestFramework):
         sync_blocks(self.nodes)
         time.sleep(1)
 
-        # under these parameters, checkpoints are formed after 4 eras
-        # we expect full nodes to keep the last 4 eras only
+        # we expect the first few eras are removed
         self.log.info(f"checking deleted blocks...")
 
         for epoch in range(0, 6 * ERA_EPOCH_COUNT):
@@ -78,7 +69,8 @@ class FullNodeRemoveOldErasTest(ConfluxTestFramework):
 
         self.log.info(f"checking existing blocks...")
 
-        for epoch in range(6 * ERA_EPOCH_COUNT, 10 * ERA_EPOCH_COUNT):
+        # we expect the last few eras are not removed
+        for epoch in range(7 * ERA_EPOCH_COUNT, 10 * ERA_EPOCH_COUNT):
             archive_block = self.rpc[ARCHIVE_NODE].block_by_epoch(hex(epoch), include_txs=True)
             assert(archive_block != None)
 


### PR DESCRIPTION
**Overview**

Due to a bug in `KvdbRocksdb` deletes were not committed. As a result, old era block info was not deleted on full nodes. This PR fixes this.

Also ensure that `cfx_getBlockByEpochNumber` returns `null` for blocks not found.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1519)
<!-- Reviewable:end -->
