### PR TITLE
Improve light node provider error handling

### DIFF
--- a/core/src/light_protocol/common/mod.rs
+++ b/core/src/light_protocol/common/mod.rs
@@ -10,7 +10,7 @@ pub use peers::{FullPeerFilter, FullPeerState, LightPeerState, Peers};
 
 use super::{Error, ErrorKind};
 use primitives::ChainIdParams;
-use std::cmp;
+use std::{cmp, fmt::Debug};
 
 pub fn max_of_collection<I, T: Ord>(collection: I) -> Option<T>
 where I: Iterator<Item = T> {
@@ -33,4 +33,17 @@ pub fn validate_chain_id(
     } else {
         Ok(())
     }
+}
+
+pub fn partition_results<I, E>(
+    it: impl Iterator<Item = Result<I, E>>,
+) -> (Vec<I>, Vec<E>)
+where
+    I: Debug,
+    E: Debug,
+{
+    let (success, failure): (Vec<_>, Vec<_>) = it.partition(Result::is_ok);
+    let success = success.into_iter().map(Result::unwrap).collect();
+    let failure = failure.into_iter().map(Result::unwrap_err).collect();
+    (success, failure)
 }

--- a/core/src/light_protocol/common/mod.rs
+++ b/core/src/light_protocol/common/mod.rs
@@ -35,6 +35,9 @@ pub fn validate_chain_id(
     }
 }
 
+// TODO(thegaram): consider distinguishing between expected and unexpected
+// errors, e.g. some errors suggest the peer requested a non-existent item
+// (normal) while others suggest a local db inconsistency (exception).
 pub fn partition_results<I, E>(
     it: impl Iterator<Item = Result<I, E>>,
 ) -> (Vec<I>, Vec<E>)

--- a/core/src/light_protocol/error.rs
+++ b/core/src/light_protocol/error.rs
@@ -185,7 +185,8 @@ pub fn handle(io: &dyn NetworkContext, peer: &NodeId, msg_id: MsgId, e: Error) {
         // should not disconnect the peer
         | ErrorKind::UnableToProduceProof
 
-        // if a peer requests a tx that has been removed, we should not disconnect the peer
+        // if the tx requested has been removed locally,
+        // we should not disconnect the peer
         | ErrorKind::UnableToProduceTxInfo(_)
 
         // NOTE: to help with backward-compatibility, we

--- a/core/src/light_protocol/error.rs
+++ b/core/src/light_protocol/error.rs
@@ -115,6 +115,11 @@ error_chain! {
             display("Unable to produce proof"),
         }
 
+        UnableToProduceTxInfo(details: String) {
+            description("Unable to produce tx info"),
+            display("Unable to produce tx info: {:?}", details),
+        }
+
         UnexpectedMessage {
             description("Unexpected message"),
             display("Unexpected message"),
@@ -179,6 +184,9 @@ pub fn handle(io: &dyn NetworkContext, peer: &NodeId, msg_id: MsgId, e: Error) {
         // with the info needed to produce a state root proof, we
         // should not disconnect the peer
         | ErrorKind::UnableToProduceProof
+
+        // if a peer requests a tx that has been removed, we should not disconnect the peer
+        | ErrorKind::UnableToProduceTxInfo(_)
 
         // NOTE: to help with backward-compatibility, we
         // should not disconnect on `UnknownMessage`

--- a/core/src/light_protocol/provider.rs
+++ b/core/src/light_protocol/provider.rs
@@ -454,7 +454,7 @@ impl Provider {
         let (state_roots, errors) = partition_results(it);
 
         if !errors.is_empty() {
-            info!("Errors while serving GetStateRoots request: {:?}", errors);
+            debug!("Errors while serving GetStateRoots request: {:?}", errors);
         }
 
         let msg: Box<dyn Message> = Box::new(GetStateRootsResponse {
@@ -495,7 +495,10 @@ impl Provider {
         let (entries, errors) = partition_results(it);
 
         if !errors.is_empty() {
-            info!("Errors while serving GetStateEntries request: {:?}", errors);
+            debug!(
+                "Errors while serving GetStateEntries request: {:?}",
+                errors
+            );
         }
 
         let msg: Box<dyn Message> = Box::new(GetStateEntriesResponse {
@@ -525,7 +528,7 @@ impl Provider {
         let (hashes, errors) = partition_results(it);
 
         if !errors.is_empty() {
-            info!(
+            debug!(
                 "Errors while serving GetBlockHashesByEpoch request: {:?}",
                 errors
             );
@@ -565,8 +568,8 @@ impl Provider {
         let (headers, errors) = partition_results(it);
 
         if !errors.is_empty() {
-            info!(
-                "Errors while serving GetBlockHashesByEpoch request: {:?}",
+            debug!(
+                "Errors while serving GetBlockHeaders request: {:?}",
                 errors
             );
         }
@@ -634,7 +637,7 @@ impl Provider {
         let (receipts, errors) = partition_results(it);
 
         if !errors.is_empty() {
-            info!("Errors while serving GetReceipts request: {:?}", errors);
+            debug!("Errors while serving GetReceipts request: {:?}", errors);
         }
 
         let msg: Box<dyn Message> = Box::new(GetReceiptsResponse {
@@ -666,10 +669,7 @@ impl Provider {
         let (txs, errors) = partition_results(it);
 
         if !errors.is_empty() {
-            info!(
-                "Errors while serving GetBlockHashesByEpoch request: {:?}",
-                errors
-            );
+            debug!("Errors while serving GetTxs request: {:?}", errors);
         }
 
         let msg: Box<dyn Message> =
@@ -695,7 +695,7 @@ impl Provider {
         let (infos, errors) = partition_results(it);
 
         if !errors.is_empty() {
-            info!("Errors while serving GetWitnessInfo request: {:?}", errors);
+            debug!("Errors while serving GetWitnessInfo request: {:?}", errors);
         }
 
         let msg: Box<dyn Message> =
@@ -721,7 +721,7 @@ impl Provider {
         let (blooms, errors) = partition_results(it);
 
         if !errors.is_empty() {
-            info!("Errors while serving GetBlooms request: {:?}", errors);
+            debug!("Errors while serving GetBlooms request: {:?}", errors);
         }
 
         let msg: Box<dyn Message> =
@@ -751,6 +751,7 @@ impl Provider {
                     .into_iter()
                     .map(|arc_tx| (*arc_tx).clone())
                     .collect();
+
                 Ok(BlockTxsWithHash {
                     hash: block.hash(),
                     block_txs,
@@ -760,7 +761,7 @@ impl Provider {
         let (block_txs, errors) = partition_results(it);
 
         if !errors.is_empty() {
-            info!("Errors while serving GetBlockTxs request: {:?}", errors);
+            debug!("Errors while serving GetBlockTxs request: {:?}", errors);
         }
 
         let msg: Box<dyn Message> = Box::new(GetBlockTxsResponse {
@@ -788,10 +789,7 @@ impl Provider {
         let (infos, errors) = partition_results(it);
 
         if !errors.is_empty() {
-            info!(
-                "Errors while serving GetBlockHashesByEpoch request: {:?}",
-                errors
-            );
+            debug!("Errors while serving GetTxInfos request: {:?}", errors);
         }
 
         let msg: Box<dyn Message> =
@@ -848,7 +846,10 @@ impl Provider {
         let (roots, errors) = partition_results(it);
 
         if !errors.is_empty() {
-            info!("Errors while serving GetStorageRoots request: {:?}", errors);
+            debug!(
+                "Errors while serving GetStorageRoots request: {:?}",
+                errors
+            );
         }
 
         let msg: Box<dyn Message> =

--- a/core/src/parameters.rs
+++ b/core/src/parameters.rs
@@ -304,6 +304,7 @@ pub mod light {
     pub const MAX_EPOCHS_TO_SEND: usize = 128;
     pub const MAX_HEADERS_TO_SEND: usize = 512;
     pub const MAX_TXS_TO_SEND: usize = 1024;
+    pub const MAX_ITEMS_TO_SEND: usize = 50;
 
     /// During syncing, we might transiently have enough malicious blaming
     /// blocks to consider a correct header incorrect. For this reason, we


### PR DESCRIPTION
**Overview**

Originally, the light node provider (running on full and archive nodes) would silently ignore errors. This PR adds some local logs when the node is unable to serve some items (headers, epoch, txs, ...) for various reasons.

@yangzhe1990 suggested to make the protocol smarter by notifying light nodes of failed queries; currently we use a simple timeout mechanism. I think we can consider that for a future protocol version.

**Compatibility**

This PR only changes the internal behavior of the light node provider (running on full and archive nodes) so it is a fully backward compatible change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1705)
<!-- Reviewable:end -->
