### PR TITLE
Fix some random test failure.

### DIFF
--- a/tests/full_node_tests/remove_old_eras_test.py
+++ b/tests/full_node_tests/remove_old_eras_test.py
@@ -70,8 +70,10 @@ class FullNodeRemoveOldErasTest(ConfluxTestFramework):
 
         self.log.info(f"checking existing blocks...")
 
+        # TODO We can use `num_blocks` here if we can guarantee all blocks form a chain.
+        latest_epoch = self.rpc[ARCHIVE_NODE].epoch_number()
         # we expect the last few eras are not removed
-        for epoch in range(7 * ERA_EPOCH_COUNT, 10 * ERA_EPOCH_COUNT):
+        for epoch in range(7 * ERA_EPOCH_COUNT, latest_epoch+1):
             archive_block = self.rpc[ARCHIVE_NODE].block_by_epoch(hex(epoch), include_txs=True)
             assert(archive_block != None)
 

--- a/tests/full_node_tests/sync_checkpoint_test.py
+++ b/tests/full_node_tests/sync_checkpoint_test.py
@@ -8,7 +8,8 @@ from jsonrpcclient.exceptions import ReceivedErrorResponseError
 sys.path.insert(1, os.path.dirname(sys.path[0]))
 
 from test_framework.test_framework import ConfluxTestFramework
-from test_framework.util import sync_blocks, connect_nodes, connect_sample_nodes, assert_equal, assert_blocks_valid
+from test_framework.util import sync_blocks, connect_nodes, connect_sample_nodes, assert_equal, assert_blocks_valid, \
+    wait_until
 from conflux.rpc import RpcClient
 
 class SyncCheckpointTests(ConfluxTestFramework):
@@ -81,6 +82,8 @@ class SyncCheckpointTests(ConfluxTestFramework):
         # There is no state from epoch 1 to snapshot_epoch
         # Note, state of genesis epoch always exists
         assert full_node_client.epoch_number() >= snapshot_epoch
+        wait_until(lambda: full_node_client.epoch_number() == archive_node_client.epoch_number() and
+                   full_node_client.epoch_number("latest_state") == archive_node_client.epoch_number("latest_state"))
         # We have snapshot_epoch for state execution but
         # don't offer snapshot_epoch for Rpc clients.
         for i in range(1, snapshot_epoch + 1):


### PR DESCRIPTION
There full node tests may fail as a part of rigorous testing when run on
a relatively slow Azure VM.

For `sync_checkpoint_test.py`, it fails if we query states before the
node finishes processing all blocks.

For `remove_old_eras_test.py`, it fails if there are some forks in the
generated blocks. Note that we update best_info after releasing
consensus inner lock, so it's possible that a generated block is not
seen by the next call of `generate_one_block`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1663)
<!-- Reviewable:end -->
