### PR TITLE
Use upgradable ChainIdParams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,11 +473,13 @@ dependencies = [
  "log 0.4.11",
  "malloc_size_of",
  "malloc_size_of_derive",
+ "parking_lot 0.11.0",
  "primitives",
  "rlp",
  "rlp_derive",
  "serde",
  "serde_derive",
+ "toml 0.4.10",
 ]
 
 [[package]]
@@ -767,6 +769,7 @@ dependencies = [
  "bigdecimal",
  "blockgen",
  "cfx-bytes",
+ "cfx-internal-common",
  "cfx-parameters",
  "cfx-statedb",
  "cfx-storage",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -18,6 +18,7 @@ io = { path = "../util/io" }
 cfxkey = { path = "../accounts/cfxkey" }
 cfxcore-accounts = { path = "../accounts" }
 cfxstore = { path = "../accounts/cfxstore" }
+cfx-internal-common = { path = "../core/internal_common" }
 cfx-statedb = { path = "../core/statedb" }
 cfx-storage = { path = "../core/storage" }
 app_dirs = "1.2.1"

--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -6,6 +6,7 @@ use crate::rpc::{
     impls::RpcImplConfiguration, HttpConfiguration, TcpConfiguration,
     WsConfiguration,
 };
+use cfx_internal_common::{ChainIdParams, ChainIdParamsInner};
 use cfx_parameters::block::DEFAULT_TARGET_BLOCK_GAS_LIMIT;
 use cfx_storage::{
     defaults::DEFAULT_DEBUG_SNAPSHOT_CHECKER_THREADS, storage_dir,
@@ -31,13 +32,17 @@ use cfxcore::{
     sync_parameters::*,
     transaction_pool::TxPoolConfig,
 };
+use lazy_static::*;
 use metrics::MetricsConfiguration;
 use network::DiscoveryConfiguration;
-use parking_lot::lock_api::RwLock;
-use primitives::ChainIdParams;
+use parking_lot::RwLock;
 use rand::Rng;
 use std::convert::TryInto;
 use txgen::TransactionGeneratorConfig;
+
+lazy_static! {
+    pub static ref CHAIN_ID: RwLock<Option<ChainIdParams>> = Default::default();
+}
 
 // usage:
 // ```
@@ -282,6 +287,12 @@ build_config! {
             }
         )
 
+        // Genesis Section
+        // chain_id_params describes a complex setup where chain id can change over epochs.
+        // Usually this is needed to describe forks. This config overrides chain_id.
+        (chain_id_params, (Option<ChainIdParamsInner>), None,
+            ChainIdParamsInner::parse_config_str)
+
         // Storage section.
         (provide_more_snapshot_for_sync,
             (Vec<ProvideExtraSnapshotSyncConfig>),
@@ -325,9 +336,12 @@ impl Configuration {
     fn network_id(&self) -> u64 {
         match self.raw_conf.network_id {
             Some(x) => x,
-            // The default network id is 1 for historic reason. It doesn't
-            // really matter.
-            None => self.raw_conf.chain_id.unwrap_or(1) as u64,
+            // If undefined, the network id is set to the chain_id at genesis.
+            None => {
+                self.chain_id_params()
+                    .read()
+                    .get_chain_id(/* epoch_number = */ 0) as u64
+            }
         }
     }
 
@@ -426,6 +440,26 @@ impl Configuration {
         )
     }
 
+    pub fn chain_id_params(&self) -> ChainIdParams {
+        if CHAIN_ID.read().is_none() {
+            let mut to_init = CHAIN_ID.write();
+            if to_init.is_none() {
+                if let Some(chain_id_params) = &self.raw_conf.chain_id_params {
+                    *to_init = Some(ChainIdParamsInner::new_from_inner(
+                        chain_id_params,
+                    ))
+                } else {
+                    *to_init = Some(ChainIdParamsInner::new_simple(
+                        self.raw_conf
+                            .chain_id
+                            .unwrap_or_else(|| rand::thread_rng().gen()),
+                    ));
+                }
+            }
+        }
+        CHAIN_ID.read().as_ref().unwrap().clone()
+    }
+
     pub fn consensus_config(&self) -> ConsensusConfig {
         let enable_optimistic_execution = if DEFERRED_STATE_EPOCH_COUNT <= 1 {
             false
@@ -433,12 +467,7 @@ impl Configuration {
             self.raw_conf.enable_optimistic_execution
         };
         ConsensusConfig {
-            chain_id: ChainIdParams {
-                chain_id: self
-                    .raw_conf
-                    .chain_id
-                    .unwrap_or_else(|| rand::thread_rng().gen()),
-            },
+            chain_id: self.chain_id_params(),
             inner_conf: ConsensusInnerConfig {
                 adaptive_weight_beta: self.raw_conf.adaptive_weight_beta,
                 heavy_block_difficulty_ratio: self

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -681,7 +681,7 @@ impl RpcImpl {
                         &mut block_size_limit,
                         num_txs_simple,
                         num_txs_erc20,
-                        &self.consensus.get_config().chain_id,
+                        self.consensus.best_chain_id(),
                     );
 
                 Ok(block_gen.generate_block(

--- a/core/internal_common/Cargo.toml
+++ b/core/internal_common/Cargo.toml
@@ -15,8 +15,10 @@ lazy_static = "1.4"
 log = "0.4"
 malloc_size_of = { path = "../../util/malloc_size_of" }
 malloc_size_of_derive = { path = "../../util/malloc_size_of_derive" }
+parking_lot = "0.11"
 primitives = { path = "../../primitives" }
 rlp = "0.4.0"
 rlp_derive = { git = "https://github.com/Conflux-Chain/conflux-parity-deps.git", rev = "1597a9cab02343eb2322ca0ac58d39b64e3f42d1"  }
 serde = "1.0"
 serde_derive = "1.0"
+toml = "0.4"

--- a/core/internal_common/src/chain_id.rs
+++ b/core/internal_common/src/chain_id.rs
@@ -1,0 +1,240 @@
+/// The parameters needed to determine the chain_id based on epoch_number.
+#[derive(Clone, Debug, Eq, RlpEncodable, RlpDecodable, PartialEq, Default)]
+pub struct ChainIdParamsDeprecated {
+    /// Preconfigured chain_id.
+    pub chain_id: u32,
+}
+
+impl ChainIdParamsDeprecated {
+    /// The function return the chain_id with given parameters
+    pub fn get_chain_id(&self, _epoch_number: u64) -> u32 { self.chain_id }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, RlpEncodable, RlpDecodable)]
+pub struct ChainIdParamsInner {
+    heights: Vec<u64>,
+    chain_ids: Vec<u32>,
+}
+
+pub type ChainIdParams = Arc<RwLock<ChainIdParamsInner>>;
+
+impl ChainIdParamsInner {
+    /// The function return the chain_id with given parameters
+    pub fn get_chain_id(&self, epoch_number: u64) -> u32 {
+        let index = self
+            .heights
+            .binary_search(&epoch_number)
+            .unwrap_or_else(|x| x - 1);
+        self.chain_ids[index]
+    }
+
+    pub fn new_inner(chain_id: u32) -> Self {
+        Self {
+            heights: vec![0],
+            chain_ids: vec![chain_id],
+        }
+    }
+
+    pub fn new_simple(chain_id: u32) -> ChainIdParams {
+        Arc::new(RwLock::new(Self::new_inner(chain_id)))
+    }
+
+    pub fn new_from_inner(x: &Self) -> ChainIdParams {
+        Arc::new(RwLock::new(x.clone()))
+    }
+
+    pub fn parse_config_str(config: &str) -> std::result::Result<Self, String> {
+        let mut parsed = Self::default();
+        let value = config
+            .parse::<toml::Value>()
+            .map_err(|e| format!("{}", e))?;
+        if let toml::Value::Table(table) = &value {
+            if let Some(height_to_chain_ids) = table.get("height_to_chain_ids")
+            {
+                if let toml::Value::Array(array) = height_to_chain_ids {
+                    if array.len() == 0 {
+                        return Err(String::from("Invalid ChainIdParams config format: height_to_chain_ids is empty"));
+                    }
+                    let mut used_chain_ids = BTreeSet::new();
+                    for element in array {
+                        if let toml::Value::Array(pair) = element {
+                            if pair.len() != 2 {
+                                return Err(String::from("Invalid ChainIdParams config format: height_to_chain_ids elements is not [height, chain_id]"));
+                            }
+                            if let [toml::Value::Integer(height), toml::Value::Integer(chain_id)] =
+                                &pair[0..2]
+                            {
+                                if *height < 0 {
+                                    return Err(String::from("Invalid ChainIdParams config format: height must be positive"));
+                                }
+                                if used_chain_ids.contains(chain_id) {
+                                    return Err(String::from("Invalid ChainIdParams config format: chain_id must be pairwise different"));
+                                }
+                                if *chain_id < 0
+                                    || *chain_id > std::u32::MAX as i64
+                                {
+                                    return Err(String::from("Invalid ChainIdParams config format: chain_id out of range for u32"));
+                                }
+                                parsed.heights.push(*height as u64);
+                                parsed.chain_ids.push(*chain_id as u32);
+                                used_chain_ids.insert(*chain_id);
+                            }
+                        } else {
+                            return Err(String::from("Invalid ChainIdParams config format: height_to_chain_ids elements is not [height, chain_id]"));
+                        }
+                    }
+                } else {
+                    return Err(String::from("Invalid ChainIdParams config format: height_to_chain_ids is not an array"));
+                }
+            } else {
+                return Err(String::from("Invalid ChainIdParams config format: height_to_chain_ids not found"));
+            }
+            if parsed.heights[0] != 0 {
+                return Err(String::from("Invalid ChainIdParams config format: height must start from 0"));
+            }
+            Ok(parsed)
+        } else {
+            return Err(String::from(
+                "Invalid ChainIdParams config format: not a table",
+            ));
+        }
+    }
+
+    pub fn matches(&self, other: &Self, peer_epoch_number: u64) -> bool {
+        // Sub-array check. One height to epoch id map must be a sub-array of
+        // another.
+        let min_len = min(self.heights.len(), other.heights.len());
+        let sub_array_check = other.heights[0..min_len]
+            == self.heights[0..min_len]
+            && other.chain_ids[0..min_len] == self.chain_ids[0..min_len];
+
+        if sub_array_check {
+            // Check if peer has a high epoch_number but a shorter height to
+            // epoch id map, so that the chain_id of ourselves is
+            // not a match anymore.
+            let index = self
+                .heights
+                .binary_search(&peer_epoch_number)
+                .unwrap_or_else(|x| x - 1);
+            min_len > index
+        } else {
+            return false;
+        }
+    }
+}
+
+impl From<ChainIdParamsDeprecated> for ChainIdParamsInner {
+    fn from(x: ChainIdParamsDeprecated) -> Self {
+        Self {
+            heights: vec![0],
+            chain_ids: vec![x.chain_id],
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_parse_config_str() {
+        let config_str =
+            "height_to_chain_ids = [[0, 0], [10000, 1], [20000, 2], [30000, 3]]";
+        let config = ChainIdParamsInner::parse_config_str(config_str).unwrap();
+        assert_eq!(
+            config,
+            ChainIdParamsInner {
+                heights: vec![0, 10000, 20000, 30000],
+                chain_ids: vec![0, 1, 2, 3],
+            }
+        );
+
+        // Config can't be empty.
+        let config_str = "";
+        let config = ChainIdParamsInner::parse_config_str(config_str);
+        assert!(config.is_err());
+
+        // Height must start from 0.
+        let config_str = "height_to_chain_ids = [[10, 1024]]";
+        let config = ChainIdParamsInner::parse_config_str(config_str);
+        assert!(config.is_err());
+
+        // Must be array of array.
+        let config_str = "height_to_chain_ids = [0, 1024]";
+        let config = ChainIdParamsInner::parse_config_str(config_str);
+        assert!(config.is_err());
+
+        // Can not reuse chain_id.
+        let config_str = "height_to_chain_ids = [[0, 0], [10000, 1], [20000, 2], [30000, 1]]";
+        let config = ChainIdParamsInner::parse_config_str(config_str);
+        assert!(config.is_err());
+
+        let config_str = "height_to_chain_ids = [[0, 1024]]";
+        let config = ChainIdParamsInner::parse_config_str(config_str).unwrap();
+        assert_eq!(
+            config,
+            ChainIdParamsInner {
+                heights: vec![0],
+                chain_ids: vec![1024],
+            }
+        );
+    }
+
+    #[test]
+    fn test_chain_id_at_height() {
+        let config_str =
+            "height_to_chain_ids = [[0, 0], [10000, 1], [20000, 2], [30000, 3]]";
+        let config = ChainIdParamsInner::parse_config_str(config_str).unwrap();
+        assert_eq!(config.get_chain_id(0), 0);
+        assert_eq!(config.get_chain_id(1), 0);
+        assert_eq!(config.get_chain_id(9999), 0);
+        assert_eq!(config.get_chain_id(10000), 1);
+        assert_eq!(config.get_chain_id(10001), 1);
+        assert_eq!(config.get_chain_id(19999), 1);
+        assert_eq!(config.get_chain_id(20000), 2);
+        assert_eq!(config.get_chain_id(20001), 2);
+        assert_eq!(config.get_chain_id(29999), 2);
+        assert_eq!(config.get_chain_id(30000), 3);
+        assert_eq!(config.get_chain_id(30001), 3);
+    }
+
+    #[test]
+    fn test_chain_id_peer_compatibility() {
+        let epoch_number = 30000;
+        let config = ChainIdParamsInner::parse_config_str(
+            "height_to_chain_ids = [[0, 0], [10000, 1], [20000, 2], [30000, 3]]",
+        )
+        .unwrap();
+        let compatible_config_1 = ChainIdParamsInner::parse_config_str(
+            "height_to_chain_ids = [[0, 0], [10000, 1], [20000, 2]]",
+        )
+        .unwrap();
+        let compatible_config_2 = ChainIdParamsInner::parse_config_str(
+            "height_to_chain_ids = [[0, 0], [10000, 1], [20000, 2], [30000, 3], [40000, 4], [50000, 5]]",
+        )
+            .unwrap();
+        let incompatible_config_1 = ChainIdParamsInner::parse_config_str(
+            "height_to_chain_ids = [[0, 0], [10000, 1], [20000, 2], [30000, 4]]",
+        )
+            .unwrap();
+        let incompatible_config_2 = ChainIdParamsInner::parse_config_str(
+            "height_to_chain_ids = [[0, 0], [10000, 1], [20000, 2], [25000, 3]]",
+        )
+            .unwrap();
+        let incompatible_config_3 = ChainIdParamsInner::parse_config_str(
+            "height_to_chain_ids = [[0, 0], [10000, 1]]",
+        )
+        .unwrap();
+
+        assert!(config.matches(&compatible_config_1, epoch_number - 1));
+        assert!(!config.matches(&compatible_config_1, epoch_number));
+        assert!(config.matches(&compatible_config_2, epoch_number));
+        assert!(!config.matches(&incompatible_config_1, epoch_number));
+        assert!(!config.matches(&incompatible_config_1, epoch_number - 1));
+        assert!(!config.matches(&incompatible_config_2, epoch_number));
+        assert!(!config.matches(&incompatible_config_3, epoch_number));
+    }
+}
+
+use parking_lot::RwLock;
+use std::{cmp::min, collections::BTreeSet, sync::Arc};

--- a/core/internal_common/src/lib.rs
+++ b/core/internal_common/src/lib.rs
@@ -4,9 +4,12 @@
 
 #[macro_use]
 extern crate log;
+#[macro_use]
+extern crate rlp_derive;
 
 #[macro_use]
 pub mod block_data_db_encoding;
+pub mod chain_id;
 pub mod consensus_api;
 pub mod debug;
 pub mod epoch_execution_commitment;
@@ -14,6 +17,7 @@ pub mod state_availability_boundary;
 pub mod state_root_with_aux_info;
 
 pub use block_data_db_encoding::*;
+pub use chain_id::*;
 pub use epoch_execution_commitment::EpochExecutionCommitment;
 pub use state_availability_boundary::StateAvailabilityBoundary;
 pub use state_root_with_aux_info::*;

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -34,6 +34,7 @@ use crate::{
     vm_factory::VmFactory,
     NodeType, Notifications,
 };
+use cfx_internal_common::ChainIdParams;
 use cfx_parameters::{
     consensus::*,
     rpc::{
@@ -58,7 +59,7 @@ use primitives::{
     filter::{Filter, FilterError},
     log_entry::LocalizedLogEntry,
     receipt::Receipt,
-    ChainIdParams, EpochId, EpochNumber, SignedTransaction, TransactionIndex,
+    EpochId, EpochNumber, SignedTransaction, TransactionIndex,
 };
 use rayon::prelude::*;
 use std::{
@@ -1341,7 +1342,11 @@ impl ConsensusGraphTrait for ConsensusGraph {
         let best_epoch_number = inner.best_epoch_number();
         BEST_EPOCH_NUMBER.update(best_epoch_number as usize);
         *best_info = Arc::new(BestInformation {
-            chain_id: self.config.chain_id.get_chain_id(best_epoch_number),
+            chain_id: self
+                .config
+                .chain_id
+                .read()
+                .get_chain_id(best_epoch_number),
             best_block_hash: inner.best_block_hash(),
             best_epoch_number,
             current_difficulty: inner.current_difficulty,

--- a/core/src/executive/context.rs
+++ b/core/src/executive/context.rs
@@ -393,6 +393,7 @@ impl<'a> ContextTrait for Context<'a> {
         self.machine
             .params()
             .chain_id
+            .read()
             .get_chain_id(self.env.epoch_height) as u64
     }
 

--- a/core/src/light_protocol/common/mod.rs
+++ b/core/src/light_protocol/common/mod.rs
@@ -9,7 +9,7 @@ pub use ledger_info::LedgerInfo;
 pub use peers::{FullPeerFilter, FullPeerState, LightPeerState, Peers};
 
 use super::{Error, ErrorKind};
-use primitives::ChainIdParams;
+use cfx_internal_common::ChainIdParamsInner;
 use std::{cmp, fmt::Debug};
 
 pub fn max_of_collection<I, T: Ord>(collection: I) -> Option<T>
@@ -21,12 +21,12 @@ where I: Iterator<Item = T> {
 }
 
 pub fn validate_chain_id(
-    ours: &ChainIdParams, theirs: &ChainIdParams,
+    ours: &ChainIdParamsInner, theirs: ChainIdParamsInner, peer_height: u64,
 ) -> Result<(), Error> {
-    if ours != theirs {
+    if !ours.matches(&theirs, peer_height) {
         let error_kind = ErrorKind::ChainIdMismatch {
             ours: ours.clone(),
-            theirs: theirs.clone(),
+            theirs,
         };
         debug!("{:?}", error_kind);
         bail!(error_kind);

--- a/core/src/light_protocol/error.rs
+++ b/core/src/light_protocol/error.rs
@@ -7,13 +7,12 @@ use crate::{
     sync::message::Throttled,
     NodeType,
 };
+use cfx_internal_common::ChainIdParamsInner;
 use cfx_types::{H160, H256};
 use error_chain::ChainedError;
 use network::{node_table::NodeId, NetworkContext, UpdateNodeOperation};
 use parking_lot::Mutex;
-use primitives::{
-    account::AccountError, filter::FilterError, ChainIdParams, StateRoot,
-};
+use primitives::{account::AccountError, filter::FilterError, StateRoot};
 use rlp::DecoderError;
 use std::sync::Arc;
 
@@ -35,7 +34,7 @@ error_chain! {
             display("packet already throttled: {:?}", msg_name),
         }
 
-        ChainIdMismatch{ ours: ChainIdParams, theirs: ChainIdParams } {
+        ChainIdMismatch{ ours: ChainIdParamsInner, theirs: ChainIdParamsInner } {
             description("ChainId mismatch"),
             display("ChainId mismatch, ours={:?}, theirs={:?}.", ours, theirs),
         }

--- a/core/src/light_protocol/message/protocol.rs
+++ b/core/src/light_protocol/message/protocol.rs
@@ -7,10 +7,11 @@ use rlp_derive::{RlpDecodable, RlpEncodable};
 
 use super::NodeType;
 use crate::message::RequestId;
+use cfx_internal_common::ChainIdParamsDeprecated;
 use cfx_storage::{NodeMerkleProof, StateProof, TrieProof};
 use primitives::{
-    BlockHeader, BlockReceipts, ChainIdParams, Receipt, SignedTransaction,
-    StateRoot, StorageRoot,
+    BlockHeader, BlockReceipts, Receipt, SignedTransaction, StateRoot,
+    StorageRoot,
 };
 
 #[derive(Clone, Debug, Default, RlpEncodable, RlpDecodable)]
@@ -31,7 +32,7 @@ pub struct StatusPongDeprecatedV1 {
 
 #[derive(Clone, Debug, RlpEncodable, RlpDecodable)]
 pub struct StatusPingV2 {
-    pub chain_id: ChainIdParams,
+    pub chain_id: ChainIdParamsDeprecated,
     pub genesis_hash: H256,
     pub node_type: NodeType,
 }
@@ -39,7 +40,7 @@ pub struct StatusPingV2 {
 #[derive(Clone, Debug, RlpEncodable, RlpDecodable)]
 pub struct StatusPongV2 {
     pub best_epoch: u64,
-    pub chain_id: ChainIdParams,
+    pub chain_id: ChainIdParamsDeprecated,
     pub genesis_hash: H256,
     pub node_type: NodeType,
     pub terminals: Vec<H256>,

--- a/core/src/light_protocol/provider.rs
+++ b/core/src/light_protocol/provider.rs
@@ -39,6 +39,7 @@ use crate::{
     verification::{compute_epoch_receipt_proof, compute_transaction_proof},
     TransactionPool,
 };
+use cfx_internal_common::ChainIdParamsDeprecated;
 use cfx_parameters::light::{
     MAX_EPOCHS_TO_SEND, MAX_HEADERS_TO_SEND, MAX_ITEMS_TO_SEND,
     MAX_TXS_TO_SEND, MAX_WITNESSES_TO_SEND,
@@ -368,7 +369,9 @@ impl Provider {
             });
         } else {
             msg = Box::new(StatusPongV2 {
-                chain_id: self.consensus.get_config().chain_id.clone(),
+                chain_id: ChainIdParamsDeprecated {
+                    chain_id: self.consensus.best_chain_id(),
+                },
                 best_epoch: best_info.best_epoch_number,
                 genesis_hash,
                 node_type: self.node_type,
@@ -409,8 +412,9 @@ impl Provider {
         self.validate_peer_type(status.node_type)?;
         self.validate_genesis_hash(status.genesis_hash)?;
         validate_chain_id(
-            &self.consensus.get_config().chain_id,
-            &status.chain_id,
+            &self.consensus.get_config().chain_id.read(),
+            status.chain_id.into(),
+            /* peer_height = */ 0,
         )?;
 
         self.send_status(io, peer)
@@ -435,7 +439,9 @@ impl Provider {
             StatusPingV2 {
                 genesis_hash: status.genesis_hash,
                 node_type: status.node_type,
-                chain_id: self.consensus.get_config().chain_id.clone(),
+                chain_id: ChainIdParamsDeprecated {
+                    chain_id: self.consensus.best_chain_id(),
+                },
             },
         )
     }

--- a/core/src/light_protocol/query_service.rs
+++ b/core/src/light_protocol/query_service.rs
@@ -761,6 +761,7 @@ impl QueryService {
             .consensus
             .get_config()
             .chain_id
+            .read()
             .get_chain_id(epoch_number))
     }
 

--- a/core/src/machine.rs
+++ b/core/src/machine.rs
@@ -7,11 +7,12 @@ use crate::{
     builtin::{builtin_factory, Linear},
     vm::Spec,
 };
+use cfx_internal_common::ChainIdParams;
 use cfx_types::{Address, H256, U256};
-use primitives::{BlockNumber, ChainIdParams};
+use primitives::BlockNumber;
 use std::{collections::BTreeMap, str::FromStr, sync::Arc};
 
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, Default)]
 pub struct CommonParams {
     /// Account start nonce.
     pub account_start_nonce: U256,

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -26,6 +26,7 @@ use crate::{
     },
     NodeType,
 };
+use cfx_internal_common::ChainIdParamsDeprecated;
 use cfx_parameters::{block::MAX_BLOCK_SIZE_IN_BYTES, sync::*};
 use cfx_types::H256;
 use io::TimerToken;
@@ -1175,7 +1176,9 @@ impl SynchronizationProtocolHandler {
 
     fn produce_status_message_v2(&self) -> StatusV2 {
         let best_info = self.graph.consensus.best_info();
-        let chain_id = self.graph.consensus.get_config().chain_id.clone();
+        let chain_id = ChainIdParamsDeprecated {
+            chain_id: best_info.best_chain_id(),
+        };
         let terminal_hashes = best_info.bounded_terminal_block_hashes.clone();
 
         StatusV2 {
@@ -1188,7 +1191,9 @@ impl SynchronizationProtocolHandler {
 
     fn produce_status_message_v3(&self) -> StatusV3 {
         let best_info = self.graph.consensus.best_info();
-        let chain_id = self.graph.consensus.get_config().chain_id.clone();
+        let chain_id = ChainIdParamsDeprecated {
+            chain_id: best_info.best_chain_id(),
+        };
         let terminal_hashes = best_info.bounded_terminal_block_hashes.clone();
 
         StatusV3 {

--- a/core/src/sync/utils.rs
+++ b/core/src/sync/utils.rs
@@ -16,6 +16,7 @@ use crate::{
     vm_factory::VmFactory,
     ConsensusGraph, NodeType, Notifications, TransactionPool,
 };
+use cfx_internal_common::ChainIdParamsInner;
 use cfx_parameters::{
     block::{MAX_BLOCK_SIZE_IN_BYTES, REFEREE_DEFAULT_BOUND},
     consensus::{GENESIS_GAS_LIMIT, TRANSACTION_DEFAULT_EPOCH_BOUND},
@@ -26,7 +27,7 @@ use cfx_storage::{StorageConfiguration, StorageManager};
 use cfx_types::{address_util::AddressUtil, Address, H256, U256};
 use core::str::FromStr;
 use parking_lot::Mutex;
-use primitives::{Block, BlockHeaderBuilder, ChainIdParams};
+use primitives::{Block, BlockHeaderBuilder};
 use std::{collections::HashMap, path::Path, sync::Arc, time::Duration};
 use threadpool::ThreadPool;
 
@@ -128,7 +129,7 @@ pub fn initialize_data_manager(
     );
 
     let machine =
-        Arc::new(new_machine_with_builtin(ChainIdParams { chain_id: 0 }));
+        Arc::new(new_machine_with_builtin(ChainIdParamsInner::new_simple(0)));
 
     let genesis_block = Arc::new(genesis_block(
         &storage_manager,
@@ -198,7 +199,7 @@ pub fn initialize_synchronization_graph_with_data_manager(
     let notifications = Notifications::init();
     let consensus = Arc::new(ConsensusGraph::new(
         ConsensusConfig {
-            chain_id: ChainIdParams { chain_id: 0 },
+            chain_id: ChainIdParamsInner::new_simple(0),
             inner_conf: ConsensusInnerConfig {
                 adaptive_weight_beta: beta,
                 heavy_block_difficulty_ratio: h,

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -47,9 +47,8 @@ pub use crate::{
     },
     storage_key::*,
     transaction::{
-        Action, ChainIdParams, SignedTransaction, Transaction,
-        TransactionWithSignature, TransactionWithSignatureSerializePart,
-        TxPropagateId,
+        Action, SignedTransaction, Transaction, TransactionWithSignature,
+        TransactionWithSignatureSerializePart, TxPropagateId,
     },
     transaction_index::TransactionIndex,
 };

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -198,18 +198,6 @@ impl Encodable for Action {
     }
 }
 
-/// The parameters needed to determine the chain_id based on epoch_number.
-#[derive(Clone, Debug, Eq, RlpEncodable, RlpDecodable, PartialEq, Default)]
-pub struct ChainIdParams {
-    /// Preconfigured chain_id.
-    pub chain_id: u32,
-}
-
-impl ChainIdParams {
-    /// The function return the chain_id with given parameters
-    pub fn get_chain_id(&self, _epoch_number: u64) -> u32 { self.chain_id }
-}
-
 #[derive(
     Default,
     Debug,

--- a/transactiongen/src/lib.rs
+++ b/transactiongen/src/lib.rs
@@ -26,7 +26,7 @@ use metrics::{register_meter_with_group, Meter};
 use parity_bytes::ToPretty;
 use parking_lot::RwLock;
 use primitives::{
-    transaction::Action, Account, ChainIdParams, SignedTransaction, Transaction,
+    transaction::Action, Account, SignedTransaction, Transaction,
 };
 use rand::prelude::*;
 use rlp::Encodable;
@@ -219,7 +219,7 @@ impl TransactionGenerator {
                 value: balance_to_transfer,
                 action: Action::Call(receiver_address),
                 storage_limit: 0,
-                chain_id: txgen.consensus.get_config().chain_id.chain_id,
+                chain_id: txgen.consensus.best_chain_id(),
                 epoch_height: txgen.consensus.best_epoch_number(),
                 data: Bytes::new(),
             };
@@ -334,7 +334,7 @@ impl DirectTransactionGenerator {
 
     pub fn generate_transactions(
         &mut self, block_size_limit: &mut usize, mut num_txs_simple: usize,
-        mut num_txs_erc20: usize, chain_id: &ChainIdParams,
+        mut num_txs_erc20: usize, chain_id: u32,
     ) -> Vec<Arc<SignedTransaction>>
     {
         let mut result = vec![];
@@ -416,7 +416,7 @@ impl DirectTransactionGenerator {
                 // large value to avoid FIXME: this sloppy zero
                 // becomes an issue in the experiments.
                 epoch_height: 0,
-                chain_id: chain_id.chain_id,
+                chain_id,
                 data: vec![0u8; 128],
             };
             let signed_transaction = tx.sign(sender_kp.secret());
@@ -507,7 +507,7 @@ impl DirectTransactionGenerator {
                 // large value to avoid FIXME: this sloppy zero
                 // becomes an issue in the experiments.
                 epoch_height: 0,
-                chain_id: chain_id.chain_id,
+                chain_id,
                 data: tx_data,
             };
             let signed_transaction = tx.sign(sender_kp.secret());


### PR DESCRIPTION
The ChainIdParams is designed to return a chain_id for specified block height. The design is useful to describe hard-forks. This PR completes the implementation of the design, and makes it possible to specify chain_id changes by block heights in configuration.

As part of this PR, there is a static upgradable CHAIN_ID params shared by all components. At this moment, MOST of these components DO NOT EXPECT the chain_id to change.

It's worth noting that, if chain_id and chain_id_params is unspecified in config, which is often the case for intranet test deployment, the chain_id will be randomly generated, and the network_id will be the same as the randomly generated chain_id. In this case, the old behavior was to set the network_id 1. The change of behavior is negligible.

There is no change to existing network messages. There is no known plan to start a hard-fork yet.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2000)
<!-- Reviewable:end -->
