### PR TITLE
Optimize snapshot write performance.

### DIFF
--- a/core/benchmark/storage/src/main.rs
+++ b/core/benchmark/storage/src/main.rs
@@ -1656,6 +1656,7 @@ impl TxReplayer {
                     "commit_log",
                     true,
                 )?),
+                false, /* unsafe_mode */
             )?
             .1,
             commit_log_vec: Default::default(),

--- a/core/src/block_data_manager/db_manager.rs
+++ b/core/src/block_data_manager/db_manager.rs
@@ -105,7 +105,7 @@ impl DBManager {
                     )
                     .unwrap(),
                 ),
-                false, /* fast_mode */
+                false, /* unsafe_mode */
             )
             .expect("Open sqlite failure");
             table_db.insert(

--- a/core/src/block_data_manager/db_manager.rs
+++ b/core/src/block_data_manager/db_manager.rs
@@ -105,6 +105,7 @@ impl DBManager {
                     )
                     .unwrap(),
                 ),
+                false, /* fast_mode */
             )
             .expect("Open sqlite failure");
             table_db.insert(

--- a/core/src/storage/impls/storage_db/delta_db_manager_sqlite.rs
+++ b/core/src/storage/impls/storage_db/delta_db_manager_sqlite.rs
@@ -67,6 +67,7 @@ impl DeltaDbManagerTrait for DeltaDbManagerSqlite {
                 path_str,
                 Self::kvdb_sqlite_statements(),
                 /* create_table = */ true,
+                /* fast_mode = */ false,
             )
         }
     }

--- a/core/src/storage/impls/storage_db/delta_db_manager_sqlite.rs
+++ b/core/src/storage/impls/storage_db/delta_db_manager_sqlite.rs
@@ -67,7 +67,7 @@ impl DeltaDbManagerTrait for DeltaDbManagerSqlite {
                 path_str,
                 Self::kvdb_sqlite_statements(),
                 /* create_table = */ true,
-                /* fast_mode = */ false,
+                /* unsafe_mode = */ false,
             )
         }
     }

--- a/core/src/storage/impls/storage_db/kvdb_sqlite.rs
+++ b/core/src/storage/impls/storage_db/kvdb_sqlite.rs
@@ -223,7 +223,7 @@ impl<ValueType> KvdbSqlite<ValueType> {
     }
 
     pub fn open_or_create<P: AsRef<Path>>(
-        path: P, statements: Arc<KvdbSqliteStatements>,
+        path: P, statements: Arc<KvdbSqliteStatements>, fast_mode: bool,
     ) -> Result<(bool, Self)> {
         if path.as_ref().exists() {
             Ok((true, Self::open(path, /* readonly = */ false, statements)?))
@@ -231,7 +231,7 @@ impl<ValueType> KvdbSqlite<ValueType> {
             Ok((
                 false,
                 Self::create_and_open(
-                    path, statements, /* create_table = */ true,
+                    path, statements, /* create_table = */ true, fast_mode,
                 )?,
             ))
         }
@@ -239,11 +239,14 @@ impl<ValueType> KvdbSqlite<ValueType> {
 
     pub fn create_and_open<P: AsRef<Path>>(
         path: P, statements: Arc<KvdbSqliteStatements>, create_table: bool,
-    ) -> Result<Self> {
+        fast_mode: bool,
+    ) -> Result<Self>
+    {
         let create_result = (|statements, path| -> Result<SqliteConnection> {
             let mut connection = SqliteConnection::create_and_open(
                 path,
                 SqliteConnection::default_open_flags(),
+                fast_mode,
             )?;
             if create_table {
                 Self::create_table(&mut connection, statements)?

--- a/core/src/storage/impls/storage_db/kvdb_sqlite.rs
+++ b/core/src/storage/impls/storage_db/kvdb_sqlite.rs
@@ -223,7 +223,7 @@ impl<ValueType> KvdbSqlite<ValueType> {
     }
 
     pub fn open_or_create<P: AsRef<Path>>(
-        path: P, statements: Arc<KvdbSqliteStatements>, fast_mode: bool,
+        path: P, statements: Arc<KvdbSqliteStatements>, unsafe_mode: bool,
     ) -> Result<(bool, Self)> {
         if path.as_ref().exists() {
             Ok((true, Self::open(path, /* readonly = */ false, statements)?))
@@ -231,7 +231,10 @@ impl<ValueType> KvdbSqlite<ValueType> {
             Ok((
                 false,
                 Self::create_and_open(
-                    path, statements, /* create_table = */ true, fast_mode,
+                    path,
+                    statements,
+                    /* create_table = */ true,
+                    unsafe_mode,
                 )?,
             ))
         }
@@ -239,14 +242,14 @@ impl<ValueType> KvdbSqlite<ValueType> {
 
     pub fn create_and_open<P: AsRef<Path>>(
         path: P, statements: Arc<KvdbSqliteStatements>, create_table: bool,
-        fast_mode: bool,
+        unsafe_mode: bool,
     ) -> Result<Self>
     {
         let create_result = (|statements, path| -> Result<SqliteConnection> {
             let mut connection = SqliteConnection::create_and_open(
                 path,
                 SqliteConnection::default_open_flags(),
-                fast_mode,
+                unsafe_mode,
             )?;
             if create_table {
                 Self::create_table(&mut connection, statements)?

--- a/core/src/storage/impls/storage_db/kvdb_sqlite_sharded.rs
+++ b/core/src/storage/impls/storage_db/kvdb_sqlite_sharded.rs
@@ -141,7 +141,7 @@ impl<ValueType> KvdbSqliteSharded<ValueType> {
 
     pub fn open_or_create<P: AsRef<Path>>(
         num_shards: u16, dir: P, statements: Arc<KvdbSqliteStatements>,
-        fast_mode: bool,
+        unsafe_mode: bool,
     ) -> Result<(bool, Self)>
     {
         if dir.as_ref().exists() {
@@ -155,8 +155,11 @@ impl<ValueType> KvdbSqliteSharded<ValueType> {
             Ok((
                 false,
                 Self::create_and_open(
-                    num_shards, dir, statements,
-                    /* create_table = */ true, fast_mode,
+                    num_shards,
+                    dir,
+                    statements,
+                    /* create_table = */ true,
+                    unsafe_mode,
                 )?,
             ))
         }
@@ -164,7 +167,7 @@ impl<ValueType> KvdbSqliteSharded<ValueType> {
 
     pub fn create_and_open<P: AsRef<Path>>(
         num_shards: u16, dir: P, statements: Arc<KvdbSqliteStatements>,
-        create_table: bool, fast_mode: bool,
+        create_table: bool, unsafe_mode: bool,
     ) -> Result<Self>
     {
         assert_valid_num_shards(num_shards);
@@ -174,7 +177,7 @@ impl<ValueType> KvdbSqliteSharded<ValueType> {
                 Self::db_path(&dir, i),
                 statements.clone(),
                 /* create_table = */ create_table,
-                fast_mode,
+                unsafe_mode,
             )?
             .into_connection()
             // Safe to unwrap since the connection is newly created.

--- a/core/src/storage/impls/storage_db/kvdb_sqlite_sharded.rs
+++ b/core/src/storage/impls/storage_db/kvdb_sqlite_sharded.rs
@@ -141,7 +141,9 @@ impl<ValueType> KvdbSqliteSharded<ValueType> {
 
     pub fn open_or_create<P: AsRef<Path>>(
         num_shards: u16, dir: P, statements: Arc<KvdbSqliteStatements>,
-    ) -> Result<(bool, Self)> {
+        fast_mode: bool,
+    ) -> Result<(bool, Self)>
+    {
         if dir.as_ref().exists() {
             Ok((
                 true,
@@ -153,7 +155,8 @@ impl<ValueType> KvdbSqliteSharded<ValueType> {
             Ok((
                 false,
                 Self::create_and_open(
-                    num_shards, dir, statements, /* create_table = */ true,
+                    num_shards, dir, statements,
+                    /* create_table = */ true, fast_mode,
                 )?,
             ))
         }
@@ -161,7 +164,7 @@ impl<ValueType> KvdbSqliteSharded<ValueType> {
 
     pub fn create_and_open<P: AsRef<Path>>(
         num_shards: u16, dir: P, statements: Arc<KvdbSqliteStatements>,
-        create_table: bool,
+        create_table: bool, fast_mode: bool,
     ) -> Result<Self>
     {
         assert_valid_num_shards(num_shards);
@@ -171,6 +174,7 @@ impl<ValueType> KvdbSqliteSharded<ValueType> {
                 Self::db_path(&dir, i),
                 statements.clone(),
                 /* create_table = */ create_table,
+                fast_mode,
             )?
             .into_connection()
             // Safe to unwrap since the connection is newly created.

--- a/core/src/storage/impls/storage_db/snapshot_db_sqlite.rs
+++ b/core/src/storage/impls/storage_db/snapshot_db_sqlite.rs
@@ -277,7 +277,7 @@ impl SnapshotDbTrait for SnapshotDbSqlite {
                     snapshot_path,
                     SNAPSHOT_DB_STATEMENTS.kvdb_statements.clone(),
                     /* create_table = */ true,
-                    /* fast_mode = */ true,
+                    /* unsafe_mode = */ true,
                 )?;
             let mut connections =
                 // Safe to unwrap since the connections are newly created.

--- a/core/src/storage/impls/storage_db/snapshot_db_sqlite.rs
+++ b/core/src/storage/impls/storage_db/snapshot_db_sqlite.rs
@@ -277,6 +277,7 @@ impl SnapshotDbTrait for SnapshotDbSqlite {
                     snapshot_path,
                     SNAPSHOT_DB_STATEMENTS.kvdb_statements.clone(),
                     /* create_table = */ true,
+                    /* fast_mode = */ true,
                 )?;
             let mut connections =
                 // Safe to unwrap since the connections are newly created.

--- a/core/src/storage/impls/storage_db/sqlite.rs
+++ b/core/src/storage/impls/storage_db/sqlite.rs
@@ -96,12 +96,23 @@ impl SqliteConnection {
         }
     }
 
-    pub fn create_and_init<P: AsRef<Path>>(path: P) -> Result<()> {
+    /// If `fast_mode` is true, data loss or database corruption may happen if
+    /// the process crashes, so it should only be used for write-once
+    /// databases where an unfinished temporary database will be removed
+    /// after process restart.
+    pub fn create_and_init<P: AsRef<Path>>(
+        path: P, fast_mode: bool,
+    ) -> Result<()> {
         let conn = Connection::open_with_flags(
             &path,
             Self::default_open_flags().set_read_write().set_create(),
         )?;
-        conn.execute("PRAGMA journal_mode=WAL")?;
+        if fast_mode {
+            conn.execute("PRAGMA journal_mode=OFF")?;
+            conn.execute("PRAGMA synchronous=OFF")?;
+        } else {
+            conn.execute("PRAGMA journal_mode=WAL")?;
+        }
         // Prevent other processes from accessing the db.
         // The "-shm" file will not be created,
         // see https://www.sqlite.org/tempfiles.html#shared_memory_files.
@@ -110,9 +121,9 @@ impl SqliteConnection {
     }
 
     pub fn create_and_open<P: AsRef<Path>>(
-        path: P, open_flags: OpenFlags,
+        path: P, open_flags: OpenFlags, fast_mode: bool,
     ) -> Result<Self> {
-        Self::create_and_init(path.as_ref())?;
+        Self::create_and_init(path.as_ref(), fast_mode)?;
         Self::open(path, false, open_flags)
     }
 

--- a/core/src/storage/impls/storage_db/sqlite.rs
+++ b/core/src/storage/impls/storage_db/sqlite.rs
@@ -96,18 +96,18 @@ impl SqliteConnection {
         }
     }
 
-    /// If `fast_mode` is true, data loss or database corruption may happen if
+    /// If `unsafe_mode` is true, data loss or database corruption may happen if
     /// the process crashes, so it should only be used for write-once
     /// databases where an unfinished temporary database will be removed
     /// after process restart.
     pub fn create_and_init<P: AsRef<Path>>(
-        path: P, fast_mode: bool,
+        path: P, unsafe_mode: bool,
     ) -> Result<()> {
         let conn = Connection::open_with_flags(
             &path,
             Self::default_open_flags().set_read_write().set_create(),
         )?;
-        if fast_mode {
+        if unsafe_mode {
             conn.execute("PRAGMA journal_mode=OFF")?;
             conn.execute("PRAGMA synchronous=OFF")?;
         } else {
@@ -121,9 +121,9 @@ impl SqliteConnection {
     }
 
     pub fn create_and_open<P: AsRef<Path>>(
-        path: P, open_flags: OpenFlags, fast_mode: bool,
+        path: P, open_flags: OpenFlags, unsafe_mode: bool,
     ) -> Result<Self> {
-        Self::create_and_init(path.as_ref(), fast_mode)?;
+        Self::create_and_init(path.as_ref(), unsafe_mode)?;
         Self::open(path, false, open_flags)
     }
 

--- a/core/src/storage/impls/storage_manager/storage_manager.rs
+++ b/core/src/storage/impls/storage_manager/storage_manager.rs
@@ -107,7 +107,7 @@ impl StorageManager {
         let (_, snapshot_info_db) = KvdbSqlite::open_or_create(
             &storage_conf.path_snapshot_info_db,
             SNAPSHOT_KVDB_STATEMENTS.clone(),
-            false, /* fast_mode */
+            false, /* unsafe_mode */
         )?;
 
         let (

--- a/core/src/storage/impls/storage_manager/storage_manager.rs
+++ b/core/src/storage/impls/storage_manager/storage_manager.rs
@@ -107,6 +107,7 @@ impl StorageManager {
         let (_, snapshot_info_db) = KvdbSqlite::open_or_create(
             &storage_conf.path_snapshot_info_db,
             SNAPSHOT_KVDB_STATEMENTS.clone(),
+            false, /* fast_mode */
         )?;
 
         let (


### PR DESCRIPTION
Data loss during snapshot writes (merging a new snapshot or writing a synchronized snapshot) should not be a problem, because a temp database will not be used. And the snapshot is renamed and used only after all write completes and the snapshot is closed.

Thus we can just set 

    PRAGMA journal_mode=OFF
    PRAGMA synchronous=OFF

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1536)
<!-- Reviewable:end -->
