### PR TITLE
Fix random test failures.

### DIFF
--- a/client/src/tests/blockgen_tests.rs
+++ b/client/src/tests/blockgen_tests.rs
@@ -22,7 +22,11 @@ fn test_mining_10_epochs_inner(
     handle: &ClientComponents<BlockGenerator, ArchiveClientExtraComponents>,
 ) {
     let bgen = handle.blockgen.clone().unwrap();
-    //println!("Pow Config: {:?}", bgen.pow_config());
+    // BlockGenerator does not wait for catching up in test mode, so we wait
+    // here.
+    while handle.other_components.sync.catch_up_mode() {
+        thread::sleep(Duration::from_millis(100));
+    }
     thread::spawn(move || {
         BlockGenerator::start_mining(bgen, 0);
     });

--- a/tests/test_framework/test_framework.py
+++ b/tests/test_framework/test_framework.py
@@ -391,12 +391,12 @@ class ConfluxTestFramework:
     def wait_for_node_exit(self, i, timeout):
         self.nodes[i].process.wait(timeout)
 
-    def maybe_restart_node(self, i, stop_probability, clean_probability):
+    def maybe_restart_node(self, i, stop_probability, clean_probability, wait_time=300):
         if random.random() <= stop_probability:
             self.log.info("stop %s", i)
             clean_data = True if random.random() <= clean_probability else False
             self.stop_node(i, clean=clean_data)
-            self.start_node(i, wait_time=120, phase_to_wait=("NormalSyncPhase"))
+            self.start_node(i, wait_time=wait_time, phase_to_wait=("NormalSyncPhase"))
 
     # Private helper methods. These should not be accessed by the subclass test scripts.
 


### PR DESCRIPTION
Wait for the node to enter the normal case in mining-related unit tests to close #1934.

`p2p_era_test` may need longer to recover a node because we have decreased the `dev_snapshot_epoch_count` to cover more cases, which means we will make snapshots more frequently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1960)
<!-- Reviewable:end -->
