### PR TITLE
Contract address is ambiguous under different call types, change its …

### DIFF
--- a/core/src/executive/executive.rs
+++ b/core/src/executive/executive.rs
@@ -1081,7 +1081,7 @@ impl<'a> CallCreateExecutive<'a> {
                     let substate = resume.unconfirmed_substate().unwrap();
                     let mut is_recursive_call = false;
                     let contracts_in_callstack = if is_not_internal_contract_and_has_code {
-                        is_recursive_call = substate.contract_address == subparams.code_address;
+                        is_recursive_call = substate.code_address == subparams.code_address;
                         let mut contracts_in_callstack = HashSet::<Address>::new();
                         mem::swap(
                             &mut contracts_in_callstack,
@@ -1260,7 +1260,7 @@ impl<'a> Executive<'a> {
         let mut is_recursive_call = false;
         let contracts_in_callstack = if is_not_internal_contract_and_has_code {
             is_recursive_call =
-                substate.contract_address == params.code_address;
+                substate.code_address == params.code_address;
             let mut contracts_in_callstack = HashSet::<Address>::new();
             mem::swap(
                 &mut contracts_in_callstack,

--- a/core/src/state/substate.rs
+++ b/core/src/state/substate.rs
@@ -39,8 +39,8 @@ pub struct Substate {
     pub contracts_in_callstack: HashSet<Address>,
     /// Reentrancy happens in current call
     pub reentrancy_encountered: bool,
-    /// Contract address in current call
-    pub contract_address: Address,
+    /// Code address in current call
+    pub code_address: Address,
 }
 
 impl Substate {
@@ -52,14 +52,14 @@ impl Substate {
     }
 
     pub fn with_contracts_in_callstack(
-        contracts: HashSet<Address>, contract_address: Address,
+        contracts: HashSet<Address>, code_address: Address,
         reentrancy_encountered: bool,
     ) -> Self
     {
         let mut substate = Substate::default();
         substate.contracts_in_callstack = contracts;
         substate.reentrancy_encountered = reentrancy_encountered;
-        substate.contract_address = contract_address;
+        substate.code_address = code_address;
         substate
     }
 
@@ -83,9 +83,9 @@ impl Substate {
         let mut contract_in_callstack = HashSet::<Address>::new();
         mem::swap(&mut contract_in_callstack, &mut s.contracts_in_callstack);
         if !s.reentrancy_encountered
-            && self.contract_address != s.contract_address
+            && self.code_address != s.code_address
         {
-            contract_in_callstack.remove(&s.contract_address);
+            contract_in_callstack.remove(&s.code_address);
         }
         self.contracts_in_callstack = contract_in_callstack;
     }


### PR DESCRIPTION
Contract address is ambiguous under different call types, change its variable name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1634)
<!-- Reviewable:end -->
