### PR TITLE
txs received from block should be inserted to tx pool

### DIFF
--- a/core/src/sync/message/get_block_txn_response.rs
+++ b/core/src/sync/message/get_block_txn_response.rs
@@ -95,6 +95,13 @@ impl Handleable for GetBlockTxnResponse {
                         received_blocks.insert(resp_hash);
                     }
                     if insert_result.is_valid() {
+                        //insert transaction to tx pool
+                        let (signed_txns, _) = ctx
+                            .manager
+                            .graph
+                            .consensus
+                            .get_tx_pool()
+                            .insert_new_transactions(self.block_txn);
                         // a transaction from compact block should be
                         // added to received pool
                         ctx.manager

--- a/core/src/sync/message/get_block_txn_response.rs
+++ b/core/src/sync/message/get_block_txn_response.rs
@@ -95,13 +95,13 @@ impl Handleable for GetBlockTxnResponse {
                         received_blocks.insert(resp_hash);
                     }
                     if insert_result.is_valid() {
-                        //insert transaction to tx pool
+                        //insert signed transaction to tx pool
                         let (signed_txns, _) = ctx
                             .manager
                             .graph
                             .consensus
                             .get_tx_pool()
-                            .insert_new_transactions(self.block_txn);
+                            .insert_new_signed_transactions(signed_txns);
                         // a transaction from compact block should be
                         // added to received pool
                         ctx.manager


### PR DESCRIPTION
txs received from block should be inserted to tx pool, otherwise, valid txs received from invalid blocks will not be packed again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1731)
<!-- Reviewable:end -->
