### PR TITLE
Upgrade log4rs to version 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 
 [[package]]
+name = "anyhow"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee67c11feeac938fae061b232e38e0b6d94f97a9df10e6271319325ac4c56a86"
+
+[[package]]
 name = "app_dirs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "0.3.11"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc4662175ead9cd84451d5c35070517777949a2ed84551764129cedb88384841"
+checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
 
 [[package]]
 name = "array-macro"
@@ -573,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "cfxcore"
-version = "1.0.0"
+version = "1.1.1"
 dependencies = [
  "bit-set",
  "bn",
@@ -757,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "1.0.0"
+version = "1.1.1"
 dependencies = [
  "app_dirs",
  "bigdecimal",
@@ -854,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "conflux"
-version = "1.0.0"
+version = "1.1.1"
 dependencies = [
  "app_dirs",
  "blockgen",
@@ -933,15 +939,6 @@ name = "core-foundation-sys"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
-
-[[package]]
-name = "crc32fast"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
-dependencies = [
- "cfg-if 1.0.0",
-]
 
 [[package]]
 name = "criterion"
@@ -1269,7 +1266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 1.3.0",
  "log 0.4.11",
  "regex",
  "termcolor",
@@ -1282,7 +1279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 1.3.0",
  "log 0.4.11",
  "regex",
  "termcolor",
@@ -1422,18 +1419,6 @@ name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
-
-[[package]]
-name = "flate2"
-version = "1.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
-dependencies = [
- "cfg-if 1.0.0",
- "crc32fast",
- "libc",
- "miniz_oxide",
-]
 
 [[package]]
 name = "fnv"
@@ -1855,6 +1840,12 @@ checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
  "quick-error",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "hyper"
@@ -2431,24 +2422,26 @@ checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
 
 [[package]]
 name = "log4rs"
-version = "0.9.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e229f32d17a1a822df4bb22ffdf1c7449d0ece700f310e87254a297be31c3b63"
+checksum = "d1572a880d1115ff867396eee7ae2bc924554225e67a0d3c85c745b3e60ca211"
 dependencies = [
- "antidote",
+ "anyhow",
  "arc-swap",
  "chrono",
- "flate2",
+ "derivative",
  "fnv",
- "humantime",
+ "humantime 2.0.1",
  "libc",
  "log 0.4.11",
  "log-mdc",
+ "parking_lot 0.11.1",
+ "regex",
  "serde",
  "serde-value",
- "serde_derive",
  "serde_json",
  "serde_yaml",
+ "thiserror",
  "thread-id",
  "typemap",
  "winapi 0.3.9",
@@ -2906,9 +2899,9 @@ checksum = "efa535d5117d3661134dbf1719b6f0ffe06f2375843b13935db186cd094105eb"
 
 [[package]]
 name = "ordered-float"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3741934be594d77de1c8461ebcbbe866f585ea616a9753aa78f2bdc69f0e4579"
+checksum = "dacdec97876ef3ede8c50efc429220641a0b11ba0048b4b0c357bccbc47c5204"
 dependencies = [
  "num-traits",
 ]
@@ -3859,9 +3852,9 @@ dependencies = [
 
 [[package]]
 name = "serde-value"
-version = "0.5.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a663f873dedc4eac1a559d4c6bc0d0b2c34dc5ac4702e105014b8281489e44f"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float",
  "serde",
@@ -4223,6 +4216,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.52",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ blockgen = { path = "blockgen" }
 txgen = { path = "transactiongen" }
 secret-store = { path = "secret_store" }
 primitives = { path = "primitives" }
-log4rs = "0.9.0"
+log4rs = "1.0.0"
 rlp = "0.4.0"
 keccak-hash = "0.5"
 rand = "0.7"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -45,7 +45,7 @@ blockgen = { path = "../blockgen" }
 txgen = { path = "../transactiongen" }
 secret-store = { path = "../secret_store" }
 primitives = { path = "../primitives" }
-log4rs = "0.9.0"
+log4rs = "1.0.0"
 rlp = "0.4.0"
 keccak-hash = "0.5"
 rand = "0.7.2"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -37,7 +37,7 @@ kvdb-rocksdb = {path="../db/src/kvdb-rocksdb"}
 lazy_static = "1.4"
 link-cut-tree = { path = "../util/link-cut-tree" }
 log = "0.4"
-log4rs = "0.9.0"
+log4rs = "1.0.0"
 lru_time_cache = "0.9.0"
 malloc_size_of = {path = "../util/malloc_size_of"}
 malloc_size_of_derive = {path = "../util/malloc_size_of_derive"}

--- a/core/benchmark/consensus/Cargo.toml
+++ b/core/benchmark/consensus/Cargo.toml
@@ -14,7 +14,7 @@ primitives = { path = "../../../primitives" }
 db = { path = "../../../db" }
 threadpool = "1.0"
 parking_lot = "0.11"
-log4rs = "0.8.1"
+log4rs = "1.0.0"
 log = "0.4"
 
 [dev-dependencies]

--- a/core/storage/Cargo.toml
+++ b/core/storage/Cargo.toml
@@ -22,7 +22,7 @@ kvdb = "0.4"
 kvdb-rocksdb = {path="../../db/src/kvdb-rocksdb"}
 lazy_static = "1.4"
 log = "0.4"
-log4rs = "0.9.0"
+log4rs = "1.0.0"
 malloc_size_of = {path = "../../util/malloc_size_of"}
 malloc_size_of_derive = {path = "../../util/malloc_size_of_derive"}
 memoffset = "0.5.1"


### PR DESCRIPTION
`log4rs`'s changelog is not too informative but I do not expect this change to break anything.

```
$ cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 170 security advisories (from /Users/peter/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (472 crate dependencies)
Crate:         ordered-float
Version:       1.1.0
Title:         ordered_float:NotNan may contain NaN after panic in assignment operators
Date:          2020-12-06
ID:            RUSTSEC-2020-0082
URL:           https://rustsec.org/advisories/RUSTSEC-2020-0082
Solution:      Upgrade to >=1.1.1, <2.0.0 OR >=2.0.1
Dependency tree: 
ordered-float 1.1.0
└── serde-value 0.5.3
    └── log4rs 0.9.0
        ├── conflux 1.1.1
        ├── client 1.1.1
        │   └── conflux 1.1.1
        ├── cfxcore 1.1.1
        │   ├── txgen 0.1.0
        │   │   ├── conflux 1.1.1
        │   │   ├── client 1.1.1
        │   │   └── blockgen 0.1.0
        │   │       ├── conflux 1.1.1
        │   │       └── client 1.1.1
        │   ├── conflux 1.1.1
        │   ├── client 1.1.1
        │   └── blockgen 0.1.0
        └── cfx-storage 1.0.0
            ├── client 1.1.1
            ├── cfxcore 1.1.1
            └── cfx-statedb 1.0.0
                ├── client 1.1.1
                └── cfxcore 1.1.1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2024)
<!-- Reviewable:end -->
