### PR TITLE
Fix some active_peer management in snapshot sync.

### DIFF
--- a/core/src/sync/state/state_sync_candidate/state_sync_candidate_manager.rs
+++ b/core/src/sync/state/state_sync_candidate/state_sync_candidate_manager.rs
@@ -109,7 +109,10 @@ impl StateSyncCandidateManager {
             requested_candidates_set.remove(&candidate);
         }
         for unsupported_candidate in requested_candidates_set {
-            match self.candidate_to_active_peers.get_mut(unsupported_candidate) {
+            match self
+                .candidate_to_active_peers
+                .get_mut(unsupported_candidate)
+            {
                 Some(peer_set) => {
                     peer_set.remove(peer);
                 }
@@ -151,7 +154,8 @@ impl StateSyncCandidateManager {
         while candidate_index < max_candidate_index {
             self.active_candidate = Some(candidate_index);
             let candidate = &self.candidates[candidate_index];
-            let peer_set = self.candidate_to_active_peers.get(candidate).unwrap();
+            let peer_set =
+                self.candidate_to_active_peers.get(candidate).unwrap();
             if peer_set.is_empty() {
                 debug!(
                     "StateSync: candidate {}={:?}, active_peers={:?}",

--- a/core/src/sync/state/state_sync_manifest/snapshot_manifest_manager.rs
+++ b/core/src/sync/state/state_sync_manifest/snapshot_manifest_manager.rs
@@ -31,6 +31,7 @@ use primitives::{
 use rand::{seq::SliceRandom, thread_rng};
 use std::{
     collections::HashSet,
+    fmt::{Debug, Formatter},
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -565,6 +566,18 @@ impl SnapshotManifestManager {
 
     fn note_failure(&mut self, node_id: &NodeId) {
         self.active_peers.remove(node_id);
+    }
+}
+
+impl Debug for SnapshotManifestManager {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "(request_status = {:?}, candidate={:?} active_peers: {})",
+            self.manifest_request_status,
+            self.snapshot_candidate,
+            self.active_peers.len(),
+        )
     }
 }
 


### PR DESCRIPTION
Since we now make ManifestManager and ChunkManager maintain their own
active_peers, they should not read `sync_candidate_manager.active_peers`
after they are initialized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1644)
<!-- Reviewable:end -->
