### PR TITLE
Use 0 as default for storage limit in `cfx_sendTransaction` and `cfx_signTransaction`

### DIFF
--- a/client/src/rpc/types/transaction.rs
+++ b/client/src/rpc/types/transaction.rs
@@ -153,10 +153,8 @@ impl SendTxRequest {
                 Some(address) => Action::Call(address.into()),
             },
             value: self.value.into(),
-            storage_limit: self
-                .storage_limit
-                .unwrap_or(std::u64::MAX.into())
-                .as_usize() as u64,
+            storage_limit: self.storage_limit.unwrap_or_default().as_usize()
+                as u64,
             epoch_height: self
                 .epoch_height
                 .unwrap_or(best_epoch_height.into())


### PR DESCRIPTION
Zero seems to be a more reasonable default, and it will work well with simple payment transactions. The current default is likely to fail due to insufficient balance.

`cfx_sendTransaction` and `cfx_signTransaction` are undocumented APIs so I would not expect this change to break anything.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1983)
<!-- Reviewable:end -->
