### PR TITLE
Fix join deadlock when dropping SocketWorker.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,6 +871,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ee0cc8804d5393478d743b035099520087a5186f3b93fa58cec08fa62407b6"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1849,6 +1859,7 @@ checksum = "141340095b15ed7491bd3d4ced9d20cebfb826174b6bb03386381f62b01e3d77"
 name = "io"
 version = "0.1.0"
 dependencies = [
+ "crossbeam-channel",
  "crossbeam-deque",
  "fnv",
  "lazy_static",

--- a/util/io/Cargo.toml
+++ b/util/io/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 fnv = "1.0"
 mio = { version = "0.6.19" }
 crossbeam-deque = "0.7"
+crossbeam-channel = "0.4"
 parking_lot = "0.10"
 log = "0.4"
 slab = "0.4"

--- a/util/io/src/service_mio.rs
+++ b/util/io/src/service_mio.rs
@@ -35,7 +35,6 @@ use slab::Slab;
 use std::{
     collections::HashMap,
     sync::{
-        mpsc::{self, Sender as AsyncSender},
         Arc, Condvar as SCondvar, Mutex as SMutex, Weak,
     },
     thread::{self, JoinHandle},
@@ -263,7 +262,8 @@ where Message: Send + Sync
     workers: Vec<Worker>,
     worker_channel: crossbeam_deque::Worker<Work<Message>>,
     work_ready: Arc<SCondvar>,
-    socket_workers: Vec<(AsyncSender<Work<Message>>, SocketWorker)>,
+    socket_workers:
+        Vec<(crossbeam_channel::Sender<Work<Message>>, SocketWorker)>,
     network_poll: Arc<Poll>,
 }
 
@@ -300,7 +300,7 @@ where Message: Send + Sync + 'static
         let num_socket_workers = 4;
         let socket_workers = (0..num_socket_workers)
             .map(|i| {
-                let (tx, rx) = mpsc::channel();
+                let (tx, rx) = crossbeam_channel::unbounded();
                 (
                     tx,
                     SocketWorker::new(

--- a/util/io/src/service_mio.rs
+++ b/util/io/src/service_mio.rs
@@ -34,9 +34,7 @@ use parking_lot::{Mutex, RwLock};
 use slab::Slab;
 use std::{
     collections::HashMap,
-    sync::{
-        Arc, Condvar as SCondvar, Mutex as SMutex, Weak,
-    },
+    sync::{Arc, Condvar as SCondvar, Mutex as SMutex, Weak},
     thread::{self, JoinHandle},
     time::Duration,
 };


### PR DESCRIPTION
Fix #939 .

If the worker thread is blocked on `recv`, simply setting `deleting` to `true` is not sufficient to stop the worker thread.

Another solution is to send a `Stop` work to make the worker thread return from `recv`, but the sender is not directly accessible when we drop the `SocketWorker`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1714)
<!-- Reviewable:end -->
