### PR TITLE
Return storage collateral and sponsor info in cfx_getTransactionReceipt

### DIFF
--- a/changelogs/CHANGELOG-1.0.x.md
+++ b/changelogs/CHANGELOG-1.0.x.md
@@ -1,6 +1,13 @@
+# 1.0.3
+
+## Improvements
+
+- Add the following new fields in the return value of `cfx_getTransactionReceipt`: `gasCoveredBySponsor`, `storageCollateralized`, `storageCoveredBySponsor`, `storageReleased`.
+
 # 1.0.2
 
 ## Bug Fixes
+
 - Fix bugs in whitelist removal at contract removal.
 
 # 1.0.1
@@ -15,7 +22,8 @@
 # 1.0.0
 
 ## Improvement
-- Start stratum services automatically if `mining_author` is set. 
+
+- Start stratum services automatically if `mining_author` is set.
 Use `mining_type` to allow start CPU mining or disable mining manually.
 - block info returned by rpc methods `cfx_getBlockByEpochNumber`, `cfx_getBlockByHash`, `cfx_getBlockByHashWithPivotAssumption` add one new field `gasUsed` (backward compatible)
 

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -882,7 +882,7 @@ impl RpcImpl {
             }
             ExecutionOutcome::Finished(executed) => executed,
         };
-        let mut storage_collateralized = 0;
+        let mut storage_collateralized = U64::from(0);
         for storage_change in &executed.storage_collateralized {
             storage_collateralized += storage_change.collaterals;
         }
@@ -915,7 +915,7 @@ impl RpcImpl {
             // 1/4 of the gas limit.
             gas_limit: executed.gas_used * 4 / 3,
             gas_used: executed.gas_used,
-            storage_collateralized: storage_collateralized.into(),
+            storage_collateralized,
         };
         Ok(response)
     }

--- a/client/src/rpc/types/call_request.rs
+++ b/client/src/rpc/types/call_request.rs
@@ -44,7 +44,7 @@ pub struct EstimateGasAndCollateralResponse {
     /// The amount of gas used in the execution.
     pub gas_used: U256,
     /// The number of bytes collateralized in the execution.
-    pub storage_collateralized: U256,
+    pub storage_collateralized: U64,
 }
 
 #[derive(Debug, Default, PartialEq, Deserialize, Serialize)]

--- a/client/src/rpc/types/receipt.rs
+++ b/client/src/rpc/types/receipt.rs
@@ -6,10 +6,28 @@ use crate::rpc::types::Log;
 use cfx_types::{Address, Bloom, H256, U256, U64};
 use cfxcore::{executive::contract_address, vm::CreateContractAddress};
 use primitives::{
-    receipt::Receipt as PrimitiveReceipt, transaction::Action,
+    receipt::{
+        Receipt as PrimitiveReceipt, StorageChange as PrimitiveStorageChange,
+    },
+    transaction::Action,
     SignedTransaction as PrimitiveTransaction, TransactionIndex,
 };
 use serde_derive::Serialize;
+
+#[derive(Debug, Serialize, Clone, Deserialize)]
+pub struct StorageChange {
+    pub address: Address,
+    pub collaterals: U64,
+}
+
+impl From<PrimitiveStorageChange> for StorageChange {
+    fn from(sc: PrimitiveStorageChange) -> StorageChange {
+        StorageChange {
+            address: sc.address,
+            collaterals: sc.collaterals.into(),
+        }
+    }
+}
 
 #[derive(Debug, Serialize, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -20,11 +38,11 @@ pub struct Receipt {
     pub index: U64,
     /// Block hash.
     pub block_hash: H256,
-    /// epoch number where this transaction was in.
+    /// Epoch number where this transaction was in.
     pub epoch_number: Option<U64>,
-    /// address of the sender.
+    /// Address of the sender.
     pub from: Address,
-    /// address of the receiver, null when it's a contract creation
+    /// Address of the receiver, null when it's a contract creation
     /// transaction.
     pub to: Option<Address>,
     /// The gas used in the execution of the transaction.
@@ -37,7 +55,7 @@ pub struct Receipt {
     pub logs: Vec<Log>,
     /// Bloom filter for light clients to quickly retrieve related logs.
     pub logs_bloom: Bloom,
-    /// state root.
+    /// State root.
     pub state_root: H256,
     /// Transaction outcome.
     pub outcome_status: U64,
@@ -45,6 +63,14 @@ pub struct Receipt {
     /// is None if tx execution is successful or it can not be offered.
     /// Error message can not be offered by light client.
     pub tx_exec_error_msg: Option<String>,
+    // Whether gas costs were covered by the sponsor.
+    pub gas_covered_by_sponsor: bool,
+    // Whether storage costs were covered by the sponsor.
+    pub storage_covered_by_sponsor: bool,
+    // The amount of storage collateralized by the sender.
+    pub storage_collateralized: U64,
+    // Storage collaterals released during the execution of the transaction.
+    pub storage_released: Vec<StorageChange>,
 }
 
 impl Receipt {
@@ -55,8 +81,21 @@ impl Receipt {
         maybe_state_root: Option<H256>, tx_exec_error_msg: Option<String>,
     ) -> Receipt
     {
+        let PrimitiveReceipt {
+            accumulated_gas_used,
+            gas_fee,
+            gas_sponsor_paid,
+            log_bloom,
+            logs,
+            outcome_status,
+            storage_collateralized,
+            storage_released,
+            storage_sponsor_paid,
+            ..
+        } = receipt;
+
         let mut address = None;
-        if Action::Create == transaction.action && receipt.outcome_status == 0 {
+        if Action::Create == transaction.action && outcome_status == 0 {
             let (created_address, _) = contract_address(
                 CreateContractAddress::FromSenderNonceAndCodeHash,
                 block_number.into(),
@@ -66,25 +105,41 @@ impl Receipt {
             );
             address = Some(created_address);
         }
+
+        // this is an array, but it will only have at most one element:
+        // the storage collateral of the sender address.
+        let storage_collateralized = storage_collateralized
+            .get(0)
+            .map(|sc| sc.collaterals)
+            .map(Into::into)
+            .unwrap_or_default();
+
+        let storage_released =
+            storage_released.into_iter().map(Into::into).collect();
+
         Receipt {
             transaction_hash: transaction.hash.into(),
             index: U64::from(transaction_index.index),
             block_hash: transaction_index.block_hash.into(),
-            gas_used: (receipt.accumulated_gas_used - prior_gas_used).into(),
-            gas_fee: receipt.gas_fee.into(),
+            gas_used: (accumulated_gas_used - prior_gas_used).into(),
+            gas_fee: gas_fee.into(),
             from: transaction.sender,
             to: match &transaction.action {
                 Action::Create => None,
                 Action::Call(address) => Some(address.clone()),
             },
-            outcome_status: U64::from(receipt.outcome_status),
+            outcome_status: U64::from(outcome_status),
             contract_created: address,
-            logs: receipt.logs.into_iter().map(Log::from).collect(),
-            logs_bloom: receipt.log_bloom,
+            logs: logs.into_iter().map(Log::from).collect(),
+            logs_bloom: log_bloom,
             state_root: maybe_state_root
                 .map_or_else(Default::default, Into::into),
             epoch_number: epoch_number.map(U64::from),
             tx_exec_error_msg,
+            gas_covered_by_sponsor: gas_sponsor_paid,
+            storage_covered_by_sponsor: storage_sponsor_paid,
+            storage_collateralized,
+            storage_released,
         }
     }
 }

--- a/client/src/rpc/types/receipt.rs
+++ b/client/src/rpc/types/receipt.rs
@@ -6,28 +6,11 @@ use crate::rpc::types::Log;
 use cfx_types::{Address, Bloom, H256, U256, U64};
 use cfxcore::{executive::contract_address, vm::CreateContractAddress};
 use primitives::{
-    receipt::{
-        Receipt as PrimitiveReceipt, StorageChange as PrimitiveStorageChange,
-    },
+    receipt::{Receipt as PrimitiveReceipt, StorageChange},
     transaction::Action,
     SignedTransaction as PrimitiveTransaction, TransactionIndex,
 };
 use serde_derive::Serialize;
-
-#[derive(Debug, Serialize, Clone, Deserialize)]
-pub struct StorageChange {
-    pub address: Address,
-    pub collaterals: U64,
-}
-
-impl From<PrimitiveStorageChange> for StorageChange {
-    fn from(sc: PrimitiveStorageChange) -> StorageChange {
-        StorageChange {
-            address: sc.address,
-            collaterals: sc.collaterals.into(),
-        }
-    }
-}
 
 #[derive(Debug, Serialize, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -113,9 +96,6 @@ impl Receipt {
             .map(|sc| sc.collaterals)
             .map(Into::into)
             .unwrap_or_default();
-
-        let storage_released =
-            storage_released.into_iter().map(Into::into).collect();
 
         Receipt {
             transaction_hash: transaction.hash.into(),

--- a/core/src/executive/executive.rs
+++ b/core/src/executive/executive.rs
@@ -1706,12 +1706,12 @@ impl<'a> Executive<'a> {
                         if inc > 0 {
                             storage_collateralized.push(StorageChange {
                                 address: *address,
-                                collaterals: inc,
+                                collaterals: inc.into(),
                             });
                         } else if sub > 0 {
                             storage_released.push(StorageChange {
                                 address: *address,
-                                collaterals: sub,
+                                collaterals: sub.into(),
                             });
                         }
                     }

--- a/core/src/executive/executive_tests.rs
+++ b/core/src/executive/executive_tests.rs
@@ -1621,7 +1621,7 @@ fn test_storage_commission_privilege() {
     assert_eq!(storage_collateralized[0].address, sender.address());
     assert_eq!(
         storage_collateralized[0].collaterals,
-        COLLATERAL_UNITS_PER_STORAGE_KEY
+        COLLATERAL_UNITS_PER_STORAGE_KEY.into()
     );
     assert_eq!(storage_released.len(), 0);
 
@@ -1766,13 +1766,13 @@ fn test_storage_commission_privilege() {
     assert_eq!(storage_collateralized[0].address, caller3.address());
     assert_eq!(
         storage_collateralized[0].collaterals,
-        COLLATERAL_UNITS_PER_STORAGE_KEY
+        COLLATERAL_UNITS_PER_STORAGE_KEY.into()
     );
     assert_eq!(storage_released.len(), 1);
     assert_eq!(storage_released[0].address, sender.address());
     assert_eq!(
         storage_released[0].collaterals,
-        COLLATERAL_UNITS_PER_STORAGE_KEY
+        COLLATERAL_UNITS_PER_STORAGE_KEY.into()
     );
     assert_eq!(gas_used, U256::from(26_017));
     assert_eq!(
@@ -1847,13 +1847,13 @@ fn test_storage_commission_privilege() {
     assert_eq!(storage_collateralized[0].address, address);
     assert_eq!(
         storage_collateralized[0].collaterals,
-        COLLATERAL_UNITS_PER_STORAGE_KEY
+        COLLATERAL_UNITS_PER_STORAGE_KEY.into()
     );
     assert_eq!(storage_released.len(), 1);
     assert_eq!(storage_released[0].address, caller3.address());
     assert_eq!(
         storage_released[0].collaterals,
-        COLLATERAL_UNITS_PER_STORAGE_KEY
+        COLLATERAL_UNITS_PER_STORAGE_KEY.into()
     );
     assert_eq!(gas_used, U256::from(26_017));
     assert_eq!(
@@ -1946,13 +1946,13 @@ fn test_storage_commission_privilege() {
     assert_eq!(storage_collateralized[0].address, caller2.address());
     assert_eq!(
         storage_collateralized[0].collaterals,
-        COLLATERAL_UNITS_PER_STORAGE_KEY
+        COLLATERAL_UNITS_PER_STORAGE_KEY.into()
     );
     assert_eq!(storage_released.len(), 1);
     assert_eq!(storage_released[0].address, address);
     assert_eq!(
         storage_released[0].collaterals,
-        COLLATERAL_UNITS_PER_STORAGE_KEY
+        COLLATERAL_UNITS_PER_STORAGE_KEY.into()
     );
     assert_eq!(gas_used, U256::from(26_017));
     assert_eq!(
@@ -2078,13 +2078,13 @@ fn test_storage_commission_privilege() {
     assert_eq!(storage_collateralized[0].address, caller1.address());
     assert_eq!(
         storage_collateralized[0].collaterals,
-        COLLATERAL_UNITS_PER_STORAGE_KEY
+        COLLATERAL_UNITS_PER_STORAGE_KEY.into()
     );
     assert_eq!(storage_released.len(), 1);
     assert_eq!(storage_released[0].address, caller2.address());
     assert_eq!(
         storage_released[0].collaterals,
-        COLLATERAL_UNITS_PER_STORAGE_KEY
+        COLLATERAL_UNITS_PER_STORAGE_KEY.into()
     );
     assert_eq!(gas_used, U256::from(26_017));
     assert_eq!(

--- a/primitives/src/receipt.rs
+++ b/primitives/src/receipt.rs
@@ -3,20 +3,30 @@
 // See http://www.gnu.org/licenses/
 
 use crate::log_entry::LogEntry;
-use cfx_types::{Address, Bloom, U256};
+use cfx_types::{Address, Bloom, U256, U64};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use rlp_derive::{RlpDecodable, RlpEncodable};
+use serde_derive::{Deserialize, Serialize};
 
 pub const TRANSACTION_OUTCOME_SUCCESS: u8 = 0;
 pub const TRANSACTION_OUTCOME_EXCEPTION_WITH_NONCE_BUMPING: u8 = 1; // gas fee charged
 pub const TRANSACTION_OUTCOME_EXCEPTION_WITHOUT_NONCE_BUMPING: u8 = 2; // no gas fee charged
 
-#[derive(Debug, Clone, PartialEq, Eq, RlpDecodable, RlpEncodable)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    RlpDecodable,
+    RlpEncodable,
+    Serialize,
+    Deserialize,
+)]
 pub struct StorageChange {
     pub address: Address,
     /// Number of storage collateral units to deposit / refund (absolute
     /// value).
-    pub collaterals: u64,
+    pub collaterals: U64,
 }
 
 /// Information describing execution of a transaction.

--- a/tests/rpc/test_tx_receipt_by_hash.py
+++ b/tests/rpc/test_tx_receipt_by_hash.py
@@ -1,0 +1,69 @@
+import eth_utils
+import sys, os
+sys.path.append("..")
+
+from conflux.rpc import RpcClient
+from conflux.utils import sha3 as keccak
+from test_framework.blocktools import encode_hex_0x
+from test_framework.util import assert_equal, assert_ne
+
+CONTRACT_PATH = "../contracts/simple_storage.dat"
+
+class TestGetTxReceiptByHash(RpcClient):
+    def test_simple_receipt(self):
+        to = self.rand_addr()
+        tx = self.new_tx(receiver=to)
+
+        tx_hash = self.send_tx(tx, wait_for_receipt=True)
+        tx2 = self.get_tx(tx_hash)
+
+        receipt = self.get_transaction_receipt(tx_hash)
+        assert_ne(receipt, None)
+
+        assert_equal(receipt['blockHash'], tx2['blockHash'])
+        assert_equal(receipt['contractCreated'], tx2['contractCreated'])
+        assert_equal(receipt['from'], tx2['from'])
+        assert_equal(receipt['index'], tx2['transactionIndex'])
+        assert_equal(receipt['to'], tx2['to'])
+        assert_equal(receipt['transactionHash'], tx_hash)
+
+        assert_equal(receipt['gasCoveredBySponsor'], False)
+        assert_equal(receipt['logs'], [])
+        assert_equal(receipt['outcomeStatus'], '0x0')
+        assert_equal(receipt['storageCollateralized'], '0x0')
+        assert_equal(receipt['storageCoveredBySponsor'], False)
+        assert_equal(receipt['storageReleased'], [])
+        assert_equal(receipt['txExecErrorMsg'], None)
+
+    def test_receipt_with_storage_changes(self):
+        bytecode_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), CONTRACT_PATH)
+        assert (os.path.isfile(bytecode_file))
+        bytecode = open(bytecode_file).read()
+
+        # deploy contract
+        tx = self.new_contract_tx(receiver="", data_hex=bytecode, storage_limit=20000)
+        assert_equal(self.send_tx(tx, True), tx.hash_hex())
+        receipt = self.get_transaction_receipt(tx.hash_hex())
+        assert_equal(receipt['outcomeStatus'], '0x0')
+        contract = receipt['contractCreated']
+
+        assert_equal(receipt['storageCollateralized'], '0x280')
+        assert_equal(receipt['storageReleased'], [])
+
+        # call increment()
+        data_hex = encode_hex_0x(keccak(b"increment()"))
+        tx = self.new_contract_tx(receiver=contract, data_hex=data_hex, storage_limit=20000)
+        assert_equal(self.send_tx(tx, True), tx.hash_hex())
+        receipt = self.get_transaction_receipt(tx.hash_hex())
+
+        assert_equal(receipt['storageCollateralized'], '0x0')
+        assert_equal(receipt['storageReleased'], [])
+
+        # call destroy()
+        data_hex = encode_hex_0x(keccak(b"destroy()"))
+        tx = self.new_contract_tx(receiver=contract, data_hex=data_hex, storage_limit=20000)
+        assert_equal(self.send_tx(tx, True), tx.hash_hex())
+        receipt = self.get_transaction_receipt(tx.hash_hex())
+
+        assert_equal(receipt['storageCollateralized'], '0x0')
+        assert_equal(receipt['storageReleased'], [{ 'address': self.GENESIS_ADDR, 'collaterals': '0x280' }])

--- a/tests/sponsored_tx_test.py
+++ b/tests/sponsored_tx_test.py
@@ -157,7 +157,7 @@ class SponsoredTxTest(ConfluxTestFramework):
         # set privilege for addr1
         b0 = client.get_balance(genesis_addr)
         c0 = client.get_collateral_for_storage(genesis_addr)
-        self.call_contract_function(
+        transaction = self.call_contract_function(
             contract=test_contract,
             name="add",
             args=[Web3.toChecksumAddress(addr1)],
@@ -168,11 +168,12 @@ class SponsoredTxTest(ConfluxTestFramework):
             storage_limit=64)
         assert_equal(client.get_balance(genesis_addr), b0 - charged_of_huge_gas(gas) - collateral_per_storage_key)
         assert_equal(client.get_collateral_for_storage(genesis_addr), c0 + collateral_per_storage_key)
+        assert_equal(self.wait_for_tx([transaction], True)[0]['gasCoveredBySponsor'], False)
 
         # addr1 call contract with privilege without enough cfx for gas fee
         sb = client.get_sponsor_balance_for_gas(contract_addr)
         b1 = client.get_balance(addr1)
-        self.call_contract_function(
+        transaction = self.call_contract_function(
             contract=test_contract,
             name="foo",
             args=[],
@@ -182,6 +183,7 @@ class SponsoredTxTest(ConfluxTestFramework):
             check_status=True)
         assert_equal(client.get_balance(addr1), 10 ** 6)
         assert_equal(client.get_sponsor_balance_for_gas(contract_addr), sb - charged_of_huge_gas(gas))
+        assert_equal(self.wait_for_tx([transaction], True)[0]['gasCoveredBySponsor'], True)
 
         self.log.info("Pass")
 


### PR DESCRIPTION
New fields returned by `cfx_getTransactionReceipt`:

- `gasCoveredBySponsor`: `Boolean`, true if this transaction's gas fee was covered by the sponsor.
- `storageCollateralized`: `QUANTITY`, the amount of storage collateral this transaction required.
- `storageCoveredBySponsor`: `Boolean`, true if this transaction's storage collateral was covered by the sponsor.
- `storageReleased`: `Array`, array of storage change objects, each specifying an address and the corresponding amount of storage collateral released, e.g., `[{ 'address': '0x0000000000000000000000000000000000000001', 'collaterals': '0x280' }]`

Closes #1958.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1967)
<!-- Reviewable:end -->
