### PR TITLE
Fix an out-of-date assert.

### DIFF
--- a/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
+++ b/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
@@ -1641,13 +1641,13 @@ impl ConsensusNewBlockHandler {
             {
                 let mut state_availability_boundary =
                     inner.data_man.state_availability_boundary.write();
-                assert!(
-                    capped_fork_at > state_availability_boundary.lower_bound,
-                    "forked_at {} should > boundary_lower_bound, boundary {:?}",
-                    capped_fork_at,
-                    state_availability_boundary
-                );
                 if pivot_changed {
+                    assert!(
+                        capped_fork_at > state_availability_boundary.lower_bound,
+                        "forked_at {} should > boundary_lower_bound, boundary {:?}",
+                        capped_fork_at,
+                        state_availability_boundary
+                    );
                     if extend_pivot {
                         state_availability_boundary
                             .pivot_chain


### PR DESCRIPTION
For the case where the pivot_chain is not switched and we receive a block before the confirmed height, this assertion does not hold.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1927)
<!-- Reviewable:end -->
