### PR TITLE
Propagate light node sync errors to RPC caller

### DIFF
--- a/core/src/light_protocol/handler/mod.rs
+++ b/core/src/light_protocol/handler/mod.rs
@@ -8,6 +8,7 @@ use crate::{
     consensus::SharedConsensusGraph,
     light_protocol::{
         common::{validate_chain_id, FullPeerState, Peers},
+        error::*,
         handle_error,
         message::{
             msgid, BlockHashes as GetBlockHashesResponse,
@@ -21,8 +22,8 @@ use crate::{
             TxInfos as GetTxInfosResponse, Txs as GetTxsResponse,
             WitnessInfo as GetWitnessInfoResponse,
         },
-        Error, ErrorKind, LIGHT_PROTOCOL_OLD_VERSIONS_TO_SUPPORT,
-        LIGHT_PROTOCOL_VERSION, LIGHT_PROTO_V1,
+        LIGHT_PROTOCOL_OLD_VERSIONS_TO_SUPPORT, LIGHT_PROTOCOL_VERSION,
+        LIGHT_PROTO_V1,
     },
     message::{decode_msg, decode_rlp_and_check_deprecation, Message, MsgId},
     network::{NetworkContext, NetworkProtocolHandler},
@@ -211,28 +212,28 @@ impl Handler {
     #[inline]
     fn get_existing_peer_state(
         &self, peer: &NodeId,
-    ) -> Result<Arc<RwLock<FullPeerState>>, Error> {
+    ) -> Result<Arc<RwLock<FullPeerState>>> {
         match self.peers.get(&peer) {
             Some(state) => Ok(state),
             None => {
                 // NOTE: this should not happen as we register
                 // all peers in `on_peer_connected`
-                error!("Received message from unknown peer={:?}", peer);
-                Err(ErrorKind::InternalError.into())
+                bail!(ErrorKind::InternalError(format!(
+                    "Received message from unknown peer={:?}",
+                    peer
+                )));
             }
         }
     }
 
     #[allow(unused)]
     #[inline]
-    fn peer_version(&self, peer: &NodeId) -> Result<ProtocolVersion, Error> {
+    fn peer_version(&self, peer: &NodeId) -> Result<ProtocolVersion> {
         Ok(self.get_existing_peer_state(peer)?.read().protocol_version)
     }
 
     #[inline]
-    fn validate_peer_state(
-        &self, peer: &NodeId, msg_id: MsgId,
-    ) -> Result<(), Error> {
+    fn validate_peer_state(&self, peer: &NodeId, msg_id: MsgId) -> Result<()> {
         let state = self.get_existing_peer_state(&peer)?;
 
         if msg_id != msgid::STATUS_PONG_DEPRECATED
@@ -240,39 +241,43 @@ impl Handler {
             && !state.read().handshake_completed
         {
             warn!("Received msg={:?} from handshaking peer={:?}", msg_id, peer);
-            return Err(ErrorKind::UnexpectedMessage.into());
+            bail!(ErrorKind::UnexpectedMessage {
+                expected: vec![
+                    msgid::STATUS_PING_DEPRECATED,
+                    msgid::STATUS_PING_V2
+                ],
+                received: msg_id,
+            });
         }
 
         Ok(())
     }
 
     #[inline]
-    fn validate_peer_type(&self, node_type: &NodeType) -> Result<(), Error> {
+    fn validate_peer_type(&self, node_type: NodeType) -> Result<()> {
         match node_type {
             NodeType::Archive => Ok(()),
             NodeType::Full => Ok(()),
-            _ => Err(ErrorKind::UnexpectedPeerType.into()),
+            _ => bail!(ErrorKind::UnexpectedPeerType { node_type }),
         }
     }
 
     #[inline]
-    fn validate_genesis_hash(&self, genesis: H256) -> Result<(), Error> {
-        match self.consensus.get_data_manager().true_genesis.hash() {
-            h if h == genesis => Ok(()),
-            h => {
-                debug!(
-                    "Genesis mismatch (ours: {:?}, theirs: {:?})",
-                    h, genesis
-                );
-                Err(ErrorKind::GenesisMismatch.into())
-            }
+    fn validate_genesis_hash(&self, genesis: H256) -> Result<()> {
+        let ours = self.consensus.get_data_manager().true_genesis.hash();
+        let theirs = genesis;
+
+        if ours != theirs {
+            bail!(ErrorKind::GenesisMismatch { ours, theirs });
         }
+
+        Ok(())
     }
 
     #[rustfmt::skip]
     fn dispatch_message(
         &self, io: &dyn NetworkContext, peer: &NodeId, msg_id: MsgId, rlp: Rlp,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         trace!("Dispatching message: peer={:?}, msg_id={:?}", peer, msg_id);
         self.validate_peer_state(peer, msg_id)?;
         let min_supported_ver = self.minimum_supported_version();
@@ -300,7 +305,7 @@ impl Handler {
             // request was throttled by service provider
             msgid::THROTTLED => self.on_throttled(io, peer, decode_rlp_and_check_deprecation(&rlp, min_supported_ver, protocol)?),
 
-            _ => Err(ErrorKind::UnknownMessage.into()),
+            _ => bail!(ErrorKind::UnknownMessage{id: msg_id}),
         }
     }
 
@@ -356,7 +361,7 @@ impl Handler {
     fn send_status(
         &self, io: &dyn NetworkContext, peer: &NodeId,
         peer_protocol_version: ProtocolVersion,
-    ) -> Result<(), Error>
+    ) -> Result<()>
     {
         let msg: Box<dyn Message>;
 
@@ -389,7 +394,7 @@ impl Handler {
     #[inline]
     pub fn send_raw_tx(
         &self, io: &dyn NetworkContext, peer: &NodeId, raw: Vec<u8>,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         let msg: Box<dyn Message> = Box::new(SendRawTx { raw });
         msg.send(io, peer)?;
         Ok(())
@@ -397,10 +402,10 @@ impl Handler {
 
     fn on_status_v2(
         &self, io: &dyn NetworkContext, peer: &NodeId, status: StatusPongV2,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         info!("on_status peer={:?} status={:?}", peer, status);
 
-        self.validate_peer_type(&status.node_type)?;
+        self.validate_peer_type(status.node_type)?;
         self.validate_genesis_hash(status.genesis_hash)?;
         validate_chain_id(
             &self.consensus.get_config().chain_id,
@@ -424,7 +429,7 @@ impl Handler {
     fn on_status_deprecated(
         &self, io: &dyn NetworkContext, peer: &NodeId,
         status: StatusPongDeprecatedV1,
-    ) -> Result<(), Error>
+    ) -> Result<()>
     {
         info!("on_status peer={:?} status={:?}", peer, status);
 
@@ -444,7 +449,7 @@ impl Handler {
     fn on_block_hashes(
         &self, io: &dyn NetworkContext, _peer: &NodeId,
         resp: GetBlockHashesResponse,
-    ) -> Result<(), Error>
+    ) -> Result<()>
     {
         debug!("on_block_hashes resp={:?}", resp);
 
@@ -460,7 +465,7 @@ impl Handler {
     fn on_block_headers(
         &self, io: &dyn NetworkContext, peer: &NodeId,
         resp: GetBlockHeadersResponse,
-    ) -> Result<(), Error>
+    ) -> Result<()>
     {
         debug!("on_block_headers resp={:?}", resp);
 
@@ -477,7 +482,7 @@ impl Handler {
     fn on_block_txs(
         &self, io: &dyn NetworkContext, peer: &NodeId,
         resp: GetBlockTxsResponse,
-    ) -> Result<(), Error>
+    ) -> Result<()>
     {
         debug!("on_block_txs resp={:?}", resp);
 
@@ -493,7 +498,7 @@ impl Handler {
 
     fn on_blooms(
         &self, io: &dyn NetworkContext, peer: &NodeId, resp: GetBloomsResponse,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         debug!("on_blooms resp={:?}", resp);
 
         self.blooms
@@ -505,7 +510,7 @@ impl Handler {
 
     fn on_new_block_hashes(
         &self, io: &dyn NetworkContext, peer: &NodeId, msg: NewBlockHashes,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         debug!("on_new_block_hashes msg={:?}", msg);
 
         if self.catch_up_mode() {
@@ -530,7 +535,7 @@ impl Handler {
     fn on_receipts(
         &self, io: &dyn NetworkContext, peer: &NodeId,
         resp: GetReceiptsResponse,
-    ) -> Result<(), Error>
+    ) -> Result<()>
     {
         debug!("on_receipts resp={:?}", resp);
 
@@ -547,7 +552,7 @@ impl Handler {
     fn on_state_entries(
         &self, io: &dyn NetworkContext, peer: &NodeId,
         resp: GetStateEntriesResponse,
-    ) -> Result<(), Error>
+    ) -> Result<()>
     {
         debug!("on_state_entries resp={:?}", resp);
 
@@ -564,7 +569,7 @@ impl Handler {
     fn on_state_roots(
         &self, io: &dyn NetworkContext, peer: &NodeId,
         resp: GetStateRootsResponse,
-    ) -> Result<(), Error>
+    ) -> Result<()>
     {
         debug!("on_state_roots resp={:?}", resp);
 
@@ -581,7 +586,7 @@ impl Handler {
     fn on_storage_roots(
         &self, io: &dyn NetworkContext, peer: &NodeId,
         resp: GetStorageRootsResponse,
-    ) -> Result<(), Error>
+    ) -> Result<()>
     {
         debug!("on_storage_roots resp={:?}", resp);
 
@@ -597,7 +602,7 @@ impl Handler {
 
     fn on_txs(
         &self, io: &dyn NetworkContext, peer: &NodeId, resp: GetTxsResponse,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         debug!("on_txs resp={:?}", resp);
 
         self.txs
@@ -609,7 +614,7 @@ impl Handler {
 
     fn on_tx_infos(
         &self, io: &dyn NetworkContext, peer: &NodeId, resp: GetTxInfosResponse,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         debug!("on_tx_infos resp={:?}", resp);
 
         self.tx_infos
@@ -622,7 +627,7 @@ impl Handler {
     fn on_witness_info(
         &self, io: &dyn NetworkContext, peer: &NodeId,
         resp: GetWitnessInfoResponse,
-    ) -> Result<(), Error>
+    ) -> Result<()>
     {
         debug!("on_witness_info resp={:?}", resp);
 
@@ -678,7 +683,7 @@ impl Handler {
 
     fn on_throttled(
         &self, _io: &dyn NetworkContext, peer: &NodeId, resp: Throttled,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         debug!("on_throttled resp={:?}", resp);
 
         let peer = self.get_existing_peer_state(peer)?;
@@ -729,7 +734,7 @@ impl NetworkProtocolHandler for Handler {
                     io,
                     peer,
                     msgid::INVALID,
-                    ErrorKind::InvalidMessageFormat.into(),
+                    &ErrorKind::InvalidMessageFormat.into(),
                 )
             }
         };
@@ -737,7 +742,7 @@ impl NetworkProtocolHandler for Handler {
         debug!("on_message: peer={:?}, msgid={:?}", peer, msg_id);
 
         if let Err(e) = self.dispatch_message(io, peer, msg_id.into(), rlp) {
-            handle_error(io, peer, msg_id.into(), e);
+            handle_error(io, peer, msg_id.into(), &e);
         }
     }
 
@@ -770,7 +775,7 @@ impl NetworkProtocolHandler for Handler {
                     io,
                     peer,
                     msgid::INVALID,
-                    ErrorKind::SendStatusFailed.into(),
+                    &ErrorKind::SendStatusFailed { peer: *peer }.into(),
                 );
             }
         }

--- a/core/src/light_protocol/handler/sync/common/sync_manager.rs
+++ b/core/src/light_protocol/handler/sync/common/sync_manager.rs
@@ -93,8 +93,10 @@ where
         match self.peers.get(peer) {
             Some(state) => Ok(state),
             None => {
-                error!("Received message from unknown peer={:?}", peer);
-                Err(ErrorKind::InternalError.into())
+                bail!(ErrorKind::InternalError(format!(
+                    "Received message from unknown peer={:?}",
+                    peer
+                )));
             }
         }
     }
@@ -123,7 +125,10 @@ where
             ThrottleResult::Success => Ok(id),
             ThrottleResult::Throttled(_) => Ok(id),
             ThrottleResult::AlreadyThrottled => {
-                Err(ErrorKind::UnexpectedResponse.into())
+                bail!(ErrorKind::UnexpectedResponse {
+                    expected: id,
+                    received: request_id,
+                });
             }
         }
     }

--- a/core/src/light_protocol/handler/sync/storage_roots.rs
+++ b/core/src/light_protocol/handler/sync/storage_roots.rs
@@ -31,9 +31,9 @@ use super::{
     state_roots::StateRoots,
 };
 use cfx_types::H160;
+use futures::future::FutureExt;
 use network::node_table::NodeId;
 use primitives::{StorageKey, StorageRoot};
-
 #[derive(Debug)]
 struct Statistics {
     cached: usize,
@@ -42,6 +42,8 @@ struct Statistics {
 }
 
 type MissingStorageRoot = TimeOrdered<StorageRootKey>;
+
+type PendingStorageRoot = PendingItem<Option<StorageRoot>, ClonableError>;
 
 pub struct StorageRoots {
     // series of unique request ids
@@ -54,8 +56,7 @@ pub struct StorageRoots {
     sync_manager: SyncManager<StorageRootKey, MissingStorageRoot>,
 
     // state entries received from full node
-    verified:
-        Arc<RwLock<LruCache<StorageRootKey, PendingItem<Option<StorageRoot>>>>>,
+    verified: Arc<RwLock<LruCache<StorageRootKey, PendingStorageRoot>>>,
 }
 
 impl StorageRoots {
@@ -90,10 +91,11 @@ impl StorageRoots {
     #[inline]
     pub fn request_now(
         &self, io: &dyn NetworkContext, epoch: u64, address: H160,
-    ) -> impl Future<Output = Option<StorageRoot>> {
+    ) -> impl Future<Output = Result<Option<StorageRoot>>> {
+        let mut verified = self.verified.write();
         let key = StorageRootKey { epoch, address };
 
-        if !self.verified.read().contains_key(&key) {
+        if !verified.contains_key(&key) {
             let missing = std::iter::once(MissingStorageRoot::new(key.clone()));
 
             self.sync_manager.request_now(missing, |peer, keys| {
@@ -101,7 +103,13 @@ impl StorageRoots {
             });
         }
 
+        verified
+            .entry(key.clone())
+            .or_insert(PendingItem::pending())
+            .clear_error();
+
         FutureItem::new(key, self.verified.clone())
+            .map(|res| res.map_err(|e| e.into()))
     }
 
     #[inline]
@@ -129,7 +137,21 @@ impl StorageRoots {
     ) -> Result<()>
     {
         // validate storage root
-        self.validate_storage_root(key.epoch, &key.address, &root, proof)?;
+        if let Err(e) =
+            self.validate_storage_root(key.epoch, key.address, &root, proof)
+        {
+            // forward error to both rpc caller(s) and sync handler
+            // so we need to make it clonable
+            let e = ClonableError::from(e);
+
+            self.verified
+                .write()
+                .entry(key.clone())
+                .or_insert(PendingItem::pending())
+                .set_error(e.clone());
+
+            bail!(e);
+        }
 
         // store storage root by storage root key
         self.verified
@@ -187,7 +209,7 @@ impl StorageRoots {
 
     #[inline]
     fn validate_storage_root(
-        &self, epoch: u64, address: &H160, storage_root: &Option<StorageRoot>,
+        &self, epoch: u64, address: H160, storage_root: &Option<StorageRoot>,
         proof: StorageRootProof,
     ) -> Result<()>
     {
@@ -196,10 +218,10 @@ impl StorageRoots {
 
         self.state_roots
             .validate_state_root(epoch, &state_root)
-            .chain_err(|| {
-                ErrorKind::InvalidStorageRootProof(
-                    "Validation of current state root failed",
-                )
+            .chain_err(|| ErrorKind::InvalidStorageRootProof {
+                epoch,
+                address,
+                reason: "Validation of current state root failed",
             })?;
 
         // validate previous state root
@@ -207,10 +229,10 @@ impl StorageRoots {
 
         self.state_roots
             .validate_prev_snapshot_state_root(epoch, &maybe_prev_root)
-            .chain_err(|| {
-                ErrorKind::InvalidStorageRootProof(
-                    "Validation of previous state root failed",
-                )
+            .chain_err(|| ErrorKind::InvalidStorageRootProof {
+                epoch,
+                address,
+                reason: "Validation of previous state root failed",
             })?;
 
         // construct padding
@@ -230,14 +252,11 @@ impl StorageRoots {
             state_root,
             maybe_intermediate_padding,
         ) {
-            warn!(
-                "Invalid storage root proof for {:?} under key {:?}",
-                storage_root, key
-            );
-            return Err(ErrorKind::InvalidStorageRootProof(
-                "Validation of merkle proof failed",
-            )
-            .into());
+            bail!(ErrorKind::InvalidStorageRootProof {
+                epoch,
+                address,
+                reason: "Validation of merkle proof failed",
+            });
         }
 
         Ok(())

--- a/core/src/light_protocol/handler/sync/txs.rs
+++ b/core/src/light_protocol/handler/sync/txs.rs
@@ -13,8 +13,8 @@ use std::{future::Future, sync::Arc};
 use crate::{
     light_protocol::{
         common::{FullPeerState, Peers},
+        error::*,
         message::{msgid, GetTxs},
-        Error, ErrorKind,
     },
     message::{Message, RequestId},
     network::NetworkContext,
@@ -26,6 +26,7 @@ use crate::{
 };
 
 use super::common::{FutureItem, PendingItem, SyncManager, TimeOrdered};
+use futures::future::FutureExt;
 use network::node_table::NodeId;
 
 #[derive(Debug)]
@@ -38,6 +39,8 @@ struct Statistics {
 // prioritize earlier requests
 type MissingTx = TimeOrdered<H256>;
 
+type PendingTx = PendingItem<SignedTransaction, ClonableError>;
+
 pub struct Txs {
     // series of unique request ids
     request_id_allocator: Arc<UniqueId>,
@@ -46,7 +49,7 @@ pub struct Txs {
     sync_manager: SyncManager<H256, MissingTx>,
 
     // txs received from full node
-    verified: Arc<RwLock<LruCache<H256, PendingItem<SignedTransaction>>>>,
+    verified: Arc<RwLock<LruCache<H256, PendingTx>>>,
 }
 
 impl Txs {
@@ -77,8 +80,10 @@ impl Txs {
     #[inline]
     pub fn request_now(
         &self, io: &dyn NetworkContext, hash: H256,
-    ) -> impl Future<Output = SignedTransaction> {
-        if !self.verified.read().contains_key(&hash) {
+    ) -> impl Future<Output = Result<SignedTransaction>> {
+        let mut verified = self.verified.write();
+
+        if !verified.contains_key(&hash) {
             let missing = std::iter::once(MissingTx::new(hash));
 
             self.sync_manager.request_now(missing, |peer, hashes| {
@@ -86,14 +91,20 @@ impl Txs {
             });
         }
 
+        verified
+            .entry(hash)
+            .or_insert(PendingItem::pending())
+            .clear_error();
+
         FutureItem::new(hash, self.verified.clone())
+            .map(|res| res.map_err(|e| e.into()))
     }
 
     #[inline]
     pub fn receive(
         &self, peer: &NodeId, id: RequestId,
         txs: impl Iterator<Item = SignedTransaction>,
-    ) -> Result<(), Error>
+    ) -> Result<()>
     {
         for tx in txs {
             let hash = tx.hash();
@@ -109,11 +120,23 @@ impl Txs {
     }
 
     #[inline]
-    pub fn validate_and_store(
-        &self, tx: SignedTransaction,
-    ) -> Result<(), Error> {
+    fn validate_and_store(&self, tx: SignedTransaction) -> Result<()> {
         let hash = tx.hash();
-        self.validate_tx(&tx)?;
+
+        // validate tx
+        if let Err(e) = self.validate_tx(&tx) {
+            // forward error to both rpc caller(s) and sync handler
+            // so we need to make it clonable
+            let e = ClonableError::from(e);
+
+            self.verified
+                .write()
+                .entry(hash)
+                .or_insert(PendingItem::pending())
+                .set_error(e.clone());
+
+            bail!(e);
+        }
 
         self.verified
             .write()
@@ -139,7 +162,7 @@ impl Txs {
     #[inline]
     fn send_request(
         &self, io: &dyn NetworkContext, peer: &NodeId, hashes: Vec<H256>,
-    ) -> Result<Option<RequestId>, Error> {
+    ) -> Result<Option<RequestId>> {
         debug!("send_request peer={:?} hashes={:?}", peer, hashes);
 
         if hashes.is_empty() {
@@ -165,12 +188,12 @@ impl Txs {
     }
 
     #[inline]
-    fn validate_tx(&self, tx: &SignedTransaction) -> Result<(), Error> {
+    pub fn validate_tx(&self, tx: &SignedTransaction) -> Result<()> {
         match tx.verify_public(false /* skip */) {
             Ok(true) => {}
             _ => {
                 warn!("Tx signature verification failed for {:?}", tx);
-                return Err(ErrorKind::InvalidTxSignature.into());
+                bail!(ErrorKind::InvalidTxSignature { hash: tx.hash() });
             }
         }
 

--- a/core/src/light_protocol/handler/sync/witnesses.rs
+++ b/core/src/light_protocol/handler/sync/witnesses.rs
@@ -303,7 +303,10 @@ impl Witnesses {
                 Some(w) => w,
                 None => {
                     warn!("Unable to get witness!");
-                    return Err(ErrorKind::InternalError.into());
+                    bail!(ErrorKind::InternalError(format!(
+                        "Witness at height {} is not available",
+                        height
+                    )));
                 }
             };
 

--- a/core/src/light_protocol/query_service.rs
+++ b/core/src/light_protocol/query_service.rs
@@ -48,8 +48,10 @@ type TxInfo = (
 // Because of this, our RPC runtime cannot handle tokio@0.2 timing primitives.
 // As a temporary workaround, we use the old `tokio_timer::Timeout` instead.
 async fn with_timeout<T>(
-    d: Duration, msg: String, fut: impl Future<Output = T> + Send + Sync,
-) -> Result<T, Error> {
+    d: Duration, msg: String,
+    fut: impl Future<Output = Result<T, Error>> + Send + Sync,
+) -> Result<T, Error>
+{
     // convert `fut` into futures@0.1
     let fut = fut.unit_error().boxed().compat();
 
@@ -63,7 +65,7 @@ async fn with_timeout<T>(
     // set error message
     with_timeout
         .await
-        .map_err(|_| ErrorKind::Timeout(msg).into())
+        .map_err(|_| Error::from(ErrorKind::Timeout(msg)))?
 }
 
 pub struct QueryService {

--- a/core/src/sync/node_type.rs
+++ b/core/src/sync/node_type.rs
@@ -5,7 +5,7 @@
 use malloc_size_of_derive::MallocSizeOf as DeriveMallocSizeOf;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 
-#[derive(Clone, Debug, PartialEq, DeriveMallocSizeOf)]
+#[derive(Clone, Copy, Debug, PartialEq, DeriveMallocSizeOf)]
 #[repr(u8)]
 pub enum NodeType {
     Archive,


### PR DESCRIPTION
**Overview**

Currently, when the light node sync layer encounters an error (e.g. invalid proof), it does not report the error to the RPC caller but will silently retry. The caller will timeout after a while but there is no way to tell what caused the timeout.

This PR allows the sync layer to propagate errors to the RPC layer. Note that, even if an RPC call fails, the sync layer will still retry the query; this way a repeated query can succeed with reduced latency.

**Architecture**

Currently, light node modules use two separate runtimes.

The sync layer runs on top of our mio event loop, similar to full nodes. Query modules (RPC, `QueryService`), on the other hand, run on a tokio future executor. In terms of query workflow, RPC requests will notify the sync layer to retrieve the corresponding item. When the item has been received and verified, all futures waiting for it are notified (`wake`).

This latter notification is done using a shared-memory cache. For instance, the transactions sync handler has a field:

```rust
verified: Arc<RwLock<LruCache<H256, PendingItem<SignedTransaction, ClonableError>>>>,
```

Originally, `PendingItem` only had two states: `Pending` and `Ready`. In this PR, this is extended with a third state `Error`. The corresponding future `FutureItem` will now resolve to `Result<T, Err>` instead of just `T`.

**Implementation challenges**

`error-chain` errors are neither `Clone` [[1](https://github.com/rust-lang-nursery/error-chain/issues/121)] [[2](https://github.com/rust-lang-nursery/error-chain/pull/163)] nor `Sync` [[3](https://github.com/rust-lang-nursery/error-chain/issues/240)] [[4](https://github.com/rust-lang-nursery/error-chain/pull/241)]. Unfortunately, we need both of these. We need `Clone` as the same error will be consumed by the sync handler (for disconnecting the peer) and by one or more RPC handlers (to report the error or retry). We need `Sync` as futures can be scheduled on different threads at different points in time when using a tokio executor.

As a hacky workaround, I use a wrapper when I need clonable errors:

```rust
pub struct ClonableError(Arc<Mutex<Error>>);

impl Into<Error> for ClonableError { ... }
impl From<Error> for ClonableError { ... }
```

... and when I need to use this as a normal `Error`, I wrap this into a special error kind:

```rust
ClonableErrorWrapper(error: ClonableError) {
    description("Clonable error"),
    display("{:?}", error.0.lock().to_string()),
}
```

The other changes in this PR are mostly adding more details to various error types and some refactoring.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1783)
<!-- Reviewable:end -->
