### PR TITLE
Rename RPC send_transaction with cfx_sendTransaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ was caused by a wrong assumption of the uniqueness of the trie proof key.
 
 ## Improvements
 
+- Rename local rpc send_transaction with cfx_sendTransaction.
+
 - Improve the performance of the consensus layer for unstable TreeGraph scenarios. 
 
 - Complete the protocol version mechanism for node communications and bump

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -370,7 +370,7 @@ impl RpcImpl {
     fn send_transaction(
         &self, tx: SendTxRequest, password: Option<String>,
     ) -> RpcResult<RpcH256> {
-        info!("RPC Request: send_transaction, tx = {:?}", tx);
+        info!("RPC Request: cfx_sendTransaction, tx = {:?}", tx);
 
         self.prepare_transaction(tx, password)
             .and_then(|tx| self.send_transaction_with_signature(tx))

--- a/client/src/rpc/impls/light.rs
+++ b/client/src/rpc/impls/light.rs
@@ -321,7 +321,7 @@ impl RpcImpl {
     fn send_transaction(
         &self, mut tx: SendTxRequest, password: Option<String>,
     ) -> BoxFuture<RpcH256> {
-        info!("RPC Request: send_transaction tx={:?}", tx);
+        info!("RPC Request: cfx_sendTransaction tx={:?}", tx);
 
         // clone `self.light` to avoid lifetime issues due to capturing `self`
         let light = self.light.clone();

--- a/client/src/rpc/traits/debug.rs
+++ b/client/src/rpc/traits/debug.rs
@@ -76,7 +76,7 @@ pub trait LocalRpc {
     #[rpc(name = "sync_graph_state")]
     fn sync_graph_state(&self) -> JsonRpcResult<SyncGraphStates>;
 
-    #[rpc(name = "send_transaction")]
+    #[rpc(name = "cfx_sendTransaction")]
     fn send_transaction(
         &self, tx: SendTxRequest, password: Option<String>,
     ) -> BoxFuture<RpcH256>;

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -558,7 +558,7 @@ subcommands:
                         about: Send a transaction and return its hash
                         args:
                             - rpc-method:
-                                default_value: send_transaction
+                                default_value: cfx_sendTransaction
                                 hidden: true
                             - rpc-args:
                                 multiple: true


### PR DESCRIPTION
The change is requested by https://github.com/Conflux-Chain/js-conflux-sdk/pull/43

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1588)
<!-- Reviewable:end -->
