### PR TITLE
Fix three state bugs

### DIFF
--- a/changelogs/CHANGELOG-1.0.x.md
+++ b/changelogs/CHANGELOG-1.0.x.md
@@ -3,6 +3,9 @@
 ## Bug Fixes
 
 - Fix bug where users need to restart node before they can use a newly created account to send transactions.
+- Fix code() return value for uninitialized contract.
+- Fix bug in kill_account after which the contract account is revived by simple transaction.
+- Fix the place of collateral refund for suicide contracts.
 
 ## Incompatible changes
 

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -494,7 +494,7 @@ impl ConsensusGraph {
         };
 
         match state_db.get_code(&address, &acc.code_hash) {
-            Ok(Some(code)) => Ok(code.code),
+            Ok(Some(code)) => Ok((*code.code).clone()),
             _ => Ok(vec![]),
         }
     }

--- a/core/src/executive/executive.rs
+++ b/core/src/executive/executive.rs
@@ -1526,7 +1526,7 @@ impl<'a> Executive<'a> {
 
         // perform suicides
         for address in &substate.suicides {
-            self.state.kill_account(address);
+            self.state.kill_account(address)?;
         }
 
         // TODO should be added back after enabling dust collection

--- a/core/src/light_protocol/query_service.rs
+++ b/core/src/light_protocol/query_service.rs
@@ -282,7 +282,7 @@ impl QueryService {
                 error!("Account {:?} found but code {:?} does not exist (epoch={:?})",  address, code_hash, epoch);
                 bail!(format!("Unable to retrieve code: internal error"));
             }
-            Some(info) => Ok(Some(info.code)),
+            Some(info) => Ok(Some((*info.code).clone())),
         }
     }
 

--- a/core/src/state/account_entry.rs
+++ b/core/src/state/account_entry.rs
@@ -528,11 +528,19 @@ impl OverlayAccount {
     ) -> DbResult<bool>
     {
         if cache_deposit_list && self.deposit_list.is_none() {
-            let deposit_list_opt = db.get_deposit_list(&self.address)?;
+            let deposit_list_opt = if self.is_newly_created_contract {
+                None
+            } else {
+                db.get_deposit_list(&self.address)?
+            };
             self.deposit_list = Some(deposit_list_opt.unwrap_or_default());
         }
         if cache_vote_list && self.vote_stake_list.is_none() {
-            let vote_list_opt = db.get_vote_list(&self.address)?;
+            let vote_list_opt = if self.is_newly_created_contract {
+                None
+            } else {
+                db.get_vote_list(&self.address)?
+            };
             self.vote_stake_list = Some(vote_list_opt.unwrap_or_default());
         }
         Ok(true)

--- a/core/src/state/account_entry.rs
+++ b/core/src/state/account_entry.rs
@@ -3,10 +3,10 @@
 // See http://www.gnu.org/licenses/
 
 use crate::{
-    bytes::{Bytes, ToPretty},
+    bytes::Bytes,
     consensus::debug::ComputeEpochDebugRecord,
     hash::{keccak, KECCAK_EMPTY},
-    state::State,
+    state::{AccountEntryProtectedMethods, State},
     statedb::{Result as DbResult, StateDb},
 };
 use cfx_types::{address_util::AddressUtil, Address, H256, U256};
@@ -77,11 +77,10 @@ pub struct OverlayAccount {
 
     // Code hash of the account.
     code_hash: H256,
-    // Size of the acccount code.
-    code_size: Option<usize>,
-    // Code cache of the account.
-    code_cache: Arc<Bytes>,
-    code_owner: Address,
+    // When code_hash isn't KECCAK_EMPTY, code must exist. If the value is
+    // None, it means that it hasn't been loaded from db. When code_hash is
+    // KECCAK_EMPTY, this is always None.
+    code: Option<CodeInfo>,
 
     // This flag indicates whether it is a newly created contract. For such
     // account, we will skip looking data from the disk. This flag will stay
@@ -108,9 +107,7 @@ impl OverlayAccount {
             deposit_list: None,
             vote_stake_list: None,
             code_hash: account.code_hash,
-            code_size: None,
-            code_cache: Arc::new(vec![]),
-            code_owner: Address::zero(),
+            code: None,
             is_newly_created_contract: false,
         };
 
@@ -135,9 +132,7 @@ impl OverlayAccount {
             deposit_list: None,
             vote_stake_list: None,
             code_hash: KECCAK_EMPTY,
-            code_size: None,
-            code_cache: Arc::new(vec![]),
-            code_owner: Address::zero(),
+            code: None,
             is_newly_created_contract: false,
         }
     }
@@ -167,9 +162,7 @@ impl OverlayAccount {
             deposit_list: None,
             vote_stake_list: None,
             code_hash: KECCAK_EMPTY,
-            code_size: None,
-            code_cache: Arc::new(Default::default()),
-            code_owner: Address::zero(),
+            code: None,
             is_newly_created_contract: true,
         }
     }
@@ -341,14 +334,6 @@ impl OverlayAccount {
         }
     }
 
-    pub fn deposit_list(&self) -> Option<&DepositList> {
-        self.deposit_list.as_ref()
-    }
-
-    pub fn vote_stake_list(&self) -> Option<&VoteStakeList> {
-        self.vote_stake_list.as_ref()
-    }
-
     #[cfg(test)]
     pub fn storage_changes(&self) -> &HashMap<Vec<u8>, U256> {
         &self.storage_changes
@@ -368,27 +353,8 @@ impl OverlayAccount {
 
     pub fn code_hash(&self) -> H256 { self.code_hash.clone() }
 
-    pub fn code_size(&self) -> Option<usize> { self.code_size.clone() }
-
-    pub fn code(&self) -> Option<Arc<Bytes>> {
-        if self.code_hash != KECCAK_EMPTY && self.code_cache.is_empty() {
-            None
-        } else {
-            Some(self.code_cache.clone())
-        }
-    }
-
-    pub fn code_owner(&self) -> Option<Address> {
-        if self.code_hash != KECCAK_EMPTY && self.code_cache.is_empty() {
-            None
-        } else {
-            Some(self.code_owner)
-        }
-    }
-
-    pub fn is_cached(&self) -> bool {
-        !self.code_cache.is_empty()
-            || (self.code_cache.is_empty() && self.code_hash == KECCAK_EMPTY)
+    pub fn is_code_loaded(&self) -> bool {
+        self.code.is_some() || self.code_hash == KECCAK_EMPTY
     }
 
     pub fn is_null(&self) -> bool {
@@ -521,23 +487,24 @@ impl OverlayAccount {
         self.collateral_for_storage -= *by;
     }
 
-    pub fn cache_code(&mut self, db: &StateDb) -> Option<Arc<Bytes>> {
-        trace!("OverlayAccount::cache_code: ic={}; self.code_hash={:?}, self.code_cache={}", self.is_cached(), self.code_hash, self.code_cache.pretty());
+    pub fn cache_code(&mut self, db: &StateDb) -> DbResult<bool> {
+        trace!(
+            "OverlayAccount::cache_code: ic={}; self.code_hash={:?}, self.code_cache={:?}",
+               self.is_code_loaded(), self.code_hash, self.code);
 
-        if self.is_cached() {
-            return Some(self.code_cache.clone());
+        if self.is_code_loaded() {
+            return Ok(true);
         }
 
-        match db.get_code(&self.address, &self.code_hash) {
-            Ok(Some(code)) => {
-                self.code_size = Some(code.code.len());
-                self.code_cache = Arc::new(code.code.to_vec());
-                self.code_owner = code.owner;
-                Some(self.code_cache.clone())
-            }
+        self.code = db.get_code(&self.address, &self.code_hash)?;
+        match &self.code {
+            Some(_) => Ok(true),
             _ => {
-                warn!("Failed reverse get of {}", self.code_hash);
-                None
+                warn!(
+                    "Failed to get code {:?} for address {:?}",
+                    self.code_hash, self.address
+                );
+                Ok(false)
             }
         }
     }
@@ -545,7 +512,7 @@ impl OverlayAccount {
     pub fn cache_staking_info(
         &mut self, cache_deposit_list: bool, cache_vote_list: bool,
         db: &StateDb,
-    ) -> DbResult<()>
+    ) -> DbResult<bool>
     {
         if cache_deposit_list && self.deposit_list.is_none() {
             let deposit_list_opt = db.get_deposit_list(&self.address)?;
@@ -555,7 +522,7 @@ impl OverlayAccount {
             let vote_list_opt = db.get_vote_list(&self.address)?;
             self.vote_stake_list = Some(vote_list_opt.unwrap_or_default());
         }
-        Ok(())
+        Ok(true)
     }
 
     pub fn clone_basic(&self) -> Self {
@@ -576,9 +543,7 @@ impl OverlayAccount {
             deposit_list: self.deposit_list.clone(),
             vote_stake_list: self.vote_stake_list.clone(),
             code_hash: self.code_hash,
-            code_size: self.code_size,
-            code_cache: self.code_cache.clone(),
-            code_owner: self.code_owner,
+            code: self.code.clone(),
             is_newly_created_contract: self.is_newly_created_contract,
         }
     }
@@ -663,9 +628,10 @@ impl OverlayAccount {
 
     pub fn init_code(&mut self, code: Bytes, owner: Address) {
         self.code_hash = keccak(&code);
-        self.code_cache = Arc::new(code);
-        self.code_owner = owner;
-        self.code_size = Some(self.code_cache.len());
+        self.code = Some(CodeInfo {
+            code: Arc::new(code),
+            owner,
+        });
     }
 
     pub fn overwrite_with(&mut self, other: OverlayAccount) {
@@ -674,9 +640,7 @@ impl OverlayAccount {
         self.admin = other.admin;
         self.sponsor_info = other.sponsor_info;
         self.code_hash = other.code_hash;
-        self.code_cache = other.code_cache;
-        self.code_owner = other.code_owner;
-        self.code_size = other.code_size;
+        self.code = other.code;
         self.storage_cache = other.storage_cache;
         self.storage_changes = other.storage_changes;
         self.ownership_cache = other.ownership_cache;
@@ -828,23 +792,16 @@ impl OverlayAccount {
             }
         }
 
-        match self.code() {
+        match &self.code {
             None => {}
-            Some(code) => {
-                if !code.is_empty() {
-                    let storage_key = StorageKey::new_code_key(
-                        &self.address,
-                        &self.code_hash,
-                    );
-                    state.db.set::<CodeInfo>(
-                        storage_key,
-                        &CodeInfo {
-                            code: (*code).clone(),
-                            owner: self.code_owner,
-                        },
-                        debug_record.as_deref_mut(),
-                    )?;
-                }
+            Some(code_info) => {
+                let storage_key =
+                    StorageKey::new_code_key(&self.address, &self.code_hash);
+                state.db.set::<CodeInfo>(
+                    storage_key,
+                    code_info,
+                    debug_record.as_deref_mut(),
+                )?;
             }
         }
 
@@ -971,5 +928,37 @@ impl AccountEntry {
 
     pub fn exists_and_is_null(&self) -> bool {
         self.account.as_ref().map_or(false, |acc| acc.is_null())
+    }
+}
+
+impl AccountEntryProtectedMethods for OverlayAccount {
+    /// This method is intentionally kept private because the field may not have
+    /// been loaded from db.
+    fn deposit_list(&self) -> Option<&DepositList> {
+        self.deposit_list.as_ref()
+    }
+
+    /// This method is intentionally kept private because the field may not have
+    /// been loaded from db.
+    fn vote_stake_list(&self) -> Option<&VoteStakeList> {
+        self.vote_stake_list.as_ref()
+    }
+
+    /// This method is intentionally kept private because the field may not have
+    /// been loaded from db.
+    fn code_size(&self) -> Option<usize> {
+        self.code.as_ref().map(|c| c.code_size())
+    }
+
+    /// This method is intentionally kept private because the field may not have
+    /// been loaded from db.
+    fn code(&self) -> Option<Arc<Bytes>> {
+        self.code.as_ref().map(|c| c.code.clone())
+    }
+
+    /// This method is intentionally kept private because the field may not have
+    /// been loaded from db.
+    fn code_owner(&self) -> Option<Address> {
+        self.code.as_ref().map(|c| c.owner)
     }
 }

--- a/core/src/state/account_entry_tests.rs
+++ b/core/src/state/account_entry_tests.rs
@@ -6,6 +6,7 @@ use super::account_entry::OverlayAccount;
 use crate::{
     hash::KECCAK_EMPTY,
     parameters::staking::*,
+    state::AccountEntryProtectedMethods,
     statedb::StateDb,
     storage::{tests::new_state_manager_for_unit_test, StorageManagerTrait},
 };

--- a/core/src/state/account_entry_tests.rs
+++ b/core/src/state/account_entry_tests.rs
@@ -23,7 +23,7 @@ fn test_overlay_account_create() {
         Account::new_empty_with_balance(&address, &U256::zero(), &U256::zero())
             .unwrap();
     // test new from account 1
-    let overlay_account = OverlayAccount::new(&address, account);
+    let overlay_account = OverlayAccount::from_loaded(&address, account);
     assert!(overlay_account.deposit_list().is_none());
     assert!(overlay_account.vote_stake_list().is_none());
     assert_eq!(*overlay_account.address(), address);
@@ -65,7 +65,7 @@ fn test_overlay_account_create() {
     .unwrap();
 
     // test new from account 2
-    let overlay_account = OverlayAccount::new(&contract_addr, account);
+    let overlay_account = OverlayAccount::from_loaded(&contract_addr, account);
     assert!(overlay_account.deposit_list().is_none());
     assert!(overlay_account.vote_stake_list().is_none());
     assert_eq!(*overlay_account.address(), contract_addr);
@@ -156,7 +156,7 @@ fn test_deposit_and_withdraw() {
                 / *INTEREST_RATE_PER_BLOCK_SCALE,
         );
     }
-    let mut overlay_account = OverlayAccount::new(&address, account);
+    let mut overlay_account = OverlayAccount::from_loaded(&address, account);
     overlay_account
         .cache_staking_info(
             true, /* cache_deposit_list */
@@ -442,7 +442,8 @@ fn init_test_account() -> OverlayAccount {
     )
     .unwrap();
 
-    let mut overlay_account = OverlayAccount::new(&address, account.clone());
+    let mut overlay_account =
+        OverlayAccount::from_loaded(&address, account.clone());
     overlay_account
         .cache_staking_info(
             true, /* cache_deposit_list */
@@ -678,8 +679,10 @@ fn test_clone_overwrite() {
     )
     .unwrap();
 
-    let mut overlay_account1 = OverlayAccount::new(&address, account1.clone());
-    let mut overlay_account2 = OverlayAccount::new(&address, account2.clone());
+    let mut overlay_account1 =
+        OverlayAccount::from_loaded(&address, account1.clone());
+    let mut overlay_account2 =
+        OverlayAccount::from_loaded(&address, account2.clone());
     assert_eq!(account1, overlay_account1.as_account().unwrap());
     assert_eq!(account2, overlay_account2.as_account().unwrap());
 

--- a/core/src/state/state_tests.rs
+++ b/core/src/state/state_tests.rs
@@ -791,9 +791,6 @@ fn kill_account_with_checkpoints() {
     state_0
         .add_collateral_for_storage(&a, &COLLATERAL_PER_STORAGE_KEY)
         .unwrap();
-    state_0
-        .register_unpaid_collateral(&a, &COLLATERAL_PER_STORAGE_KEY)
-        .unwrap();
     state_0.discard_checkpoint();
     let epoch_id_1 = EpochId::from_uint(&U256::from(1));
     state_0
@@ -866,9 +863,6 @@ fn check_result_of_simple_payment_to_killed_account() {
         .unwrap();
     state_0
         .add_collateral_for_storage(&sender_addr, &COLLATERAL_PER_STORAGE_KEY)
-        .unwrap();
-    state_0
-        .register_unpaid_collateral(&sender_addr, &COLLATERAL_PER_STORAGE_KEY)
         .unwrap();
     state_0.discard_checkpoint();
     let epoch_id_1 = EpochId::from_uint(&U256::from(1));

--- a/core/src/state/state_tests.rs
+++ b/core/src/state/state_tests.rs
@@ -5,7 +5,8 @@
 use super::{CleanupMode, CollateralCheckResult, State, Substate};
 
 use crate::{
-    parameters::staking::*,
+    genesis::DEV_GENESIS_KEY_PAIR,
+    parameters::{consensus::ONE_CFX_IN_DRIP, staking::*},
     statedb::StateDb,
     storage::{
         tests::new_state_manager_for_unit_test, StateIndex, StorageManager,
@@ -15,7 +16,8 @@ use crate::{
     vm_factory::VmFactory,
 };
 use cfx_types::{address_util::AddressUtil, Address, BigEndianHash, U256};
-use primitives::{EpochId, StorageLayout};
+use keccak_hash::{keccak, KECCAK_EMPTY};
+use primitives::{EpochId, StorageKey, StorageLayout};
 
 fn get_state(storage_manager: &StorageManager, epoch_id: &EpochId) -> State {
     State::new(
@@ -770,7 +772,9 @@ fn kill_account_with_checkpoints() {
     let k = u256_to_vec(&U256::from(0));
     // Need the checkpoint for ownership commitment.
     state_0.checkpoint();
-    state_0.new_contract(&a, U256::zero(), U256::one()).unwrap();
+    state_0
+        .new_contract(&a, *COLLATERAL_PER_STORAGE_KEY, U256::one())
+        .unwrap();
     state_0.set_storage(&a, k.clone(), U256::one(), a).unwrap();
     state_0
         .set_storage_layout(&a, StorageLayout::Regular(0))
@@ -781,6 +785,15 @@ fn kill_account_with_checkpoints() {
         .unwrap()
         .commit_ownership_change(&state_0.db)
         .unwrap();
+    state_0
+        .add_sponsor_balance_for_collateral(&a, &COLLATERAL_PER_STORAGE_KEY)
+        .unwrap();
+    state_0
+        .add_collateral_for_storage(&a, &COLLATERAL_PER_STORAGE_KEY)
+        .unwrap();
+    state_0
+        .register_unpaid_collateral(&a, &COLLATERAL_PER_STORAGE_KEY)
+        .unwrap();
     state_0.discard_checkpoint();
     let epoch_id_1 = EpochId::from_uint(&U256::from(1));
     state_0
@@ -790,7 +803,7 @@ fn kill_account_with_checkpoints() {
     let mut state = get_state(&storage_manager, &epoch_id_1);
     // Storage before the account is killed.
     assert_eq!(state.storage_at(&a, &k).unwrap(), U256::one());
-    state.kill_account(&a);
+    state.kill_account(&a).unwrap();
     // The account is killed. The storage should be empty.
     assert_eq!(state.storage_at(&a, &k).unwrap(), U256::zero());
     // The new contract in the same place should have empty storage.
@@ -806,7 +819,7 @@ fn kill_account_with_checkpoints() {
     // Test checkpoint.
     let mut state = get_state(&storage_manager, &epoch_id_1);
     state.checkpoint();
-    state.kill_account(&a);
+    state.kill_account(&a).unwrap();
     // The new contract in the same place should have empty storage.
     state.checkpoint();
     state.new_contract(&a, U256::zero(), U256::one()).unwrap();
@@ -818,6 +831,72 @@ fn kill_account_with_checkpoints() {
     state.revert_to_checkpoint();
     // Storage before the account is killed.
     assert_eq!(state.storage_at(&a, &k).unwrap(), U256::one());
+}
+
+#[test]
+fn check_result_of_simple_payment_to_killed_account() {
+    let storage_manager = new_state_manager_for_unit_test();
+    let mut state_0 = get_state_for_genesis_write(&storage_manager);
+    let sender_addr = DEV_GENESIS_KEY_PAIR.address();
+    state_0
+        .require_or_new_basic_account(&sender_addr)
+        .unwrap()
+        .add_balance(&ONE_CFX_IN_DRIP.into());
+    let mut a = Address::zero();
+    a.set_contract_type_bits();
+    let code = b"asdf"[..].into();
+    let code_hash = keccak(&code);
+    let code_key = StorageKey::new_code_key(&a, &code_hash);
+    let k = u256_to_vec(&U256::from(0));
+    // Need the checkpoint for ownership commitment.
+    state_0.checkpoint();
+    state_0.new_contract(&a, U256::zero(), U256::one()).unwrap();
+    state_0.init_code(&a, code, sender_addr).unwrap();
+    state_0
+        .set_storage(&a, k.clone(), U256::one(), sender_addr)
+        .unwrap();
+    state_0
+        .set_storage_layout(&a, StorageLayout::Regular(0))
+        .unwrap();
+    // We don't charge the collateral in this test.
+    state_0
+        .require_exists(&a, /* require_code = */ false)
+        .unwrap()
+        .commit_ownership_change(&state_0.db)
+        .unwrap();
+    state_0
+        .add_collateral_for_storage(&sender_addr, &COLLATERAL_PER_STORAGE_KEY)
+        .unwrap();
+    state_0
+        .register_unpaid_collateral(&sender_addr, &COLLATERAL_PER_STORAGE_KEY)
+        .unwrap();
+    state_0.discard_checkpoint();
+    let epoch_id_1 = EpochId::from_uint(&U256::from(1));
+    state_0
+        .commit(epoch_id_1, /* debug_record = */ None)
+        .unwrap();
+
+    let mut state = get_state(&storage_manager, &epoch_id_1);
+    state.kill_account(&a).unwrap();
+    // The account is killed. The storage should be empty.
+    assert_eq!(state.storage_at(&a, &k).unwrap(), U256::zero());
+    // Transfer balance to the killed account.
+    state
+        .transfer_balance(&sender_addr, &a, &U256::one(), CleanupMode::NoEmpty)
+        .unwrap();
+    let epoch_id = EpochId::from_uint(&U256::from(2));
+    // Assert that the account has no storage and no code.
+    assert_eq!(state.code_hash(&a).unwrap(), Some(KECCAK_EMPTY));
+    assert_eq!(state.code(&a).unwrap(), None);
+    assert_eq!(state.storage_at(&a, &k).unwrap(), U256::zero());
+    state.commit(epoch_id, /* debug_record = */ None).unwrap();
+
+    // Commit the state and assert that the account has no storage and no code.
+    let state = get_state(&storage_manager, &epoch_id);
+    assert_eq!(state.code_hash(&a).unwrap(), Some(KECCAK_EMPTY));
+    assert_eq!(state.code(&a).unwrap(), None);
+    assert_eq!(state.db.get_raw(code_key).unwrap(), None);
+    assert_eq!(state.storage_at(&a, &k).unwrap(), U256::zero());
 }
 
 #[test]

--- a/core/src/statedb/mod.rs
+++ b/core/src/statedb/mod.rs
@@ -6,9 +6,9 @@ use crate::{
     executive::STORAGE_INTEREST_STAKING_CONTRACT_ADDRESS,
     parameters::staking::*,
     storage::{
-        Error as StorageError, ErrorKind as StorageErrorKind, MptKeyValue,
-        NodeMerkleProof, StateProof, StateRootWithAuxInfo, StorageState,
-        StorageStateTrait,
+        utils::access_mode, Error as StorageError,
+        ErrorKind as StorageErrorKind, MptKeyValue, NodeMerkleProof,
+        StateProof, StateRootWithAuxInfo, StorageState, StorageStateTrait,
     },
 };
 use cfx_types::{Address, H256, U256};
@@ -20,7 +20,10 @@ use primitives::{
 mod error;
 
 pub use self::error::{Error, ErrorKind, Result};
-use crate::consensus::debug::{ComputeEpochDebugRecord, StateOp};
+use crate::{
+    consensus::debug::{ComputeEpochDebugRecord, StateOp},
+    storage::state::{NoProof, WithProof},
+};
 use rlp::Rlp;
 
 pub struct StateDb {
@@ -100,9 +103,8 @@ impl StateDb {
     ) -> Result<Option<StorageRoot>> {
         let key = StorageKey::new_storage_root_key(address);
 
-        let (triplet, _) = self
-            .storage
-            .get_node_merkle_all_versions(key, false /* with_proof */)?;
+        let (triplet, _) =
+            self.storage.get_node_merkle_all_versions::<NoProof>(key)?;
 
         Ok(StorageRoot::from_node_merkle_triplet(triplet))
     }
@@ -114,7 +116,7 @@ impl StateDb {
 
         let (triplet, proof) = self
             .storage
-            .get_node_merkle_all_versions(key, true /* with_proof */)?;
+            .get_node_merkle_all_versions::<WithProof>(key)?;
 
         let root = StorageRoot::from_node_merkle_triplet(triplet);
         Ok((root, proof))
@@ -193,7 +195,7 @@ impl StateDb {
                 maybe_value: None,
             })
         }
-        Ok(self.storage.delete_all(key_prefix)?)
+        Ok(self.storage.delete_all::<access_mode::Write>(key_prefix)?)
     }
 
     /// This method is only used for genesis block because state root is

--- a/core/src/statedb/statedb_ext.rs
+++ b/core/src/statedb/statedb_ext.rs
@@ -1,0 +1,249 @@
+// Copyright 2020 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+pub trait StateDbExt {
+    fn get<T>(&self, key: StorageKey) -> Result<Option<T>>
+    where T: ::rlp::Decodable;
+
+    fn set<T>(
+        &mut self, key: StorageKey, value: &T,
+        debug_record: Option<&mut ComputeEpochDebugRecord>,
+    ) -> Result<()>
+    where
+        T: ::rlp::Encodable;
+
+    fn get_account(&self, address: &Address) -> Result<Option<Account>>;
+
+    fn get_code(
+        &self, address: &Address, code_hash: &H256,
+    ) -> Result<Option<CodeInfo>>;
+
+    fn get_deposit_list(
+        &self, address: &Address,
+    ) -> Result<Option<DepositList>>;
+
+    fn get_vote_list(&self, address: &Address)
+        -> Result<Option<VoteStakeList>>;
+
+    fn get_annual_interest_rate(&self) -> Result<U256>;
+    fn set_annual_interest_rate(
+        &mut self, interest_rate: &U256,
+        debug_record: Option<&mut ComputeEpochDebugRecord>,
+    ) -> Result<()>;
+
+    fn get_accumulate_interest_rate(&self) -> Result<U256>;
+    fn set_accumulate_interest_rate(
+        &mut self, accumulate_interest_rate: &U256,
+        debug_record: Option<&mut ComputeEpochDebugRecord>,
+    ) -> Result<()>;
+
+    fn get_total_issued_tokens(&self) -> Result<U256>;
+    fn set_total_issued_tokens(
+        &mut self, total_issued_tokens: &U256,
+        debug_record: Option<&mut ComputeEpochDebugRecord>,
+    ) -> Result<()>;
+
+    fn get_total_staking_tokens(&self) -> Result<U256>;
+    fn set_total_staking_tokens(
+        &mut self, total_staking_tokens: &U256,
+        debug_record: Option<&mut ComputeEpochDebugRecord>,
+    ) -> Result<()>;
+
+    fn get_total_storage_tokens(&self) -> Result<U256>;
+    fn set_total_storage_tokens(
+        &mut self, total_storage_tokens: &U256,
+        debug_record: Option<&mut ComputeEpochDebugRecord>,
+    ) -> Result<()>;
+}
+
+const ACCUMULATE_INTEREST_RATE_KEY: &'static [u8] = b"accumulate_interest_rate";
+const INTEREST_RATE_KEY: &'static [u8] = b"interest_rate";
+const TOTAL_BANK_TOKENS_KEY: &'static [u8] = b"total_staking_tokens";
+const TOTAL_STORAGE_TOKENS_KEY: &'static [u8] = b"total_storage_tokens";
+const TOTAL_TOKENS_KEY: &'static [u8] = b"total_issued_tokens";
+
+impl StateDbExt for StateDb {
+    fn get<T>(&self, key: StorageKey) -> Result<Option<T>>
+    where T: ::rlp::Decodable {
+        match self.get_raw(key) {
+            Ok(None) => Ok(None),
+            Ok(Some(raw)) => Ok(Some(::rlp::decode::<T>(raw.as_ref())?)),
+            Err(e) => bail!(e),
+        }
+    }
+
+    fn set<T>(
+        &mut self, key: StorageKey, value: &T,
+        debug_record: Option<&mut ComputeEpochDebugRecord>,
+    ) -> Result<()>
+    where
+        T: ::rlp::Encodable,
+    {
+        self.set_raw(key, ::rlp::encode(value).into_boxed_slice(), debug_record)
+    }
+
+    fn get_account(&self, address: &Address) -> Result<Option<Account>> {
+        match self.get_raw(StorageKey::new_account_key(address)) {
+            Ok(None) => Ok(None),
+            Ok(Some(raw)) => {
+                Ok(Some(Account::new_from_rlp(*address, &Rlp::new(&raw))?))
+            }
+            Err(e) => bail!(e),
+        }
+    }
+
+    fn get_code(
+        &self, address: &Address, code_hash: &H256,
+    ) -> Result<Option<CodeInfo>> {
+        self.get::<CodeInfo>(StorageKey::new_code_key(address, code_hash))
+    }
+
+    fn get_deposit_list(
+        &self, address: &Address,
+    ) -> Result<Option<DepositList>> {
+        self.get::<DepositList>(StorageKey::new_deposit_list_key(address))
+    }
+
+    fn get_vote_list(
+        &self, address: &Address,
+    ) -> Result<Option<VoteStakeList>> {
+        self.get::<VoteStakeList>(StorageKey::new_vote_list_key(address))
+    }
+
+    fn get_annual_interest_rate(&self) -> Result<U256> {
+        let interest_rate_key = StorageKey::new_storage_key(
+            &STORAGE_INTEREST_STAKING_CONTRACT_ADDRESS,
+            INTEREST_RATE_KEY,
+        );
+        let interest_rate_opt = self.get::<U256>(interest_rate_key)?;
+        Ok(interest_rate_opt.unwrap_or(
+            *INITIAL_INTEREST_RATE_PER_BLOCK * U256::from(BLOCKS_PER_YEAR),
+        ))
+    }
+
+    fn set_annual_interest_rate(
+        &mut self, interest_rate: &U256,
+        debug_record: Option<&mut ComputeEpochDebugRecord>,
+    ) -> Result<()>
+    {
+        let interest_rate_key = StorageKey::new_storage_key(
+            &STORAGE_INTEREST_STAKING_CONTRACT_ADDRESS,
+            INTEREST_RATE_KEY,
+        );
+        self.set::<U256>(interest_rate_key, interest_rate, debug_record)
+    }
+
+    fn get_accumulate_interest_rate(&self) -> Result<U256> {
+        let acc_interest_rate_key = StorageKey::new_storage_key(
+            &STORAGE_INTEREST_STAKING_CONTRACT_ADDRESS,
+            ACCUMULATE_INTEREST_RATE_KEY,
+        );
+        let acc_interest_rate_opt = self.get::<U256>(acc_interest_rate_key)?;
+        Ok(acc_interest_rate_opt.unwrap_or(*ACCUMULATED_INTEREST_RATE_SCALE))
+    }
+
+    fn set_accumulate_interest_rate(
+        &mut self, accumulate_interest_rate: &U256,
+        debug_record: Option<&mut ComputeEpochDebugRecord>,
+    ) -> Result<()>
+    {
+        let acc_interest_rate_key = StorageKey::new_storage_key(
+            &STORAGE_INTEREST_STAKING_CONTRACT_ADDRESS,
+            ACCUMULATE_INTEREST_RATE_KEY,
+        );
+        self.set::<U256>(
+            acc_interest_rate_key,
+            accumulate_interest_rate,
+            debug_record,
+        )
+    }
+
+    fn get_total_issued_tokens(&self) -> Result<U256> {
+        let total_issued_tokens_key = StorageKey::new_storage_key(
+            &STORAGE_INTEREST_STAKING_CONTRACT_ADDRESS,
+            TOTAL_TOKENS_KEY,
+        );
+        let total_issued_tokens_opt =
+            self.get::<U256>(total_issued_tokens_key)?;
+        Ok(total_issued_tokens_opt.unwrap_or(U256::zero()))
+    }
+
+    fn set_total_issued_tokens(
+        &mut self, total_issued_tokens: &U256,
+        debug_record: Option<&mut ComputeEpochDebugRecord>,
+    ) -> Result<()>
+    {
+        let total_issued_tokens_key = StorageKey::new_storage_key(
+            &STORAGE_INTEREST_STAKING_CONTRACT_ADDRESS,
+            TOTAL_TOKENS_KEY,
+        );
+        self.set::<U256>(
+            total_issued_tokens_key,
+            total_issued_tokens,
+            debug_record,
+        )
+    }
+
+    fn get_total_staking_tokens(&self) -> Result<U256> {
+        let total_staking_tokens_key = StorageKey::new_storage_key(
+            &STORAGE_INTEREST_STAKING_CONTRACT_ADDRESS,
+            TOTAL_BANK_TOKENS_KEY,
+        );
+        let total_staking_tokens_opt =
+            self.get::<U256>(total_staking_tokens_key)?;
+        Ok(total_staking_tokens_opt.unwrap_or(U256::zero()))
+    }
+
+    fn set_total_staking_tokens(
+        &mut self, total_staking_tokens: &U256,
+        debug_record: Option<&mut ComputeEpochDebugRecord>,
+    ) -> Result<()>
+    {
+        let total_staking_tokens_key = StorageKey::new_storage_key(
+            &STORAGE_INTEREST_STAKING_CONTRACT_ADDRESS,
+            TOTAL_BANK_TOKENS_KEY,
+        );
+        self.set::<U256>(
+            total_staking_tokens_key,
+            total_staking_tokens,
+            debug_record,
+        )
+    }
+
+    fn get_total_storage_tokens(&self) -> Result<U256> {
+        let total_storage_tokens_key = StorageKey::new_storage_key(
+            &STORAGE_INTEREST_STAKING_CONTRACT_ADDRESS,
+            TOTAL_STORAGE_TOKENS_KEY,
+        );
+        let total_storage_tokens_opt =
+            self.get::<U256>(total_storage_tokens_key)?;
+        Ok(total_storage_tokens_opt.unwrap_or(U256::zero()))
+    }
+
+    fn set_total_storage_tokens(
+        &mut self, total_storage_tokens: &U256,
+        debug_record: Option<&mut ComputeEpochDebugRecord>,
+    ) -> Result<()>
+    {
+        let total_storage_tokens_key = StorageKey::new_storage_key(
+            &STORAGE_INTEREST_STAKING_CONTRACT_ADDRESS,
+            TOTAL_STORAGE_TOKENS_KEY,
+        );
+        self.set::<U256>(
+            total_storage_tokens_key,
+            total_storage_tokens,
+            debug_record,
+        )
+    }
+}
+
+use super::{Result, StateDb};
+use crate::{
+    consensus::debug::ComputeEpochDebugRecord,
+    executive::STORAGE_INTEREST_STAKING_CONTRACT_ADDRESS,
+    parameters::staking::*,
+};
+use cfx_types::{Address, H256, U256};
+use primitives::{Account, CodeInfo, DepositList, StorageKey, VoteStakeList};
+use rlp::Rlp;

--- a/core/src/storage/impls/delta_mpt/subtrie_visitor.rs
+++ b/core/src/storage/impls/delta_mpt/subtrie_visitor.rs
@@ -95,7 +95,7 @@ impl<'trie, 'db: 'trie> SubTrieVisitor<'trie, 'db> {
             if is_loaded_from_db {
                 db_load_count += 1;
             }
-            match trie_node.walk::<Read>(key) {
+            match trie_node.walk::<access_mode::Read>(key) {
                 WalkStop::Arrived => {
                     node_memory_manager.log_uncached_key_access(db_load_count);
                     let (guard, trie_node) = trie_node.into();
@@ -161,7 +161,7 @@ impl<'trie, 'db: 'trie> SubTrieVisitor<'trie, 'db> {
                 )?;
 
             // update variables for subsequent traversal
-            match trie_node.walk::<Read>(key) {
+            match trie_node.walk::<access_mode::Read>(key) {
                 WalkStop::Arrived => {
                     finished = true;
                 }
@@ -264,7 +264,7 @@ impl<'trie, 'db: 'trie> SubTrieVisitor<'trie, 'db> {
             &allocator,
             &mut **self.db.get_mut(),
         )?;
-        match trie_node_ref.walk::<Read>(key) {
+        match trie_node_ref.walk::<access_mode::Read>(key) {
             WalkStop::Arrived => {
                 // If value doesn't exists, returns invalid key error.
                 let result = trie_node_ref.check_delete_value();
@@ -432,7 +432,7 @@ impl<'trie, 'db: 'trie> SubTrieVisitor<'trie, 'db> {
         )?;
 
         let key_prefix: CompressedPathRaw;
-        match trie_node_ref.walk::<Write>(key_remaining) {
+        match trie_node_ref.walk::<access_mode::Write>(key_remaining) {
             WalkStop::ChildNotFound {
                 key_remaining: _,
                 child_index: _,
@@ -580,7 +580,7 @@ impl<'trie, 'db: 'trie> SubTrieVisitor<'trie, 'db> {
         )?;
 
         let key_prefix: CompressedPathRaw;
-        match trie_node_ref.walk::<Write>(key_remaining) {
+        match trie_node_ref.walk::<access_mode::Write>(key_remaining) {
             WalkStop::ChildNotFound { .. } => return Ok(None),
             WalkStop::Arrived => {
                 // To enumerate the subtree.
@@ -656,7 +656,7 @@ impl<'trie, 'db: 'trie> SubTrieVisitor<'trie, 'db> {
             &allocator,
             &mut **self.db.get_mut(),
         )?;
-        match trie_node_ref.walk::<Write>(key) {
+        match trie_node_ref.walk::<access_mode::Write>(key) {
             WalkStop::Arrived => {
                 let node_ref_changed = !is_owned;
                 let trie_node = GuardedValue::take(trie_node_ref);
@@ -831,13 +831,13 @@ use super::{
     super::{
         super::{
             storage_db::delta_db_manager::DeltaDbOwnedReadTraitObj,
-            utils::guarded_value::GuardedValue,
+            utils::{access_mode, guarded_value::GuardedValue},
         },
         errors::*,
         merkle_patricia_trie::{
             merkle::*,
             trie_proof::TrieProofNode,
-            walk::{access_mode::*, KeyPart, TrieNodeWalkTrait, WalkStop},
+            walk::{KeyPart, TrieNodeWalkTrait, WalkStop},
             *,
         },
     },

--- a/core/src/storage/impls/errors.rs
+++ b/core/src/storage/impls/errors.rs
@@ -130,6 +130,11 @@ error_chain! {
             ),
         }
 
+        UnsupportedByFreshlySyncedSnapshot(op: &'static str) {
+            description("The operation isn't possible on freshly synced snapshot."),
+            display("The operation \"{}\" isn't possible on freshly synced snapshot.", op),
+        }
+
         InvalidTrieProof {
             description("Trie proof is invalid."),
             display("Trie proof is invalid."),

--- a/core/src/storage/impls/merkle_patricia_trie/mod.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/mod.rs
@@ -29,7 +29,6 @@ pub use self::{
     mpt_value::MptValue,
     trie_node::{TrieNodeTrait, VanillaTrieNode},
     trie_proof::TrieProof,
-    walk::access_mode,
 };
 
 pub type MptKeyValue = (Vec<u8>, Box<[u8]>);

--- a/core/src/storage/impls/merkle_patricia_trie/mpt_cursor.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/mpt_cursor.rs
@@ -1571,6 +1571,7 @@ use crate::storage::{
         },
     },
     storage_db::snapshot_mpt::*,
+    utils::access_mode,
 };
 use primitives::{MerkleHash, MERKLE_NULL_NODE};
 use std::{

--- a/core/src/storage/impls/merkle_patricia_trie/simple_mpt.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/simple_mpt.rs
@@ -117,11 +117,12 @@ use crate::storage::{
     impls::merkle_patricia_trie::{
         mpt_cursor::{BasicPathNode, MptCursor},
         trie_node::TrieNodeTrait,
-        walk::{access_mode, GetChildTrait},
+        walk::GetChildTrait,
         CompressedPathRaw, MptMerger, TrieProof,
     },
     storage_db::SnapshotMptTraitRead,
     tests::DumpedMptKvIterator,
+    utils::access_mode,
 };
 use primitives::{MerkleHash, MERKLE_NULL_NODE};
 

--- a/core/src/storage/impls/merkle_patricia_trie/trie_proof.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/trie_proof.rs
@@ -219,7 +219,7 @@ impl TrieProof {
                 }
             };
 
-            match node.walk::<Read>(key) {
+            match node.walk::<access_mode::Read>(key) {
                 WalkStop::Arrived => {
                     return pred(Some(node));
                 }
@@ -309,7 +309,7 @@ impl TrieProof {
                 full_paths.push(full_path);
             }
 
-            match node.walk::<Read>(key_remaining) {
+            match node.walk::<access_mode::Read>(key_remaining) {
                 WalkStop::Arrived => {
                     return keys_child_indices_and_nodes;
                 }
@@ -372,9 +372,9 @@ impl DerefMut for TrieProofNode {
 }
 
 use super::{
-    super::errors::*,
+    super::{super::utils::access_mode, errors::*},
     merkle::compute_merkle,
-    walk::{access_mode::Read, TrieNodeWalkTrait, WalkStop},
+    walk::{TrieNodeWalkTrait, WalkStop},
     CompressedPathRaw, CompressedPathTrait, TrieNodeTrait,
     VanillaChildrenTable, VanillaTrieNode,
 };

--- a/core/src/storage/impls/merkle_patricia_trie/walk.rs
+++ b/core/src/storage/impls/merkle_patricia_trie/walk.rs
@@ -2,7 +2,10 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use super::{compressed_path::*, trie_node::TrieNodeTrait};
+use super::{
+    super::super::utils::access_mode, compressed_path::*,
+    trie_node::TrieNodeTrait,
+};
 use std::cmp::min;
 
 /// Key length should be multiple of 8.
@@ -60,23 +63,6 @@ impl<'key, ChildIdType> WalkStop<'key, ChildIdType> {
             unmatched_child_index: 0,
             unmatched_path_remaining: Default::default(),
         }
-    }
-}
-
-pub mod access_mode {
-    pub trait AccessMode {
-        fn is_read_only() -> bool;
-    }
-
-    pub struct Read {}
-    pub struct Write {}
-
-    impl AccessMode for Read {
-        fn is_read_only() -> bool { return true; }
-    }
-
-    impl AccessMode for Write {
-        fn is_read_only() -> bool { return false; }
     }
 }
 

--- a/core/src/storage/impls/snapshot_sync/offer/mpt_slicer.rs
+++ b/core/src/storage/impls/snapshot_sync/offer/mpt_slicer.rs
@@ -113,8 +113,11 @@ impl<'a> MptSlicer<'a> {
 }
 
 use super::super::super::{
-    super::storage_db::snapshot_mpt::{
-        SnapshotMptTraitRead, SubtreeMerkleWithSize,
+    super::{
+        storage_db::snapshot_mpt::{
+            SnapshotMptTraitRead, SubtreeMerkleWithSize,
+        },
+        utils::access_mode,
     },
     errors::*,
     merkle_patricia_trie::{mpt_cursor::*, *},

--- a/core/src/storage/impls/snapshot_sync/restoration/mpt_slice_verifier.rs
+++ b/core/src/storage/impls/snapshot_sync/restoration/mpt_slice_verifier.rs
@@ -344,15 +344,15 @@ impl GetRwMpt for SliceMptRebuilder {
     fn is_in_place_update(&self) -> bool { true }
 }
 
-use super::{
-    super::super::{
-        super::storage_db::snapshot_mpt::*,
+use super::slice_restore_read_write_path_node::SliceVerifyReadWritePathNode;
+use crate::storage::{
+    impls::{
         errors::*,
-        merkle_patricia_trie::{mpt_cursor::*, *},
+        merkle_patricia_trie::{mpt_cursor::*, walk::GetChildTrait, *},
     },
-    slice_restore_read_write_path_node::SliceVerifyReadWritePathNode,
+    storage_db::snapshot_mpt::*,
+    utils::access_mode,
 };
-use crate::storage::impls::merkle_patricia_trie::walk::GetChildTrait;
 use primitives::MerkleHash;
 use std::{
     borrow::Borrow,

--- a/core/src/storage/impls/storage_manager/storage_manager.rs
+++ b/core/src/storage/impls/storage_manager/storage_manager.rs
@@ -1331,20 +1331,6 @@ lazy_static! {
     );
 }
 
-use super::super::{
-    super::{
-        snapshot_manager::*,
-        state_manager::*,
-        storage_db::{
-            delta_db_manager::*, snapshot_db::*,
-            snapshot_db_manager::SnapshotDbManagerTrait,
-        },
-        utils::arc_ext::*,
-    },
-    delta_mpt::*,
-    errors::*,
-    state_manager::*,
-};
 use crate::{
     block_data_manager::StateAvailabilityBoundary,
     consensus::ConsensusGraphInner,
@@ -1356,23 +1342,25 @@ use crate::{
                 },
                 node_ref_map::DeltaMptId,
             },
-            merkle_patricia_trie::{
-                mpt_cursor::{BasicPathNode, MptCursor},
-                walk::access_mode,
-            },
+            errors::*,
+            merkle_patricia_trie::mpt_cursor::{BasicPathNode, MptCursor},
+            state_manager::{DeltaDbManager, SnapshotDb, SnapshotDbManager},
             storage_db::kvdb_sqlite::{
                 kvdb_sqlite_iter_range_impl, KvdbSqliteDestructureTrait,
                 KvdbSqliteStatements,
             },
             storage_manager::snapshot_manager::SnapshotManager,
         },
+        snapshot_manager::SnapshotManagerTrait,
         storage_db::{
-            key_value_db::KeyValueDbIterableTrait, SnapshotMptTraitRead,
+            key_value_db::KeyValueDbIterableTrait,
+            snapshot_db::OpenSnapshotMptTrait, DeltaDbManagerTrait,
+            SnapshotDbManagerTrait, SnapshotInfo, SnapshotMptTraitRead,
         },
         storage_dir,
-        utils::guarded_value::GuardedValue,
-        KeyValueDbTrait, KvdbSqlite, StateRootWithAuxInfo,
-        StorageConfiguration,
+        utils::{access_mode, arc_ext::*, guarded_value::GuardedValue},
+        DeltaMpt, DeltaMptIdGen, DeltaMptIterator, KeyValueDbTrait, KvdbSqlite,
+        StateIndex, StateRootWithAuxInfo, StorageConfiguration,
     },
 };
 use fallible_iterator::FallibleIterator;

--- a/core/src/storage/state.rs
+++ b/core/src/storage/state.rs
@@ -11,10 +11,12 @@
 /// state manager. State is supposed to be owned by single user.
 pub use super::impls::state::State;
 
+pub type WithProof = utils::Yes;
+pub type NoProof = utils::No;
+
 // The trait is created to separate the implementation to another file, and the
 // concrete struct is put into inner mod, because the implementation is
 // anticipated to be too complex to present in the same file of the API.
-// TODO(yz): check if this is the best way to organize code for this library.
 pub trait StateTrait {
     // Verifiable proof related methods.
     fn get_with_proof(
@@ -30,7 +32,7 @@ pub trait StateTrait {
     ) -> Result<Option<Box<[u8]>>>;
     // Delete everything prefixed by access_key and return deleted key value
     // pairs.
-    fn delete_all(
+    fn delete_all<AM: access_mode::AccessMode>(
         &mut self, access_key_prefix: StorageKey,
     ) -> Result<Option<Vec<MptKeyValue>>>;
 
@@ -45,8 +47,8 @@ pub trait StateTrait {
     /// Compute the merkle of the node under `access_key` in all tries.
     /// Node merkle is computed on the value and children hashes, ignoring the
     /// compressed path.
-    fn get_node_merkle_all_versions(
-        &self, access_key: StorageKey, with_proof: bool,
+    fn get_node_merkle_all_versions<WithProof: utils::StaticBool>(
+        &self, access_key: StorageKey,
     ) -> Result<(NodeMerkleTriplet, NodeMerkleProof)>;
 }
 
@@ -54,6 +56,7 @@ use super::{
     impls::{
         errors::*, node_merkle_proof::NodeMerkleProof, state_proof::StateProof,
     },
+    utils::{self, access_mode},
     MptKeyValue, StateRootWithAuxInfo,
 };
 use primitives::{EpochId, NodeMerkleTriplet, StorageKey};

--- a/core/src/storage/tests/proofs.rs
+++ b/core/src/storage/tests/proofs.rs
@@ -386,7 +386,9 @@ fn test_valid_node_merkle_proof_for_existing_key() {
 
     for key in keys {
         let (triplet, proof) = state
-            .get_node_merkle_all_versions(StorageKey::AccountKey(&key), true)
+            .get_node_merkle_all_versions::<WithProof>(StorageKey::AccountKey(
+                &key,
+            ))
             .expect("node merkle lookup should succeed");
 
         assert!(
@@ -421,7 +423,9 @@ fn test_valid_node_merkle_proof_for_nonexistent_key() {
 
     for key in keys {
         let (triplet, proof) = state
-            .get_node_merkle_all_versions(StorageKey::AccountKey(&key), true)
+            .get_node_merkle_all_versions::<WithProof>(StorageKey::AccountKey(
+                &key,
+            ))
             .expect("node merkle lookup should succeed");
 
         assert_eq!(triplet.delta, None);
@@ -453,7 +457,9 @@ fn test_invalid_node_merkle_proof() {
 
     for key in keys {
         let (triplet, proof) = state
-            .get_node_merkle_all_versions(StorageKey::AccountKey(&key), true)
+            .get_node_merkle_all_versions::<WithProof>(StorageKey::AccountKey(
+                &key,
+            ))
             .expect("node merkle lookup should succeed");
 
         assert!(

--- a/core/src/storage/tests/state.rs
+++ b/core/src/storage/tests/state.rs
@@ -500,7 +500,9 @@ fn test_set_delete_all() {
         let key_prefix = &key[0..(2 + rng.gen::<usize>() % 2)];
 
         let value = state
-            .delete_all(StorageKey::AccountKey(key_prefix))
+            .delete_all::<access_mode::Write>(StorageKey::AccountKey(
+                key_prefix,
+            ))
             .expect("Failed to delete key.");
         if value.is_none() {
             continue;
@@ -516,7 +518,7 @@ fn test_set_delete_all() {
         }
 
         let value = state
-            .delete_all(StorageKey::AccountKey(key))
+            .delete_all::<access_mode::Write>(StorageKey::AccountKey(key))
             .expect("Failed to delete key.");
         assert_eq!(value, None);
     }
@@ -690,12 +692,14 @@ fn test_set_order_concurrent() {
     }
 }
 
-use super::{
-    super::{state::*, state_manager::*},
-    generate_keys, get_rng_for_test, new_state_manager_for_unit_test,
-};
 use crate::storage::{
-    tests::{FakeStateManager, TEST_NUMBER_OF_KEYS},
+    state::*,
+    state_manager::*,
+    tests::{
+        generate_keys, get_rng_for_test, new_state_manager_for_unit_test,
+        FakeStateManager, TEST_NUMBER_OF_KEYS,
+    },
+    utils::access_mode,
     StateRootWithAuxInfo,
 };
 use cfx_types::{address_util::AddressUtil, Address, H256, U256};

--- a/tests/reentrancy_test.py
+++ b/tests/reentrancy_test.py
@@ -122,8 +122,10 @@ class ReentrancyTest(ConfluxTestFramework):
 
         user1, _ = ec_random_keys()
         user1_addr = priv_to_addr(user1)
+        user1_addr_hex = eth_utils.encode_hex(user1_addr)
         user2, _ = ec_random_keys()
         user2_addr = priv_to_addr(user2)
+        user2_addr_hex = eth_utils.encode_hex(user2_addr)
 
         # setup balance
         value = (10 ** 15 + 2000) * 10 ** 18 + ReentrancyTest.REQUEST_BASE['gas']
@@ -143,11 +145,9 @@ class ReentrancyTest(ConfluxTestFramework):
             gas_price=ReentrancyTest.REQUEST_BASE['gas'])
         self.send_transaction(tx, True, False)
 
-        addr = eth_utils.encode_hex(user1_addr)
-        balance = parse_as_int(self.nodes[0].cfx_getBalance(addr))
-        assert_equal(balance, value)
-        addr = eth_utils.encode_hex(user2_addr)
-        user2_balance_before_contract_construction = parse_as_int(self.nodes[0].cfx_getBalance(addr))
+        user1_balance = parse_as_int(self.nodes[0].cfx_getBalance(user1_addr_hex))
+        assert_equal(user1_balance, value)
+        user2_balance_before_contract_construction = parse_as_int(self.nodes[0].cfx_getBalance(user2_addr_hex))
         assert_equal(user2_balance_before_contract_construction, value)
 
         transaction = self.call_contract_function(self.buggy_contract, "constructor", [], self.genesis_priv_key, storage_limit=20000)
@@ -155,38 +155,39 @@ class ReentrancyTest(ConfluxTestFramework):
 
         transaction = self.call_contract_function(self.exploit_contract, "constructor", [], user2, storage_limit=200000)
         exploit_addr = self.wait_for_tx([transaction], True)[0]['contractCreated']
-        addr = eth_utils.encode_hex(user2_addr)
-        user2_balance_after_contract_construction = parse_as_int(self.nodes[0].cfx_getBalance(addr))
+        user2_balance_after_contract_construction = parse_as_int(self.nodes[0].cfx_getBalance(user2_addr_hex))
+        self.log.debug("user2 balance contract created %s" % user2_balance_after_contract_construction)
         assert_greater_than_or_equal(user2_balance_before_contract_construction, user2_balance_after_contract_construction)
         user2_balance_refund_upper_bound = user2_balance_before_contract_construction - user2_balance_after_contract_construction
 
-        transaction = self.call_contract_function(self.buggy_contract, "addBalance", [], user1, 100000000000000000000000000000000,
+        transaction = self.call_contract_function(self.buggy_contract, "addBalance", [], user1, 10 ** 18,
                                                   contract_addr, True, True, storage_limit=128)
-        transaction = self.call_contract_function(self.exploit_contract, "deposit", [Web3.toChecksumAddress(contract_addr)], user2, 100000000000000000000000000000000,
+        transaction = self.call_contract_function(self.exploit_contract, "deposit", [Web3.toChecksumAddress(contract_addr)], user2, 10 ** 18,
                                                   exploit_addr, True, True, storage_limit=128)
 
-        addr = eth_utils.encode_hex(user1_addr)
-        balance = parse_as_int(self.nodes[0].cfx_getBalance(addr))
-        assert_greater_than_or_equal(balance, 899999999999999999999999950000000)
-        addr = eth_utils.encode_hex(user2_addr)
-        user2_balance = parse_as_int(self.nodes[0].cfx_getBalance(addr))
-        assert_greater_than_or_equal(balance, 899999999999999999999999900000000)
-        balance = parse_as_int(self.nodes[0].cfx_getBalance(contract_addr))
-        assert_equal(balance, 200000000000000000000000000000000)
+        user1_balance = parse_as_int(self.nodes[0].cfx_getBalance(user1_addr_hex))
+        assert_greater_than_or_equal(user1_balance, 899999999999999999999999950000000)
+        user2_balance_after_deposit = parse_as_int(self.nodes[0].cfx_getBalance(user2_addr_hex))
+        self.log.debug("user2 balance after deposit %s" % user2_balance_after_deposit)
+        assert_greater_than_or_equal(user2_balance_after_contract_construction, user2_balance_after_deposit + 10 ** 18)
+        assert_greater_than_or_equal(user2_balance_after_deposit, 899999999999999999999999900000000)
+        contract_balance = parse_as_int(self.nodes[0].cfx_getBalance(contract_addr))
+        assert_equal(contract_balance, 2 * 10 ** 18)
 
         transaction = self.call_contract_function(self.exploit_contract, "launch_attack", [], user2, 0,
                                                   exploit_addr, True, True, storage_limit=128)
         transaction = self.call_contract_function(self.exploit_contract, "get_money", [], user2, 0,
                                                   exploit_addr, True, True, storage_limit=128)
 
-        addr = eth_utils.encode_hex(user1_addr)
-        balance = parse_as_int(self.nodes[0].cfx_getBalance(addr))
-        assert_greater_than_or_equal(balance, 899999999999999999999999950000000)
-        balance = parse_as_int(self.nodes[0].cfx_getBalance(contract_addr))
-        assert_equal(balance, 200000000000000000000000000000000)
-        addr = eth_utils.encode_hex(user2_addr)
-        balance = parse_as_int(self.nodes[0].cfx_getBalance(addr))
-        assert_greater_than_or_equal(user2_balance + user2_balance_refund_upper_bound, balance)
+        user1_balance = parse_as_int(self.nodes[0].cfx_getBalance(user1_addr_hex))
+        assert_greater_than_or_equal(user1_balance, 899999999999999999999999950000000)
+        contract_balance = parse_as_int(self.nodes[0].cfx_getBalance(contract_addr))
+        assert_equal(contract_balance, 2 * 10 ** 18)
+        user2_balance_after_contract_destruct = parse_as_int(self.nodes[0].cfx_getBalance(user2_addr_hex))
+        self.log.debug("user2 balance after contract destruct %s" % user2_balance_after_contract_destruct)
+        assert_greater_than_or_equal(
+            user2_balance_after_deposit + user2_balance_refund_upper_bound + 10 ** 18 // 16,
+            user2_balance_after_contract_destruct)
 
         block_gen_thread.stop()
         block_gen_thread.join()


### PR DESCRIPTION
- Fix code() return value for uninitialized contract;
- fix bug in kill_account after which the contract account is revived by simple transaction;
- fix the place of collateral refund for suicide contracts.

Along with the change
- Add ReadOnly mode for state delete_all method, which returns the values to be deleted without actually deleting them.
- replaced with_proof flag with a static bool generic type.
- worked around an issue in reentrance test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1737)
<!-- Reviewable:end -->
