### PR TITLE
fix db_dir in default config file

### DIFF
--- a/run/default.toml
+++ b/run/default.toml
@@ -370,7 +370,7 @@ jsonrpc_local_http_port=12539
 
 # The directory to store block-related data.
 #
-# db_dir = "./blockchain_db"
+# block_db_dir = "./blockchain_db"
 
 # Maximum size of cached ledger data (block, receipts, e.t.c.)
 # The unit is MB.

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -848,5 +848,5 @@ subcommands:
                                 about: Get the current status of Conflux
                                 args:
                                     - rpc-method:
-                                        default_value: getstatus
+                                        default_value: cfx_getStatus
                                         hidden: true

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -133,9 +133,9 @@ args:
         long: db-compact-profile
         value_name: ENUM
         takes_value: true
-    - db-dir:
+    - block-db-dir:
         help: Sets the root path of db.
-        long: db-dir
+        long: block-db-dir
         value_name: DIR
         takes_value: true
     - load-test-chain:


### PR DESCRIPTION
The run/default.toml has a wrong spell field `db_dir` should be `block_db_dir`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1825)
<!-- Reviewable:end -->
