### PR TITLE
Disconnect peers sending invalid headers on light nodes

### DIFF
--- a/core/src/light_protocol/error.rs
+++ b/core/src/light_protocol/error.rs
@@ -221,12 +221,12 @@ pub fn handle(
 
 
         ErrorKind::GenesisMismatch{..}
+        | ErrorKind::InvalidHeader
         | ErrorKind::ChainIdMismatch{..}
         | ErrorKind::UnexpectedMessage{..}
         | ErrorKind::UnexpectedPeerType{..} => op = Some(UpdateNodeOperation::Failure),
 
-        ErrorKind::InvalidHeader
-        | ErrorKind::UnexpectedResponse{..} => {
+        ErrorKind::UnexpectedResponse{..} => {
             op = Some(UpdateNodeOperation::Demotion)
         }
 

--- a/core/src/light_protocol/error.rs
+++ b/core/src/light_protocol/error.rs
@@ -59,6 +59,11 @@ error_chain! {
             display("Logs bloom hash validation for epoch {} failed, expected={:?}, received={:?}", epoch, expected, received),
         }
 
+        InvalidHeader {
+            description("Header verification failed"),
+            display("Header verification failed"),
+        }
+
         InvalidLedgerProofSize{ hash: H256, expected: u64, received: u64 } {
             description("Invalid ledger proof size"),
             display("Invalid ledger proof size for header {:?}: expected={}, received={}", hash, expected, received),
@@ -220,7 +225,8 @@ pub fn handle(
         | ErrorKind::UnexpectedMessage{..}
         | ErrorKind::UnexpectedPeerType{..} => op = Some(UpdateNodeOperation::Failure),
 
-        ErrorKind::UnexpectedResponse{..} => {
+        ErrorKind::InvalidHeader
+        | ErrorKind::UnexpectedResponse{..} => {
             op = Some(UpdateNodeOperation::Demotion)
         }
 


### PR DESCRIPTION
**Overview**

With the upcoming hardfork, disconnecting peers when header validation fails is becoming more relevant. This PR adds this functionality to light nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2009)
<!-- Reviewable:end -->
