### PR TITLE
Do not process block header in phase CatchUpRecoverBlockFromDB.

### DIFF
--- a/core/src/sync/message/get_block_headers_response.rs
+++ b/core/src/sync/message/get_block_headers_response.rs
@@ -10,7 +10,7 @@ use crate::{
             Handleable,
         },
         synchronization_state::PeerFilter,
-        Error, ErrorKind, SyncPhaseType,
+        Error, ErrorKind,
     },
 };
 use cfx_parameters::{

--- a/core/src/sync/message/get_block_headers_response.rs
+++ b/core/src/sync/message/get_block_headers_response.rs
@@ -59,8 +59,8 @@ impl Handleable for GetBlockHeadersResponse {
         }
 
         // We may receive some messages from peer during recover from db
-        // phase. We should ignore it, since it may cause some
-        // inconsistency.
+        // phase. We should ignore it, since it may cause some inconsistency.
+        // This will be double checked later with `phase_manager_lock` locked.
         if ctx.manager.in_recover_from_db_phase() {
             return Ok(());
         }
@@ -186,9 +186,7 @@ impl GetBlockHeadersResponse {
                 // If we insert headers in CatchUpRecoverBlockFromDB,
                 // the bodies may never be requested.
                 // See issue https://github.com/Conflux-Chain/conflux-rust/issues/1869.
-                if ctx.manager.phase_manager.get_current_phase().phase_type()
-                    == SyncPhaseType::CatchUpRecoverBlockFromDB
-                {
+                if ctx.manager.in_recover_from_db_phase() {
                     return;
                 }
                 ctx.manager.graph.insert_block_header(


### PR DESCRIPTION
Close #1869.

We need to lock `phase_manager_lock` to ensure that we are not in CatchUpRecoverBlockFromDB when we insert the block header. Any suggestion on a better condition here is welcome...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1871)
<!-- Reviewable:end -->
