### PR TITLE
Use https url for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests/extra-test-toolkits"]
 	path = tests/extra-test-toolkits
-	url = git@github.com:Conflux-Chain/conflux-rust-test-toolkits.git
+	url = https://github.com/Conflux-Chain/conflux-rust-test-toolkits.git


### PR DESCRIPTION
Use https url is more compatible and more commonly used since it doesn't require to login to github.
This makes it easier to `git clone --recursive` on VPS.

r? @sparkmiw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1837)
<!-- Reviewable:end -->
