### PR TITLE
Fix typos in recent docs

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -12,51 +12,51 @@ Code/protocol changes are classified into the following four different types.
 Based on the type of the proposed change, it will go through slightly different
 process.
 
-**Backward Compatible Changes:** The updated client will be fully compatible. It
-may introduce additional RPC or introduce new features. To submit a backward compatible change,
-here is the process:
+**Backward Compatible Changes:** The updated client will be fully compatible with older versions. Such changes
+may introduce additional RPC APIs or other new features. To submit a backward compatible change,
+please follow this process:
 
 * Fork the conflux-rust repository and submit a pull request.
-* If it is a complicated change, please fire an [issue](https://github.com/Conflux-Chain/conflux-rust/issues) to communicate with the core devs first.
+* If it is a complicated change, please submit an [issue](https://github.com/Conflux-Chain/conflux-rust/issues) to communicate with the core devs first.
 
 **Database/RPC Breaking Changes:** The updated client will be able to co-exist
-with previous versions, but it udpates the interface/behavior of an existing
+with previous versions, but it updates the interface/behavior of an existing
 RPC or it changes the blockchain database format. This would require
 modifications for applications depending on these RPCs and/or clean up the
 database to sync from the scratch. To submit a Database/RPC breaking change,
-you can follow the above process but you have to fire an issue first.
+you can follow the above process but you have to submit an issue first.
 
-**Protocol Breaking Changes:** Those changes do not touch the specification of
+**Protocol Breaking Changes:** These changes do not touch the specification of
 the Conflux Protocol, but require an update to the P2P network protocol in
-Conflux/Conflux-Rust. It is possible to enable the change without hard-fork but
-it would require special protocol version handling and compatability testing.
-To submit a protocol breaking changes, here is the process:
+Conflux/Conflux-Rust. It is possible to enable the change without a hard-fork but
+it would require special protocol version handling and compatibility testing.
+To submit a protocol breaking change, please follow this process:
 
 * Submit a Conflux Improvement Proposal ([CIP](https://github.com/Conflux-Chain/CIPs)) draft.
 * Discuss the CIP until it is accepted. Note that in the CIP, it is important
-to specify how the implementation can keep the compatability with the previous
-protocol (via versioning or other techniques). If this cannot be done, the
+to specify how the implementation can maintain compatibility with previous
+protocol versions (via versioning or other techniques). If this cannot be done, the
 change should be classified and treated as a spec breaking change instead.
 * Create an issue in Conflux-Rust corresponding to the CIP.
-* Submit a pull request implementing the CIP. 
-* Audit, test, and/or verify the implemetation. The PR will be merged into the
+* Submit a pull request implementing the CIP.
+* Audit, test, and/or verify the implementation. The PR will be merged into the
 master branch. The core developer team may choose to also merge the PR to other
-branch for Conflux-Rust client releases.
-* Once a release enables the change. Change the CIP status to final.
+branches for Conflux-Rust client releases.
+* Once a release enables the change, update the CIP status to final.
 
-**Spec Breaking Changes:** Those changes require an update to the specification
+**Spec Breaking Changes:** These changes require an update to the specification
 of the Conflux protocol. It would require a hard-fork to enable the change. It
-has no backward compatability at all. The general process for making spec
+has no backward compatibility at all. The general process for making spec
 breaking changes are:
 
 * Submit a Conflux Improvement Proposal (CIP) draft. The draft should discuss how
 to enable this change in a hard-fork.
 * Discuss the CIP until it is accepted.
 * Create an issue in the Conflux-Protocol repo corresponding to the CIP.
-* Submit a pull request to Conflux-Protocol to change the spec according to the CIP.
+* Submit a pull request to the Conflux-Protocol repo to change the spec according to the CIP.
 * Create an issue in the Conflux-Rust repo corresponding to the CIP.
-* Submit a pull request implementing the CIP. 
-* Audit, test, and/or verify the implemetation. The PR will be merged into the
+* Submit a pull request implementing the CIP.
+* Audit, test, and/or verify the implementation. The PR will be merged into the
 master branch.
 * Wait for a hard-fork to enable the change. Change the CIP status to final.
 
@@ -64,22 +64,22 @@ Note that now light client modes in Conflux-Rust are considered experimental. Al
 
 ## Submit an Issue
 
-If you encounter a bug when running Conflux-Rust or you have enhancement suggestions. You are welcome to submit an issue. Note that Conflux-Rust is the full node client for Conflux. If you are experiencing bugs when using wallet, scan, etc., it is most likely a bug in these products rather than Conflux-Rust. Also note that for protocol/spec breaking changes, please create a CIP as well. Here is how issues will be managed:
+If you encounter a bug when running Conflux-Rust or you have enhancement suggestions, you are welcome to submit an issue. Note that Conflux-Rust is the full node client for Conflux. If you are experiencing bugs when using wallet, scan, etc., it is most likely a bug in these products rather than Conflux-Rust. Also note that for protocol/spec breaking changes, please create a CIP as well. Here is how issues will be managed:
 
-* Submit a new issue. For bug reports, please provide as detailed steps as possible about how to *reproduce* this bug. If you have log files you can provide, that would be very helpful as well. For enhancement suggestions, please explain in details about the *motivation* of the proposed changes, i.e., how this change will help applications running on top of Conflux-Rust.
-* One of the core development team member will be assigned to the issue to drive the discussion. After the discussion, the issue would be assigned with the "bug", "enhancement", or "wontchange" label. For issues with the "wontchange" label, it will be closed in 7 days. For "bug" and "enhancement" issues, it will also receive a label to classify the estimated changes as "spec-breaking", "protocol-breaking", "database/rpc-breaking", and "backward compatible".
+* Submit a new issue. For bug reports, please provide steps as detailed as possible about how to *reproduce* this bug. If you have log files you can provide, that would be very helpful as well. For enhancement suggestions, please explain in details about the *motivation* of the proposed changes, i.e., how this change will help applications running on top of Conflux-Rust.
+* One of the core development team members will be assigned to the issue to drive the discussion. After the discussion, the issue would be tagged with the "bug", "enhancement", or "wontchange" label. Issues tagged with the "wontchange" label will be closed within 7 days. For "bug" and "enhancement" issues, it will also receive a label to classify the estimated changes as "spec-breaking", "protocol-breaking", "database/rpc-breaking", and "backward compatible".
 * If a PR is already submitted together with the Issue, then the PR will be reviewed by the assigned discussion lead. Once the PR is merged, this issue will be closed.
-* If the issue needs the core development team to address, it will receive the label "need triage". A new core team member will be assigned as the implementation lead together with a priority label "P0", "P1", "P2", and "P3". Once the implementation PR are developed and merged, the issue will be closed. 
+* If the issue needs the core development team to address, it will receive the label "need triage". A new core team member will be assigned as the implementation lead together with a priority label "P0", "P1", "P2", and "P3". Once the implementation PR has been developed and merged, the issue will be closed.
 
 ## Submit a Pull Request
 
-We would love your contribution to Conflux-Rust repository. Here are basic rules for submitting PRs.
+We welcome your contribution to the Conflux-Rust repository. Here are the basic rules for submitting PRs.
 
 * Pull requests need to be based on and opened against the `master` branch.
 * Code must be formatted using [cargo_fmt.sh](https://github.com/Conflux-Chain/conflux-rust/blob/master/cargo_fmt.sh).
 * We use reviewable.io as our code review tool for any pull request.
-* If neccessary, update CHANGELOG.md to document your changes.
+* If necessary, update CHANGELOG.md to document your changes.
 
 ## Submit a Conflux Improvement Proposal (CIP)
 
-We have a saperate repository to manage all CIP. See [README](https://github.com/Conflux-Chain/CIPs/blob/master/README.md) in the repo.
+We have a separate repository to manage all CIPs. See [README](https://github.com/Conflux-Chain/CIPs/blob/master/README.md) in the repo.

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -3,7 +3,7 @@
 Thank you for considering helping out Conflux. This document specifies rules
 for proposing changes to Conflux protocol as well as Conflux-Rust
 implementation. Note that we differentiate Conflux protocol and Conflux-Rust
-implementation because we envision in future there will be implementations of
+implementation because we envision in the future there will be multiple implementations of
 Conflux in different languages.
 
 ## Change Types

--- a/internal_contract/README.md
+++ b/internal_contract/README.md
@@ -7,7 +7,7 @@ keywords:
   - contract
 ---
 
-Conflux introduces several built-in internal contracts for better system maintenance and on-chain governance. And this document will show you how to use these internal contracts.
+Conflux introduces several built-in internal contracts for better system maintenance and on-chain governance. This document will show you how to use these internal contracts.
 
 The following document will use [js-conflux-sdk](https://github.com/Conflux-Chain/js-conflux-sdk) as an example.
 
@@ -23,7 +23,7 @@ The **SponsorControl** contract keeps the following information for each user-es
 + `sponsor_limit_for_gas_fee`: this is the upper bound for the gas fee subsidy paid for every sponsored transaction;
 + `whitelist`: this is the list of normal accounts that are eligible for the subsidy, where a special all-zero address refers to all normal accounts. Only the contract itself has the authority to change this list.
 
-There are two resources could be sponsored: gas consumption and storage collateral. 
+There are two resources that can be sponsored: gas consumption and storage collateral.
 
 + *For gas consumption*: If a transaction calls a contract with non-empty `sponsor_for_gas` and the sender is in the `whitelist` of the contract and the gas fee specified by the transaction is within the `sponsor_limit_for_gas_fee`, the gas consumption of the transaction is paid from the `sponsor_balance_for_gas` of the contract (if it is sufficient) rather than from the sender’s balance, and the execution of the transaction would fail if the `sponsor_balance_for_gas` cannot afford the gas consumption. Otherwise, the sender should pay for the gas consumption.
 + *For storage collateral*: If a transaction calls a contract with non-empty `sponsor_balance_for_collateral` and the sender is in the `whitelist` of the contract,  the collateral for storage incurred in the execution of the transaction is deducted from `sponsor_balance_for_collateral` of the contract, and the owner of those modified storage entries is set to the contract address accordingly. Otherwise, the sender should pay for the collateral for storage incurred in the execution.
@@ -41,7 +41,7 @@ The replacement of `sponsor_for_collateral` is similar except that there is no a
 
 The built-in contract address is `0x0888000000000000000000000000000000000001`. The abi for the internal contract could be found [here](https://github.com/Conflux-Chain/conflux-rust/blob/master/internal_contract/metadata/SponsorWhitelistControl.json) and [here](https://github.com/Conflux-Chain/conflux-rust/blob/master/internal_contract/contracts/SponsorWhitelistControl.sol).
 
-+ `set_sponsor_for_gas(address contract, uint upper_bound)`: If someone wants to sponsor the gas fee for a contract with address `contract`, he/she (it can be a contract account) should call this function and in the meantime transfer some tokens to the address `0x0888000000000000000000000000000000000001`. The parameter `upper_bound` is the upper bound of the gas fee the sponsor will pay for a single transaction. The number of transfered tokens should be at least 1000 times of the `upper_bound`. The sponsor could be replaced if the new sponsor transfers more tokens and sets a larger upper bound. The current sponsor can also call the function to transfer more tokens to sponsor the contract. The `upper_bound` can be changed to a smaller one if current sponsor balance is less than the `upper_bound`.
++ `set_sponsor_for_gas(address contract, uint upper_bound)`: If someone wants to sponsor the gas fee for a contract with address `contract`, he/she (it can be a contract account) should call this function and in the meantime transfer some tokens to the address `0x0888000000000000000000000000000000000001`. The parameter `upper_bound` is the upper bound of the gas fee the sponsor will pay for a single transaction. The number of transferred tokens should be at least 1000 times of the `upper_bound`. The sponsor could be replaced if the new sponsor transfers more tokens and sets a larger upper bound. The current sponsor can also call the function to transfer more tokens to sponsor the contract. The `upper_bound` can be changed to a smaller one if the current sponsor balance is less than the `upper_bound`.
 + `set_sponsor_for_collateral(address contract_addr)`: If someone wants to sponsor the CFS (collateral for storage) for a contract with address `contract`, he/she (it can be a contract account) should call this function and in the meantime transfer some tokens to the address `0x0888000000000000000000000000000000000001`. The sponsor could be replaced if the new sponsor transfers more tokens. The current sponsor can also call the function to transfer more tokens to sponsor the contract.
 + `add_privilege(address[] memory)`: A contract can call this function to add some normal account address to the whitelist. It means that if the `sponsor_for_gas` is set, the contract will pay the gas fee for the accounts in the whitelist, and if the `sponsor_for_collateral` is set, the contract will pay the CFS (collateral for storage) for the accounts in the whitelist. A special address `0x0000000000000000000000000000000000000000` could be used if the contract wants to add all account to the whitelist.
 + `remove_privilege(address[] memory)`: A contract can call this function to remove some normal account address from the whitelist.
@@ -124,7 +124,7 @@ After that the accounts in `whiltelist` will pay nothing while calling `you_cont
 
 ## Admin Management
 
-The **AdminControl** contract is introduced for better maintenance of other smart contracts, espeically which are generated tentatively without a proper destruction routine: it records the administrator of every user-established smart contract and handles the destruction on request of corresponding administrators.
+The **AdminControl** contract is introduced for better maintenance of other smart contracts, especially which are generated tentatively without a proper destruction routine: it records the administrator of every user-established smart contract and handles the destruction on request of corresponding administrators.
 
 The default administrator of a smart contract is the creator of the contract, i.e. the sender α of the transaction that causes the creation of the contract. The current administrator of a smart contract can transfer its authority to another normal account by sending a request to the AdminControl contract. Contract accounts are not allowed to be the administrator of other contracts, since this mechanism is mainly for tentative maintenance. Any long term administration with customized authorization rules should be implemented inside the contract, i.e. as a specific function that handles destruction requests.
 
@@ -140,7 +140,7 @@ processed as follows:
 
 The contract address is `0x0888000000000000000000000000000000000000`. The abi for the internal contract could be found [here](https://github.com/Conflux-Chain/conflux-rust/blob/master/internal_contract/metadata/AdminControl.json) and [here](https://github.com/Conflux-Chain/conflux-rust/blob/master/internal_contract/contracts/AdminControl.sol).
 
-+ `set_admin(address contract, address admin)`: Set the administrator of contract `contract` to `admin`. The caller should be the administrator of `contract` and it should be a normal account. Caller should make sure that `contract` should be an address of a contract and `admin` should be a normal account address. Otherwise, the call will fail.
++ `set_admin(address contract, address admin)`: Set the administrator of contract `contract` to `admin`. The caller should be the administrator of `contract` and it should be a normal account. The caller should make sure that `contract` should be an address of a contract and `admin` should be a normal account address. Otherwise, the call will fail.
 
 + `destroy(address contract)`: Perform a suicide of the contract `contract`. The caller should be the administrator of `contract` and it should be a normal account. If the collateral for storage of the contract is not zero, the suicide will fail. Otherwise, the `balance` of `contract` will be refunded to the current administrator, the `sponsor_balance_for_gas` will be refunded to `sponsor_for_gas`, the `sponsor_balance_for_collateral` will be refunded to `sponsor_for_collateral`.
 
@@ -190,7 +190,7 @@ When executing a transaction sent by account `addr` at block `B` to withdraw a f
 interest issued = v * (4% / 63072000)^T
 ```
 
-where `T = BlockNo(B)−BlockNo(B')` is the staking period measured by number of blocks, and `63072000` is the expected number of blocks generated in `365` days with the target block time `0.5` seconds. 
+where `T = BlockNo(B)−BlockNo(B')` is the staking period measured by the number of blocks, and `63072000` is the expected number of blocks generated in `365` days with the target block time `0.5` seconds.
 
 ### Staking for Voting Power
 
@@ -200,8 +200,8 @@ See the details in [Conflux Protocol Specification](https://confluxnetwork.org/d
 
 The contract address is `0x0888000000000000000000000000000000000002`. The abi for the internal contract could be found [here](https://github.com/Conflux-Chain/conflux-rust/blob/master/internal_contract/metadata/Staking.json) and [here](https://github.com/Conflux-Chain/conflux-rust/blob/master/internal_contract/contracts/Staking.sol).
 
-+ `deposit(uint amount)`: The caller can call this function to deposit some tokens to Conflux Internal Staking Contract. The current annual interest rate is 4%.
-+ `withdraw(uint amount)`: The caller can call this function to withdraw some tokens to Conflux Internal Staking Contract. It will trigger a interest settlement. The staking capital and staking interest will be transferred to the user's balance in time. All the withdrawal applications will be processed on a first-come-first-served basis according to the sequence of staking orders.
++ `deposit(uint amount)`: The caller can call this function to deposit some tokens to the Conflux Internal Staking Contract. The current annual interest rate is 4%.
++ `withdraw(uint amount)`: The caller can call this function to withdraw some tokens from the Conflux Internal Staking Contract. This will also trigger interest settlement. The staking capital and staking interest will be transferred to the user's balance in time. All the withdrawal applications will be processed on a first-come-first-served basis according to the sequence of staking orders.
 + `vote_lock(uint amount, uint unlock_block_number)`: This function is related with Voting Rights in Conflux. Staking users can choose the voting amount and locking maturity by locking a certain amount of CFX in a certain maturity from staking. The `unlock_block_number` is measured in the number of blocks since genesis block.
 
 ### Examples


### PR DESCRIPTION
Fix typos and add some minor improvements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1628)
<!-- Reviewable:end -->
