### PR TITLE
Make sure accounts created through CLI are re-read on running node

### DIFF
--- a/accounts/cfxstore/src/cfxstore.rs
+++ b/accounts/cfxstore/src/cfxstore.rs
@@ -397,15 +397,19 @@ impl CfxMultiStore {
     fn reload_if_changed(&self) -> Result<(), Error> {
         let mut last_timestamp = self.timestamp.lock();
         let now = Instant::now();
+
         if now - last_timestamp.last_checked > last_timestamp.refresh_time {
             let dir_hash = Some(self.dir.unique_repr()?);
             last_timestamp.last_checked = now;
+
             if last_timestamp.dir_hash == dir_hash {
                 return Ok(());
             }
+
             self.reload_accounts()?;
             last_timestamp.dir_hash = dir_hash;
         }
+
         Ok(())
     }
 

--- a/changelogs/CHANGELOG-1.0.x.md
+++ b/changelogs/CHANGELOG-1.0.x.md
@@ -1,1 +1,5 @@
 # 1.0.0
+
+## Bug Fixes
+
+- Fix bug where users need to restart node before they can use a newly created account to send transactions.

--- a/client/src/accounts.rs
+++ b/client/src/accounts.rs
@@ -6,17 +6,25 @@ use app_dirs::{get_app_root, AppDataType, AppInfo};
 use cfxcore_accounts::{AccountProvider, AccountProviderSettings};
 use cfxstore::{accounts_dir::RootDiskDirectory, CfxStore};
 use dir::helpers::replace_home;
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Duration};
 
 pub fn account_provider(
     dir: Option<String>, sstore_iterations: Option<u32>,
-) -> Result<AccountProvider, String> {
+    refresh_time: Option<Duration>,
+) -> Result<AccountProvider, String>
+{
     let dir = match dir {
         Some(dir) => dir,
         None => keys_path(),
     };
+
     let dir = Box::new(keys_dir(dir)?);
     let secret_store = Box::new(secret_store(dir, sstore_iterations)?);
+
+    if let Some(t) = refresh_time {
+        secret_store.set_refresh_time(t);
+    }
+
     Ok(AccountProvider::new(
         secret_store,
         AccountProviderSettings::default(),

--- a/client/src/common/mod.rs
+++ b/client/src/common/mod.rs
@@ -264,9 +264,15 @@ pub fn initialize_common_modules(
     };
 
     let accounts = Arc::new(
-        account_provider(Some(keys_path()), None)
-            .ok()
-            .expect("failed to initialize account provider"),
+        account_provider(
+            Some(keys_path()),
+            None,
+            Some(Duration::from_millis(
+                conf.raw_conf.account_provider_refresh_time_ms,
+            )),
+        )
+        .ok()
+        .expect("failed to initialize account provider"),
     );
 
     let common_impl = Arc::new(CommonRpcImpl::new(

--- a/client/src/common/mod.rs
+++ b/client/src/common/mod.rs
@@ -263,13 +263,14 @@ pub fn initialize_common_modules(
         Arc::new(network)
     };
 
+    let refresh_time =
+        Duration::from_millis(conf.raw_conf.account_provider_refresh_time_ms);
+
     let accounts = Arc::new(
         account_provider(
             Some(keys_path()),
-            None,
-            Some(Duration::from_millis(
-                conf.raw_conf.account_provider_refresh_time_ms,
-            )),
+            None, /* sstore_iterations */
+            Some(refresh_time),
         )
         .ok()
         .expect("failed to initialize account provider"),

--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -226,6 +226,7 @@ build_config! {
         (storage_max_open_snapshots, (u16), storage::defaults::DEFAULT_MAX_OPEN_SNAPSHOTS)
 
         // General/Unclassified section.
+        (account_provider_refresh_time_ms, (u64), 1000)
         (enable_optimistic_execution, (bool), true)
         (future_block_buffer_capacity, (usize), 32768)
         (get_logs_filter_max_limit, (Option<usize>), None)

--- a/run/default.toml
+++ b/run/default.toml
@@ -400,6 +400,10 @@ jsonrpc_local_http_port=12539
 
 # -------------------- Others -------------------
 
+# Time (in milliseconds) after which accounts are re-read from disk.
+#
+# account_provider_refresh_time_ms = 1000
+
 # Whether to allow execution without deferring if the execution thread is idle.
 #
 # enable_optimistic_execution = true

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -163,6 +163,11 @@ args:
         long: get-logs-epoch-batch-size
         value_name: SIZE
         takes_value: true
+    - account-provider-refresh-time-ms:
+        help: Sets the time after which accounts are re-read from disk.
+        long: account-provider-refresh-time-ms
+        value_name: MS
+        takes_value: true
     - light:
         long: light
     - archive:

--- a/src/command/account.rs
+++ b/src/command/account.rs
@@ -101,8 +101,12 @@ fn new(new_cmd: NewAccount) -> Result<String, String> {
         None => password_prompt()?,
     };
 
-    let acc_provider =
-        account_provider(new_cmd.path, Some(new_cmd.iterations), None)?;
+    let acc_provider = account_provider(
+        new_cmd.path,
+        Some(new_cmd.iterations), /* sstore_iterations */
+        None,                     /* refresh_time */
+    )?;
+
     let new_account = acc_provider
         .new_account(&password)
         .map_err(|e| format!("Could not create new account: {}", e))?;
@@ -110,7 +114,12 @@ fn new(new_cmd: NewAccount) -> Result<String, String> {
 }
 
 fn list(list_cmd: ListAccounts) -> Result<String, String> {
-    let acc_provider = account_provider(list_cmd.path, None, None)?;
+    let acc_provider = account_provider(
+        list_cmd.path,
+        None, /* sstore_iterations */
+        None, /* refresh_time */
+    )?;
+
     let accounts = acc_provider.accounts().map_err(|e| format!("{}", e))?;
     let result = accounts
         .into_iter()

--- a/src/command/account.rs
+++ b/src/command/account.rs
@@ -102,7 +102,7 @@ fn new(new_cmd: NewAccount) -> Result<String, String> {
     };
 
     let acc_provider =
-        account_provider(new_cmd.path, Some(new_cmd.iterations))?;
+        account_provider(new_cmd.path, Some(new_cmd.iterations), None)?;
     let new_account = acc_provider
         .new_account(&password)
         .map_err(|e| format!("Could not create new account: {}", e))?;
@@ -110,7 +110,7 @@ fn new(new_cmd: NewAccount) -> Result<String, String> {
 }
 
 fn list(list_cmd: ListAccounts) -> Result<String, String> {
-    let acc_provider = account_provider(list_cmd.path, None)?;
+    let acc_provider = account_provider(list_cmd.path, None, None)?;
     let accounts = acc_provider.accounts().map_err(|e| format!("{}", e))?;
     let result = accounts
         .into_iter()


### PR DESCRIPTION
**Overview**

By default, a running node's account provider is not refreshed, even if the contents on disk change. This might happen, for instance, when the user adds a new account through the CLI. This PR enables disk lookups on [cache miss](https://github.com/Conflux-Chain/conflux-rust/blob/d4ed976f42ac2f166f2f47949f5ceb8aeaab3abe/accounts/cfxstore/src/cfxstore.rs#L455).

`set_refresh_time` has a [comment](https://github.com/Conflux-Chain/conflux-rust/blob/d4ed976f42ac2f166f2f47949f5ceb8aeaab3abe/accounts/cfxstore/src/cfxstore.rs#L384) about efficiency. I'm not sure it is a relevant concern though, as we only read when there is a request (not periodically) and then too only if the account is not cached.

Fixes #1690.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1697)
<!-- Reviewable:end -->
