### PR TITLE
Fix issue where the `logs` pub-sub API would skip logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ dependencies = [
  "log4rs",
  "malloc_size_of",
  "malloc_size_of_derive",
- "memoffset",
+ "memoffset 0.5.6",
  "parity-util-mem",
  "parking_lot 0.11.1",
  "primitives",
@@ -610,7 +610,7 @@ dependencies = [
  "malloc_size_of",
  "malloc_size_of_derive",
  "memmap",
- "memoffset",
+ "memoffset 0.5.6",
  "memory-cache",
  "metrics",
  "network",
@@ -995,7 +995,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils 0.8.1",
 ]
 
 [[package]]
@@ -1016,8 +1016,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-epoch 0.9.0",
- "crossbeam-utils 0.8.0",
+ "crossbeam-epoch 0.9.1",
+ "crossbeam-utils 0.8.1",
 ]
 
 [[package]]
@@ -1031,21 +1031,21 @@ dependencies = [
  "crossbeam-utils 0.7.2",
  "lazy_static",
  "maybe-uninit",
- "memoffset",
+ "memoffset 0.5.6",
  "scopeguard 1.1.0",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
+checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
 dependencies = [
  "cfg-if 1.0.0",
  "const_fn",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils 0.8.1",
  "lazy_static",
- "memoffset",
+ "memoffset 0.6.1",
  "scopeguard 1.1.0",
 ]
 
@@ -1073,13 +1073,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
- "const_fn",
  "lazy_static",
 ]
 
@@ -1111,9 +1110,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4666154fd004af3fd6f1da2e81a96fd5a81927fe8ddb6ecc79e2aa6e138b54"
+checksum = "f9d58633299b24b515ac72a3f869f8b91306a3cec616a602843a383acd6f9e97"
 dependencies = [
  "bstr",
  "csv-core",
@@ -1166,7 +1165,7 @@ version = "0.4.2"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.52",
 ]
 
 [[package]]
@@ -1177,7 +1176,7 @@ checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.52",
 ]
 
 [[package]]
@@ -1257,7 +1256,7 @@ checksum = "e5c450cf304c9e18d45db562025a14fb1ca0f5c769b6f609309f81d4c31de455"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.52",
 ]
 
 [[package]]
@@ -1374,7 +1373,7 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.52",
  "synstructure 0.12.4",
 ]
 
@@ -1466,9 +1465,9 @@ dependencies = [
 
 [[package]]
 name = "fs-swap"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921d332c89b3b61a826de38c61ee5b6e02c56806cade1b0e5d81bd71f57a71bb"
+checksum = "5839fda247e24ca4919c87c71dd5ca658f1f39e4f06829f80e3f15c3bafcfc2c"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1577,7 +1576,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.52",
 ]
 
 [[package]]
@@ -1992,7 +1991,7 @@ checksum = "7ef5550a42e3740a0e71f909d4c861056a284060af885ae7aa6242820f920d9d"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.52",
 ]
 
 [[package]]
@@ -2162,7 +2161,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.52",
 ]
 
 [[package]]
@@ -2495,7 +2494,7 @@ name = "malloc_size_of_derive"
 version = "0.1.1"
 dependencies = [
  "proc-macro2 1.0.24",
- "syn 1.0.51",
+ "syn 1.0.52",
  "synstructure 0.12.4",
 ]
 
@@ -2532,6 +2531,15 @@ name = "memoffset"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
 dependencies = [
  "autocfg",
 ]
@@ -2590,7 +2598,7 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log 0.4.11",
- "miow 0.2.1",
+ "miow 0.2.2",
  "net2",
  "slab",
  "winapi 0.2.8",
@@ -2633,9 +2641,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
 dependencies = [
  "kernel32-sys",
  "net2",
@@ -2682,9 +2690,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
+checksum = "d7cf75f38f16cb05ea017784dc6dbfd354f76c223dba37701734c4f5a9337d02"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -3008,7 +3016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
  "proc-macro2 1.0.24",
- "syn 1.0.51",
+ "syn 1.0.52",
  "synstructure 0.12.4",
 ]
 
@@ -3196,7 +3204,7 @@ checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.52",
 ]
 
 [[package]]
@@ -3551,7 +3559,7 @@ checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "crossbeam-deque 0.8.0",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils 0.8.1",
  "lazy_static",
  "num_cpus",
 ]
@@ -3864,7 +3872,7 @@ checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.52",
 ]
 
 [[package]]
@@ -4130,9 +4138,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4f34193997d92804d359ed09953e25d5138df6bcc055a71bf68ee89fdf9223"
+checksum = "6c1e438504729046a5cfae47f97c30d6d083c7d91d94603efdae3477fc070d4c"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -4159,7 +4167,7 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.52",
  "unicode-xid 0.2.1",
 ]
 
@@ -4436,7 +4444,7 @@ checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.52",
 ]
 
 [[package]]

--- a/changelogs/CHANGELOG-1.0.x.md
+++ b/changelogs/CHANGELOG-1.0.x.md
@@ -8,6 +8,7 @@
 ## Bug Fixes
 
 - Change the `blame` field returned from the `newHeads` pub-sub to hex.
+- Fix issue where the `logs` pub-sub API would skip logs.
 
 # 1.0.3
 

--- a/client/src/rpc/helpers/epoch_queue.rs
+++ b/client/src/rpc/helpers/epoch_queue.rs
@@ -1,0 +1,119 @@
+// Copyright 2020 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use std::collections::VecDeque;
+
+/// The goal of EpochQueue is to keep a distance from the tip of the ledger.
+/// This way, we can ensure that the epoch being processed has already been
+/// executed (deferred execution) and we can reduce the number of chain reorgs
+/// that we need to notify subscribers about.
+
+pub struct EpochQueue<T> {
+    capacity: usize,
+    queue: VecDeque<(u64, T)>,
+}
+
+impl<T> EpochQueue<T> {
+    pub fn with_capacity(capacity: usize) -> Self {
+        let mut queue = VecDeque::new();
+        queue.reserve(capacity);
+        Self { capacity, queue }
+    }
+
+    pub fn push(&mut self, new: (u64, T)) -> Option<(u64, T)> {
+        // remove epochs from queue that are greater or equal to the new one
+        while matches!(self.queue.back(), Some((e, _)) if *e >= new.0) {
+            self.queue.pop_back();
+        }
+
+        // we should not skip any epochs
+        if let Some((e, _)) = self.queue.back() {
+            if *e != new.0 - 1 {
+                error!("Skipped epoch in epoch queue: {} --> {}", *e, new.0);
+            }
+        }
+
+        // only return epoch if queue is full
+        match self.queue.len() {
+            n if n < self.capacity => {
+                self.queue.push_back(new);
+                return None;
+            }
+            n if n == self.capacity => {
+                let e = self.queue.pop_front().unwrap();
+                self.queue.push_back(new);
+                return Some(e);
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_no_reorgs() {
+        let mut queue = EpochQueue::with_capacity(5);
+
+        assert_eq!(queue.push((0, 0)), None);
+        assert_eq!(queue.push((1, 1)), None);
+        assert_eq!(queue.push((2, 2)), None);
+        assert_eq!(queue.push((3, 3)), None);
+        assert_eq!(queue.push((4, 4)), None);
+        assert_eq!(queue.push((5, 5)), Some((0, 0)));
+        assert_eq!(queue.push((6, 6)), Some((1, 1)));
+        assert_eq!(queue.push((7, 7)), Some((2, 2)));
+        assert_eq!(queue.push((8, 8)), Some((3, 3)));
+    }
+
+    #[test]
+    fn test_shallow_reorgs() {
+        let mut queue = EpochQueue::with_capacity(5);
+
+        assert_eq!(queue.push((0, 0)), None);
+        assert_eq!(queue.push((1, 1)), None);
+        assert_eq!(queue.push((2, 2)), None);
+        assert_eq!(queue.push((1, 3)), None); // reorg: 2 --> 1
+        assert_eq!(queue.push((2, 4)), None);
+        assert_eq!(queue.push((3, 5)), None);
+        assert_eq!(queue.push((4, 6)), None);
+        assert_eq!(queue.push((1, 7)), None); // reorg: 4 --> 1
+        assert_eq!(queue.push((2, 8)), None);
+        assert_eq!(queue.push((3, 9)), None);
+        assert_eq!(queue.push((4, 10)), None);
+        assert_eq!(queue.push((5, 11)), Some((0, 0)));
+        assert_eq!(queue.push((6, 12)), Some((1, 7)));
+        assert_eq!(queue.push((4, 13)), None); // reorg: 6 --> 4
+        assert_eq!(queue.push((5, 14)), None);
+        assert_eq!(queue.push((6, 15)), None);
+        assert_eq!(queue.push((7, 16)), Some((2, 8)));
+        assert_eq!(queue.push((8, 17)), Some((3, 9)));
+    }
+
+    #[test]
+    fn test_deep_reorgs() {
+        let mut queue = EpochQueue::with_capacity(5);
+
+        assert_eq!(queue.push((0, 0)), None);
+        assert_eq!(queue.push((1, 1)), None);
+        assert_eq!(queue.push((2, 2)), None);
+        assert_eq!(queue.push((3, 3)), None);
+        assert_eq!(queue.push((4, 4)), None);
+        assert_eq!(queue.push((5, 5)), Some((0, 0)));
+        assert_eq!(queue.push((6, 6)), Some((1, 1)));
+        assert_eq!(queue.push((7, 7)), Some((2, 2)));
+        assert_eq!(queue.push((8, 8)), Some((3, 3)));
+        assert_eq!(queue.push((0, 9)), None); // reorg: 8 --> 0
+        assert_eq!(queue.push((1, 10)), None);
+        assert_eq!(queue.push((2, 11)), None);
+        assert_eq!(queue.push((3, 12)), None);
+        assert_eq!(queue.push((4, 13)), None);
+        assert_eq!(queue.push((5, 14)), Some((0, 9)));
+        assert_eq!(queue.push((6, 15)), Some((1, 10)));
+        assert_eq!(queue.push((7, 16)), Some((2, 11)));
+        assert_eq!(queue.push((8, 17)), Some((3, 12)));
+    }
+}

--- a/client/src/rpc/helpers/mod.rs
+++ b/client/src/rpc/helpers/mod.rs
@@ -1,5 +1,10 @@
+// Copyright 2020 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+mod epoch_queue;
 mod poll_manager;
 mod subscribers;
-//mod subscription_mananger;
 
-pub use self::subscribers::{Id as SubscriberId, Subscribers};
+pub use epoch_queue::EpochQueue;
+pub use subscribers::{Id as SubscriberId, Subscribers};

--- a/tests/pubsub/logs_test.py
+++ b/tests/pubsub/logs_test.py
@@ -80,6 +80,10 @@ class PubSubTest(ConfluxTestFramework):
             receipts.append(r)
             assert(r != None)
 
+        # make sure the pub-sub layer processes the logs
+        self.rpc[FULLNODE0].generate_blocks(20)
+        sync_blocks(self.nodes)
+
         # collect pub-sub notifications
         logs1 = [l async for l in sub_all.iter()]
         logs2 = [l async for l in sub_one.iter()]
@@ -132,6 +136,10 @@ class PubSubTest(ConfluxTestFramework):
         self.rpc[FULLNODE0].generate_blocks(4)
         receipt = self.rpc[FULLNODE0].get_transaction_receipt(tx.hash_hex())
         assert_ne(receipt, None)
+
+        # make sure the pub-sub layer processes the logs
+        self.rpc[FULLNODE0].generate_blocks(20)
+        sync_blocks(self.nodes)
 
         # this would timeout before #1989 was fixed
         await sub_all.next()

--- a/tests/pubsub/logs_test.py
+++ b/tests/pubsub/logs_test.py
@@ -2,7 +2,7 @@
 
 # allow imports from parent directory
 # source: https://stackoverflow.com/a/11158224
-import os, sys
+import os, sys, time
 sys.path.insert(1, os.path.join(sys.path[0], '..'))
 
 import asyncio
@@ -16,7 +16,7 @@ from conflux.rpc import RpcClient
 from conflux.utils import sha3 as keccak, priv_to_addr, bytes_to_int
 from test_framework.blocktools import encode_hex_0x
 from test_framework.test_framework import ConfluxTestFramework
-from test_framework.util import assert_equal, assert_is_hex_string, connect_nodes, sync_blocks
+from test_framework.util import assert_equal, assert_ne, assert_is_hex_string, connect_nodes, sync_blocks
 
 FULLNODE0 = 0
 FULLNODE1 = 1
@@ -116,6 +116,27 @@ class PubSubTest(ConfluxTestFramework):
         assert_equal(len(logs), num_to_reexecute)
 
         self.log.info(f"Pass -- retrieved re-executed logs after fork")
+
+        # create one transaction that is mined but not executed yet
+        sync_blocks(self.nodes)
+        tx = self.rpc[FULLNODE0].new_contract_tx(receiver=contract1, data_hex=FOO_TOPIC, sender=sender, priv_key=priv_key, storage_limit=20000)
+        assert_equal(self.rpc[FULLNODE0].send_tx(tx, wait_for_receipt=False), tx.hash_hex())
+        self.rpc[FULLNODE0].generate_block(num_txs=1)
+
+        receipt = self.rpc[FULLNODE0].get_transaction_receipt(tx.hash_hex())
+        assert_equal(receipt, None)
+
+        time.sleep(1)
+
+        # mine more blocks, the transaction is now executed
+        self.rpc[FULLNODE0].generate_blocks(4)
+        receipt = self.rpc[FULLNODE0].get_transaction_receipt(tx.hash_hex())
+        assert_ne(receipt, None)
+
+        # this would timeout before #1989 was fixed
+        await sub_all.next()
+
+        self.log.info(f"Pass -- test #1989 fix")
 
     def run_test(self):
         asyncio.get_event_loop().run_until_complete(self.run_async())


### PR DESCRIPTION
**Overview**

As `ConsensusNewBlocksHandler` is sending the epochs, the `epochs` and `logs` pub-sub APIs would process them immediately one-by-one. For `logs` we try to retrieve the receipts from db and fail with a warning after 1 second. Due to the growth rate of the pivot chain, it is quite likely that the epoch is not executed within this time limit due to deferred execution, which leads to logs being skipped.

To address this issue, I added `EpochQueue` which is used to keep a distance from the tip of the ledger and thus make sure that the epoch being processed has already been executed. The associated memory overhead (one queue per subscription) seems insignificant.

The other advantage of this approach is that we can *filter out* most chain reorgs that would otherwise have to be handled by the client. I am considering exposing the queue size as an optional subscription parameter in a subsequent PR. The longer the queue, the less common chain reorgs on the client side are.

Fixes #1989.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2001)
<!-- Reviewable:end -->
