### PR TITLE
Refactor storage interface

### DIFF
--- a/core/statedb/src/lib.rs
+++ b/core/statedb/src/lib.rs
@@ -40,7 +40,7 @@ mod impls {
     type Checkpoint = BTreeMap<Key, Option<Value>>;
 
     // Use generic type for better test-ability.
-    pub struct StateDb<Storage: StorageStateTrait> {
+    pub struct StateDb<Storage> {
         /// Contains the original storage key values for all loaded and
         /// modified key values.
         accessed_entries: RwLock<AccessedEntries>,
@@ -489,7 +489,7 @@ mod impls {
         }
     }
 
-    impl<Storage: StorageStateTrait> StateDbGetOriginalMethods
+    impl<Storage: StorageStateTraitExt> StateDbGetOriginalMethods
         for StateDb<Storage>
     {
         fn get_original_raw_with_proof(
@@ -628,6 +628,7 @@ mod impls {
         state::{NoProof, WithProof},
         utils::{access_mode, to_key_prefix_iter_upper_bound},
         MptKeyValue, StateProof, StorageRootProof, StorageStateTrait,
+        StorageStateTraitExt,
     };
     use cfx_types::{address_util::AddressUtil, Address};
     use hashbrown::HashMap;

--- a/core/statedb/src/tests.rs
+++ b/core/statedb/src/tests.rs
@@ -5,12 +5,9 @@
 use super::StateDbGeneric;
 use cfx_internal_common::StateRootWithAuxInfo;
 use cfx_storage::{
-    utils::access_mode, ErrorKind, MptKeyValue, NodeMerkleProof, Result,
-    StateProof, StorageStateTrait,
+    utils::access_mode, ErrorKind, MptKeyValue, Result, StorageStateTrait,
 };
-use primitives::{
-    EpochId, NodeMerkleTriplet, StaticBool, StorageKey, MERKLE_NULL_NODE,
-};
+use primitives::{EpochId, StorageKey, MERKLE_NULL_NODE};
 use std::{cell::RefCell, collections::HashMap};
 
 type StorageValue = Box<[u8]>;
@@ -102,23 +99,9 @@ impl StorageStateTrait for MockStorage {
         Ok(self.contents.get(&key).cloned())
     }
 
-    fn get_node_merkle_all_versions<WithProof: StaticBool>(
-        &self, access_key: StorageKey,
-    ) -> Result<(NodeMerkleTriplet, NodeMerkleProof)> {
-        unimplemented!()
-    }
-
     fn get_state_root(&self) -> Result<StateRootWithAuxInfo> {
         Err(ErrorKind::Msg("No state root".to_owned()).into())
     }
-
-    fn get_with_proof(
-        &self, access_key: StorageKey,
-    ) -> Result<(Option<Box<[u8]>>, StateProof)> {
-        unimplemented!()
-    }
-
-    fn revert(&mut self) { unimplemented!() }
 
     fn set(&mut self, access_key: StorageKey, value: Box<[u8]>) -> Result<()> {
         *self.num_writes.get_mut() += 1;

--- a/core/storage/src/lib.rs
+++ b/core/storage/src/lib.rs
@@ -172,7 +172,10 @@ pub use self::{
             sqlite::SqliteConnection,
         },
     },
-    state::{State as StorageState, StateTrait as StorageStateTrait},
+    state::{
+        State as StorageState, StateTrait as StorageStateTrait,
+        StateTraitExt as StorageStateTraitExt,
+    },
     state_manager::{
         StateIndex, StateManager as StorageManager,
         StateManagerTrait as StorageManagerTrait,

--- a/core/storage/src/state.rs
+++ b/core/storage/src/state.rs
@@ -18,11 +18,6 @@ pub type NoProof = primitives::static_bool::No;
 // concrete struct is put into inner mod, because the implementation is
 // anticipated to be too complex to present in the same file of the API.
 pub trait StateTrait {
-    // Verifiable proof related methods.
-    fn get_with_proof(
-        &self, access_key: StorageKey,
-    ) -> Result<(Option<Box<[u8]>>, StateProof)>;
-
     // Actions.
     fn get(&self, access_key: StorageKey) -> Result<Option<Box<[u8]>>>;
     fn set(&mut self, access_key: StorageKey, value: Box<[u8]>) -> Result<()>;
@@ -42,7 +37,12 @@ pub trait StateTrait {
     fn compute_state_root(&mut self) -> Result<StateRootWithAuxInfo>;
     fn get_state_root(&self) -> Result<StateRootWithAuxInfo>;
     fn commit(&mut self, epoch: EpochId) -> Result<StateRootWithAuxInfo>;
-    fn revert(&mut self);
+}
+
+pub trait StateTraitExt {
+    fn get_with_proof(
+        &self, access_key: StorageKey,
+    ) -> Result<(Option<Box<[u8]>>, StateProof)>;
 
     /// Compute the merkle of the node under `access_key` in all tries.
     /// Node merkle is computed on the value and children hashes, ignoring the

--- a/core/storage/src/tests/snapshot.rs
+++ b/core/storage/src/tests/snapshot.rs
@@ -2,8 +2,6 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use crate::storage_db::SnapshotMptTraitReadAndIterate;
-
 #[cfg(test)]
 mod slicer;
 #[cfg(test)]
@@ -624,7 +622,8 @@ use crate::{
     },
     storage_db::{
         snapshot_mpt::CHECK_LOADED_SNAPSHOT_MPT_NODE, SnapshotMptIteraterTrait,
-        SnapshotMptNode, SnapshotMptTraitRead, SnapshotMptTraitRw,
+        SnapshotMptNode, SnapshotMptTraitRead, SnapshotMptTraitReadAndIterate,
+        SnapshotMptTraitRw,
     },
 };
 use fallible_iterator::FallibleIterator;
@@ -645,7 +644,7 @@ use crate::{
         snapshot::verifier::FakeSnapshotDb, DumpedMptKvIterator,
         TEST_NUMBER_OF_KEYS,
     },
-    StateIndex,
+    StateIndex, StorageStateTraitExt,
 };
 #[cfg(test)]
 use parking_lot::Mutex;


### PR DESCRIPTION
**Overview**

This PR adds two minor improvements:

- Remove `revert` from `StorageStateTrait`. This is only called internally so it does not need to be part of the public interface.
- Move `get_with_proof` and `get_node_merkle_all_versions` to a separate Trait `StorageStateTraitExt`. These methods are just used for "querying" storage, they are not called during transaction execution so I think they should not be part of the main storage interface. The same is true for `delete_test_only` but I did not move it in this PR.

These are just minor changes, not crucial ones. This also reduces the boilerplate needed for adding new storage implementations.

Please note that the functionality in `core/storage/src/impls/state.rs` is moved without any changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2007)
<!-- Reviewable:end -->
