### PR TITLE
Fix issue #1830.

### DIFF
--- a/core/src/consensus/consensus_inner/mod.rs
+++ b/core/src/consensus/consensus_inner/mod.rs
@@ -1204,10 +1204,12 @@ impl ConsensusGraphInner {
             }
             my_past.add(index as u32);
             let idx_parent = self.arena[index].parent;
-            if anticone.contains(idx_parent as u32)
-                || self.arena[idx_parent].era_block == NULL
-            {
-                queue.push_back(idx_parent);
+            if idx_parent != NULL {
+                if anticone.contains(idx_parent as u32)
+                    || self.arena[idx_parent].era_block == NULL
+                {
+                    queue.push_back(idx_parent);
+                }
             }
             for referee in &self.arena[index].referees {
                 if anticone.contains(*referee as u32)


### PR DESCRIPTION
Close #1830 .

It's possible to reach a block whose parent is NULL (in the past of `era_genesis`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1833)
<!-- Reviewable:end -->
