### PR TITLE
Fix build

### DIFF
--- a/core/src/state/state_tests.rs
+++ b/core/src/state/state_tests.rs
@@ -788,7 +788,8 @@ fn kill_account_with_checkpoints() {
     state_0
         .require_exists(&a, /* require_code = */ false)
         .unwrap()
-        .commit_ownership_change(&state_0.db);
+        .commit_ownership_change(&state_0.db)
+        .unwrap();
     state_0.discard_checkpoint();
     let epoch_id_1 = EpochId::from_uint(&U256::from(1));
     state_0


### PR DESCRIPTION
Latest master builds fail on this warning:

```
13:27:48 error: unused `std::result::Result` that must be used
13:27:48    --> core/src/state/state_tests.rs:788:5
13:27:48     |
13:27:48 788 | /     state_0
13:27:48 789 | |         .require_exists(&a, /* require_code = */ false)
13:27:48 790 | |         .unwrap()
13:27:48 791 | |         .commit_ownership_change(&state_0.db);
13:27:48     | |______________________________________________^
13:27:48     |
13:27:48     = note: `-D unused-must-use` implied by `-D warnings`
13:27:48     = note: this `Result` may be an `Err` variant, which should be handled
13:27:48 
13:27:49 error: aborting due to previous error
```

Not sure how #1729 passed CI...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1733)
<!-- Reviewable:end -->
