### PR TITLE
Remove wrong asserts when a node is connected to multiple miners.

### DIFF
--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -1110,6 +1110,10 @@ impl SynchronizationProtocolHandler {
         let parent_hash = *block.block_header.parent_hash();
 
         assert!(self.graph.contains_block_header(&parent_hash));
+        if self.graph.contains_block_header(&hash) {
+            warn!("Mined an duplicate block, the mining power is wasted!");
+            return;
+        }
         self.graph.insert_block_header(
             &mut block.block_header,
             false,

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -1110,16 +1110,13 @@ impl SynchronizationProtocolHandler {
         let parent_hash = *block.block_header.parent_hash();
 
         assert!(self.graph.contains_block_header(&parent_hash));
-        assert!(!self.graph.contains_block_header(&hash));
-        let (insert_result, _to_relay) = self.graph.insert_block_header(
+        self.graph.insert_block_header(
             &mut block.block_header,
             false,
             false,
             false,
             true,
         );
-        assert!(insert_result.is_new_valid());
-        assert!(!self.graph.contains_block(&hash));
         // Do not need to look at the result since this new block will be
         // broadcast to peers.
         self.graph.insert_block(


### PR DESCRIPTION
If these miners submit the same nonce solution to the node, the node
will "mine" the same block multiple times and violate these assertions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/1992)
<!-- Reviewable:end -->
