### PR TITLE
apply CIP-26

### DIFF
--- a/changelogs/CHANGELOG-1.0.x.md
+++ b/changelogs/CHANGELOG-1.0.x.md
@@ -19,7 +19,8 @@ Use `mining_type` to allow start CPU mining or disable mining manually.
 - CIP-10 Base mining reward finalization.
 - CIP-12 Allow non-zero collateral contract to be killed.
 - CIP-13 Use Big-Endian MPT Keys.
-- CIP-16 Collect suicide logic at the end of transaction processing
+- CIP-16 Collect suicide logic at the end of transaction processing.
+- CIP-26 Use timestamp from pivot block as TIMESTAMP (opcode 42).
 - CIP-27 Remove sponsor whitelist keys at contract deletion.
 - Set snapshot epoch count to 2000.
 - Update code collateral calculation to a more reasonable method.

--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -1120,7 +1120,7 @@ impl ConsensusExecutionHandler {
             let mut env = Env {
                 number: block_number,
                 author: block.block_header.author().clone(),
-                timestamp: pivot_block.timestamp(),
+                timestamp: pivot_block.block_header.timestamp(),
                 difficulty: block.block_header.difficulty().clone(),
                 accumulated_gas_used: U256::zero(),
                 last_hash: last_block_hash,

--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -1120,7 +1120,7 @@ impl ConsensusExecutionHandler {
             let mut env = Env {
                 number: block_number,
                 author: block.block_header.author().clone(),
-                timestamp: block.block_header.timestamp(),
+                timestamp: pivot_block.timestamp(),
                 difficulty: block.block_header.difficulty().clone(),
                 accumulated_gas_used: U256::zero(),
                 last_hash: last_block_hash,


### PR DESCRIPTION
This PR applied https://github.com/Conflux-Chain/CIPs/pull/26: Use timestamp from pivot block as TIMESTAMP (opcode 42)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1929)
<!-- Reviewable:end -->
