### PR TITLE
Allow transfer() in reentrancy check. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ before.
 
 - The SELFDECONSTRUCT operation will fail if refund to invalid address.
 
+- Change the logic when reentrancy happens. (Message call with empty data and <= 2300 gas is exempt from reentrancy check.)
+
+
 ## Improvements
 
 - Unify all public rpc with hex number, the following fields from RPC will be changed from decimal to hexadecimal:

--- a/core/src/evm/interpreter/mod.rs
+++ b/core/src/evm/interpreter/mod.rs
@@ -912,7 +912,12 @@ impl<Cost: CostType> Interpreter<Cost> {
                     _ => unreachable!(),
                 };
                 let not_reentrancy_attack =
-                    if context.is_reentrancy(recipient_address) {
+                    // If this message call is not recursive call and reentering another contract,
+                    // we regard it as reentrancy.
+                    if context.is_reentrancy(&self.params.address, recipient_address) {
+                        // If this message call is invoked by `transfer()` or `send()`,
+                        // formally, the call data is empty and available gas is no more than 2300,
+                        // the reentrancy protection will not be triggered.
                         if in_size.is_zero() {
                             call_gas <= Cost::from(context.spec().call_stipend)
                         } else {

--- a/core/src/executive/context.rs
+++ b/core/src/executive/context.rs
@@ -443,6 +443,16 @@ impl<'a> ContextTrait for Context<'a> {
     ) {
         // TODO
     }
+
+    fn is_reentrancy(&self, caller: &Address, callee: &Address) -> bool {
+        let is_recursive_call = *caller == *callee;
+        let contract_in_callstack = self
+            .substate
+            .contracts_in_callstack
+            .borrow()
+            .contains_key(callee);
+        return !is_recursive_call && contract_in_callstack;
+    }
 }
 
 #[cfg(test)]

--- a/core/src/executive/executive.rs
+++ b/core/src/executive/executive.rs
@@ -390,7 +390,6 @@ impl<'a> CallCreateExecutive<'a> {
                 state.revert_to_checkpoint();
                 result
             }
-            Err(vm::Error::Reentrancy) => unreachable!(),
             // The whole epoch execution fails. No need to revert state.
             Err(vm::Error::StateDbError(_)) => result,
             Ok(_) => {
@@ -662,14 +661,6 @@ impl<'a> CallCreateExecutive<'a> {
                         Self::transfer_exec_balance(
                             &params, spec, state, substate,
                         )?;
-                        if unconfirmed_substate
-                            .contracts_in_callstack
-                            .borrow()
-                            .is_reentrancy_at_this_level(&params.address)
-                        {
-                            state.discard_checkpoint();
-                            return Err(VmError::Reentrancy);
-                        }
                         Ok(())
                     };
 

--- a/core/src/executive/executive.rs
+++ b/core/src/executive/executive.rs
@@ -23,8 +23,7 @@ use crate::{
     verification::VerificationConfig,
     vm::{
         self, ActionParams, ActionValue, CallType, CreateContractAddress, Env,
-        Error as VmError, ResumeCall, ResumeCreate, ReturnData, Spec,
-        TrapError,
+        ResumeCall, ResumeCreate, ReturnData, Spec, TrapError,
     },
     vm_factory::VmFactory,
 };

--- a/core/src/state/substate.rs
+++ b/core/src/state/substate.rs
@@ -46,17 +46,6 @@ impl CallStackInfo {
     pub fn contains_key(&self, key: &Address) -> bool {
         self.address_counter.contains_key(key)
     }
-
-    pub fn is_reentrancy_at_this_level(&self, callee: &Address) -> bool {
-        let maybe_caller = self.last();
-        if let Some(caller) = maybe_caller {
-            if *callee == *caller {
-                // Recursive call is not regarded as reentrancy.
-                return false;
-            }
-        }
-        self.contains_key(callee)
-    }
 }
 
 /// State changes which should be applied in finalize,

--- a/core/src/vm/context.rs
+++ b/core/src/vm/context.rs
@@ -181,4 +181,9 @@ pub trait Context {
 
     /// Check if running in static context.
     fn is_static(&self) -> bool;
+
+    /// Check if reentrancy happens
+    /// The call stack doesn't have the current executive, so the caller address
+    /// should be passed.
+    fn is_reentrancy(&self, caller: &Address, callee: &Address) -> bool;
 }

--- a/core/src/vm/error.rs
+++ b/core/src/vm/error.rs
@@ -115,8 +115,6 @@ pub enum Error {
     OutOfBounds,
     /// Execution has been reverted with REVERT.
     Reverted,
-    /// Reentrancy encountered
-    Reentrancy,
     /// Invalid address
     InvalidAddress(Address),
 }
@@ -185,7 +183,6 @@ impl fmt::Display for Error {
             Wasm(ref msg) => write!(f, "Internal error: {}", msg),
             OutOfBounds => write!(f, "Out of bounds"),
             Reverted => write!(f, "Reverted"),
-            Reentrancy => write!(f, "Reentrancy"),
             InvalidAddress(ref addr) => write!(f, "InvalidAddress: {}", addr),
         }
     }

--- a/core/src/vm/tests.rs
+++ b/core/src/vm/tests.rs
@@ -244,6 +244,7 @@ impl Context for MockContext {
     }
 
     fn is_reentrancy(&self, _: &Address, _: &Address) -> bool {
-        unimplemented!()
+        // The MockContext doesn't have message call
+        false
     }
 }

--- a/core/src/vm/tests.rs
+++ b/core/src/vm/tests.rs
@@ -242,4 +242,8 @@ impl Context for MockContext {
     ) -> bool {
         self.tracing
     }
+
+    fn is_reentrancy(&self, _: &Address, _: &Address) -> bool {
+        unimplemented!()
+    }
 }

--- a/tests/reentrancy_test.py
+++ b/tests/reentrancy_test.py
@@ -183,10 +183,10 @@ class ReentrancyTest(ConfluxTestFramework):
         balance = parse_as_int(self.nodes[0].cfx_getBalance(addr))
         assert_greater_than_or_equal(balance, 899999999999999999999999950000000)
         balance = parse_as_int(self.nodes[0].cfx_getBalance(contract_addr))
-        assert_equal(balance, 100000000000000000000000000000000)
+        assert_equal(balance, 200000000000000000000000000000000)
         addr = eth_utils.encode_hex(user2_addr)
         balance = parse_as_int(self.nodes[0].cfx_getBalance(addr))
-        assert_greater_than_or_equal(user2_balance + user2_balance_refund_upper_bound + 100000000000000000000000000000000, balance)
+        assert_greater_than_or_equal(user2_balance + user2_balance_refund_upper_bound, balance)
 
         block_gen_thread.stop()
         block_gen_thread.join()


### PR DESCRIPTION
Change the logic when reentrancy happens. Now, only the message call with empty call data and <= 2300 gas can executed when reentrancy happens. For recursive call (same recipient address), we don't check reentrancy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1669)
<!-- Reviewable:end -->
