### PR TITLE
Remove changelog review requirement

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -29,6 +29,3 @@ core/src/light_protocol/message/message.rs	@yangzhe1990
 core/src/light_protocol/mod.rs			@yangzhe1990
 core/src/sync/message/message.rs		@yangzhe1990
 core/src/sync/mod.rs			@yangzhe1990
-
-
-changelogs/*.md	@Conflux-Chain/spec-change-review


### PR DESCRIPTION
**Overview**

The compulsory review requirement by the `spec-change-review` for any changelog updates seems to disincentivize people from maintaining the changelog. In the near future, there are no breaking changes expected anyway. If there are any breaking interface changes, the PR author and reviewers can remember to notify the SDK developers. So I think for now, we can remove that requirement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1948)
<!-- Reviewable:end -->
