### PR TITLE
Set default gas price of cfx_call to 1 .

### DIFF
--- a/client/src/rpc/types/call_request.rs
+++ b/client/src/rpc/types/call_request.rs
@@ -73,7 +73,7 @@ pub fn sign_call(
         nonce: request.nonce.unwrap_or_default(),
         action: request.to.map_or(Action::Create, Action::Call),
         gas,
-        gas_price: request.gas_price.unwrap_or_default(),
+        gas_price: request.gas_price.unwrap_or(1.into()),
         value: request.value.unwrap_or_default(),
         storage_limit: request
             .storage_limit


### PR DESCRIPTION
Because we do not allow zero-gas-price tx.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1925)
<!-- Reviewable:end -->
