### PR TITLE
Reject unknown filter fields in cfx_getLogs

### DIFF
--- a/client/src/rpc/types/filter.rs
+++ b/client/src/rpc/types/filter.rs
@@ -71,7 +71,7 @@ where T: DeserializeOwned
 }
 
 #[derive(PartialEq, Debug, Serialize, Deserialize, Eq, Hash, Clone)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Filter {
     /// Search will be applied from this epoch number.
     pub from_epoch: Option<EpochNumber>,

--- a/tests/rpc/test_get_logs.py
+++ b/tests/rpc/test_get_logs.py
@@ -63,6 +63,11 @@ class TestGetLogs(RpcClient):
         filter = Filter(limit=1)
         assert_raises_rpc_error(None, None, self.get_logs, filter)
 
+        # invalid filter fields
+        filter = Filter()
+        filter.fromBlock = "0x0"
+        assert_raises_rpc_error(None, None, self.get_logs, filter)
+
     def test_valid_filter(self):
         # epoch fields inclusive
         filter = Filter(from_epoch="0x1", to_epoch="0x1")


### PR DESCRIPTION
**Overview**

When moving to Conflux from Ethereum, it is easy to miss some of the subtle differences in our RPCs. For instance, providing unknown filter fields in `cfx_getLogs` is silently ignored, which might lead to confusion. In this PR I change this behavior so that we explicitly reject log queries with unknown fields.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1808)
<!-- Reviewable:end -->
