### PR TITLE
Add a window for maintaining recent PoW problems, instead of dropping all stale PoW solutions

### DIFF
--- a/blockgen/src/lib.rs
+++ b/blockgen/src/lib.rs
@@ -692,6 +692,8 @@ impl BlockGenerator {
 
     pub fn start_mining(bg: Arc<BlockGenerator>, _payload_len: u32) {
         let mut current_mining_block = None;
+        let mut recent_mining_blocks = vec![];
+        let mut recent_mining_problems = vec![];
         let mut current_problem: Option<ProofOfWorkProblem> = None;
         let sleep_duration =
             time::Duration::from_millis(BLOCKGEN_LOOP_SLEEP_IN_MILISECS);
@@ -727,6 +729,13 @@ impl BlockGenerator {
                     vec![],
                 ));
 
+                if recent_mining_blocks.len()
+                    == bg.pow_config.pow_problem_window_size as usize
+                {
+                    recent_mining_blocks.remove(0);
+                    recent_mining_problems.remove(0);
+                }
+
                 // set a mining problem
                 let current_difficulty = current_mining_block
                     .as_ref()
@@ -751,41 +760,51 @@ impl BlockGenerator {
                 BlockGenerator::send_problem(bg.clone(), problem);
                 last_notify = SystemTime::now();
                 current_problem = Some(problem);
+
+                recent_mining_blocks
+                    .push(current_mining_block.clone().unwrap());
+                recent_mining_problems.push(problem);
             } else {
                 // check if the problem solved
                 let mut new_solution = receiver.try_recv();
+                let mut maybe_mined_block = None;
+
                 loop {
                     trace!("new solution: {:?}", new_solution);
                     // check if the block received valid
-                    if new_solution.is_ok()
-                        && !validate(
+                    if !new_solution.is_ok() {
+                        break;
+                    }
+
+                    for index in 0..recent_mining_problems.len() {
+                        if validate(
                             bg.pow.clone(),
-                            &current_problem.unwrap(),
+                            &recent_mining_problems[index],
                             &new_solution.unwrap(),
-                        )
-                    {
+                        ) {
+                            maybe_mined_block =
+                                Some(recent_mining_blocks[index].clone());
+                            break;
+                        }
+                    }
+
+                    if maybe_mined_block.is_none() {
                         warn!(
                             "Received invalid solution from miner: nonce = {}!",
                             &new_solution.unwrap().nonce
                         );
                         new_solution = receiver.try_recv();
-                    } else {
-                        break;
+                        continue;
                     }
+                    break;
                 }
+
                 if new_solution.is_ok() {
                     let solution = new_solution.unwrap();
-                    current_mining_block
-                        .as_mut()
-                        .unwrap()
-                        .block_header
-                        .set_nonce(solution.nonce);
-                    current_mining_block
-                        .as_mut()
-                        .unwrap()
-                        .block_header
-                        .compute_hash();
-                    bg.on_mined_block(current_mining_block.unwrap());
+                    let mut mined_block = maybe_mined_block.unwrap();
+                    mined_block.block_header.set_nonce(solution.nonce);
+                    mined_block.block_header.compute_hash();
+                    bg.on_mined_block(mined_block);
                     current_mining_block = None;
                     current_problem = None;
                 } else {

--- a/blockgen/src/lib.rs
+++ b/blockgen/src/lib.rs
@@ -730,7 +730,7 @@ impl BlockGenerator {
                 ));
 
                 if recent_mining_blocks.len()
-                    == bg.pow_config.pow_problem_window_size as usize
+                    == bg.pow_config.pow_problem_window_size
                 {
                     recent_mining_blocks.remove(0);
                     recent_mining_problems.remove(0);

--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -130,7 +130,7 @@ build_config! {
         (stratum_port, (u16), 32525)
         (stratum_secret, (Option<String>), None)
         (use_octopus_in_test_mode, (bool), false)
-        (pow_problem_window_size, (Option<u64>), None)
+        (pow_problem_window_size, (usize), 1)
 
         // Network section.
         (jsonrpc_local_tcp_port, (Option<u16>), None)

--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -130,6 +130,7 @@ build_config! {
         (stratum_port, (u16), 32525)
         (stratum_secret, (Option<String>), None)
         (use_octopus_in_test_mode, (bool), false)
+        (pow_problem_window_size, (Option<u64>), None)
 
         // Network section.
         (jsonrpc_local_tcp_port, (Option<u16>), None)
@@ -483,6 +484,7 @@ impl Configuration {
             self.raw_conf.stratum_listen_address.clone(),
             self.raw_conf.stratum_port,
             stratum_secret,
+            self.raw_conf.pow_problem_window_size,
         )
     }
 

--- a/client/src/tests/blockgen_tests.rs
+++ b/client/src/tests/blockgen_tests.rs
@@ -100,7 +100,7 @@ fn test_mining_10_epochs_with_larger_pow_problem_window() {
     let mut conf = Configuration::default();
     conf.raw_conf.mode = Some("test".to_owned());
     conf.raw_conf.initial_difficulty = Some(10_000);
-    conf.raw_conf.pow_problem_window_size = Some(4);
+    conf.raw_conf.pow_problem_window_size = 4;
 
     let tmp_dir = TempDir::new("conflux-test").unwrap();
     conf.raw_conf.conflux_data_dir =

--- a/client/src/tests/blockgen_tests.rs
+++ b/client/src/tests/blockgen_tests.rs
@@ -94,3 +94,41 @@ fn test_mining_10_epochs() {
 
     client_methods::shutdown(handle);
 }
+
+#[test]
+fn test_mining_10_epochs_with_larger_pow_problem_window() {
+    let mut conf = Configuration::default();
+    conf.raw_conf.mode = Some("test".to_owned());
+    conf.raw_conf.initial_difficulty = Some(10_000);
+    conf.raw_conf.pow_problem_window_size = Some(4);
+
+    let tmp_dir = TempDir::new("conflux-test").unwrap();
+    conf.raw_conf.conflux_data_dir =
+        tmp_dir.path().to_str().unwrap().to_string() + "/";
+    conf.raw_conf.block_db_dir = tmp_dir
+        .path()
+        .join("db")
+        .into_os_string()
+        .into_string()
+        .unwrap();
+    conf.raw_conf.netconf_dir = Some(
+        tmp_dir
+            .path()
+            .join("config")
+            .into_os_string()
+            .into_string()
+            .unwrap(),
+    );
+    conf.raw_conf.tcp_port = 13001;
+    conf.raw_conf.jsonrpc_http_port = Some(18001);
+    conf.raw_conf.mining_author =
+        Some("1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into());
+    conf.raw_conf.mining_type = Some("cpu".into());
+
+    let exit = Arc::new((Mutex::new(false), Condvar::new()));
+    let handle = ArchiveClient::start(conf, exit).unwrap();
+
+    test_mining_10_epochs_inner(&handle);
+
+    client_methods::shutdown(handle);
+}

--- a/client/src/tests/blockgen_tests.rs
+++ b/client/src/tests/blockgen_tests.rs
@@ -119,8 +119,8 @@ fn test_mining_10_epochs_with_larger_pow_problem_window() {
             .into_string()
             .unwrap(),
     );
-    conf.raw_conf.tcp_port = 13001;
-    conf.raw_conf.jsonrpc_http_port = Some(18001);
+    conf.raw_conf.tcp_port = 13002;
+    conf.raw_conf.jsonrpc_http_port = Some(18002);
     conf.raw_conf.mining_author =
         Some("1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into());
     conf.raw_conf.mining_type = Some("cpu".into());

--- a/core/src/pow/mod.rs
+++ b/core/src/pow/mod.rs
@@ -93,7 +93,7 @@ pub struct ProofOfWorkConfig {
     pub stratum_listen_addr: String,
     pub stratum_port: u16,
     pub stratum_secret: Option<H256>,
-    pub pow_problem_window_size: u64,
+    pub pow_problem_window_size: usize,
 }
 
 impl ProofOfWorkConfig {
@@ -101,7 +101,7 @@ impl ProofOfWorkConfig {
         test_mode: bool, use_octopus_in_test_mode: bool, mining_type: &str,
         initial_difficulty: Option<u64>, stratum_listen_addr: String,
         stratum_port: u16, stratum_secret: Option<H256>,
-        pow_problem_window_size: Option<u64>,
+        pow_problem_window_size: usize,
     ) -> Self
     {
         if test_mode {
@@ -115,7 +115,7 @@ impl ProofOfWorkConfig {
                 stratum_listen_addr,
                 stratum_port,
                 stratum_secret,
-                pow_problem_window_size: pow_problem_window_size.unwrap_or(1),
+                pow_problem_window_size,
             }
         } else {
             ProofOfWorkConfig {
@@ -129,7 +129,7 @@ impl ProofOfWorkConfig {
                 stratum_listen_addr,
                 stratum_port,
                 stratum_secret,
-                pow_problem_window_size: pow_problem_window_size.unwrap_or(1),
+                pow_problem_window_size,
             }
         }
     }

--- a/core/src/pow/mod.rs
+++ b/core/src/pow/mod.rs
@@ -93,6 +93,7 @@ pub struct ProofOfWorkConfig {
     pub stratum_listen_addr: String,
     pub stratum_port: u16,
     pub stratum_secret: Option<H256>,
+    pub pow_problem_window_size: u64,
 }
 
 impl ProofOfWorkConfig {
@@ -100,6 +101,7 @@ impl ProofOfWorkConfig {
         test_mode: bool, use_octopus_in_test_mode: bool, mining_type: &str,
         initial_difficulty: Option<u64>, stratum_listen_addr: String,
         stratum_port: u16, stratum_secret: Option<H256>,
+        pow_problem_window_size: Option<u64>,
     ) -> Self
     {
         if test_mode {
@@ -113,6 +115,7 @@ impl ProofOfWorkConfig {
                 stratum_listen_addr,
                 stratum_port,
                 stratum_secret,
+                pow_problem_window_size: pow_problem_window_size.unwrap_or(1),
             }
         } else {
             ProofOfWorkConfig {
@@ -126,6 +129,7 @@ impl ProofOfWorkConfig {
                 stratum_listen_addr,
                 stratum_port,
                 stratum_secret,
+                pow_problem_window_size: pow_problem_window_size.unwrap_or(1),
             }
         }
     }

--- a/core/src/sync/utils.rs
+++ b/core/src/sync/utils.rs
@@ -181,7 +181,7 @@ pub fn initialize_synchronization_graph_with_data_manager(
         String::from(""), /* stratum_listen_addr */
         0,                /* stratum_port */
         None,             /* stratum_secret */
-        None,             /* pow_problem_window_size */
+        1,                /* pow_problem_window_size */
     );
     let sync_config = SyncGraphConfig {
         future_block_buffer_capacity: 1,

--- a/core/src/sync/utils.rs
+++ b/core/src/sync/utils.rs
@@ -181,6 +181,7 @@ pub fn initialize_synchronization_graph_with_data_manager(
         String::from(""), /* stratum_listen_addr */
         0,                /* stratum_port */
         None,             /* stratum_secret */
+        None,             /* pow_problem_window_size */
     );
     let sync_config = SyncGraphConfig {
         future_block_buffer_capacity: 1,

--- a/run/oceanus.toml
+++ b/run/oceanus.toml
@@ -64,6 +64,10 @@ bootnodes="cfxnode://25265e1aa470d9d8667947820c4830a64e9f9678d6cb23ecde91e044752
 #
 # stratum_port = 32525
 
+# Window size for PoW manager
+#
+# pow_problem_window_size = 1
+
 # Secret key for stratum.
 # The value is 64-digit hex string.
 # If not set, the RPC subscription will not check the authorization.


### PR DESCRIPTION
Add a config in .toml file:
``` pow_problem_window_size = 1 ```

The PoW manager will receive any PoW solution that can be validated by recent ```pow_problem_window_size``` PoW problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1857)
<!-- Reviewable:end -->
