### PR TITLE
Avoid recomputation of pow_quality.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,8 +130,6 @@ avoids inconsistent transaction pool issues during the catch up.
 
 - Change CREATE/CREATE2 maximum code size from 24K to 48K
 
-- Remove `pow_quality` from block fields in block-related RPCs.
-
 # 0.5.0
 
 ## Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,8 @@ avoids inconsistent transaction pool issues during the catch up.
 
 - Change CREATE/CREATE2 maximum code size from 24K to 48K
 
+- Remove `pow_quality` from block fields in block-related RPCs.
+
 # 0.5.0
 
 ## Improvements

--- a/client/src/rpc/types/block.rs
+++ b/client/src/rpc/types/block.rs
@@ -15,7 +15,7 @@ use cfx_types::{H160, H256, U256, U64};
 use cfxcore::{
     block_data_manager::{BlockDataManager, BlockExecutionResultWithEpoch},
     consensus::ConsensusGraphInner,
-    SharedConsensusGraph,
+    pow, SharedConsensusGraph,
 };
 use primitives::{
     receipt::{
@@ -228,7 +228,10 @@ impl Block {
             gas_limit: b.block_header.gas_limit().into(),
             timestamp: b.block_header.timestamp().into(),
             difficulty: b.block_header.difficulty().clone().into(),
-            pow_quality: b.block_header.pow_quality.map(Into::into),
+            pow_quality: b
+                .block_header
+                .pow_hash
+                .map(|h| pow::pow_hash_to_quality(&h, &b.block_header.nonce())),
             adaptive: b.block_header.adaptive(),
             referee_hashes: b
                 .block_header
@@ -363,8 +366,10 @@ impl Header {
             adaptive: h.adaptive(),
             referee_hashes,
             nonce: h.nonce().into(),
-            pow_quality: h.pow_quality.map(Into::into), /* TODO(thegaram):
-                                                         * include custom */
+            pow_quality: h.pow_hash.map(|pow_hash| {
+                pow::pow_hash_to_quality(&pow_hash, &h.nonce())
+            }), /* TODO(thegaram):
+                 * include custom */
         }
     }
 }

--- a/client/src/rpc/types/block.rs
+++ b/client/src/rpc/types/block.rs
@@ -228,7 +228,7 @@ impl Block {
             gas_limit: b.block_header.gas_limit().into(),
             timestamp: b.block_header.timestamp().into(),
             difficulty: b.block_header.difficulty().clone().into(),
-            pow_quality: Some(b.block_header.pow_quality.clone().into()),
+            pow_quality: b.block_header.pow_quality.map(Into::into),
             adaptive: b.block_header.adaptive(),
             referee_hashes: b
                 .block_header
@@ -363,8 +363,8 @@ impl Header {
             adaptive: h.adaptive(),
             referee_hashes,
             nonce: h.nonce().into(),
-            pow_quality: Some(h.pow_quality.into()), /* TODO(thegaram):
-                                                      * include custom */
+            pow_quality: h.pow_quality.map(Into::into), /* TODO(thegaram):
+                                                         * include custom */
         }
     }
 }

--- a/core/src/block_data_manager/db_manager.rs
+++ b/core/src/block_data_manager/db_manager.rs
@@ -143,8 +143,8 @@ impl DBManager {
     pub fn block_header_from_db(&self, hash: &H256) -> Option<BlockHeader> {
         let mut block_header =
             self.load_decodable_val(DBTable::Blocks, hash.as_bytes())?;
-        VerificationConfig::fill_header_pow_quality(
-            self.pow.clone(),
+        VerificationConfig::get_or_fill_header_pow_quality(
+            &self.pow,
             &mut block_header,
         );
         Some(block_header)

--- a/core/src/block_data_manager/db_manager.rs
+++ b/core/src/block_data_manager/db_manager.rs
@@ -143,7 +143,7 @@ impl DBManager {
     pub fn block_header_from_db(&self, hash: &H256) -> Option<BlockHeader> {
         let mut block_header =
             self.load_decodable_val(DBTable::Blocks, hash.as_bytes())?;
-        VerificationConfig::compute_pow_hash_and_fill_header_pow_quality(
+        VerificationConfig::fill_header_pow_quality(
             self.pow.clone(),
             &mut block_header,
         );

--- a/core/src/block_data_manager/mod.rs
+++ b/core/src/block_data_manager/mod.rs
@@ -827,14 +827,13 @@ impl BlockDataManager {
         V: Clone,
         LoadF: Fn(&K) -> Option<V>,
     {
-        let upgradable_read_lock = in_mem.upgradable_read();
-        if let Some(value) = upgradable_read_lock.get(key) {
+        if let Some(value) = in_mem.read().get(key) {
             return Some(value.clone());
         }
         load_f(key).map(|value| {
             if let Some(cache_id) = maybe_cache_id {
-                RwLockUpgradableReadGuard::upgrade(upgradable_read_lock)
-                    .insert(key.clone(), value.clone());
+                let mut write = in_mem.write();
+                write.insert(key.clone(), value.clone());
                 self.cache_man.lock().note_used(cache_id);
             }
             value

--- a/core/src/block_data_manager/mod.rs
+++ b/core/src/block_data_manager/mod.rs
@@ -225,6 +225,10 @@ pub struct BlockDataManager {
     tx_data_manager: TransactionDataManager,
     pub db_manager: DBManager,
 
+    // TODO Add MallocSizeOf.
+    #[ignore_malloc_size_of = "Add later"]
+    pub pow: Arc<PowComputer>,
+
     /// This is the original genesis block.
     pub true_genesis: Arc<Block>,
     pub storage_manager: Arc<StorageManager>,
@@ -275,10 +279,11 @@ impl BlockDataManager {
             worker_pool,
         );
         let db_manager = match config.db_type {
-            DbType::Rocksdb => DBManager::new_from_rocksdb(db, pow),
-            DbType::Sqlite => {
-                DBManager::new_from_sqlite(Path::new("./sqlite_db"), pow)
-            }
+            DbType::Rocksdb => DBManager::new_from_rocksdb(db, pow.clone()),
+            DbType::Sqlite => DBManager::new_from_sqlite(
+                Path::new("./sqlite_db"),
+                pow.clone(),
+            ),
         };
 
         let data_man = Self {
@@ -306,6 +311,7 @@ impl BlockDataManager {
             cur_consensus_era_stable_hash: RwLock::new(true_genesis.hash()),
             tx_data_manager,
             db_manager,
+            pow,
             state_availability_boundary: RwLock::new(
                 StateAvailabilityBoundary::new(true_genesis.hash(), 0),
             ),

--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -1313,14 +1313,17 @@ impl ConsensusExecutionHandler {
                     debug_out.no_reward_blocks.push(block.hash());
                 }
             } else {
-                let mut reward = if block.block_header.pow_quality.unwrap()
-                    >= *epoch_difficulty
-                {
+                let pow_quality =
+                    VerificationConfig::get_or_compute_header_pow_quality(
+                        &self.data_man.pow,
+                        &block.block_header,
+                    );
+                let mut reward = if pow_quality >= *epoch_difficulty {
                     base_reward_per_block
                 } else {
                     debug!(
                         "Block {} pow_quality {} is less than epoch_difficulty {}!",
-                        block.hash(), block.block_header.pow_quality.unwrap(), epoch_difficulty
+                        block.hash(), pow_quality, epoch_difficulty
                     );
                     0.into()
                 };

--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -1313,14 +1313,14 @@ impl ConsensusExecutionHandler {
                     debug_out.no_reward_blocks.push(block.hash());
                 }
             } else {
-                let mut reward = if block.block_header.pow_quality
+                let mut reward = if block.block_header.pow_quality.unwrap()
                     >= *epoch_difficulty
                 {
                     base_reward_per_block
                 } else {
                     debug!(
                         "Block {} pow_quality {} is less than epoch_difficulty {}!",
-                        block.hash(), block.block_header.pow_quality, epoch_difficulty
+                        block.hash(), block.block_header.pow_quality.unwrap(), epoch_difficulty
                     );
                     0.into()
                 };

--- a/core/src/consensus/consensus_inner/mod.rs
+++ b/core/src/consensus/consensus_inner/mod.rs
@@ -1659,10 +1659,10 @@ impl ConsensusGraphInner {
     fn insert(&mut self, block_header: &BlockHeader) -> (usize, usize) {
         let hash = block_header.hash();
 
-        let is_heavy = U512::from(block_header.pow_quality)
+        let is_heavy = U512::from(block_header.pow_quality.unwrap())
             >= U512::from(self.inner_conf.heavy_block_difficulty_ratio)
                 * U512::from(block_header.difficulty());
-        let is_timer = U512::from(block_header.pow_quality)
+        let is_timer = U512::from(block_header.pow_quality.unwrap())
             >= U512::from(self.inner_conf.timer_chain_block_difficulty_ratio)
                 * U512::from(block_header.difficulty());
 
@@ -1915,7 +1915,7 @@ impl ConsensusGraphInner {
                 .data_man
                 .block_by_hash(
                     &self.arena[*idx].hash,
-                    false, /* update_cache */
+                    true, /* update_cache */
                 )
                 .expect("Exist");
             epoch_blocks.push(block);

--- a/core/src/consensus/consensus_inner/mod.rs
+++ b/core/src/consensus/consensus_inner/mod.rs
@@ -19,6 +19,7 @@ use crate::{
     parameters::{consensus::*, consensus_internal::*},
     pow::{target_difficulty, PowComputer, ProofOfWorkConfig},
     state_exposer::{ConsensusGraphBlockExecutionState, STATE_EXPOSER},
+    verification::VerificationConfig,
 };
 use cfx_types::{H256, U256, U512};
 use hashbrown::HashMap as FastHashMap;
@@ -1659,10 +1660,15 @@ impl ConsensusGraphInner {
     fn insert(&mut self, block_header: &BlockHeader) -> (usize, usize) {
         let hash = block_header.hash();
 
-        let is_heavy = U512::from(block_header.pow_quality.unwrap())
+        let pow_quality =
+            U512::from(VerificationConfig::get_or_compute_header_pow_quality(
+                &self.pow,
+                block_header,
+            ));
+        let is_heavy = pow_quality
             >= U512::from(self.inner_conf.heavy_block_difficulty_ratio)
                 * U512::from(block_header.difficulty());
-        let is_timer = U512::from(block_header.pow_quality.unwrap())
+        let is_timer = pow_quality
             >= U512::from(self.inner_conf.timer_chain_block_difficulty_ratio)
                 * U512::from(block_header.difficulty());
 

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -153,6 +153,7 @@ pub fn genesis_block(
         genesis.hash()
     );
     state.commit(genesis.block_header.hash()).unwrap();
+    genesis.block_header.pow_quality = Some(0.into());
     genesis
 }
 

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -153,7 +153,7 @@ pub fn genesis_block(
         genesis.hash()
     );
     state.commit(genesis.block_header.hash()).unwrap();
-    genesis.block_header.pow_quality = Some(0.into());
+    genesis.block_header.pow_hash = Some(Default::default());
     genesis
 }
 

--- a/core/src/pow/mod.rs
+++ b/core/src/pow/mod.rs
@@ -177,6 +177,19 @@ pub fn pow_hash_to_quality(hash: &H256, nonce: &U256) -> U256 {
     }
 }
 
+/// This should only be used in tests.
+pub fn pow_quality_to_hash(pow_quality: &U256, nonce: &U256) -> H256 {
+    let lower_bound = nonce_to_lower_bound(nonce);
+    let hash_u256 = if pow_quality.eq(&U256::MAX) {
+        U256::one()
+    } else {
+        let boundary = difficulty_to_boundary(&(pow_quality + U256::one()));
+        let (against_bound_u256, _) = boundary.overflowing_add(lower_bound);
+        against_bound_u256
+    };
+    BigEndianHash::from_uint(&hash_u256)
+}
+
 /// Convert boundary to its original difficulty. Basically just `f(x) = 2^256 /
 /// x`.
 pub fn boundary_to_difficulty(boundary: &U256) -> U256 {

--- a/core/src/pow/mod.rs
+++ b/core/src/pow/mod.rs
@@ -53,6 +53,12 @@ impl ProofOfWorkProblem {
         against_lower_bound_u256.lt(boundary)
             || boundary.eq(&ProofOfWorkProblem::NO_BOUNDARY)
     }
+
+    pub fn validate_pow_quality_against_difficulty(
+        pow_quality: &U256, difficulty: &U256,
+    ) -> bool {
+        pow_quality.gt(difficulty)
+    }
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/core/src/pow/mod.rs
+++ b/core/src/pow/mod.rs
@@ -53,12 +53,6 @@ impl ProofOfWorkProblem {
         against_lower_bound_u256.lt(boundary)
             || boundary.eq(&ProofOfWorkProblem::NO_BOUNDARY)
     }
-
-    pub fn validate_pow_quality_against_difficulty(
-        pow_quality: &U256, difficulty: &U256,
-    ) -> bool {
-        pow_quality.gt(difficulty)
-    }
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -1555,11 +1555,11 @@ impl SynchronizationGraph {
                 // become ready and being processed in the loop later. It
                 // requires this block already being inserted
                 // into the BlockDataManager!
-                if index == header_index_to_insert {
+                if index == header_index_to_insert && persistent {
                     self.data_man.insert_block_header(
                         inner.arena[index].block_header.hash(),
                         inner.arena[index].block_header.clone(),
-                        persistent,
+                        true,
                     );
                 }
                 if insert_to_consensus {
@@ -1608,11 +1608,11 @@ impl SynchronizationGraph {
                     inner.arena[index].parent,
                     inner.arena[index].block_header.hash()
                 );
-                if index == header_index_to_insert {
+                if index == header_index_to_insert && persistent {
                     self.data_man.insert_block_header(
                         inner.arena[index].block_header.hash(),
                         inner.arena[index].block_header.clone(),
-                        persistent,
+                        true,
                     );
                 }
             }

--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -1647,9 +1647,8 @@ impl SynchronizationGraph {
                 if need_to_verify && !self.is_consortium() {
                     // Compute pow_quality, because the input header may be used
                     // as a part of block later
-                    VerificationConfig::fill_header_pow_quality(
-                        self.pow.clone(),
-                        header,
+                    VerificationConfig::get_or_fill_header_pow_quality(
+                        &self.pow, header,
                     );
                 }
                 return (
@@ -1663,9 +1662,8 @@ impl SynchronizationGraph {
             if need_to_verify {
                 // Compute pow_quality, because the input header may be used as
                 // a part of block later
-                VerificationConfig::fill_header_pow_quality(
-                    self.pow.clone(),
-                    header,
+                VerificationConfig::get_or_fill_header_pow_quality(
+                    &self.pow, header,
                 );
             }
             return (
@@ -1681,7 +1679,7 @@ impl SynchronizationGraph {
                 || !(self.parent_or_referees_invalid(header)
                     || self
                         .verification_config
-                        .verify_header_params(self.pow.clone(), header)
+                        .verify_header_params(&self.pow, header)
                         .or_else(|e| {
                             warn!(
                                 "Invalid header: err={} header={:?}",
@@ -1693,7 +1691,7 @@ impl SynchronizationGraph {
         } else {
             if !bench_mode && !self.is_consortium() {
                 self.verification_config
-                    .verify_pow(self.pow.clone(), header)
+                    .verify_pow(&self.pow, header)
                     .expect("local mined block should pass this check!");
             }
             true

--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -1386,23 +1386,25 @@ impl SynchronizationGraph {
                         header
                     })
                 } else {
-                    self.data_man.block_by_hash(hash, false).map(|block| {
-                        let mut header = block.block_header.clone();
-                        self.insert_block_header(
-                            &mut header,
-                            true,  /* need_to_verify */
-                            false, /* bench_mode */
-                            false, /* insert_to_consensus */
-                            false, /* persistent */
-                        );
-                        self.insert_block(
-                            block.as_ref().clone(),
-                            true,  /* need_to_verify */
-                            false, /* persistent */
-                            true,  /* recover_from_db */
-                        );
-                        Arc::new(header)
-                    })
+                    self.data_man
+                        .block_by_hash(hash, true /* update_cache */)
+                        .map(|block| {
+                            let mut header = block.block_header.clone();
+                            self.insert_block_header(
+                                &mut header,
+                                true,  /* need_to_verify */
+                                false, /* bench_mode */
+                                false, /* insert_to_consensus */
+                                false, /* persistent */
+                            );
+                            self.insert_block(
+                                block.as_ref().clone(),
+                                true,  /* need_to_verify */
+                                false, /* persistent */
+                                true,  /* recover_from_db */
+                            );
+                            Arc::new(header)
+                        })
                 }
             };
 
@@ -1645,7 +1647,10 @@ impl SynchronizationGraph {
                 if need_to_verify && !self.is_consortium() {
                     // Compute pow_quality, because the input header may be used
                     // as a part of block later
-                    VerificationConfig::compute_pow_hash_and_fill_header_pow_quality(self.pow.clone(), header);
+                    VerificationConfig::fill_header_pow_quality(
+                        self.pow.clone(),
+                        header,
+                    );
                 }
                 return (
                     BlockHeaderInsertionResult::AlreadyProcessedInConsensus,
@@ -1658,7 +1663,10 @@ impl SynchronizationGraph {
             if need_to_verify {
                 // Compute pow_quality, because the input header may be used as
                 // a part of block later
-                VerificationConfig::compute_pow_hash_and_fill_header_pow_quality(self.pow.clone(), header);
+                VerificationConfig::fill_header_pow_quality(
+                    self.pow.clone(),
+                    header,
+                );
             }
             return (
                 BlockHeaderInsertionResult::AlreadyProcessedInSync,

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -1649,7 +1649,7 @@ impl SynchronizationProtocolHandler {
         if let Some(block) = self
             .graph
             .data_man
-            .block_by_hash(hash, false /* update_cache */)
+            .block_by_hash(hash, true /* update_cache */)
         {
             debug!("Recovered block {:?} from db", hash);
             // Process blocks from db

--- a/core/src/sync/utils.rs
+++ b/core/src/sync/utils.rs
@@ -14,7 +14,7 @@ use crate::{
         consensus_internal::INITIAL_BASE_MINING_REWARD_IN_UCFX,
         WORKER_COMPUTATION_PARALLELISM,
     },
-    pow::{difficulty_to_boundary, PowComputer, ProofOfWorkConfig},
+    pow::{self, PowComputer, ProofOfWorkConfig},
     statistics::Statistics,
     storage::{StorageConfiguration, StorageManager},
     sync::{SyncGraphConfig, SynchronizationGraph},
@@ -23,9 +23,7 @@ use crate::{
     vm_factory::VmFactory,
     ConsensusGraph, Notifications, TransactionPool,
 };
-use cfx_types::{
-    address_util::AddressUtil, Address, BigEndianHash, H256, U256,
-};
+use cfx_types::{address_util::AddressUtil, Address, H256, U256};
 use core::str::FromStr;
 use parking_lot::Mutex;
 use primitives::{Block, BlockHeaderBuilder, ChainIdParams};
@@ -58,9 +56,11 @@ pub fn create_simple_block_impl(
     };
     // To convert pow_quality back to pow_hash can be inaccurate, but it should
     // be okay in tests.
-    header.pow_hash = Some(BigEndianHash::from_uint(&difficulty_to_boundary(
-        &pow_quality,
-    )));
+    header.pow_hash =
+        Some(pow::pow_quality_to_hash(&pow_quality, &header.nonce()));
+    // println!("simple_block: difficulty={:?} pow_hash={:?} pow_quality={}",
+    // pow_quality, header.pow_hash,
+    // pow::pow_hash_to_quality(&header.pow_hash.unwrap(), &header.nonce()));
     let block = Block::new(header, vec![]);
     (block.hash(), block)
 }

--- a/core/src/sync/utils.rs
+++ b/core/src/sync/utils.rs
@@ -49,11 +49,13 @@ pub fn create_simple_block_impl(
         .with_author(author)
         .build();
     header.compute_hash();
-    header.pow_quality = if block_weight > 1 {
-        diff * block_weight
-    } else {
-        diff
-    };
+    header.pow_quality = Some(
+        if block_weight > 1 {
+            diff * block_weight
+        } else {
+            diff
+        },
+    );
     let block = Block::new(header, vec![]);
     (block.hash(), block)
 }

--- a/core/src/verification.rs
+++ b/core/src/verification.rs
@@ -6,10 +6,7 @@ use crate::{
     error::{BlockError, Error},
     executive::Executive,
     parameters::block::*,
-    pow::{
-        self, difficulty_to_boundary, nonce_to_lower_bound, PowComputer,
-        ProofOfWorkProblem,
-    },
+    pow::{self, nonce_to_lower_bound, PowComputer, ProofOfWorkProblem},
     storage::{make_simple_mpt, simple_mpt_merkle_root, TrieProof},
     sync::{Error as SyncError, ErrorKind as SyncErrorKind},
     vm,
@@ -98,6 +95,18 @@ impl VerificationConfig {
     }
 
     #[inline]
+    /// Note that this function returns *pow_hash* of the block, not its quality
+    pub fn compute_pow_hash_and_fill_header_pow_quality(
+        pow: Arc<PowComputer>, header: &mut BlockHeader,
+    ) -> H256 {
+        let nonce = header.nonce();
+        let pow_hash: H256 = pow
+            .compute(&nonce, &header.problem_hash(), header.height())
+            .into();
+        header.pow_quality = Some(pow::pow_hash_to_quality(&pow_hash, &nonce));
+        pow_hash
+    }
+
     pub fn fill_header_pow_quality(
         pow: Arc<PowComputer>, header: &mut BlockHeader,
     ) {
@@ -115,7 +124,8 @@ impl VerificationConfig {
     pub fn verify_pow(
         &self, pow: Arc<PowComputer>, header: &mut BlockHeader,
     ) -> Result<(), Error> {
-        Self::fill_header_pow_quality(pow, header);
+        let pow_hash =
+            Self::compute_pow_hash_and_fill_header_pow_quality(pow, header);
         if header.difficulty().is_zero() {
             return Err(BlockError::InvalidDifficulty(OutOfBounds {
                 min: Some(0.into()),
@@ -124,14 +134,12 @@ impl VerificationConfig {
             })
             .into());
         }
-        if !ProofOfWorkProblem::validate_pow_quality_against_difficulty(
-            &header.pow_quality.unwrap(),
-            &header.difficulty(),
+        let boundary = pow::difficulty_to_boundary(header.difficulty());
+        if !ProofOfWorkProblem::validate_hash_against_boundary(
+            &pow_hash,
+            &header.nonce(),
+            &boundary,
         ) {
-            let boundary = pow::difficulty_to_boundary(header.difficulty());
-            let pow_hash: H256 = BigEndianHash::from_uint(
-                &difficulty_to_boundary(&header.pow_quality.unwrap()),
-            );
             let lower_bound = nonce_to_lower_bound(&header.nonce());
             // Because the lower_bound first bit is always zero, as long as the
             // difficulty is not 1, this should not overflow.

--- a/core/src/verification.rs
+++ b/core/src/verification.rs
@@ -103,8 +103,21 @@ impl VerificationConfig {
         let pow_hash: H256 = pow
             .compute(&nonce, &header.problem_hash(), header.height())
             .into();
-        header.pow_quality = pow::pow_hash_to_quality(&pow_hash, &nonce);
+        header.pow_quality = Some(pow::pow_hash_to_quality(&pow_hash, &nonce));
         pow_hash
+    }
+
+    pub fn fill_header_pow_quality(
+        pow: Arc<PowComputer>, header: &mut BlockHeader,
+    ) {
+        if header.pow_quality.is_some() {
+            return;
+        }
+        let nonce = header.nonce();
+        let pow_hash: H256 = pow
+            .compute(&nonce, &header.problem_hash(), header.height())
+            .into();
+        header.pow_quality = Some(pow::pow_hash_to_quality(&pow_hash, &nonce));
     }
 
     #[inline]
@@ -143,7 +156,7 @@ impl VerificationConfig {
             )));
         }
 
-        assert!(header.pow_quality >= *header.difficulty());
+        assert!(header.pow_quality.unwrap() >= *header.difficulty());
 
         Ok(())
     }

--- a/primitives/src/block_header.rs
+++ b/primitives/src/block_header.rs
@@ -78,7 +78,7 @@ pub struct BlockHeader {
     /// Hash of the block
     hash: Option<H256>,
     /// POW quality of the block
-    pub pow_quality: U256,
+    pub pow_quality: Option<U256>,
     /// Approximated rlp size of the block header
     pub approximated_rlp_size: usize,
 }
@@ -407,7 +407,7 @@ impl BlockHeaderBuilder {
                 nonce: self.nonce,
             },
             hash: None,
-            pow_quality: U256::zero(),
+            pow_quality: None,
             approximated_rlp_size: 0,
         };
 
@@ -494,7 +494,7 @@ impl Decodable for BlockHeader {
         let mut header = BlockHeader {
             rlp_part,
             hash: None,
-            pow_quality: U256::zero(),
+            pow_quality: None,
             approximated_rlp_size: rlp_size,
         };
         header.compute_hash();

--- a/primitives/src/block_header.rs
+++ b/primitives/src/block_header.rs
@@ -78,7 +78,7 @@ pub struct BlockHeader {
     /// Hash of the block
     hash: Option<H256>,
     /// POW quality of the block
-    pub pow_quality: Option<U256>,
+    pub pow_hash: Option<H256>,
     /// Approximated rlp size of the block header
     pub approximated_rlp_size: usize,
 }
@@ -407,7 +407,7 @@ impl BlockHeaderBuilder {
                 nonce: self.nonce,
             },
             hash: None,
-            pow_quality: None,
+            pow_hash: None,
             approximated_rlp_size: 0,
         };
 
@@ -494,7 +494,7 @@ impl Decodable for BlockHeader {
         let mut header = BlockHeader {
             rlp_part,
             hash: None,
-            pow_quality: None,
+            pow_hash: None,
             approximated_rlp_size: rlp_size,
         };
         header.compute_hash();


### PR DESCRIPTION
And fix some locking to allow parallel computation of pow_quality when loading headers from db.

Note that two `upgradable_read` cannot acquire a lock at the same time. Using different `read` and `write` may lead to duplicate loading from db if two threads read the same key with catch miss at the same time. This should be quite rare.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1675)
<!-- Reviewable:end -->
