### PR TITLE
Add `jemalloc-global` feature to enable using jemalloc allocator.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,7 @@ dependencies = [
  "futures 0.1.29",
  "home 0.5.3",
  "io",
+ "jemallocator",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-http-server",
@@ -866,6 +867,7 @@ dependencies = [
  "kvdb-rocksdb",
  "log 0.4.11",
  "log4rs",
+ "malloc_size_of",
  "mio",
  "network",
  "panic_hook",
@@ -1995,6 +1997,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
+name = "jemalloc-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2363,6 +2386,7 @@ dependencies = [
  "cfg-if",
  "cfx-types",
  "hashbrown 0.7.2",
+ "jemallocator",
  "parking_lot 0.10.2",
  "slab",
  "smallvec 1.4.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,11 @@ cfxkey = { path = "accounts/cfxkey" }
 parity-wordlist = "1.3.0"
 rustc-hex = "2.0.1"
 env_logger = "0.5"
+malloc_size_of = {path="util/malloc_size_of"}
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies.jemallocator]
+version = "0.3.2"
+optional = true
 
 [[bin]]
 name = "consensus_bench"
@@ -73,7 +77,8 @@ path = "tools/tg_config_gen/main.rs"
 [workspace]
 
 [features]
-deadlock_detection = ["parking_lot/deadlock_detection"]
+deadlock-detection = ["parking_lot/deadlock_detection"]
+jemalloc-global = ["jemallocator", "malloc_size_of/jemalloc-global"]
 
 [patch.crates-io]
 sqlite3-sys = { git = "https://github.com/Conflux-Chain/sqlite3-sys.git", rev = "1de8e5998f7c2d919336660b8ef4e8f52ac43844" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,12 @@
 #[cfg(test)]
 mod test;
 
+#[cfg(all(not(target_env = "msvc"), feature = "jemalloc-global"))]
+use jemallocator::Jemalloc;
+#[cfg(all(not(target_env = "msvc"), feature = "jemalloc-global"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 mod command;
 
 use crate::command::rpc::RpcCommand;
@@ -28,7 +34,7 @@ use parking_lot::{Condvar, Mutex};
 use std::sync::Arc;
 
 fn main() -> Result<(), String> {
-    #[cfg(feature = "deadlock_detection")]
+    #[cfg(feature = "deadlock-detection")]
     {
         // only for #[cfg]
         use parking_lot::deadlock;

--- a/util/malloc_size_of/Cargo.toml
+++ b/util/malloc_size_of/Cargo.toml
@@ -12,3 +12,10 @@ winapi = "0.3.7"
 slab = "0.4"
 parking_lot = "0.10"
 smallvec = "1.4"
+
+[features]
+jemalloc-global = ["jemallocator"]
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies.jemallocator]
+version = "0.3.2"
+optional = true

--- a/util/malloc_size_of/src/lib.rs
+++ b/util/malloc_size_of/src/lib.rs
@@ -11,6 +11,9 @@
 //! A reduced fork of Firefox's malloc_size_of crate, for bundling with
 //! WebRender.
 
+#[cfg(all(not(target_env = "msvc"), feature = "jemalloc-global"))]
+use jemallocator;
+
 use cfg_if::cfg_if;
 use cfx_types::{H160, H256, H512, U256, U512};
 use hashbrown::HashMap as FastHashMap;
@@ -24,7 +27,6 @@ use std::{
     os::raw::c_void,
     sync::Arc,
 };
-
 /// A C function that takes a pointer to a heap allocation and returns its size.
 type VoidPtrToSizeFn = unsafe extern "C" fn(ptr: *const c_void) -> usize;
 


### PR DESCRIPTION
Running `cargo build --release --feature jemalloc-global` should enable `jemalloc` now.

Check if using `jemalloc` can reduce memory usage by reducing memory fragmentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1860)
<!-- Reviewable:end -->
