### PR TITLE
add author info in RewardInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ was caused by a wrong assumption of the uniqueness of the trie proof key.
 - Remove address from Account rlp format, which was included unexpectedly
 before.
 
+- Changed RewardInfo struct to add author info.
+
 ## Improvements
 
 - Rename local rpc send_transaction with cfx_sendTransaction.

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -753,7 +753,15 @@ impl RpcImpl {
                 .get_data_manager()
                 .block_reward_result_by_hash(&b)
             {
-                ret.push(RpcRewardInfo::new(b, reward_result));
+                if let Some(block_header) =
+                    self.consensus.get_data_manager().block_header_by_hash(&b)
+                {
+                    ret.push(RpcRewardInfo::new(
+                        b,
+                        block_header.author().clone(),
+                        reward_result,
+                    ));
+                }
             }
         }
         Ok(ret)

--- a/client/src/rpc/types/reward_info.rs
+++ b/client/src/rpc/types/reward_info.rs
@@ -1,20 +1,24 @@
-use crate::rpc::types::{H256, U256};
-use cfx_types::H256 as CfxH256;
+use crate::rpc::types::{H160, H256, U256};
+use cfx_types::{H160 as CfxH160, H256 as CfxH256};
 use cfxcore::block_data_manager::BlockRewardResult;
 
 #[derive(Debug, Serialize, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RewardInfo {
     block_hash: H256,
+    author: H160,
     total_reward: U256,
     base_reward: U256,
     tx_fee: U256,
 }
 
 impl RewardInfo {
-    pub fn new(block_hash: CfxH256, reward_result: BlockRewardResult) -> Self {
+    pub fn new(
+        block_hash: CfxH256, author: CfxH160, reward_result: BlockRewardResult,
+    ) -> Self {
         RewardInfo {
             block_hash: block_hash.into(),
+            author: author.into(),
             total_reward: reward_result.total_reward.into(),
             base_reward: reward_result.base_reward.into(),
             tx_fee: reward_result.tx_fee.into(),


### PR DESCRIPTION
Add author for reward info to enable scripts to collect mining reward information for miners.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1641)
<!-- Reviewable:end -->
