### PR TITLE
Fix an underflow for timerchain computation.

### DIFF
--- a/core/src/consensus/consensus_inner/mod.rs
+++ b/core/src/consensus/consensus_inner/mod.rs
@@ -3208,6 +3208,9 @@ impl ConsensusGraphInner {
                 None => self.cur_era_genesis_block_arena_index,
             };
             for i in self.timer_chain.len()..(fork_at_index + tmp_chain.len()) {
+                if i < self.inner_conf.timer_chain_beta as usize {
+                    continue;
+                }
                 // `end` is the timer chain index of the end of
                 // `timer_chain_beta` consecutive blocks which
                 // we will compute accumulative lca.


### PR DESCRIPTION
The following `end` may underflow, and we do not maintain `accumulative_lca` in this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1661)
<!-- Reviewable:end -->
