### PR TITLE
Add a new contract address scheme which use block_number in contract address calculation.

### DIFF
--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -450,6 +450,7 @@ impl RpcImpl {
                 None => PackedOrExecuted::Packed(tx_index),
                 Some(MaybeExecutedTxExtraInfo {
                     receipt,
+                    block_number,
                     prior_gas_used,
                     tx_exec_error_msg,
                 }) => {
@@ -468,6 +469,7 @@ impl RpcImpl {
                         tx_index,
                         prior_gas_used,
                         epoch_number,
+                        block_number,
                         maybe_state_root,
                         tx_exec_error_msg,
                     ))
@@ -555,6 +557,7 @@ impl RpcImpl {
             tx_index,
             prior_gas_used,
             Some(epoch_number),
+            execution_result.block_receipts.block_number,
             maybe_state_root,
             if tx_exec_error_msg.is_empty() {
                 None

--- a/client/src/rpc/impls/light.rs
+++ b/client/src/rpc/impls/light.rs
@@ -488,9 +488,13 @@ impl RpcImpl {
         let light = self.light.clone();
 
         let fut = async move {
-            // FIXME: why not return an RpcReceipt directly?
+            // TODO:
+            //  return an RpcReceipt directly after splitting cfxcore into
+            //  smaller crates. It's impossible now because of circular
+            //  dependency.
             let TxInfo {
                 tx,
+                maybe_block_number,
                 receipt,
                 tx_index,
                 maybe_epoch,
@@ -502,12 +506,17 @@ impl RpcImpl {
                 .map_err(|e| e.to_string()) // TODO(thegaram): return meaningful error
                 .map_err(RpcError::invalid_params)?;
 
+            if maybe_block_number.is_none() {
+                return Ok(None);
+            }
+
             let receipt = RpcReceipt::new(
                 tx,
                 receipt,
                 tx_index,
                 prior_gas_used,
                 maybe_epoch,
+                maybe_block_number.unwrap(),
                 maybe_state_root,
                 // Can not offer error_message from light node.
                 None,

--- a/client/src/rpc/types/block.rs
+++ b/client/src/rpc/types/block.rs
@@ -187,6 +187,7 @@ impl Block {
                                             tx_index,
                                             prior_gas_used,
                                             epoch_number,
+                                            execution_result.block_receipts.block_number,
                                             maybe_state_root,
                                             if tx_exec_error_msg.is_empty() {
                                                 None

--- a/client/src/rpc/types/receipt.rs
+++ b/client/src/rpc/types/receipt.rs
@@ -51,14 +51,15 @@ impl Receipt {
     pub fn new(
         transaction: PrimitiveTransaction, receipt: PrimitiveReceipt,
         transaction_index: TransactionIndex, prior_gas_used: U256,
-        epoch_number: Option<u64>, maybe_state_root: Option<H256>,
-        tx_exec_error_msg: Option<String>,
+        epoch_number: Option<u64>, block_number: u64,
+        maybe_state_root: Option<H256>, tx_exec_error_msg: Option<String>,
     ) -> Receipt
     {
         let mut address = None;
         if Action::Create == transaction.action && receipt.outcome_status == 0 {
             let (created_address, _) = contract_address(
                 CreateContractAddress::FromSenderNonceAndCodeHash,
+                block_number.into(),
                 &transaction.sender,
                 &transaction.nonce,
                 &transaction.data,
@@ -72,9 +73,9 @@ impl Receipt {
             gas_used: (receipt.accumulated_gas_used - prior_gas_used).into(),
             gas_fee: receipt.gas_fee.into(),
             from: transaction.sender,
-            to: match transaction.action {
+            to: match &transaction.action {
                 Action::Create => None,
-                Action::Call(ref address) => Some(address.clone()),
+                Action::Call(address) => Some(address.clone()),
             },
             outcome_status: U64::from(receipt.outcome_status),
             contract_created: address,

--- a/core/src/block_data_manager/block_data_types.rs
+++ b/core/src/block_data_manager/block_data_types.rs
@@ -21,6 +21,7 @@ pub struct EpochExecutionContext {
 /// block's view.
 #[derive(Clone, Debug)]
 pub struct BlockExecutionResult {
+    // FIXME: why it's an Arc.
     pub block_receipts: Arc<BlockReceipts>,
     pub bloom: Bloom,
 }
@@ -30,6 +31,7 @@ impl MallocSizeOf for BlockExecutionResult {
     }
 }
 
+// FIXME: RlpEncodable.
 impl Encodable for BlockExecutionResult {
     fn rlp_append(&self, s: &mut RlpStream) {
         s.begin_list(2)

--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -1250,6 +1250,7 @@ impl ConsensusExecutionHandler {
 
             let block_receipts = Arc::new(BlockReceipts {
                 receipts,
+                block_number,
                 secondary_reward,
                 tx_execution_error_messages: tx_exec_error_messages,
             });

--- a/core/src/consensus/consensus_inner/mod.rs
+++ b/core/src/consensus/consensus_inner/mod.rs
@@ -2164,7 +2164,7 @@ impl ConsensusGraphInner {
 
     /// This function differs from `get_pivot_hash_from_epoch_number` in that it
     /// only returns the hash if it is in the current consensus graph.
-    fn epoch_hash(&self, epoch_number: u64) -> Option<H256> {
+    pub fn epoch_hash(&self, epoch_number: u64) -> Option<H256> {
         let pivot_index = self.height_to_pivot_index(epoch_number);
         self.pivot_chain
             .get(pivot_index)
@@ -2389,6 +2389,7 @@ impl ConsensusGraphInner {
                         .get(tx_index.index)
                         .expect("Error: can't get receipt by tx_index ")
                         .clone(),
+                    block_number: block_receipts.block_number,
                     prior_gas_used,
                     tx_exec_error_msg: if tx_exec_error_msg.is_empty() {
                         None

--- a/core/src/consensus/consensus_trait.rs
+++ b/core/src/consensus/consensus_trait.rs
@@ -75,6 +75,10 @@ pub trait ConsensusGraphTrait: Send + Sync {
 
     fn get_block_epoch_number(&self, hash: &H256) -> Option<u64>;
 
+    fn get_block_number(
+        &self, block_hash: &H256,
+    ) -> Result<Option<u64>, String>;
+
     fn get_trusted_blame_block_for_snapshot(
         &self, snapshot_epoch_id: &EpochId,
     ) -> Option<H256>;

--- a/core/src/executive/context.rs
+++ b/core/src/executive/context.rs
@@ -174,6 +174,7 @@ impl<'a> ContextTrait for Context<'a> {
         // create new contract address
         let (address, code_hash) = self::contract_address(
             address_scheme,
+            self.env.number.into(),
             &self.origin.address,
             &self.state.nonce(&self.origin.address)?,
             &code,

--- a/core/src/executive/executive.rs
+++ b/core/src/executive/executive.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 use cfx_parameters::staking::*;
 use cfx_statedb::Result as DbResult;
-use cfx_types::{address_util::AddressUtil, Address, H256, U256, U512};
+use cfx_types::{address_util::AddressUtil, Address, H256, U256, U512, U64};
 use primitives::{
     receipt::StorageChange, storage::STORAGE_LAYOUT_REGULAR_V0,
     transaction::Action, SignedTransaction, StorageLayout,
@@ -41,19 +41,41 @@ use std::{
     sync::Arc,
 };
 
-/// Returns new address created from address, nonce, and code hash
+/// Calculate new contract address.
 pub fn contract_address(
-    address_scheme: CreateContractAddress, sender: &Address, nonce: &U256,
-    code: &[u8],
+    address_scheme: CreateContractAddress, block_number: U64, sender: &Address,
+    nonce: &U256, code: &[u8],
 ) -> (Address, Option<H256>)
 {
+    let code_hash = keccak(code);
     match address_scheme {
+        CreateContractAddress::FromBlockNumberSenderNonceAndCodeHash => {
+            let mut buffer = [0u8; 1 + 8 + 20 + 32 + 32];
+            let (lead_bytes, rest) = buffer.split_at_mut(1);
+            let (block_number_bytes, rest) = rest.split_at_mut(8);
+            let (sender_bytes, rest) = rest.split_at_mut(Address::len_bytes());
+            let (nonce_bytes, code_hash_bytes) =
+                rest.split_at_mut(H256::len_bytes());
+            // In Conflux, we take block_number and CodeHash into address
+            // calculation. This is required to enable us to clean
+            // up unused user account in future.
+            lead_bytes[0] = 0x0;
+            block_number.to_little_endian(block_number_bytes);
+            sender_bytes.copy_from_slice(&sender[..]);
+            nonce.to_little_endian(nonce_bytes);
+            code_hash_bytes.copy_from_slice(&code_hash[..]);
+            // In Conflux, we use the first four bits to indicate the type of
+            // the address. For contract address, the bits will be
+            // set to 0x8.
+            let mut h = Address::from(keccak(&buffer[..]));
+            h.set_contract_type_bits();
+            (h, Some(code_hash))
+        }
         CreateContractAddress::FromSenderNonceAndCodeHash => {
             let mut buffer = [0u8; 1 + 20 + 32 + 32];
             // In Conflux, we append CodeHash to determine the address as well.
             // This is required to enable us to clean up unused user account in
             // future.
-            let code_hash = keccak(code);
             buffer[0] = 0x0;
             &mut buffer[1..(1 + 20)].copy_from_slice(&sender[..]);
             nonce.to_little_endian(&mut buffer[(1 + 20)..(1 + 20 + 32)]);
@@ -66,7 +88,6 @@ pub fn contract_address(
             (h, Some(code_hash))
         }
         CreateContractAddress::FromSenderSaltAndCodeHash(salt) => {
-            let code_hash = keccak(code);
             let mut buffer = [0u8; 1 + 20 + 32 + 32];
             buffer[0] = 0xff;
             &mut buffer[1..(1 + 20)].copy_from_slice(&sender[..]);
@@ -1401,6 +1422,7 @@ impl<'a> Executive<'a> {
             Action::Create => {
                 let (new_address, _code_hash) = contract_address(
                     CreateContractAddress::FromSenderNonceAndCodeHash,
+                    self.env.number.into(),
                     &sender,
                     &nonce,
                     &tx.data,

--- a/core/src/executive/executive_tests.rs
+++ b/core/src/executive/executive_tests.rs
@@ -55,6 +55,7 @@ fn test_contract_address() {
         expected_address,
         contract_address(
             CreateContractAddress::FromSenderNonceAndCodeHash,
+            /* block_number = */ 0.into(),
             &address,
             &U256::from(88),
             &[],
@@ -70,6 +71,7 @@ fn test_sender_balance() {
         Address::from_str("1f572e5295c57f15886f9b263e2f6d2d6c7b5ec6").unwrap();
     let address = contract_address(
         CreateContractAddress::FromSenderNonceAndCodeHash,
+        /* block_number = */ 0.into(),
         &sender,
         &U256::zero(),
         &[],
@@ -172,6 +174,7 @@ fn test_create_contract_out_of_depth() {
         Address::from_str("1d1722f3947def4cf144679da39c4c32bdc35681").unwrap();
     let address = contract_address(
         CreateContractAddress::FromSenderNonceAndCodeHash,
+        /* block_number = */ 0.into(),
         &sender,
         &U256::zero(),
         &[],
@@ -229,6 +232,7 @@ fn test_suicide_when_creation() {
         Address::from_str("1d1722f3947def4cf144679da39c4c32bdc35681").unwrap();
     let contract_addr = contract_address(
         CreateContractAddress::FromSenderNonceAndCodeHash,
+        /* block_number = */ 0.into(),
         &sender_addr,
         &U256::zero(),
         &[],
@@ -310,6 +314,7 @@ fn test_call_to_create() {
         Address::from_str("1d1722f3947def4cf144679da39c4c32bdc35681").unwrap();
     let address = contract_address(
         CreateContractAddress::FromSenderNonceAndCodeHash,
+        /* block_number = */ 0.into(),
         &sender,
         &U256::zero(),
         &[],
@@ -475,6 +480,7 @@ fn test_keccak() {
         Address::from_str("1f572e5295c57f15886f9b263e2f6d2d6c7b5ec6").unwrap();
     let address = contract_address(
         CreateContractAddress::FromSenderNonceAndCodeHash,
+        /* block_number = */ 0.into(),
         &sender,
         &U256::zero(),
         &[],
@@ -1019,6 +1025,7 @@ fn test_commission_privilege() {
     let caller3 = Random.generate().unwrap();
     let address = contract_address(
         CreateContractAddress::FromSenderNonceAndCodeHash,
+        /* block_number = */ 0.into(),
         &sender.address(),
         &U256::zero(),
         &[],
@@ -1387,6 +1394,7 @@ fn test_storage_commission_privilege() {
     let caller3 = Random.generate().unwrap();
     let address = contract_address(
         CreateContractAddress::FromSenderNonceAndCodeHash,
+        /* block_number = */ 0.into(),
         &sender.address(),
         &U256::zero(),
         &[],

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -129,6 +129,7 @@ pub fn genesis_block(
         .unwrap();
     let receipt_root = compute_receipts_root(&vec![Arc::new(BlockReceipts {
         receipts: vec![],
+        block_number: 0,
         secondary_reward: U256::zero(),
         tx_execution_error_messages: vec![],
     })]);

--- a/core/src/vm/context.rs
+++ b/core/src/vm/context.rs
@@ -64,6 +64,9 @@ pub enum CreateContractAddress {
     /// Address is calculated from sender, nonce, and code hash. Conflux
     /// `create` scheme.
     FromSenderNonceAndCodeHash,
+    /// Address is calculated from block_hash, sender, nonce and code_hash.
+    /// Potential new Conflux `create` scheme when kill_dust is enabled.
+    FromBlockNumberSenderNonceAndCodeHash,
     /// Address is calculated from sender, salt and code hash. pWASM `create2`
     /// scheme.
     FromSenderSaltAndCodeHash(H256),

--- a/primitives/src/block_header.rs
+++ b/primitives/src/block_header.rs
@@ -592,6 +592,7 @@ mod tests {
             .map(|_| {
                 Arc::new(BlockReceipts {
                     receipts: vec![],
+                    block_number: 0,
                     secondary_reward: U256::zero(),
                     tx_execution_error_messages: vec![],
                 })
@@ -620,6 +621,7 @@ mod tests {
             .map(|_| {
                 Arc::new(BlockReceipts {
                     receipts: (1..11).map(|_| receipt.clone()).collect(),
+                    block_number: 0,
                     secondary_reward: U256::zero(),
                     tx_execution_error_messages: vec!["".into(); 10],
                 })
@@ -692,6 +694,7 @@ mod tests {
                     storage_released: vec![],
                 },
             ],
+            block_number: 0,
             secondary_reward: U256::zero(),
             tx_execution_error_messages: vec!["".into(); 2],
         };
@@ -726,6 +729,7 @@ mod tests {
                 storage_collateralized: vec![],
                 storage_released: vec![],
             }],
+            block_number: 0,
             secondary_reward: U256::zero(),
             tx_execution_error_messages: vec!["".into()],
         };

--- a/primitives/src/receipt.rs
+++ b/primitives/src/receipt.rs
@@ -84,6 +84,7 @@ pub struct BlockReceipts {
     pub receipts: Vec<Receipt>,
     // FIXME:
     //   These fields below do not belong to receipts root calculation.
+    pub block_number: u64,
     /// This is the amount of secondary reward this block.
     pub secondary_reward: U256,
     /// The error messages for each transaction. A successful transaction has

--- a/transactiongen/src/lib.rs
+++ b/transactiongen/src/lib.rs
@@ -284,7 +284,6 @@ pub struct DirectTransactionGenerator {
     erc20_address: Address,
 }
 
-// Allow use of hex() in H256, etc.
 #[allow(deprecated)]
 impl DirectTransactionGenerator {
     const MAX_TOTAL_ACCOUNTS: usize = 100_000;
@@ -311,8 +310,12 @@ impl DirectTransactionGenerator {
 
         let erc20_address = contract_address(
             CreateContractAddress::FromSenderNonceAndCodeHash,
+            // A fake block_number. There field is unnecessary in Ethereum
+            // replay test.
+            0.into(),
             &contract_creator,
             &0.into(),
+            // A fake code. There field is unnecessary in Ethereum replay test.
             &[],
         )
         .0;


### PR DESCRIPTION
The new address scheme is proposed in CIP-28 against contract recreation at the same address.
The default contract address scheme is still the old one, until the CIP-28 is finalized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1853)
<!-- Reviewable:end -->
