### PR TITLE
Make CacheManager include block header and local block info size.

### DIFF
--- a/core/src/block_data_manager/mod.rs
+++ b/core/src/block_data_manager/mod.rs
@@ -1191,8 +1191,9 @@ impl BlockDataManager {
         let mut local_block_info = self.local_block_info.write();
         let mut cache_man = self.cache_man.lock();
         debug!(
-            "Before gc cache_size={} {} {} {} {} {} {}",
+            "Before gc cache_size={} {} {} {} {} {} {} {}",
             current_size,
+            block_headers.len(),
             blocks.len(),
             compact_blocks.len(),
             executed_results.len(),

--- a/core/src/cache_manager.rs
+++ b/core/src/cache_manager.rs
@@ -145,10 +145,12 @@ pub struct CacheSize {
 impl CacheSize {
     /// Total amount used by the cache.
     pub fn total(&self) -> usize {
-        self.blocks
+        self.block_headers
+            + self.blocks
+            + self.compact_blocks
             + self.block_receipts
             + self.block_rewards
             + self.transaction_indices
-            + self.compact_blocks
+            + self.local_block_infos
     }
 }


### PR DESCRIPTION
This might be one of the reasons for OOM in main net servers.

Another OOM-related issue is #1569.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1570)
<!-- Reviewable:end -->
