### PR TITLE
Decrease delay in logs pub-sub

### DIFF
--- a/changelogs/CHANGELOG-1.1.x.md
+++ b/changelogs/CHANGELOG-1.1.x.md
@@ -1,5 +1,9 @@
 # 1.1.1
 
+## Improvements
+
+- Reduce delay in logs pub-sub; now we send logs immediately after they become available.
+
 # 1.1.0
 
 ## Incompatible changes

--- a/client/src/rpc/impls/pubsub.rs
+++ b/client/src/rpc/impls/pubsub.rs
@@ -9,10 +9,7 @@ use crate::rpc::{
     traits::PubSub,
     types::{pubsub, Header as RpcHeader, Log as RpcLog},
 };
-use cfx_parameters::{
-    consensus::DEFERRED_STATE_EPOCH_COUNT,
-    consensus_internal::REWARD_EPOCH_COUNT,
-};
+use cfx_parameters::consensus::DEFERRED_STATE_EPOCH_COUNT;
 use cfx_types::H256;
 use cfxcore::{
     channel::Channel, BlockDataManager, Notifications, SharedConsensusGraph,
@@ -150,7 +147,7 @@ impl PubSubClient {
         // use a queue to make sure we only process an epoch once it has been
         // executed for sure
         let mut queue = EpochQueue::<Vec<H256>>::with_capacity(
-            (DEFERRED_STATE_EPOCH_COUNT + REWARD_EPOCH_COUNT) as usize,
+            (DEFERRED_STATE_EPOCH_COUNT - 1) as usize,
         );
 
         // loop asynchronously
@@ -313,13 +310,19 @@ impl ChainNotificationHandler {
     async fn retrieve_block_receipts(
         &self, block: &H256, pivot: &H256,
     ) -> Option<Arc<BlockReceipts>> {
-        const NUM_POLLS: i8 = 10;
         const POLL_INTERVAL_MS: Duration = Duration::from_millis(100);
 
-        for _ in 0..NUM_POLLS {
+        // we assume that all epochs we receive (with a distance of at least
+        // `DEFERRED_STATE_EPOCH_COUNT` from the tip of the pivot chain) are
+        // eventually executed, i.e. epochs are not dropped from the execution
+        // queue on pivot chain reorgs. moreover, multiple execution results
+        // might be stored for the same block for all epochs it was executed in.
+        // if these assumptions hold, we will eventually successfully read these
+        // execution results, even if they are outdated.
+        for ii in 0.. {
             match self.data_man.block_execution_result_by_hash_with_epoch(
                 &block, &pivot, false, /* update_pivot_assumption */
-                true,  /* update_cache */
+                false, /* update_cache */
             ) {
                 Some(res) => return Some(res.block_receipts.clone()),
                 None => {
@@ -327,12 +330,15 @@ impl ChainNotificationHandler {
                     let _ = sleep(POLL_INTERVAL_MS).compat().await;
                 }
             }
+
+            // this should not happen
+            if ii > 100 {
+                error!("Cannot find receipts with {:?}/{:?}", block, pivot);
+                return None;
+            }
         }
 
-        // note: this can only happen if there was a chain reorg, in which case
-        // we will eventually re-process this epoch with the correct pivot hash
-        warn!("Cannot find receipts with {:?}/{:?}", block, pivot);
-        None
+        unreachable!()
     }
 
     async fn retrieve_epoch_logs(

--- a/tests/pubsub/logs_test.py
+++ b/tests/pubsub/logs_test.py
@@ -80,8 +80,6 @@ class PubSubTest(ConfluxTestFramework):
             receipts.append(r)
             assert(r != None)
 
-        # make sure the pub-sub layer processes the logs
-        self.rpc[FULLNODE0].generate_blocks(20)
         sync_blocks(self.nodes)
 
         # collect pub-sub notifications
@@ -136,9 +134,6 @@ class PubSubTest(ConfluxTestFramework):
         self.rpc[FULLNODE0].generate_blocks(4)
         receipt = self.rpc[FULLNODE0].get_transaction_receipt(tx.hash_hex())
         assert_ne(receipt, None)
-
-        # make sure the pub-sub layer processes the logs
-        self.rpc[FULLNODE0].generate_blocks(20)
         sync_blocks(self.nodes)
 
         # this would timeout before #1989 was fixed


### PR DESCRIPTION
Before, the pub-sub layer kept a distance of 17 epochs (`DEFERRED_STATE_EPOCH_COUNT + REWARD_EPOCH_COUNT`) from the tip of the pivot chain to ensure that the epochs it receives from `ConsensusNewBlockHandler` have already been executed. This causes a large delay which in turn has a negative impact on user experience.

Instead, this PR proposes to keep the distance to a minimum and keeps retrying getting execution results until they become available. This approach assumes that `block_execution_result_by_hash_with_epoch` will **always** return something *eventually*.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2028)
<!-- Reviewable:end -->
