### PR TITLE
Add a field gas_used to rpc Block type

### DIFF
--- a/changelogs/CHANGELOG-0.6.x.md
+++ b/changelogs/CHANGELOG-0.6.x.md
@@ -1,3 +1,9 @@
+# 0.6.3
+
+## Improvement
+
+- block info returned by rpc methods `cfx_getBlockByEpochNumber`, `cfx_getBlockByHash`, `cfx_getBlockByHashWithPivotAssumption` add one new field 'gasUsed' (backward compatible) 
+
 # 0.6.2
 
 ## Improvement

--- a/changelogs/CHANGELOG-1.0.x.md
+++ b/changelogs/CHANGELOG-1.0.x.md
@@ -3,6 +3,7 @@
 ## Improvement
 - Start stratum services automatically if `mining_author` is set. 
 Use `mining_type` to allow start CPU mining or disable mining manually.
+- block info returned by rpc methods `cfx_getBlockByEpochNumber`, `cfx_getBlockByHash`, `cfx_getBlockByHashWithPivotAssumption` add one new field `gasUsed` (backward compatible)
 
 ## Bug Fixes
 

--- a/client/src/rpc/types/block.rs
+++ b/client/src/rpc/types/block.rs
@@ -451,6 +451,7 @@ mod tests {
             transactions_root: KECCAK_EMPTY_LIST_RLP.into(),
             epoch_number: None,
             gas_limit: U256::default(),
+            gas_used: None,
             timestamp: 0.into(),
             difficulty: U256::default(),
             pow_quality: None,
@@ -462,7 +463,7 @@ mod tests {
         };
         let serialized_block = serde_json::to_string(&block).unwrap();
 
-        assert_eq!(serialized_block, r#"{"hash":"0x0000000000000000000000000000000000000000000000000000000000000000","parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000","height":"0x0","miner":"0x0000000000000000000000000000000000000000","deferredStateRoot":"0x0000000000000000000000000000000000000000000000000000000000000000","deferredReceiptsRoot":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","deferredLogsBloomHash":"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5","blame":"0x0","transactionsRoot":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","epochNumber":null,"gasLimit":"0x0","timestamp":"0x0","difficulty":"0x0","powQuality":null,"refereeHashes":[],"adaptive":false,"nonce":"0x0","transactions":[],"size":"0x45"}"#);
+        assert_eq!(serialized_block, r#"{"hash":"0x0000000000000000000000000000000000000000000000000000000000000000","parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000","height":"0x0","miner":"0x0000000000000000000000000000000000000000","deferredStateRoot":"0x0000000000000000000000000000000000000000000000000000000000000000","deferredReceiptsRoot":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","deferredLogsBloomHash":"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5","blame":"0x0","transactionsRoot":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","epochNumber":null,"gasLimit":"0x0","gasUsed":null,"timestamp":"0x0","difficulty":"0x0","powQuality":null,"refereeHashes":[],"adaptive":false,"nonce":"0x0","transactions":[],"size":"0x45"}"#);
     }
 
     #[test]
@@ -480,6 +481,7 @@ mod tests {
             transactions_root: KECCAK_EMPTY_LIST_RLP.into(),
             epoch_number: Some(0.into()),
             gas_limit: U256::default(),
+            gas_used: None,
             timestamp: 0.into(),
             difficulty: U256::default(),
             pow_quality: None,


### PR DESCRIPTION
In conflux scan we want to show block gas_used/gas_limit as the network jam situation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1811)
<!-- Reviewable:end -->
