### PR TITLE
Bug fixes in storage persistent snapshot & delta mpt logics and recovery logics

### DIFF
--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -218,7 +218,7 @@ build_config! {
         (tx_weight_exp, (u8), 1)
 
         // Storage Section.
-        (additional_maintained_snapshot_count, (u32), 0)
+        (additional_maintained_snapshot_count, (u32), 1)
         (block_cache_gc_period_ms, (u64), 5_000)
         // FIXME: use a fixed sub-dir of conflux_data_dir instead.
         (block_db_dir, (String), "./blockchain_db".to_string())

--- a/core/storage/src/impls/storage_manager/snapshot_manager.rs
+++ b/core/storage/src/impls/storage_manager/snapshot_manager.rs
@@ -24,6 +24,7 @@ impl<SnapshotDbManager: SnapshotDbManagerTrait> SnapshotManagerTrait
     fn remove_old_pivot_snapshot(
         &self, snapshot_epoch_id: &EpochId,
     ) -> Result<()> {
+        debug!("remove_old_pivot_snapshot {:?}", snapshot_epoch_id);
         self.get_snapshot_db_manager()
             .destroy_snapshot(snapshot_epoch_id)
     }
@@ -31,6 +32,7 @@ impl<SnapshotDbManager: SnapshotDbManagerTrait> SnapshotManagerTrait
     fn remove_non_pivot_snapshot(
         &self, snapshot_epoch_id: &EpochId,
     ) -> Result<()> {
+        debug!("remove_non_pivot_snapshot {:?}", snapshot_epoch_id);
         self.get_snapshot_db_manager()
             .destroy_snapshot(snapshot_epoch_id)
     }

--- a/core/storage/src/storage_db/delta_db_manager.rs
+++ b/core/storage/src/storage_db/delta_db_manager.rs
@@ -83,9 +83,14 @@ pub trait DeltaDbManagerTrait {
         }
 
         let mut missing_delta_dbs = vec![];
-        for (snapshot_epoch_id, _) in snapshot_info_map {
-            if !delta_mpts.contains_key(snapshot_epoch_id) {
-                missing_delta_dbs.push(snapshot_epoch_id.clone())
+        for (snapshot_epoch_id, snapshot_info) in snapshot_info_map {
+            // Skip if the snapshot doesn't exist.
+            if snapshot_info.snapshot_info_kept_to_provide_sync
+                == SnapshotKeptToProvideSyncStatus::No
+            {
+                if !delta_mpts.contains_key(snapshot_epoch_id) {
+                    missing_delta_dbs.push(snapshot_epoch_id.clone())
+                }
             }
         }
 
@@ -105,7 +110,9 @@ pub trait DeltaDbManagerTrait {
 
 use crate::{
     impls::errors::*,
-    storage_db::{key_value_db::*, SnapshotInfo},
+    storage_db::{
+        key_value_db::*, SnapshotInfo, SnapshotKeptToProvideSyncStatus,
+    },
 };
 use malloc_size_of::MallocSizeOf;
 use primitives::EpochId;


### PR DESCRIPTION
This PR probably fixed a rare crash case.

- Improve load_persistent_state logics;
- Not removing delta mpt for missing snapshot, if the corresponding snapshot_info is kept only for sync purpose;
- Try not to overwrite delta mpt with None when register a new snapshot in recovery;
- Persist one more snapshot to prevent missing delta mpt just to be more safe. This is not a must.
- Change non_pivot_snapshots_to_remove back to HashSet because duplication may happen.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1916)
<!-- Reviewable:end -->
