### PR TITLE
Fix a race that prevents block bodies from being inserted.

### DIFF
--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -964,10 +964,11 @@ impl SynchronizationProtocolHandler {
                         false, // insert_into_consensus
                         true,  // persistent
                     );
-                    if !insert_result.is_new_valid() {
-                        // If header is invalid or already processed, we do not
-                        // need to request the block, so
-                        // just mark it received
+                    if !insert_result.should_process_body() {
+                        // If the header is invalid or the block has been
+                        // processed in consensus, we do not need to request the
+                        // block, so just mark it
+                        // received.
                         received_blocks.insert(hash);
                         continue;
                     }


### PR DESCRIPTION
There was a rare execution order that triggers this bug:

1. A full node requests a block body and header at the same time. (This is possible because of issue #1549.)
2. The body and header are received at the same time.
3. The body is processed first, and it sees the header was not inserted. https://github.com/Conflux-Chain/conflux-rust/blob/f923f6795829c1cd8b8c5f6f90884b9cbb7f1cfa/core/src/sync/synchronization_protocol_handler.rs#L953-L955
4. The received independent header is inserted.
5. The body inserts the block header and finds it already processed, so skips inserting the body. https://github.com/Conflux-Chain/conflux-rust/blob/f923f6795829c1cd8b8c5f6f90884b9cbb7f1cfa/core/src/sync/synchronization_protocol_handler.rs#L960-L973

Now the body is ignored unexpectedly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1550)
<!-- Reviewable:end -->
