### PR TITLE
Remove is_contract field. Make the underlying state code consistent w…

### DIFF
--- a/core/src/executive/executive.rs
+++ b/core/src/executive/executive.rs
@@ -1409,7 +1409,7 @@ impl<'a> Executive<'a> {
         let mut storage_sponsored = false;
         match tx.action {
             Action::Call(ref address) => {
-                if self.state.is_contract(address) {
+                if address.is_contract_address() {
                     code_address = *address;
                     if self
                         .state
@@ -1569,7 +1569,12 @@ impl<'a> Executive<'a> {
                     &tx.data,
                 );
 
-                if self.state.is_contract(&new_address) {
+                // For a contract address already with code, we do not allow
+                // overlap the address. This should generally
+                // not happen. Unless we enable account dust in
+                // future. We add this check just in case it
+                // helps in future.
+                if self.state.is_contract_with_code(&new_address) {
                     return Ok(ExecutionOutcome::ExecutionErrorBumpNonce(
                         ExecutionError::ContractAddressConflict,
                         Executed::execution_error_fully_charged(tx),

--- a/core/src/executive/internal_contract/impls/sponsor.rs
+++ b/core/src/executive/internal_contract/impls/sponsor.rs
@@ -7,7 +7,7 @@ use crate::{
     state::{State, Substate},
     vm::{self, ActionParams, CallType, Spec},
 };
-use cfx_types::{Address, U256};
+use cfx_types::{address_util::AddressUtil, Address, U256};
 use std::str::FromStr;
 
 lazy_static! {
@@ -51,7 +51,7 @@ impl SponsorWhitelistControl {
             ));
         }
 
-        if !state.is_contract(&contract_address) {
+        if !contract_address.is_contract_address() {
             return Err(vm::Error::InternalContract(
                 "not allowed to sponsor non-contract account",
             ));
@@ -157,7 +157,7 @@ impl SponsorWhitelistControl {
             ));
         }
 
-        if !state.is_contract(&contract_address) {
+        if !contract_address.is_contract_address() {
             return Err(vm::Error::InternalContract(
                 "not allowed to sponsor non-contract account",
             ));
@@ -229,7 +229,7 @@ impl SponsorWhitelistControl {
     fn add_privilege(
         &self, input: &[u8], params: &ActionParams, state: &mut State,
     ) -> vm::Result<()> {
-        if !state.is_contract(&params.sender) {
+        if !params.sender.is_contract_address() {
             return Err(vm::Error::InternalContract(
                 "normal account is not allowed to set commission_privilege",
             ));
@@ -268,7 +268,7 @@ impl SponsorWhitelistControl {
     fn remove_privilege(
         &self, input: &[u8], params: &ActionParams, state: &mut State,
     ) -> vm::Result<()> {
-        if !state.is_contract(&params.sender) {
+        if !params.sender.is_contract_address() {
             return Err(vm::Error::InternalContract(
                 "normal account is not allowed to set commission_privilege",
             ));

--- a/core/src/state/account_entry_tests.rs
+++ b/core/src/state/account_entry_tests.rs
@@ -9,7 +9,7 @@ use crate::{
     statedb::StateDb,
     storage::{tests::new_state_manager_for_unit_test, StorageManagerTrait},
 };
-use cfx_types::{Address, H256, U256};
+use cfx_types::{address_util::AddressUtil, Address, H256, U256};
 use primitives::{Account, SponsorInfo, VoteStakeList};
 
 #[test]
@@ -41,7 +41,10 @@ fn test_overlay_account_create() {
     assert_eq!(*overlay_account.admin(), Address::zero());
     assert_eq!(*overlay_account.sponsor_info(), Default::default());
 
-    let address = Address::random();
+    let mut address = Address::random();
+    address.set_user_account_type_bits();
+    let mut contract_address = Address::random();
+    contract_address.set_contract_type_bits();
     let admin = Address::random();
     let sponsor_info = SponsorInfo {
         sponsor_for_gas: Address::random(),
@@ -96,11 +99,14 @@ fn test_overlay_account_create() {
     assert_eq!(*overlay_account.sponsor_info(), Default::default());
 
     // test new contract
-    let mut overlay_account =
-        OverlayAccount::new_contract(&address, 5678.into(), 1234.into());
+    let mut overlay_account = OverlayAccount::new_contract(
+        &contract_address,
+        5678.into(),
+        1234.into(),
+    );
     assert!(overlay_account.deposit_list().is_none());
     assert!(overlay_account.vote_stake_list().is_none());
-    assert_eq!(*overlay_account.address(), address);
+    assert_eq!(*overlay_account.address(), contract_address);
     assert_eq!(*overlay_account.balance(), 5678.into());
     assert_eq!(*overlay_account.nonce(), 1234.into());
     assert_eq!(*overlay_account.staking_balance(), 0.into());
@@ -116,14 +122,14 @@ fn test_overlay_account_create() {
 
     // test new contract with admin
     let overlay_account = OverlayAccount::new_contract_with_admin(
-        &address,
+        &contract_address,
         5678.into(),
         1234.into(),
         &admin,
     );
     assert!(overlay_account.deposit_list().is_none());
     assert!(overlay_account.vote_stake_list().is_none());
-    assert_eq!(*overlay_account.address(), address);
+    assert_eq!(*overlay_account.address(), contract_address);
     assert_eq!(*overlay_account.balance(), 5678.into());
     assert_eq!(*overlay_account.nonce(), 1234.into());
     assert_eq!(*overlay_account.staking_balance(), 0.into());

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -210,7 +210,7 @@ impl State {
         }
         if inc > 0 {
             let delta = U256::from(inc) * *COLLATERAL_PER_STORAGE_KEY;
-            if self.is_contract(addr) {
+            if addr.is_contract_address() {
                 let sponsor_balance =
                     self.sponsor_balance_for_collateral(addr)?;
                 // sponsor_balance is not enough to cover storage incremental.
@@ -408,10 +408,12 @@ impl State {
         })
     }
 
-    // TODO: first check the type bits of the address.
-    pub fn is_contract(&self, address: &Address) -> bool {
+    pub fn is_contract_with_code(&self, address: &Address) -> bool {
+        if !address.is_contract_address() {
+            return false;
+        }
         self.ensure_cached(address, RequireCache::None, |acc| {
-            acc.map_or(false, |acc| acc.is_contract())
+            acc.map_or(false, |acc| acc.code_hash() != KECCAK_EMPTY)
         })
         .unwrap_or(false)
     }


### PR DESCRIPTION
…ith the above implementation that uses type_bits.

This will avoid potential inconsistency issues.

Also fixes test cases that does not follow type bits

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1564)
<!-- Reviewable:end -->
