### PR TITLE
This commit sorts out issues around address type bits, sending to non…

### DIFF
--- a/cfx_types/src/lib.rs
+++ b/cfx_types/src/lib.rs
@@ -29,7 +29,6 @@ pub fn hexstr_to_h256(hex_str: &str) -> H256 {
 
 pub mod address_util {
     use super::Address;
-    use std::collections::BTreeMap;
 
     pub const TYPE_BITS_BUILTIN: u8 = 0x00;
     pub const TYPE_BITS_CONTRACT: u8 = 0x80;

--- a/cfx_types/src/lib.rs
+++ b/cfx_types/src/lib.rs
@@ -51,10 +51,10 @@ pub mod address_util {
         }
 
         #[inline]
-        fn is_valid_address<T>(&self, builtin_map: &BTreeMap<Self, T>) -> bool {
+        fn is_valid_address(&self) -> bool {
             self.is_contract_address()
                 || self.is_user_account_address()
-                || self.is_builtin_address(builtin_map)
+                || self.is_builtin_address()
         }
 
         #[inline]
@@ -68,11 +68,8 @@ pub mod address_util {
         }
 
         #[inline]
-        fn is_builtin_address<T>(
-            &self, builtin_map: &BTreeMap<Self, T>,
-        ) -> bool {
+        fn is_builtin_address(&self) -> bool {
             self.address_type_bits() == TYPE_BITS_BUILTIN
-                && builtin_map.contains_key(self)
         }
 
         #[inline]

--- a/client/src/common/mod.rs
+++ b/client/src/common/mod.rs
@@ -296,7 +296,7 @@ pub fn initialize_not_light_node_modules(
     String,
 > {
     let (
-        machine,
+        _machine,
         secret_store,
         data_man,
         txpool,
@@ -425,7 +425,6 @@ pub fn initialize_not_light_node_modules(
         maybe_txgen.clone(),
         maybe_direct_txgen,
         conf.rpc_impl_config(),
-        machine,
     ));
 
     let debug_rpc_http_server = super::rpc::start_http(

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -299,7 +299,7 @@ impl RpcImpl {
         &self, tx: TransactionWithSignature,
     ) -> RpcResult<RpcH256> {
         if let Call(address) = &tx.transaction.action {
-            if !address.is_valid_address(self.machine.builtins()) {
+            if !address.is_valid_address() {
                 bail!(invalid_params("tx", "Sending transactions to invalid address. The first four bits must be 0x0 (built-in/reserved), 0x1 (user-account), or 0x8 (contract)."));
             }
         }

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -22,7 +22,7 @@ use crate::rpc::{
 use blockgen::BlockGenerator;
 use cfx_types::{H160, H256, U256};
 use cfxcore::{
-    block_data_manager::BlockExecutionResultWithEpoch, machine::Machine,
+    block_data_manager::BlockExecutionResultWithEpoch,
     state_exposer::STATE_EXPOSER, test_context::*, vm, ConsensusGraph,
     ConsensusGraphTrait, PeerInfo, SharedConsensusGraph,
     SharedSynchronizationService, SharedTransactionPool,

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -50,7 +50,6 @@ pub struct RpcImpl {
     tx_pool: SharedTransactionPool,
     maybe_txgen: Option<Arc<TransactionGenerator>>,
     maybe_direct_txgen: Option<Arc<Mutex<DirectTransactionGenerator>>>,
-    machine: Arc<Machine>,
 }
 
 impl RpcImpl {
@@ -59,7 +58,7 @@ impl RpcImpl {
         block_gen: Arc<BlockGenerator>, tx_pool: SharedTransactionPool,
         maybe_txgen: Option<Arc<TransactionGenerator>>,
         maybe_direct_txgen: Option<Arc<Mutex<DirectTransactionGenerator>>>,
-        config: RpcImplConfiguration, machine: Arc<Machine>,
+        config: RpcImplConfiguration,
     ) -> Self
     {
         RpcImpl {
@@ -70,7 +69,6 @@ impl RpcImpl {
             maybe_txgen,
             maybe_direct_txgen,
             config,
-            machine,
         }
     }
 

--- a/core/src/executive/executive.rs
+++ b/core/src/executive/executive.rs
@@ -330,7 +330,7 @@ impl<'a> CallCreateExecutive<'a> {
     ) -> vm::Result<()>
     {
         if let ActionValue::Transfer(val) = params.value {
-            // It is a common practice to first send money to a pre-calculated
+            // It is possible to first send money to a pre-calculated
             // contract address.
             let prev_balance = state.balance(&params.address)?;
             state.sub_balance(

--- a/core/src/executive/executive.rs
+++ b/core/src/executive/executive.rs
@@ -330,6 +330,9 @@ impl<'a> CallCreateExecutive<'a> {
     ) -> vm::Result<()>
     {
         if let ActionValue::Transfer(val) = params.value {
+            // It is a common practice to first send money to a pre-calculated
+            // contract address.
+            let prev_balance = state.balance(&params.address)?;
             state.sub_balance(
                 &params.sender,
                 &val,
@@ -338,7 +341,7 @@ impl<'a> CallCreateExecutive<'a> {
             state.new_contract_with_admin(
                 &params.address,
                 &params.original_sender,
-                val,
+                val.saturating_add(prev_balance),
                 state.contract_start_nonce(),
             )?;
         } else {

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -1364,7 +1364,7 @@ impl State {
     ) -> DbResult<MappedRwLockWriteGuard<OverlayAccount>> {
         self.require_or_set(address, false, |address| {
             if address.is_valid_address() {
-                // Note that it is a common practice to first send money to a pre-calculated contract
+                // Note that it is possible to first send money to a pre-calculated contract
                 // address and then deploy contracts. So we are going to *allow* sending to a contract
                 // address and use new_basic() to create a *stub* there. Because the contract serialization
                 // is a super-set of the normal address serialization, this should just work.

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -718,7 +718,7 @@ impl State {
         &mut self, address: &Address, by: &U256, cleanup_mode: CleanupMode,
     ) -> DbResult<()> {
         let exists = self.exists(address)?;
-        if !exists && !address.is_valid_address() {
+        if !address.is_valid_address() {
             // Sending to invalid addresses are not allowed. Note that this
             // check is required because at serialization we assume
             // only valid addresses.

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -688,14 +688,14 @@ impl State {
     }
 
     pub fn inc_nonce(&mut self, address: &Address) -> DbResult<()> {
-        self.require_or_new_user_account(address)
+        self.require_or_new_basic_account(address)
             .map(|mut x| x.inc_nonce())
     }
 
     pub fn set_nonce(
         &mut self, address: &Address, nonce: &U256,
     ) -> DbResult<()> {
-        self.require_or_new_user_account(address)
+        self.require_or_new_basic_account(address)
             .map(|mut x| x.set_nonce(nonce))
     }
 
@@ -718,16 +718,17 @@ impl State {
         &mut self, address: &Address, by: &U256, cleanup_mode: CleanupMode,
     ) -> DbResult<()> {
         let exists = self.exists(address)?;
-        if !exists && !address.is_user_account_address() {
-            // Sending to non-existent non user account address is
-            // not allowed.
+        if !exists && !address.is_valid_address() {
+            // Sending to invalid addresses are not allowed. Note that this
+            // check is required because at serialization we assume
+            // only valid addresses.
             //
             // There are checks to forbid it at transact level.
             //
             // The logic here is intended for incorrect miner coin-base. In this
             // case, the mining reward get lost.
             warn!(
-                "add_balance: address does not already exist and is not an user account. {:?}",
+                "add_balance: address does not already exist and is not a valid address. {:?}",
                 address
             );
             return Ok(());
@@ -735,7 +736,7 @@ impl State {
         if !by.is_zero()
             || (cleanup_mode == CleanupMode::ForceCreate && !exists)
         {
-            self.require_or_new_user_account(address)?.add_balance(by);
+            self.require_or_new_basic_account(address)?.add_balance(by);
         }
 
         if let CleanupMode::TrackTouched(set) = cleanup_mode {
@@ -1358,11 +1359,15 @@ impl State {
         self.require_or_set(address, require_code, no_account_is_an_error)
     }
 
-    fn require_or_new_user_account(
+    fn require_or_new_basic_account(
         &self, address: &Address,
     ) -> DbResult<MappedRwLockWriteGuard<OverlayAccount>> {
         self.require_or_set(address, false, |address| {
-            if address.is_user_account_address() {
+            if address.is_valid_address() {
+                // Note that it is a common practice to first send money to a pre-calculated contract
+                // address and then deploy contracts. So we are going to *allow* sending to a contract
+                // address and use new_basic() to create a *stub* there. Because the contract serialization
+                // is a super-set of the normal address serialization, this should just work.
                 Ok(OverlayAccount::new_basic(
                     address,
                     U256::zero(),

--- a/tests/rpc/test_send_tx.py
+++ b/tests/rpc/test_send_tx.py
@@ -29,8 +29,7 @@ class TestSendTx(RpcClient):
         assert_equal(self.send_tx(tx, True), tx.hash_hex())
         # non-builtin address starts with 0x0
         tx = self.new_tx(receiver="0x00e45681ac6c53d5a40475f7526bac1fe7590fb8")
-        encoded = eth_utils.encode_hex(rlp.encode(tx))
-        assert_raises_rpc_error(None, None, self.send_raw_tx, encoded)
+        assert_equal(self.send_tx(tx, True), tx.hash_hex())
         # call address starts with 0x30
         tx = self.new_tx(receiver="0x30e45681ac6c53d5a40475f7526bac1fe7590fb8")
         encoded = eth_utils.encode_hex(rlp.encode(tx))


### PR DESCRIPTION
…-existing contract address, and serilization.

1. Sending to valid addresses (0x0, 0x1, 0x8) is allowed.

2. Send to contract addresses will create a stub

3. Fix RLP encoding/decoding that do not consider built-in addresses.

4. On contract creation, it will fetch old balance and add on top of it.

Note that sending to non-existent pre-calculated contract address is a common practice.
In fact, we will need to do similar things for #1162.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1575)
<!-- Reviewable:end -->
