### PR TITLE
Call CacheManager.note_used for transaction_indices.

### DIFF
--- a/core/src/block_data_manager/mod.rs
+++ b/core/src/block_data_manager/mod.rs
@@ -805,6 +805,9 @@ impl BlockDataManager {
             self.transaction_indices
                 .write()
                 .insert(hash.clone(), tx_index.clone());
+            self.cache_man
+                .lock()
+                .note_used(CacheId::TransactionAddress(*hash));
         }
     }
 


### PR DESCRIPTION
Otherwise, they will not be garbage collected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1580)
<!-- Reviewable:end -->
