### PR TITLE
Build constant lookup table for base reward

### DIFF
--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -719,7 +719,9 @@ impl Configuration {
     pub fn execution_config(&self) -> ConsensusExecutionConfiguration {
         ConsensusExecutionConfiguration {
             anticone_penalty_ratio: self.raw_conf.anticone_penalty_ratio,
-            base_reward_table_in_ucfx: build_base_reward_table(),
+            base_reward_table_in_ucfx: Vec::from(
+                BASE_MINING_REWARD_IN_UCFX_LOOKUP_TABLE,
+            ),
         }
     }
 
@@ -767,20 +769,4 @@ pub fn to_bootnodes(bootnodes: &Option<String>) -> Result<Vec<String>, String> {
         Some(_) => Ok(vec![]),
         None => Ok(vec![]),
     }
-}
-
-pub fn build_base_reward_table() -> Vec<u64> {
-    let mut base_reward_table = Vec::new();
-    base_reward_table.resize(MINING_REWARD_DECAY_PERIOD_IN_QUARTER, 0);
-    for i in 0..MINING_REWARD_DECAY_PERIOD_IN_QUARTER {
-        let reward = if i == 0 {
-            INITIAL_BASE_MINING_REWARD_IN_UCFX
-        } else {
-            (base_reward_table[i - 1] as f64
-                * MINING_REWARD_DECAY_RATIO_PER_QUARTER)
-                .round() as u64
-        };
-        base_reward_table[i] = reward;
-    }
-    base_reward_table
 }

--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -719,9 +719,8 @@ impl Configuration {
     pub fn execution_config(&self) -> ConsensusExecutionConfiguration {
         ConsensusExecutionConfiguration {
             anticone_penalty_ratio: self.raw_conf.anticone_penalty_ratio,
-            base_reward_table_in_ucfx: Vec::from(
-                BASE_MINING_REWARD_IN_UCFX_LOOKUP_TABLE,
-            ),
+            base_reward_table_in_ucfx: BASE_MINING_REWARD_IN_UCFX_LOOKUP_TABLE
+                .to_vec(),
         }
     }
 

--- a/core/src/parameters.rs
+++ b/core/src/parameters.rs
@@ -52,6 +52,20 @@ pub mod consensus_internal {
     pub const MINING_REWARD_DECAY_RATIO_PER_QUARTER: f64 = 0.958;
     // How many quarters that the mining reward keep decaying.
     pub const MINING_REWARD_DECAY_PERIOD_IN_QUARTER: usize = 40;
+    // Computed from `INITIAL_BASE_MINING_REWARD_IN_UCFX` and
+    // `MINING_REWARD_DECAY_RATIO_PER_QUARTER`. The n^th element equals to
+    // floor(11300000 * 0.958^n)
+    pub const BASE_MINING_REWARD_IN_UCFX_LOOKUP_TABLE: [u64;
+        MINING_REWARD_DECAY_PERIOD_IN_QUARTER] = [
+        11_300_000, 10_825_400, 10_370_733, 9_935_162, 9_517_885, 9_118_134,
+        8_735_172, 8_368_295, 8_016_827, 7_680_120, 7_357_555, 7_048_537,
+        6_752_499, 6_468_894, 6_197_200, 5_936_918, 5_687_567, 5_448_689,
+        5_219_844, 5_000_611, 4_790_585, 4_589_381, 4_396_627, 4_211_968,
+        4_035_066, 3_865_593, 3_703_238, 3_547_702, 3_398_698, 3_255_953,
+        3_119_203, 2_988_196, 2_862_692, 2_742_459, 2_627_276, 2_516_930,
+        2_411_219, 2_309_948, 2_212_930, 2_119_987,
+    ];
+
     pub const GAS_PRICE_BLOCK_SAMPLE_SIZE: usize = 100;
     pub const GAS_PRICE_TRANSACTION_SAMPLE_SIZE: usize = 10000;
 


### PR DESCRIPTION
In the constant lookup table, the element with index `n` equals to `floor(11_300_000 * (0.958) ^ n)`. This table is inconsistent with the current rust implementation started at the 12-th quarter. Since we believe the third phase of mainnet must be launched in less than three years, this PR is backward compatible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1712)
<!-- Reviewable:end -->
