### PR TITLE
Add periodic heartbeats to the light protocol

### DIFF
--- a/core/parameters/src/lib.rs
+++ b/core/parameters/src/lib.rs
@@ -274,6 +274,9 @@ pub mod light {
         /// Frequency of checking request timeouts.
         pub static ref CLEANUP_PERIOD: Duration = Duration::from_secs(1);
 
+        /// Frequency of sending StatusPing message to peers.
+        pub static ref HEARTBEAT_PERIOD: Duration = Duration::from_secs(30);
+
         /// Request timeouts.
         pub static ref EPOCH_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
         pub static ref HEADER_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);

--- a/core/src/light_protocol/handler/mod.rs
+++ b/core/src/light_protocol/handler/mod.rs
@@ -59,6 +59,7 @@ const SYNC_TIMER: TimerToken = 0;
 const REQUEST_CLEANUP_TIMER: TimerToken = 1;
 const LOG_STATISTICS_TIMER: TimerToken = 2;
 const HEARTBEAT_TIMER: TimerToken = 3;
+const TOTAL_WEIGHT_IN_PAST_TIMER: TimerToken = 4;
 
 /// Handler is responsible for maintaining peer meta-information and
 /// dispatching messages to the query and sync sub-handlers.
@@ -931,6 +932,9 @@ impl NetworkProtocolHandler for Handler {
 
         io.register_timer(HEARTBEAT_TIMER, *HEARTBEAT_PERIOD)
             .expect("Error registering heartbeat timer");
+
+        io.register_timer(TOTAL_WEIGHT_IN_PAST_TIMER, Duration::from_secs(20))
+            .expect("Error registering total weight in past timer");
     }
 
     fn on_message(&self, io: &dyn NetworkContext, peer: &NodeId, raw: &[u8]) {
@@ -1016,6 +1020,9 @@ impl NetworkProtocolHandler for Handler {
             }
             HEARTBEAT_TIMER => {
                 self.send_heartbeat(io);
+            }
+            TOTAL_WEIGHT_IN_PAST_TIMER => {
+                self.consensus.update_total_weight_delta_heartbeat();
             }
             // TODO(thegaram): add other timers (e.g. data_man gc)
             _ => warn!("Unknown timer {} triggered.", timer),

--- a/core/src/light_protocol/handler/mod.rs
+++ b/core/src/light_protocol/handler/mod.rs
@@ -436,12 +436,32 @@ impl Handler {
 
     #[inline]
     fn print_stats(&self) {
-        info!(
-            "Catch-up mode: {}, latest epoch: {}, latest verified: {}",
-            self.catch_up_mode(),
-            self.consensus.best_epoch_number(),
-            self.witnesses.latest_verified()
-        );
+        match self.catch_up_mode() {
+            true => {
+                let latest_epoch = self.consensus.best_epoch_number();
+                let best_peer_epoch = self.epochs.best_peer_epoch();
+
+                let progress = if best_peer_epoch == 0 {
+                    0.0
+                } else {
+                    100.0 * (latest_epoch as f64) / (best_peer_epoch as f64)
+                };
+
+                info!(
+                    "Catch-up mode: true, latest epoch: {} / {} ({:.2}%), latest verified: {}, inserted header count: {}",
+                    latest_epoch,
+                    best_peer_epoch,
+                    progress,
+                    self.witnesses.latest_verified(),
+                    self.headers.inserted_count.load(Ordering::Relaxed),
+                )
+            }
+            false => info!(
+                "Catch-up mode: false, latest epoch: {}, latest verified: {}",
+                self.consensus.best_epoch_number(),
+                self.witnesses.latest_verified(),
+            ),
+        }
     }
 
     #[inline]

--- a/core/src/light_protocol/handler/sync/epochs.rs
+++ b/core/src/light_protocol/handler/sync/epochs.rs
@@ -36,6 +36,8 @@ struct Statistics {
     received: u64,
     unexpected: u64,
     timeout: u64,
+    latest_requested: u64,
+    peer_best: u64,
 }
 
 #[derive(Debug)]
@@ -153,6 +155,8 @@ impl Epochs {
                 received: self.received_count.load(Ordering::Relaxed),
                 unexpected: self.unexpected_count.load(Ordering::Relaxed),
                 timeout: self.timeout_count.load(Ordering::Relaxed),
+                latest_requested: self.latest.load(Ordering::Relaxed),
+                peer_best: self.best_peer_epoch(),
             }
         );
     }

--- a/core/src/light_protocol/handler/sync/epochs.rs
+++ b/core/src/light_protocol/handler/sync/epochs.rs
@@ -139,7 +139,7 @@ impl Epochs {
     }
 
     #[inline]
-    fn best_peer_epoch(&self) -> u64 {
+    pub fn best_peer_epoch(&self) -> u64 {
         self.peers.fold(0, |current_best, state| {
             let best_for_peer = state.read().best_epoch;
             cmp::max(current_best, best_for_peer)

--- a/core/src/light_protocol/handler/sync/headers.rs
+++ b/core/src/light_protocol/handler/sync/headers.rs
@@ -95,7 +95,7 @@ pub struct Headers {
     graph: Arc<SynchronizationGraph>,
 
     // number of headers inserted into the sync graph
-    inserted_count: AtomicU64,
+    pub inserted_count: AtomicU64,
 
     // series of unique request ids
     request_id_allocator: Arc<UniqueId>,

--- a/core/src/light_protocol/provider.rs
+++ b/core/src/light_protocol/provider.rs
@@ -403,7 +403,7 @@ impl Provider {
     fn on_status_v2(
         &self, io: &dyn NetworkContext, peer: &NodeId, status: StatusPingV2,
     ) -> Result<()> {
-        debug!("on_status peer={:?} status={:?}", peer, status);
+        debug!("on_status (v2) peer={:?} status={:?}", peer, status);
         self.throttle(peer, &status)?;
 
         self.validate_peer_type(status.node_type)?;
@@ -427,6 +427,8 @@ impl Provider {
         status: StatusPingDeprecatedV1,
     ) -> Result<()>
     {
+        debug!("on_status (v1) peer={:?} status={:?}", peer, status);
+
         self.on_status_v2(
             io,
             peer,


### PR DESCRIPTION
**Overview**

Before, light nodes only received their peers' status once. This will cause the node to still be lagging behind when it switches from catch-up mode to normal sync mode, as its peers' best epoch might have changed during syncing. In some corner cases this might also lead to a node being stuck.

This PR adds a heartbeat mechanism similar to that used by full nodes. The heartbeat is a simple ping-pong status exchange every 30 seconds, initiated by the light node.

This PR also adds a missing confirmation meter maintenance timer, and some user-friendly logs during catch-up mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1947)
<!-- Reviewable:end -->
