### PR TITLE
Upgrade rocksdb to fix compilation errors.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2176,7 +2176,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=7ee55edcd956cfb857de9717a7ab3b1f6e6d4348#7ee55edcd956cfb857de9717a7ab3b1f6e6d4348"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=07fd4431b248e5fb1a493554a6fa023e01b01335#07fd4431b248e5fb1a493554a6fa023e01b01335"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -2193,7 +2193,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=7ee55edcd956cfb857de9717a7ab3b1f6e6d4348#7ee55edcd956cfb857de9717a7ab3b1f6e6d4348"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=07fd4431b248e5fb1a493554a6fa023e01b01335#07fd4431b248e5fb1a493554a6fa023e01b01335"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -3514,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=7ee55edcd956cfb857de9717a7ab3b1f6e6d4348#7ee55edcd956cfb857de9717a7ab3b1f6e6d4348"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=07fd4431b248e5fb1a493554a6fa023e01b01335#07fd4431b248e5fb1a493554a6fa023e01b01335"
 dependencies = [
  "libc",
  "librocksdb_sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd71393f1ec0509b553aa012b9b58e81dadbdff7130bd3b8cba576e69b32f75"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "cfg-if",
+ "clang-sys",
+ "clap",
+ "env_logger 0.6.2",
+ "lazy_static",
+ "log 0.4.8",
+ "peeking_take_while",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "which",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,12 +376,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "build_const"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
-
-[[package]]
 name = "byte-slice-cast"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,7 +432,8 @@ dependencies = [
 [[package]]
 name = "bzip2-sys"
 version = "0.1.9+1.0.8"
-source = "git+https://github.com/alexcrichton/bzip2-rs.git#284e6d4b59c33b5d7a2a88ee35cfed2269e78da5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad3b39a260062fca31f7b0b12f207e8f2590a67d32ec7d59c20484b07ea7285e"
 dependencies = [
  "cc",
  "libc",
@@ -441,6 +459,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,7 +485,7 @@ name = "cfx-stratum"
 version = "1.12.0"
 dependencies = [
  "cfx-types",
- "env_logger",
+ "env_logger 0.5.13",
  "jsonrpc-core",
  "jsonrpc-tcp-server",
  "keccak-hash",
@@ -640,6 +667,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,7 +794,7 @@ dependencies = [
  "db",
  "dir",
  "docopt",
- "env_logger",
+ "env_logger 0.5.13",
  "error-chain",
  "futures 0.1.29",
  "home 0.5.3",
@@ -813,15 +851,6 @@ name = "core-foundation-sys"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
-
-[[package]]
-name = "crc"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
-dependencies = [
- "build_const",
-]
 
 [[package]]
 name = "crc32fast"
@@ -1110,6 +1139,19 @@ name = "env_logger"
 version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
+dependencies = [
+ "atty",
+ "humantime",
+ "log 0.4.8",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 dependencies = [
  "atty",
  "humantime",
@@ -2134,8 +2176,9 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=6d96482ddb51c1779af615767fd1967da9d98377#6d96482ddb51c1779af615767fd1967da9d98377"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=7ee55edcd956cfb857de9717a7ab3b1f6e6d4348#7ee55edcd956cfb857de9717a7ab3b1f6e6d4348"
 dependencies = [
+ "bindgen",
  "bzip2-sys",
  "cc",
  "cmake",
@@ -2150,7 +2193,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=6d96482ddb51c1779af615767fd1967da9d98377#6d96482ddb51c1779af615767fd1967da9d98377"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=7ee55edcd956cfb857de9717a7ab3b1f6e6d4348#7ee55edcd956cfb857de9717a7ab3b1f6e6d4348"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -2575,6 +2618,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+dependencies = [
+ "memchr",
+ "version_check 0.1.5",
+]
+
+[[package]]
 name = "num"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2961,6 +3014,12 @@ dependencies = [
  "sha2 0.8.2",
  "subtle 1.0.0",
 ]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -3455,9 +3514,8 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=6d96482ddb51c1779af615767fd1967da9d98377#6d96482ddb51c1779af615767fd1967da9d98377"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=7ee55edcd956cfb857de9717a7ab3b1f6e6d4348#7ee55edcd956cfb857de9717a7ab3b1f6e6d4348"
 dependencies = [
- "crc",
  "libc",
  "librocksdb_sys",
 ]
@@ -3485,6 +3543,12 @@ name = "rustc-demangle"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hex"
@@ -3732,6 +3796,12 @@ dependencies = [
  "winapi 0.2.8",
  "winapi-build",
 ]
+
+[[package]]
+name = "shlex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "signal-hook-registry"
@@ -4611,6 +4681,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
+name = "which"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4747,7 +4826,8 @@ dependencies = [
 [[package]]
 name = "zstd-sys"
 version = "1.4.17+zstd.1.4.5"
-source = "git+https://github.com/gyscos/zstd-rs.git#6185d828eb43e129989fa8c47eb49a1612e6e254"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89249644df056b522696b1bb9e7c18c87e8ffa3e2f0dc3b0155875d6498f01b"
 dependencies = [
  "cc",
  "glob",

--- a/db/src/kvdb-rocksdb/Cargo.toml
+++ b/db/src/kvdb-rocksdb/Cargo.toml
@@ -29,4 +29,4 @@ tempdir = "0.3.7"
 
 [dependencies.rocksdb]
 git = "https://github.com/Conflux-Chain/rust-rocksdb.git"
-rev = "d3fd949a4fb4216e63e47f20aa4de4d2662d5c76"
+rev = "952f70d4776beb3a9268e2f4bc6decaf8958e9ad"

--- a/db/src/kvdb-rocksdb/Cargo.toml
+++ b/db/src/kvdb-rocksdb/Cargo.toml
@@ -29,4 +29,4 @@ tempdir = "0.3.7"
 
 [dependencies.rocksdb]
 git = "https://github.com/Conflux-Chain/rust-rocksdb.git"
-rev = "6d96482ddb51c1779af615767fd1967da9d98377"
+rev = "d3fd949a4fb4216e63e47f20aa4de4d2662d5c76"


### PR DESCRIPTION
Fix the rocksdb compilation error in #1744 .

The changes of dependencies include:

* Merge the latest changes of https://github.com/tikv/rust-rocksdb.git into our forked repo .

* Maintain our own `rocksdb` crate and use our own `rocksdb` in `rust-rocksdb`.

*  Apply the fix in https://github.com/facebook/rocksdb/commit/03dbd11ead69f822eca2eeeac5cd20993da2f267.

* Apply the fix in https://github.com/cockroachdb/rocksdb/commit/92572072dc46c1c35191ca529f860fe219007fd0.

* Manually fix the warning in `options/options_parser.cc`.

Now the reported issue can be reproduced after merging this PR in an Ubuntu 20.04 system.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1745)
<!-- Reviewable:end -->
