### PR TITLE
Fix occasional random failure of full_nodes/p2p_era_test.py.

### DIFF
--- a/tests/full_node_tests/p2p_era_test.py
+++ b/tests/full_node_tests/p2p_era_test.py
@@ -47,7 +47,9 @@ class P2PTest(ConfluxTestFramework):
 
     def setup_network(self):
         self.setup_nodes()
-        connect_sample_nodes(self.nodes, self.log)
+        # Make all nodes fully connected, so a crashed archive node can be connected to another
+        # archive node to catch up
+        connect_sample_nodes(self.nodes, self.log, sample=self.num_nodes - 1)
         sync_blocks(self.nodes)
 
     def run_test(self):


### PR DESCRIPTION
If all 3 peers of an archive node are full nodes, when its data
are cleaned up and it is restarted, it will be unable to catch up
because its peer have deleted the early blocks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1606)
<!-- Reviewable:end -->
