### PR TITLE
Remove intermediate_padding from StateProof

### DIFF
--- a/core/src/light_protocol/error.rs
+++ b/core/src/light_protocol/error.rs
@@ -65,9 +65,9 @@ error_chain! {
             display("Invalid receipts"),
         }
 
-        InvalidStateProof {
+        InvalidStateProof(reason: &'static str) {
             description("Invalid state proof"),
-            display("Invalid state proof"),
+            display("Invalid state proof: {}", reason),
         }
 
         InvalidStateRoot {
@@ -199,7 +199,7 @@ pub fn handle(io: &dyn NetworkContext, peer: &NodeId, msg_id: MsgId, e: Error) {
         | ErrorKind::InvalidLedgerProof
         | ErrorKind::InvalidMessageFormat
         | ErrorKind::InvalidReceipts
-        | ErrorKind::InvalidStateProof
+        | ErrorKind::InvalidStateProof(_)
         | ErrorKind::InvalidStateRoot
         | ErrorKind::InvalidStorageRootProof(_)
         | ErrorKind::InvalidTxInfo

--- a/core/src/light_protocol/handler/mod.rs
+++ b/core/src/light_protocol/handler/mod.rs
@@ -150,9 +150,13 @@ impl Handler {
             witnesses.clone(),
         ));
 
+        let snapshot_epoch_count =
+            consensus.get_data_manager().get_snapshot_epoch_count() as u64;
+
         let state_roots = Arc::new(StateRoots::new(
             peers.clone(),
             request_id_allocator.clone(),
+            snapshot_epoch_count,
             witnesses.clone(),
         ));
 
@@ -162,12 +166,8 @@ impl Handler {
             request_id_allocator.clone(),
         );
 
-        let snapshot_epoch_count =
-            consensus.get_data_manager().get_snapshot_epoch_count() as u64;
-
         let storage_roots = StorageRoots::new(
             peers.clone(),
-            snapshot_epoch_count,
             state_roots.clone(),
             request_id_allocator.clone(),
         );

--- a/core/src/light_protocol/message/mod.rs
+++ b/core/src/light_protocol/message/mod.rs
@@ -13,8 +13,9 @@ pub use protocol::{
     Blooms, GetBlockHashesByEpoch, GetBlockHeaders, GetBlockTxs, GetBlooms,
     GetReceipts, GetStateEntries, GetStateRoots, GetStorageRoots, GetTxInfos,
     GetTxs, GetWitnessInfo, NewBlockHashes, Receipts, ReceiptsWithEpoch,
-    SendRawTx, StateEntries, StateEntryWithKey, StateKey, StateRootWithEpoch,
-    StateRoots, StatusPingDeprecatedV1, StatusPingV2, StatusPongDeprecatedV1,
-    StatusPongV2, StorageRootKey, StorageRootProof, StorageRootWithKey,
-    StorageRoots, TxInfo, TxInfos, Txs, WitnessInfo, WitnessInfoWithHeight,
+    SendRawTx, StateEntries, StateEntryProof, StateEntryWithKey, StateKey,
+    StateRootWithEpoch, StateRoots, StatusPingDeprecatedV1, StatusPingV2,
+    StatusPongDeprecatedV1, StatusPongV2, StorageRootKey, StorageRootProof,
+    StorageRootWithKey, StorageRoots, TxInfo, TxInfos, Txs, WitnessInfo,
+    WitnessInfoWithHeight,
 };

--- a/core/src/light_protocol/message/protocol.rs
+++ b/core/src/light_protocol/message/protocol.rs
@@ -213,11 +213,20 @@ pub struct GetStateEntries {
 }
 
 #[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
+pub struct StateEntryProof {
+    pub state_proof: StateProof,
+
+    // state root is validated against witness info retrieved previously;
+    // no additional proof needed
+    pub state_root: StateRoot,
+    pub prev_snapshot_state_root: Option<StateRoot>,
+}
+
+#[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
 pub struct StateEntryWithKey {
     pub key: StateKey,
     pub entry: Option<Vec<u8>>,
-    pub proof: StateProof,
-    pub state_root: StateRoot,
+    pub proof: StateEntryProof,
 }
 
 #[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]

--- a/core/src/light_protocol/provider.rs
+++ b/core/src/light_protocol/provider.rs
@@ -24,10 +24,11 @@ use crate::{
             GetStateEntries, GetStateRoots, GetStorageRoots, GetTxInfos,
             GetTxs, GetWitnessInfo, NewBlockHashes, NodeType,
             Receipts as GetReceiptsResponse, ReceiptsWithEpoch, SendRawTx,
-            StateEntries as GetStateEntriesResponse, StateEntryWithKey,
-            StateRootWithEpoch, StateRoots as GetStateRootsResponse,
-            StatusPingDeprecatedV1, StatusPingV2, StatusPongDeprecatedV1,
-            StatusPongV2, StorageRootKey, StorageRootProof, StorageRootWithKey,
+            StateEntries as GetStateEntriesResponse, StateEntryProof,
+            StateEntryWithKey, StateKey, StateRootWithEpoch,
+            StateRoots as GetStateRootsResponse, StatusPingDeprecatedV1,
+            StatusPingV2, StatusPongDeprecatedV1, StatusPongV2, StorageRootKey,
+            StorageRootProof, StorageRootWithKey,
             StorageRoots as GetStorageRootsResponse, TxInfo,
             TxInfos as GetTxInfosResponse, Txs as GetTxsResponse,
             WitnessInfo as GetWitnessInfoResponse, WitnessInfoWithHeight,
@@ -438,6 +439,35 @@ impl Provider {
         Ok(())
     }
 
+    fn state_entry(&self, key: StateKey) -> Result<StateEntryWithKey, Error> {
+        let snapshot_epoch_count = self.ledger.snapshot_epoch_count() as u64;
+
+        // state root in current snapshot period
+        let state_root = self.ledger.state_root_of(key.epoch)?.state_root;
+
+        // state root in previous snapshot period
+        let prev_snapshot_state_root = match key.epoch {
+            e if e <= snapshot_epoch_count => None,
+            _ => Some(
+                self.ledger
+                    .state_root_of(key.epoch - snapshot_epoch_count)?
+                    .state_root,
+            ),
+        };
+
+        // state entry and state proof
+        let (entry, state_proof) =
+            self.ledger.state_entry_at(key.epoch, &key.key)?;
+
+        let proof = StateEntryProof {
+            state_root,
+            prev_snapshot_state_root,
+            state_proof,
+        };
+
+        Ok(StateEntryWithKey { key, entry, proof })
+    }
+
     fn on_get_state_entries(
         &self, io: &dyn NetworkContext, peer: &NodeId, req: GetStateEntries,
     ) -> Result<(), Error> {
@@ -448,20 +478,7 @@ impl Provider {
         let entries = req
             .keys
             .into_iter()
-            .map::<Result<_, Error>, _>(|key| {
-                let state_root =
-                    self.ledger.state_root_of(key.epoch)?.state_root;
-
-                let (entry, proof) =
-                    self.ledger.state_entry_at(key.epoch, &key.key)?;
-
-                Ok(StateEntryWithKey {
-                    key,
-                    entry,
-                    proof,
-                    state_root,
-                })
-            })
+            .map(|key| self.state_entry(key))
             .filter_map(Result::ok)
             .collect();
 

--- a/core/src/storage/impls/state.rs
+++ b/core/src/storage/impls/state.rs
@@ -193,10 +193,7 @@ impl State {
                     with_proof,
                 )?;
 
-                proof.with_intermediate(
-                    maybe_proof,
-                    self.maybe_intermediate_trie_key_padding.clone(),
-                );
+                proof.with_intermediate(maybe_proof);
 
                 match maybe_value {
                     MptValue::Some(value) => {

--- a/core/src/storage/impls/state_proof.rs
+++ b/core/src/storage/impls/state_proof.rs
@@ -10,8 +10,6 @@
 // TODO: at intermediate_epoch_id with delta_proof.
 #[derive(Clone, Debug, Default, PartialEq, RlpEncodable, RlpDecodable)]
 pub struct StateProof {
-    // TODO(thegaram): get rid of maybe_intermediate_padding
-    pub maybe_intermediate_padding: Option<DeltaMptKeyPadding>,
     pub delta_proof: Option<TrieProof>,
     pub intermediate_proof: Option<TrieProof>,
     pub snapshot_proof: Option<TrieProof>,
@@ -27,11 +25,8 @@ impl StateProof {
 
     pub fn with_intermediate(
         &mut self, maybe_intermediate_proof: Option<TrieProof>,
-        maybe_intermediate_padding: Option<DeltaMptKeyPadding>,
-    ) -> &mut Self
-    {
+    ) -> &mut Self {
         self.intermediate_proof = maybe_intermediate_proof;
-        self.maybe_intermediate_padding = maybe_intermediate_padding;
         self
     }
 
@@ -44,7 +39,9 @@ impl StateProof {
 
     pub fn is_valid_kv(
         &self, key: &Vec<u8>, value: Option<&[u8]>, root: StateRoot,
-    ) -> bool {
+        maybe_intermediate_padding: Option<DeltaMptKeyPadding>,
+    ) -> bool
+    {
         let delta_root = &root.delta_root;
         let intermediate_root = &root.intermediate_delta_root;
         let snapshot_root = &root.snapshot_root;
@@ -54,8 +51,7 @@ impl StateProof {
         let storage_key = StorageKey::from_key_bytes(&key);
         let delta_mpt_key =
             storage_key.to_delta_mpt_key_bytes(&delta_mpt_padding);
-        let maybe_intermediate_mpt_key = self
-            .maybe_intermediate_padding
+        let maybe_intermediate_mpt_key = maybe_intermediate_padding
             .as_ref()
             .map(|p| storage_key.to_delta_mpt_key_bytes(p));
 


### PR DESCRIPTION
**Overview**

`intermediate_padding` (constructed from `state_root.snapshot_root` and `state_root.intermediate_delta_root` of the previous snapshot) is necessary for constructing intermediate delta MPT keys.

Previously, when sending a state entry along with a state proof to a light node, we just sent this padding without doing any kind of validation on it. By sending an incorrect padding, a malicious peer can make a light node believe that the intermediate delta MPT contains no value under a given key, even when there actually is a value.

To alleviate this issue, we let the peer send the previous snapshot state root instead (which the light node can verify) and then derive the padding from this locally.

**Compatibility**

This is a breaking change in the light node sync protocol. However, as this protocol is not considered stable yet, this will be considered a backward compatible change (see [`CONTRIBUTING.md`](https://github.com/Conflux-Chain/conflux-rust/blob/master/CONTRIBUTING.md)).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1700)
<!-- Reviewable:end -->
