### PR TITLE
Do not panic on db errors during transaction execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "cfxcore"
-version = "1.0.0"
+version = "1.1.1"
 dependencies = [
  "bit-set",
  "bn",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "1.0.0"
+version = "1.1.1"
 dependencies = [
  "app_dirs",
  "bigdecimal",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "conflux"
-version = "1.0.0"
+version = "1.1.1"
 dependencies = [
  "app_dirs",
  "blockgen",

--- a/client/benches/benchmark.rs
+++ b/client/benches/benchmark.rs
@@ -85,7 +85,9 @@ fn txexe_benchmark(c: &mut Criterion) {
                 VmFactory::new(1024 * 32),
                 &spec,
                 0, /* block_number */
-            );
+            )
+            .expect("Failed to initialize state");
+
             let mut ex = Executive::new(
                 &mut state,
                 &env,
@@ -93,10 +95,11 @@ fn txexe_benchmark(c: &mut Criterion) {
                 &spec,
                 &internal_contract_map,
             );
+
             b.iter(|| {
                 let options = TransactOptions::with_no_tracing();
                 ex.transact(&tx, options).unwrap();
-                ex.state.clear();
+                ex.state.clear().expect("Db error during state clearing");
             })
         })
         .measurement_time(Duration::from_secs(10))

--- a/client/benches/benchmark.rs
+++ b/client/benches/benchmark.rs
@@ -99,7 +99,7 @@ fn txexe_benchmark(c: &mut Criterion) {
             b.iter(|| {
                 let options = TransactOptions::with_no_tracing();
                 ex.transact(&tx, options).unwrap();
-                ex.state.clear();
+                ex.state.clear_test_only();
             })
         })
         .measurement_time(Duration::from_secs(10))

--- a/client/benches/benchmark.rs
+++ b/client/benches/benchmark.rs
@@ -99,7 +99,7 @@ fn txexe_benchmark(c: &mut Criterion) {
             b.iter(|| {
                 let options = TransactOptions::with_no_tracing();
                 ex.transact(&tx, options).unwrap();
-                ex.state.clear().expect("Db error during state clearing");
+                ex.state.clear();
             })
         })
         .measurement_time(Duration::from_secs(10))

--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -994,7 +994,9 @@ impl ConsensusExecutionHandler {
             self.vm.clone(),
             &spec,
             start_block_number - 1, /* block_number */
-        );
+        )
+        .expect("Failed to initialize state");
+
         let epoch_receipts = self
             .process_epoch_transactions(
                 &spec,
@@ -1661,7 +1663,7 @@ impl ConsensusExecutionHandler {
             self.vm.clone(),
             &spec,
             start_block_number - 1, /* block_number */
-        );
+        )?;
         self.process_epoch_transactions(
             &spec,
             *pivot_hash,
@@ -1722,7 +1724,7 @@ impl ConsensusExecutionHandler {
             self.vm.clone(),
             &spec,
             start_block_number,
-        );
+        )?;
         drop(state_availability_boundary);
 
         let env = Env {

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -1379,7 +1379,7 @@ impl ConsensusGraphTrait for ConsensusGraph {
             Default::default(), /* vm */
             &Spec::new_spec(),
             start_block_number,
-        ))
+        )?)
     }
 
     fn get_state_db_by_epoch_number(

--- a/core/src/executive/context.rs
+++ b/core/src/executive/context.rs
@@ -189,7 +189,7 @@ impl<'a, S: StorageStateTrait + Send + Sync + 'static> ContextTrait
         // address. This should generally not happen. Unless we enable
         // account dust in future. We add this check just in case it
         // helps in future.
-        if self.state.is_contract_with_code(&address) {
+        if self.state.is_contract_with_code(&address)? {
             debug!("Contract address conflict!");
             return Ok(Ok(ContractCreateResult::Failed));
         }

--- a/core/src/executive/executive.rs
+++ b/core/src/executive/executive.rs
@@ -1502,7 +1502,7 @@ impl<'a, S: StorageStateTrait + Send + Sync + 'static> ExecutiveGeneric<'a, S> {
                 // not happen. Unless we enable account dust in
                 // future. We add this check just in case it
                 // helps in future.
-                if self.state.is_contract_with_code(&new_address) {
+                if self.state.is_contract_with_code(&new_address)? {
                     self.state.revert_to_checkpoint();
                     return Ok(ExecutionOutcome::ExecutionErrorBumpNonce(
                         ExecutionError::ContractAddressConflict,

--- a/core/src/executive/executive_tests.rs
+++ b/core/src/executive/executive_tests.rs
@@ -1094,7 +1094,9 @@ fn test_commission_privilege_all_whitelisted_across_epochs() {
         factory.clone().into(),
         &spec,
         1, /* block_number */
-    );
+    )
+    .expect("Failed to initialize state");
+
     state.checkpoint();
     assert_eq!(
         true,
@@ -1167,7 +1169,9 @@ fn test_commission_privilege_all_whitelisted_across_epochs() {
         factory.clone().into(),
         &spec,
         2, /* block_number */
-    );
+    )
+    .expect("Failed to initialize state");
+
     assert_eq!(
         true,
         state

--- a/core/src/spec/genesis.rs
+++ b/core/src/spec/genesis.rs
@@ -134,7 +134,8 @@ pub fn genesis_block(
         Default::default(),
         &Spec::new_spec(),
         0, /* block_number */
-    );
+    )
+    .expect("Failed to initialize state");
 
     let mut genesis_block_author = test_net_version;
     genesis_block_author.set_user_account_type_bits();
@@ -350,7 +351,9 @@ pub fn genesis_block(
         }
     }
 
-    state.clean_account(&genesis_account_address);
+    state
+        .clean_account(&genesis_account_address)
+        .expect("Clean account failed");
 
     let state_root = state
         .compute_state_root(/* debug_record = */ debug_record.as_mut())

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -1657,6 +1657,7 @@ impl<StateDbStorage: StorageStateTrait> StateGeneric<StateDbStorage> {
         }))
     }
 
+    #[cfg(test)]
     pub fn clear(&mut self) {
         assert!(self.checkpoints.get_mut().is_empty());
         assert!(self.staking_state_checkpoints.get_mut().is_empty());

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -1308,15 +1308,14 @@ impl<StateDbStorage: StorageStateTrait> StateGeneric<StateDbStorage> {
             Ok(false) => Ok(false),
             Ok(true) => {
                 // Try to load the code.
-                if let Err(e) = self.ensure_account_loaded(
+                match self.ensure_account_loaded(
                     address,
                     RequireCache::Code,
                     |_| (),
                 ) {
-                    return Err(e);
+                    Ok(()) => Ok(true),
+                    Err(e) => Err(e),
                 }
-
-                Ok(true)
             }
         }
     }

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -1657,8 +1657,7 @@ impl<StateDbStorage: StorageStateTrait> StateGeneric<StateDbStorage> {
         }))
     }
 
-    #[cfg(test)]
-    pub fn clear(&mut self) {
+    pub fn clear_test_only(&mut self) {
         assert!(self.checkpoints.get_mut().is_empty());
         assert!(self.staking_state_checkpoints.get_mut().is_empty());
         self.cache.get_mut().clear();

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -156,27 +156,26 @@ impl<StateDbStorage: StorageStateTrait> StateGeneric<StateDbStorage> {
             }
         } else {
             // If db is not initialized, all the loaded value should be zero.
-            if !annual_interest_rate.is_zero() {
-                bail!("annual_interest_rate is non-zero when db is un-init");
-            }
-
-            if !accumulate_interest_rate.is_zero() {
-                bail!(
-                    "accumulate_interest_rate is non-zero when db is un-init"
-                );
-            }
-
-            if !total_issued_tokens.is_zero() {
-                bail!("total_issued_tokens is non-zero when db is un-init");
-            }
-
-            if !total_staking_tokens.is_zero() {
-                bail!("total_staking_tokens is non-zero when db is un-init");
-            }
-
-            if !total_storage_tokens.is_zero() {
-                bail!("total_storage_tokens is non-zero when db is un-init");
-            }
+            assert!(
+                annual_interest_rate.is_zero(),
+                "annual_interest_rate is non-zero when db is un-init"
+            );
+            assert!(
+                accumulate_interest_rate.is_zero(),
+                "accumulate_interest_rate is non-zero when db is un-init"
+            );
+            assert!(
+                total_issued_tokens.is_zero(),
+                "total_issued_tokens is non-zero when db is un-init"
+            );
+            assert!(
+                total_staking_tokens.is_zero(),
+                "total_staking_tokens is non-zero when db is un-init"
+            );
+            assert!(
+                total_storage_tokens.is_zero(),
+                "total_storage_tokens is non-zero when db is un-init"
+            );
 
             StakingState {
                 total_issued_tokens: U256::default(),
@@ -1653,21 +1652,21 @@ impl<StateDbStorage: StorageStateTrait> StateGeneric<StateDbStorage> {
         }))
     }
 
-    pub fn clear(&mut self) -> DbResult<()> {
+    pub fn clear(&mut self) {
         assert!(self.checkpoints.get_mut().is_empty());
         assert!(self.staking_state_checkpoints.get_mut().is_empty());
         self.cache.get_mut().clear();
         self.staking_state.interest_rate_per_block =
-            self.db.get_annual_interest_rate()? / U256::from(BLOCKS_PER_YEAR);
+            self.db.get_annual_interest_rate().expect("no db error")
+                / U256::from(BLOCKS_PER_YEAR);
         self.staking_state.accumulate_interest_rate =
-            self.db.get_accumulate_interest_rate()?;
+            self.db.get_accumulate_interest_rate().expect("no db error");
         self.staking_state.total_issued_tokens =
-            self.db.get_total_issued_tokens()?;
+            self.db.get_total_issued_tokens().expect("no db error");
         self.staking_state.total_staking_tokens =
-            self.db.get_total_staking_tokens()?;
+            self.db.get_total_staking_tokens().expect("no db error");
         self.staking_state.total_storage_tokens =
-            self.db.get_total_storage_tokens()?;
-        Ok(())
+            self.db.get_total_storage_tokens().expect("no db error");
     }
 }
 

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -1300,16 +1300,19 @@ impl<StateDbStorage: StorageStateTrait> StateGeneric<StateDbStorage> {
     }
 
     /// Return whether or not the address exists.
-    pub fn try_load(&self, address: &Address) -> DbResult<bool> {
-        if self.ensure_account_loaded(address, RequireCache::None, |maybe| {
-            maybe.is_some()
-        })? {
+    pub fn try_load(&self, address: &Address) -> bool {
+        if self
+            .ensure_account_loaded(address, RequireCache::None, |maybe| {
+                maybe.is_some()
+            })
+            .unwrap()
+        {
             // Try to load the code, but don't fail if there is no code.
-            self.ensure_account_loaded(address, RequireCache::Code, |_| ())?;
-
-            Ok(true)
+            self.ensure_account_loaded(address, RequireCache::Code, |_| ())
+                .unwrap();
+            true
         } else {
-            Ok(false)
+            false
         }
     }
 

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -137,20 +137,15 @@ impl<StateDbStorage: StorageStateTrait> StateGeneric<StateDbStorage> {
     pub fn new(
         db: StateDb<StateDbStorage>, vm: VmFactory, spec: &Spec,
         block_number: u64,
-    ) -> Self
+    ) -> DbResult<Self>
     {
-        let annual_interest_rate =
-            db.get_annual_interest_rate().expect("no db error");
-        let accumulate_interest_rate =
-            db.get_accumulate_interest_rate().expect("no db error");
-        let total_issued_tokens =
-            db.get_total_issued_tokens().expect("No db error");
-        let total_staking_tokens =
-            db.get_total_staking_tokens().expect("No db error");
-        let total_storage_tokens =
-            db.get_total_storage_tokens().expect("No db error");
+        let annual_interest_rate = db.get_annual_interest_rate()?;
+        let accumulate_interest_rate = db.get_accumulate_interest_rate()?;
+        let total_issued_tokens = db.get_total_issued_tokens()?;
+        let total_staking_tokens = db.get_total_staking_tokens()?;
+        let total_storage_tokens = db.get_total_storage_tokens()?;
 
-        let staking_state = if db.is_initialized().expect("no db error") {
+        let staking_state = if db.is_initialized()? {
             StakingState {
                 total_issued_tokens,
                 total_staking_tokens,
@@ -161,26 +156,28 @@ impl<StateDbStorage: StorageStateTrait> StateGeneric<StateDbStorage> {
             }
         } else {
             // If db is not initialized, all the loaded value should be zero.
-            assert!(
-                annual_interest_rate.is_zero(),
-                "annual_interest_rate is non-zero when db is un-init"
-            );
-            assert!(
-                accumulate_interest_rate.is_zero(),
-                "accumulate_interest_rate is non-zero when db is un-init"
-            );
-            assert!(
-                total_issued_tokens.is_zero(),
-                "total_issued_tokens is non-zero when db is un-init"
-            );
-            assert!(
-                total_staking_tokens.is_zero(),
-                "total_staking_tokens is non-zero when db is un-init"
-            );
-            assert!(
-                total_storage_tokens.is_zero(),
-                "total_storage_tokens is non-zero when db is un-init"
-            );
+            if !annual_interest_rate.is_zero() {
+                bail!("annual_interest_rate is non-zero when db is un-init");
+            }
+
+            if !accumulate_interest_rate.is_zero() {
+                bail!(
+                    "accumulate_interest_rate is non-zero when db is un-init"
+                );
+            }
+
+            if !total_issued_tokens.is_zero() {
+                bail!("total_issued_tokens is non-zero when db is un-init");
+            }
+
+            if !total_staking_tokens.is_zero() {
+                bail!("total_staking_tokens is non-zero when db is un-init");
+            }
+
+            if !total_storage_tokens.is_zero() {
+                bail!("total_storage_tokens is non-zero when db is un-init");
+            }
+
             StakingState {
                 total_issued_tokens: U256::default(),
                 total_staking_tokens: U256::default(),
@@ -201,7 +198,7 @@ impl<StateDbStorage: StorageStateTrait> StateGeneric<StateDbStorage> {
         } else {
             U256::zero()
         };
-        StateGeneric {
+        Ok(StateGeneric {
             db,
             cache: Default::default(),
             staking_state_checkpoints: Default::default(),
@@ -212,7 +209,7 @@ impl<StateDbStorage: StorageStateTrait> StateGeneric<StateDbStorage> {
             block_number,
             vm,
             accounts_to_notify: Default::default(),
-        }
+        })
     }
 
     pub fn contract_start_nonce(&self) -> U256 { self.contract_start_nonce }
@@ -468,14 +465,13 @@ impl<StateDbStorage: StorageStateTrait> StateGeneric<StateDbStorage> {
         })
     }
 
-    pub fn is_contract_with_code(&self, address: &Address) -> bool {
+    pub fn is_contract_with_code(&self, address: &Address) -> DbResult<bool> {
         if !address.is_contract_address() {
-            return false;
+            return Ok(false);
         }
         self.ensure_account_loaded(address, RequireCache::None, |acc| {
             acc.map_or(false, |acc| acc.code_hash() != KECCAK_EMPTY)
         })
-        .unwrap_or(false)
     }
 
     fn maybe_address(address: &Address) -> Option<Address> {
@@ -770,9 +766,10 @@ impl<StateDbStorage: StorageStateTrait> StateGeneric<StateDbStorage> {
         )
     }
 
-    pub fn clean_account(&mut self, address: &Address) {
-        *&mut *self.require_or_new_basic_account(address).unwrap() =
+    pub fn clean_account(&mut self, address: &Address) -> DbResult<()> {
+        *&mut *self.require_or_new_basic_account(address)? =
             OverlayAccount::from_loaded(address, Default::default());
+        Ok(())
     }
 
     pub fn inc_nonce(&mut self, address: &Address) -> DbResult<()> {
@@ -1302,18 +1299,16 @@ impl<StateDbStorage: StorageStateTrait> StateGeneric<StateDbStorage> {
     }
 
     /// Return whether or not the address exists.
-    pub fn try_load(&self, address: &Address) -> bool {
-        if let Ok(true) =
-            self.ensure_account_loaded(address, RequireCache::None, |maybe| {
-                maybe.is_some()
-            })
-        {
+    pub fn try_load(&self, address: &Address) -> DbResult<bool> {
+        if self.ensure_account_loaded(address, RequireCache::None, |maybe| {
+            maybe.is_some()
+        })? {
             // Try to load the code, but don't fail if there is no code.
-            self.ensure_account_loaded(address, RequireCache::Code, |_| ())
-                .ok();
-            true
+            self.ensure_account_loaded(address, RequireCache::Code, |_| ())?;
+
+            Ok(true)
         } else {
-            false
+            Ok(false)
         }
     }
 
@@ -1391,10 +1386,10 @@ impl<StateDbStorage: StorageStateTrait> StateGeneric<StateDbStorage> {
 
     pub fn storage_at(&self, address: &Address, key: &[u8]) -> DbResult<U256> {
         self.ensure_account_loaded(address, RequireCache::None, |acc| {
-            acc.map_or(U256::zero(), |account| {
-                account.storage_at(&self.db, key).unwrap_or(U256::zero())
+            acc.map_or(Ok(U256::zero()), |account| {
+                account.storage_at(&self.db, key)
             })
-        })
+        })?
     }
 
     /// Get the value of storage at a specific checkpoint.
@@ -1658,21 +1653,21 @@ impl<StateDbStorage: StorageStateTrait> StateGeneric<StateDbStorage> {
         }))
     }
 
-    pub fn clear(&mut self) {
+    pub fn clear(&mut self) -> DbResult<()> {
         assert!(self.checkpoints.get_mut().is_empty());
         assert!(self.staking_state_checkpoints.get_mut().is_empty());
         self.cache.get_mut().clear();
         self.staking_state.interest_rate_per_block =
-            self.db.get_annual_interest_rate().expect("no db error")
-                / U256::from(BLOCKS_PER_YEAR);
+            self.db.get_annual_interest_rate()? / U256::from(BLOCKS_PER_YEAR);
         self.staking_state.accumulate_interest_rate =
-            self.db.get_accumulate_interest_rate().expect("no db error");
+            self.db.get_accumulate_interest_rate()?;
         self.staking_state.total_issued_tokens =
-            self.db.get_total_issued_tokens().expect("No db error");
+            self.db.get_total_issued_tokens()?;
         self.staking_state.total_staking_tokens =
-            self.db.get_total_staking_tokens().expect("No db error");
+            self.db.get_total_staking_tokens()?;
         self.staking_state.total_storage_tokens =
-            self.db.get_total_storage_tokens().expect("No db error");
+            self.db.get_total_storage_tokens()?;
+        Ok(())
     }
 }
 

--- a/core/src/state/prefetcher.rs
+++ b/core/src/state/prefetcher.rs
@@ -107,9 +107,7 @@ impl PrefetcherThreadWorker {
                 }
                 self.cancel_task_id.store(0, Ordering::Relaxed);
             }
-            state
-                .try_load(address)
-                .expect("db error during account load");
+            state.try_load(address);
         }
     }
 

--- a/core/src/state/prefetcher.rs
+++ b/core/src/state/prefetcher.rs
@@ -107,7 +107,9 @@ impl PrefetcherThreadWorker {
                 }
                 self.cancel_task_id.store(0, Ordering::Relaxed);
             }
-            state.try_load(address);
+            state
+                .try_load(address)
+                .expect("db error during account load");
         }
     }
 

--- a/core/src/state/state_tests.rs
+++ b/core/src/state/state_tests.rs
@@ -36,6 +36,7 @@ fn get_state(
         &Spec::new_spec(),
         if epoch_id.is_zero() { 0 } else { 1 }, /* block_number */
     )
+    .expect("Failed to initialize state")
 }
 
 fn u256_to_vec(val: &U256) -> Vec<u8> {
@@ -174,7 +175,7 @@ fn checkpoint_from_empty_get_storage_at() {
     let k2 = u256_to_vec(&U256::from(1));
 
     assert_eq!(state.storage_at(&a, &k).unwrap(), U256::zero());
-    state.clear();
+    state.clear().unwrap();
 
     let mut substates = Vec::<Substate>::new();
     substates.push(Substate::new());
@@ -460,7 +461,7 @@ fn checkpoint_get_storage_at() {
     state
         .commit(BigEndianHash::from_uint(&U256::from(1u64)), None)
         .unwrap();
-    state.clear();
+    state.clear().unwrap();
     substates.clear();
     substates.push(Substate::new());
 
@@ -484,7 +485,7 @@ fn checkpoint_get_storage_at() {
         state.collateral_for_storage(&a).unwrap(),
         *COLLATERAL_DRIPS_PER_STORAGE_KEY
     );
-    state.clear();
+    state.clear().unwrap();
     substates.clear();
     substates.push(Substate::new());
     let cm1 = state.checkpoint();
@@ -1009,7 +1010,7 @@ fn create_contract_fail_previous_storage() {
     state
         .commit(BigEndianHash::from_uint(&U256::from(1)), None)
         .unwrap();
-    state.clear();
+    state.clear().unwrap();
     substates.clear();
     substates.push(Substate::new());
 
@@ -1017,7 +1018,7 @@ fn create_contract_fail_previous_storage() {
         state.storage_at(&contract_addr, &k).unwrap(),
         U256::from(0xffff)
     );
-    state.clear();
+    state.clear().unwrap();
     substates.clear();
     substates.push(Substate::new());
     state =

--- a/core/src/state/state_tests.rs
+++ b/core/src/state/state_tests.rs
@@ -175,7 +175,7 @@ fn checkpoint_from_empty_get_storage_at() {
     let k2 = u256_to_vec(&U256::from(1));
 
     assert_eq!(state.storage_at(&a, &k).unwrap(), U256::zero());
-    state.clear();
+    state.clear_test_only();
 
     let mut substates = Vec::<Substate>::new();
     substates.push(Substate::new());
@@ -461,7 +461,7 @@ fn checkpoint_get_storage_at() {
     state
         .commit(BigEndianHash::from_uint(&U256::from(1u64)), None)
         .unwrap();
-    state.clear();
+    state.clear_test_only();
     substates.clear();
     substates.push(Substate::new());
 
@@ -485,7 +485,7 @@ fn checkpoint_get_storage_at() {
         state.collateral_for_storage(&a).unwrap(),
         *COLLATERAL_DRIPS_PER_STORAGE_KEY
     );
-    state.clear();
+    state.clear_test_only();
     substates.clear();
     substates.push(Substate::new());
     let cm1 = state.checkpoint();
@@ -1010,7 +1010,7 @@ fn create_contract_fail_previous_storage() {
     state
         .commit(BigEndianHash::from_uint(&U256::from(1)), None)
         .unwrap();
-    state.clear();
+    state.clear_test_only();
     substates.clear();
     substates.push(Substate::new());
 
@@ -1018,7 +1018,7 @@ fn create_contract_fail_previous_storage() {
         state.storage_at(&contract_addr, &k).unwrap(),
         U256::from(0xffff)
     );
-    state.clear();
+    state.clear_test_only();
     substates.clear();
     substates.push(Substate::new());
     state =

--- a/core/src/state/state_tests.rs
+++ b/core/src/state/state_tests.rs
@@ -175,7 +175,7 @@ fn checkpoint_from_empty_get_storage_at() {
     let k2 = u256_to_vec(&U256::from(1));
 
     assert_eq!(state.storage_at(&a, &k).unwrap(), U256::zero());
-    state.clear().unwrap();
+    state.clear();
 
     let mut substates = Vec::<Substate>::new();
     substates.push(Substate::new());
@@ -461,7 +461,7 @@ fn checkpoint_get_storage_at() {
     state
         .commit(BigEndianHash::from_uint(&U256::from(1u64)), None)
         .unwrap();
-    state.clear().unwrap();
+    state.clear();
     substates.clear();
     substates.push(Substate::new());
 
@@ -485,7 +485,7 @@ fn checkpoint_get_storage_at() {
         state.collateral_for_storage(&a).unwrap(),
         *COLLATERAL_DRIPS_PER_STORAGE_KEY
     );
-    state.clear().unwrap();
+    state.clear();
     substates.clear();
     substates.push(Substate::new());
     let cm1 = state.checkpoint();
@@ -1010,7 +1010,7 @@ fn create_contract_fail_previous_storage() {
     state
         .commit(BigEndianHash::from_uint(&U256::from(1)), None)
         .unwrap();
-    state.clear().unwrap();
+    state.clear();
     substates.clear();
     substates.push(Substate::new());
 
@@ -1018,7 +1018,7 @@ fn create_contract_fail_previous_storage() {
         state.storage_at(&contract_addr, &k).unwrap(),
         U256::from(0xffff)
     );
-    state.clear().unwrap();
+    state.clear();
     substates.clear();
     substates.push(Substate::new());
     state =

--- a/core/src/test_helpers.rs
+++ b/core/src/test_helpers.rs
@@ -25,7 +25,8 @@ pub fn get_state_for_genesis_write_with_factory(
         factory.clone().into(),
         &Spec::new_spec(),
         0, /* block_number */
-    );
+    )
+    .expect("Failed to initialize state");
 
     initialize_internal_contract_accounts(&mut state);
     let genesis_epoch_id = EpochId::default();
@@ -50,4 +51,5 @@ pub fn get_state_for_genesis_write_with_factory(
         &Spec::new_spec(),
         1, /* block_number */
     )
+    .expect("Failed to initialize state")
 }

--- a/core/src/transaction_pool/mod.rs
+++ b/core/src/transaction_pool/mod.rs
@@ -750,24 +750,27 @@ impl TransactionPool {
     fn best_executed_state(
         data_man: &BlockDataManager, best_executed_epoch: StateIndex,
     ) -> StorageResult<Arc<State>> {
-        Ok(Arc::new(State::new(
-            StateDb::new(
-                data_man
-                    .storage_manager
-                    .get_state_no_commit(
-                        best_executed_epoch,
-                        /* try_open = */ false,
-                    )?
-                    // Safe because the state is guaranteed to be available
-                    .unwrap(),
-            ),
-            Default::default(),
-            &Spec::new_spec(),
-            // So far block_number is unused in txpool's state, it's fine to
-            // specify a fake number. block_number 1 corresponds to the state
-            // of genesis block.
-            1, /* block_number */
-        )))
+        Ok(Arc::new(
+            State::new(
+                StateDb::new(
+                    data_man
+                        .storage_manager
+                        .get_state_no_commit(
+                            best_executed_epoch,
+                            /* try_open = */ false,
+                        )?
+                        // Safe because the state is guaranteed to be available
+                        .unwrap(),
+                ),
+                Default::default(),
+                &Spec::new_spec(),
+                // So far block_number is unused in txpool's state, it's fine
+                // to specify a fake number. block_number 1
+                // corresponds to the state of genesis block.
+                1, /* block_number */
+            )
+            .expect("Failed to initialize state"),
+        ))
     }
 
     pub fn set_best_executed_epoch(


### PR DESCRIPTION
**Overview**

Currently, some db errors are ignored by `State`. Others are treated as fatal and result in panic. An example of this is when we check the interest rate during state init (`State::new`).

If we allow execution over states provided by peers, these hard assumptions might not hold anymore. The goal of this PR is to provide a way to handle such cases gracefully.

Tracking issue: #2010.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2027)
<!-- Reviewable:end -->
