### PR TITLE
Only load the header in get_best_info_with_packed_transactions.

### DIFF
--- a/core/src/transaction_pool/mod.rs
+++ b/core/src/transaction_pool/mod.rs
@@ -699,13 +699,9 @@ impl TransactionPool {
 
         let parent_block_gas_limit = self
             .data_man
-            .block_by_hash(
-                &consensus_best_info_clone.best_block_hash,
-                /* update_cache = */ true,
-            )
+            .block_header_by_hash(&consensus_best_info_clone.best_block_hash)
             // The parent block must exists.
             .expect(&concat!(file!(), ":", line!(), ":", column!()))
-            .block_header
             .gas_limit()
             .clone();
 


### PR DESCRIPTION
Related to #1832 .

Although it's not the root cause, it looks unnecessary to load the block body here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1834)
<!-- Reviewable:end -->
