### PR TITLE
Add checked storage key deserialization

### DIFF
--- a/core/src/light_protocol/common/ledger_info.rs
+++ b/core/src/light_protocol/common/ledger_info.rs
@@ -16,7 +16,7 @@ use cfx_storage::{
 };
 use cfx_types::{Address, Bloom, H256};
 use primitives::{
-    Block, BlockHeader, BlockHeaderBuilder, BlockReceipts, Checked,
+    Block, BlockHeader, BlockHeaderBuilder, BlockReceipts, CheckInput,
     EpochNumber, StorageKey, StorageRoot,
 };
 
@@ -211,7 +211,7 @@ impl LedgerInfo {
     ) -> Result<(Option<Vec<u8>>, StateProof), Error> {
         let state = self.state_of(epoch)?;
 
-        let key = StorageKey::from_key_bytes::<Checked>(&key)?;
+        let key = StorageKey::from_key_bytes::<CheckInput>(&key)?;
 
         let (value, proof) =
             StateDb::new(state).get_original_raw_with_proof(key)?;

--- a/core/src/light_protocol/common/ledger_info.rs
+++ b/core/src/light_protocol/common/ledger_info.rs
@@ -16,8 +16,8 @@ use cfx_storage::{
 };
 use cfx_types::{Address, Bloom, H256};
 use primitives::{
-    Block, BlockHeader, BlockHeaderBuilder, BlockReceipts, EpochNumber,
-    StorageKey, StorageRoot,
+    Block, BlockHeader, BlockHeaderBuilder, BlockReceipts, Checked,
+    EpochNumber, StorageKey, StorageRoot,
 };
 
 pub struct LedgerInfo {
@@ -211,8 +211,10 @@ impl LedgerInfo {
     ) -> Result<(Option<Vec<u8>>, StateProof), Error> {
         let state = self.state_of(epoch)?;
 
-        let (value, proof) = StateDb::new(state)
-            .get_original_raw_with_proof(StorageKey::from_key_bytes(&key))?;
+        let key = StorageKey::from_key_bytes::<Checked>(&key)?;
+
+        let (value, proof) =
+            StateDb::new(state).get_original_raw_with_proof(key)?;
 
         let value = value.map(|x| x.to_vec());
         Ok((value, proof))

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -32,8 +32,8 @@ use parking_lot::{
 #[cfg(test)]
 use primitives::storage::STORAGE_LAYOUT_REGULAR_V0;
 use primitives::{
-    Account, DepositList, EpochId, SponsorInfo, StorageKey, StorageLayout,
-    StorageValue, VoteStakeList,
+    Account, DepositList, EpochId, NotChecked, SponsorInfo, StorageKey,
+    StorageLayout, StorageValue, VoteStakeList,
 };
 use std::{
     collections::{hash_map::Entry, HashMap, HashSet},
@@ -1174,7 +1174,7 @@ impl<StateDbStorage: StorageStateTrait> StateGeneric<StateDbStorage> {
         )?;
         for (key, value) in &key_values {
             if let StorageKey::StorageKey { storage_key, .. } =
-                StorageKey::from_key_bytes(&key[..])
+                StorageKey::from_key_bytes::<NotChecked>(&key[..])
             {
                 let storage_value =
                     rlp::decode::<StorageValue>(value.as_ref())?;
@@ -1247,7 +1247,7 @@ impl<StateDbStorage: StorageStateTrait> StateGeneric<StateDbStorage> {
         )?;
         for (key, value) in &storage_key_value {
             if let StorageKey::StorageKey { storage_key, .. } =
-                StorageKey::from_key_bytes(&key[..])
+                StorageKey::from_key_bytes::<NotChecked>(&key[..])
             {
                 // Check if the key has been touched. We use the local
                 // information to find out if collateral refund is necessary

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -32,7 +32,7 @@ use parking_lot::{
 #[cfg(test)]
 use primitives::storage::STORAGE_LAYOUT_REGULAR_V0;
 use primitives::{
-    Account, DepositList, EpochId, NotChecked, SponsorInfo, StorageKey,
+    Account, DepositList, EpochId, SkipInputCheck, SponsorInfo, StorageKey,
     StorageLayout, StorageValue, VoteStakeList,
 };
 use std::{
@@ -1174,7 +1174,7 @@ impl<StateDbStorage: StorageStateTrait> StateGeneric<StateDbStorage> {
         )?;
         for (key, value) in &key_values {
             if let StorageKey::StorageKey { storage_key, .. } =
-                StorageKey::from_key_bytes::<NotChecked>(&key[..])
+                StorageKey::from_key_bytes::<SkipInputCheck>(&key[..])
             {
                 let storage_value =
                     rlp::decode::<StorageValue>(value.as_ref())?;
@@ -1247,7 +1247,7 @@ impl<StateDbStorage: StorageStateTrait> StateGeneric<StateDbStorage> {
         )?;
         for (key, value) in &storage_key_value {
             if let StorageKey::StorageKey { storage_key, .. } =
-                StorageKey::from_key_bytes::<NotChecked>(&key[..])
+                StorageKey::from_key_bytes::<SkipInputCheck>(&key[..])
             {
                 // Check if the key has been touched. We use the local
                 // information to find out if collateral refund is necessary

--- a/core/statedb/src/lib.rs
+++ b/core/statedb/src/lib.rs
@@ -383,7 +383,8 @@ mod impls {
             // First of all, apply all changes to the underlying storage.
             for (k, v) in accessed_entries {
                 if v.is_modified() {
-                    let storage_key = StorageKey::from_key_bytes(k);
+                    let storage_key =
+                        StorageKey::from_key_bytes::<NotChecked>(k);
                     match &v.current_value {
                         Some(v) => {
                             self.storage.set(storage_key, (&**v).into())?;
@@ -631,7 +632,9 @@ mod impls {
     use cfx_types::{address_util::AddressUtil, Address};
     use hashbrown::HashMap;
     use parking_lot::RwLock;
-    use primitives::{EpochId, StorageKey, StorageLayout, StorageRoot};
+    use primitives::{
+        EpochId, NotChecked, StorageKey, StorageLayout, StorageRoot,
+    };
     use std::{
         collections::{btree_map::Entry::Occupied, BTreeMap},
         ops::Bound::{Excluded, Included, Unbounded},

--- a/core/statedb/src/lib.rs
+++ b/core/statedb/src/lib.rs
@@ -384,7 +384,7 @@ mod impls {
             for (k, v) in accessed_entries {
                 if v.is_modified() {
                     let storage_key =
-                        StorageKey::from_key_bytes::<NotChecked>(k);
+                        StorageKey::from_key_bytes::<SkipInputCheck>(k);
                     match &v.current_value {
                         Some(v) => {
                             self.storage.set(storage_key, (&**v).into())?;
@@ -633,7 +633,7 @@ mod impls {
     use hashbrown::HashMap;
     use parking_lot::RwLock;
     use primitives::{
-        EpochId, NotChecked, StorageKey, StorageLayout, StorageRoot,
+        EpochId, SkipInputCheck, StorageKey, StorageLayout, StorageRoot,
     };
     use std::{
         collections::{btree_map::Entry::Occupied, BTreeMap},

--- a/core/statedb/src/tests.rs
+++ b/core/statedb/src/tests.rs
@@ -5,11 +5,12 @@
 use super::StateDbGeneric;
 use cfx_internal_common::StateRootWithAuxInfo;
 use cfx_storage::{
-    utils::{access_mode, StaticBool},
-    ErrorKind, MptKeyValue, NodeMerkleProof, Result, StateProof,
-    StorageStateTrait,
+    utils::access_mode, ErrorKind, MptKeyValue, NodeMerkleProof, Result,
+    StateProof, StorageStateTrait,
 };
-use primitives::{EpochId, NodeMerkleTriplet, StorageKey, MERKLE_NULL_NODE};
+use primitives::{
+    EpochId, NodeMerkleTriplet, StaticBool, StorageKey, MERKLE_NULL_NODE,
+};
 use std::{cell::RefCell, collections::HashMap};
 
 type StorageValue = Box<[u8]>;

--- a/core/storage/src/impls/node_merkle_proof.rs
+++ b/core/storage/src/impls/node_merkle_proof.rs
@@ -43,7 +43,13 @@ impl NodeMerkleProof {
         let intermediate_root = &state_root.intermediate_delta_root;
         let snapshot_root = &state_root.snapshot_root;
 
-        let storage_key = StorageKey::from_key_bytes(&key);
+        let storage_key = match StorageKey::from_key_bytes::<Checked>(&key) {
+            Ok(k) => k,
+            Err(e) => {
+                warn!("Checking proof with invalid key: {:?}", e);
+                return false;
+            }
+        };
 
         match self.delta_proof {
             None => {
@@ -140,7 +146,7 @@ impl NodeMerkleProof {
 
 use super::merkle_patricia_trie::TrieProof;
 use primitives::{
-    DeltaMptKeyPadding, MptValue, StateRoot, StorageKey, StorageRoot,
+    Checked, DeltaMptKeyPadding, MptValue, StateRoot, StorageKey, StorageRoot,
     MERKLE_NULL_NODE,
 };
 use rlp_derive::{RlpDecodable, RlpEncodable};

--- a/core/storage/src/impls/node_merkle_proof.rs
+++ b/core/storage/src/impls/node_merkle_proof.rs
@@ -43,7 +43,7 @@ impl NodeMerkleProof {
         let intermediate_root = &state_root.intermediate_delta_root;
         let snapshot_root = &state_root.snapshot_root;
 
-        let storage_key = match StorageKey::from_key_bytes::<Checked>(&key) {
+        let storage_key = match StorageKey::from_key_bytes::<CheckInput>(&key) {
             Ok(k) => k,
             Err(e) => {
                 warn!("Checking proof with invalid key: {:?}", e);
@@ -146,7 +146,7 @@ impl NodeMerkleProof {
 
 use super::merkle_patricia_trie::TrieProof;
 use primitives::{
-    Checked, DeltaMptKeyPadding, MptValue, StateRoot, StorageKey, StorageRoot,
-    MERKLE_NULL_NODE,
+    CheckInput, DeltaMptKeyPadding, MptValue, StateRoot, StorageKey,
+    StorageRoot, MERKLE_NULL_NODE,
 };
 use rlp_derive::{RlpDecodable, RlpEncodable};

--- a/core/storage/src/impls/state.rs
+++ b/core/storage/src/impls/state.rs
@@ -554,7 +554,7 @@ impl StateTrait for State {
         // No need to check v.len() because there are no tombStone values in
         // snapshot.
         for (k, v) in snapshot_kvs {
-            let storage_key = StorageKey::from_key_bytes(&k);
+            let storage_key = StorageKey::from_key_bytes::<NotChecked>(&k);
             if !AM::is_read_only() {
                 self.delete(storage_key)?;
             }
@@ -901,13 +901,14 @@ use crate::{
     },
     state::*,
     storage_db::*,
-    utils::{access_mode, to_key_prefix_iter_upper_bound, StaticBool},
+    utils::{access_mode, to_key_prefix_iter_upper_bound},
 };
 use cfx_internal_common::{StateRootAuxInfo, StateRootWithAuxInfo};
 use fallible_iterator::FallibleIterator;
 use primitives::{
     DeltaMptKeyPadding, EpochId, MerkleHash, MptValue, NodeMerkleTriplet,
-    StateRoot, StorageKey, MERKLE_NULL_NODE, NULL_EPOCH,
+    NotChecked, StateRoot, StaticBool, StorageKey, MERKLE_NULL_NODE,
+    NULL_EPOCH,
 };
 use rustc_hex::ToHex;
 use std::{

--- a/core/storage/src/impls/state.rs
+++ b/core/storage/src/impls/state.rs
@@ -554,7 +554,7 @@ impl StateTrait for State {
         // No need to check v.len() because there are no tombStone values in
         // snapshot.
         for (k, v) in snapshot_kvs {
-            let storage_key = StorageKey::from_key_bytes::<NotChecked>(&k);
+            let storage_key = StorageKey::from_key_bytes::<SkipInputCheck>(&k);
             if !AM::is_read_only() {
                 self.delete(storage_key)?;
             }
@@ -907,7 +907,7 @@ use cfx_internal_common::{StateRootAuxInfo, StateRootWithAuxInfo};
 use fallible_iterator::FallibleIterator;
 use primitives::{
     DeltaMptKeyPadding, EpochId, MerkleHash, MptValue, NodeMerkleTriplet,
-    NotChecked, StateRoot, StaticBool, StorageKey, MERKLE_NULL_NODE,
+    SkipInputCheck, StateRoot, StaticBool, StorageKey, MERKLE_NULL_NODE,
     NULL_EPOCH,
 };
 use rustc_hex::ToHex;

--- a/core/storage/src/impls/state_proof.rs
+++ b/core/storage/src/impls/state_proof.rs
@@ -48,7 +48,15 @@ impl StateProof {
 
         let delta_mpt_padding =
             StorageKey::delta_mpt_padding(&snapshot_root, &intermediate_root);
-        let storage_key = StorageKey::from_key_bytes(&key);
+
+        let storage_key = match StorageKey::from_key_bytes::<Checked>(&key) {
+            Ok(k) => k,
+            Err(e) => {
+                warn!("Checking proof with invalid key: {:?}", e);
+                return false;
+            }
+        };
+
         let delta_mpt_key =
             storage_key.to_delta_mpt_key_bytes(&delta_mpt_padding);
         let maybe_intermediate_mpt_key = maybe_intermediate_padding
@@ -123,6 +131,7 @@ impl StateProof {
 
 use crate::impls::merkle_patricia_trie::TrieProof;
 use primitives::{
-    DeltaMptKeyPadding, MptValue, StateRoot, StorageKey, MERKLE_NULL_NODE,
+    Checked, DeltaMptKeyPadding, MptValue, StateRoot, StorageKey,
+    MERKLE_NULL_NODE,
 };
 use rlp_derive::{RlpDecodable, RlpEncodable};

--- a/core/storage/src/impls/state_proof.rs
+++ b/core/storage/src/impls/state_proof.rs
@@ -49,7 +49,7 @@ impl StateProof {
         let delta_mpt_padding =
             StorageKey::delta_mpt_padding(&snapshot_root, &intermediate_root);
 
-        let storage_key = match StorageKey::from_key_bytes::<Checked>(&key) {
+        let storage_key = match StorageKey::from_key_bytes::<CheckInput>(&key) {
             Ok(k) => k,
             Err(e) => {
                 warn!("Checking proof with invalid key: {:?}", e);
@@ -131,7 +131,7 @@ impl StateProof {
 
 use crate::impls::merkle_patricia_trie::TrieProof;
 use primitives::{
-    Checked, DeltaMptKeyPadding, MptValue, StateRoot, StorageKey,
+    CheckInput, DeltaMptKeyPadding, MptValue, StateRoot, StorageKey,
     MERKLE_NULL_NODE,
 };
 use rlp_derive::{RlpDecodable, RlpEncodable};

--- a/core/storage/src/state.rs
+++ b/core/storage/src/state.rs
@@ -11,8 +11,8 @@
 /// state manager. State is supposed to be owned by single user.
 pub use super::impls::state::State;
 
-pub type WithProof = utils::Yes;
-pub type NoProof = utils::No;
+pub type WithProof = primitives::static_bool::Yes;
+pub type NoProof = primitives::static_bool::No;
 
 // The trait is created to separate the implementation to another file, and the
 // concrete struct is put into inner mod, because the implementation is
@@ -47,7 +47,7 @@ pub trait StateTrait {
     /// Compute the merkle of the node under `access_key` in all tries.
     /// Node merkle is computed on the value and children hashes, ignoring the
     /// compressed path.
-    fn get_node_merkle_all_versions<WithProof: utils::StaticBool>(
+    fn get_node_merkle_all_versions<WithProof: StaticBool>(
         &self, access_key: StorageKey,
     ) -> Result<(NodeMerkleTriplet, NodeMerkleProof)>;
 }
@@ -56,7 +56,7 @@ use super::{
     impls::{
         errors::*, node_merkle_proof::NodeMerkleProof, state_proof::StateProof,
     },
-    utils::{self, access_mode},
+    utils::access_mode,
     MptKeyValue, StateRootWithAuxInfo,
 };
-use primitives::{EpochId, NodeMerkleTriplet, StorageKey};
+use primitives::{EpochId, NodeMerkleTriplet, StaticBool, StorageKey};

--- a/core/storage/src/utils/mod.rs
+++ b/core/storage/src/utils/mod.rs
@@ -54,22 +54,6 @@ pub mod access_mode {
     }
 }
 
-// General static bool value for compile time flag optimization.
-pub trait StaticBool {
-    fn value() -> bool;
-}
-
-pub struct No {}
-pub struct Yes {}
-
-impl StaticBool for No {
-    fn value() -> bool { false }
-}
-
-impl StaticBool for Yes {
-    fn value() -> bool { true }
-}
-
 /// The purpose of this trait is to create a new value of a passed object,
 /// when the passed object is the value, simply move the value;
 /// when the passed object is the reference, create the new value by clone.

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -20,15 +20,15 @@ pub mod block;
 pub mod block_header;
 pub mod epoch;
 pub mod filter;
+pub mod is_default;
 pub mod log_entry;
 pub mod receipt;
 pub mod state_root;
+pub mod static_bool;
 pub mod storage;
 pub mod storage_key;
 pub mod transaction;
 pub mod transaction_index;
-
-pub mod is_default;
 
 pub use crate::{
     account::{
@@ -41,6 +41,7 @@ pub use crate::{
     log_entry::LogEntry,
     receipt::{BlockReceipts, Receipt},
     state_root::*,
+    static_bool::StaticBool,
     storage::{
         MptValue, NodeMerkleTriplet, StorageLayout, StorageRoot, StorageValue,
     },

--- a/primitives/src/static_bool.rs
+++ b/primitives/src/static_bool.rs
@@ -1,0 +1,19 @@
+// Copyright 2020 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+// General static bool value for compile time flag optimization.
+pub trait StaticBool {
+    fn value() -> bool;
+}
+
+pub struct No {}
+pub struct Yes {}
+
+impl StaticBool for No {
+    fn value() -> bool { false }
+}
+
+impl StaticBool for Yes {
+    fn value() -> bool { true }
+}

--- a/primitives/src/storage_key.rs
+++ b/primitives/src/storage_key.rs
@@ -247,8 +247,9 @@ impl<'a> StorageKey<'a> {
         }
     }
 
-    // from_key_bytes::<Checked>(...) returns Result<StorageKey, String>
-    // from_key_bytes::<NotChecked>(...) returns StorageKey, crashes on error
+    // from_key_bytes::<CheckInput>(...) returns Result<StorageKey, String>
+    // from_key_bytes::<SkipInputCheck>(...) returns StorageKey, crashes on
+    // error
     pub fn from_key_bytes<ShouldCheckInput: StaticBool>(
         mut bytes: &'a [u8],
     ) -> <FromKeyBytesResult<ShouldCheckInput> as ConditionalReturnValue<'a>>::Output


### PR DESCRIPTION
**Overview**

Add checked version of `StorageKey::from_key_bytes`. With this PR, we have:
- `StorageKey::from_key_bytes::<CheckInput>(...)` which returns `Result<StorageKey>`, and
- `StorageKey::from_key_byes::<SkipInputCheck>(...)` which returns `StorageKey` and panics on error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1980)
<!-- Reviewable:end -->
