### PR TITLE
Only delete block bodies of blocks in the past of a checkpoint.

### DIFF
--- a/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
+++ b/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
@@ -62,6 +62,41 @@ impl ConsensusNewBlockHandler {
         }
     }
 
+    /// Return (old_era_block_set, new_era_block_set).
+    fn compute_old_era_and_new_era_block_set(
+        inner: &mut ConsensusGraphInner, new_era_block_arena_index: usize,
+    ) -> (HashSet<usize>, HashSet<usize>) {
+        // We first compute the set of blocks inside the new era and we
+        // recompute the past_weight inside the stable height.
+        let mut old_era_block_arena_index_set = HashSet::new();
+        let mut queue = VecDeque::new();
+        queue.push_back(new_era_block_arena_index);
+        while let Some(x) = queue.pop_front() {
+            if inner.arena[x].parent != NULL
+                && !old_era_block_arena_index_set
+                    .contains(&inner.arena[x].parent)
+            {
+                old_era_block_arena_index_set.insert(inner.arena[x].parent);
+                queue.push_back(inner.arena[x].parent);
+            }
+            for referee in &inner.arena[x].referees {
+                if *referee != NULL
+                    && !old_era_block_arena_index_set.contains(referee)
+                {
+                    old_era_block_arena_index_set.insert(*referee);
+                    queue.push_back(*referee);
+                }
+            }
+        }
+        let mut new_era_block_arena_index_set = HashSet::new();
+        for (i, _) in &inner.arena {
+            if !old_era_block_arena_index_set.contains(&i) {
+                new_era_block_arena_index_set.insert(i);
+            }
+        }
+        (old_era_block_arena_index_set, new_era_block_arena_index_set)
+    }
+
     /// Note that there is an important assumption: the timer chain must have no
     /// block in the anticone of new_era_block_arena_index. If this is not
     /// true, it cannot become a checkpoint block
@@ -69,29 +104,15 @@ impl ConsensusNewBlockHandler {
         inner: &mut ConsensusGraphInner, new_era_block_arena_index: usize,
     ) {
         let new_era_height = inner.arena[new_era_block_arena_index].height;
+        let (outside_block_arena_indices, new_era_block_arena_index_set) =
+            Self::compute_old_era_and_new_era_block_set(
+                inner,
+                new_era_block_arena_index,
+            );
 
-        // We first compute the set of blocks inside the new era and we
-        // recompute the past_weight inside the stable height.
-        let mut new_era_block_arena_index_set = HashSet::new();
-        let mut queue = VecDeque::new();
-        queue.push_back(new_era_block_arena_index);
-        new_era_block_arena_index_set.insert(new_era_block_arena_index);
-        while let Some(x) = queue.pop_front() {
-            for child in &inner.arena[x].children {
-                if !new_era_block_arena_index_set.contains(child) {
-                    queue.push_back(*child);
-                    new_era_block_arena_index_set.insert(*child);
-                }
-            }
-            for referrer in &inner.arena[x].referrers {
-                if !new_era_block_arena_index_set.contains(referrer) {
-                    queue.push_back(*referrer);
-                    new_era_block_arena_index_set.insert(*referrer);
-                }
-            }
-        }
-        // This is the arena indices for legacy blocks
+        // This is the arena indices for legacy blocks.
         let mut new_era_genesis_subtree = HashSet::new();
+        let mut queue = VecDeque::new();
         queue.push_back(new_era_block_arena_index);
         while let Some(x) = queue.pop_front() {
             new_era_genesis_subtree.insert(x);
@@ -104,13 +125,6 @@ impl ConsensusNewBlockHandler {
                 .difference(&new_era_genesis_subtree)
                 .collect();
 
-        // Now we topologically sort the blocks outside the era
-        let mut outside_block_arena_indices = HashSet::new();
-        for (index, _) in inner.arena.iter() {
-            if !new_era_block_arena_index_set.contains(&index) {
-                outside_block_arena_indices.insert(index);
-            }
-        }
         // Next we are going to recompute all referee and referrer information
         // in arena
         let new_era_pivot_index = inner.height_to_pivot_index(new_era_height);

--- a/core/src/consensus/consensus_inner/mod.rs
+++ b/core/src/consensus/consensus_inner/mod.rs
@@ -1561,7 +1561,8 @@ impl ConsensusGraphInner {
         }
 
         if parent == NULL && referees.is_empty() {
-            self.old_era_block_set.lock().push_back(hash);
+            // FIXME These blocks will not be garbage collected from disk if
+            // they are never referred.
             return (sn, NULL);
         }
 

--- a/tests/full_node_tests/remove_old_eras_test.py
+++ b/tests/full_node_tests/remove_old_eras_test.py
@@ -73,7 +73,7 @@ class FullNodeRemoveOldErasTest(ConfluxTestFramework):
         # TODO We can use `num_blocks` here if we can guarantee all blocks form a chain.
         latest_epoch = self.rpc[ARCHIVE_NODE].epoch_number()
         # we expect the last few eras are not removed
-        for epoch in range(7 * ERA_EPOCH_COUNT, latest_epoch+1):
+        for epoch in range(8 * ERA_EPOCH_COUNT, latest_epoch+1):
             archive_block = self.rpc[ARCHIVE_NODE].block_by_epoch(hex(epoch), include_txs=True)
             assert(archive_block != None)
 


### PR DESCRIPTION
The consensus graph also only removes blocks in the past of a checkpoint.

Close #1662 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1718)
<!-- Reviewable:end -->
