### PR TITLE
Remove file handlers in python test logging.

### DIFF
--- a/tests/test_framework/test_framework.py
+++ b/tests/test_framework/test_framework.py
@@ -264,6 +264,10 @@ class ConfluxTestFramework:
                     os.path.dirname(os.path.realpath(__file__)) +
                     "/../combine_logs.py"), self.options.tmpdir))
             exit_code = TEST_EXIT_FAILED
+        handlers = self.log.handlers[:]
+        for handler in handlers:
+            self.log.removeHandler(handler)
+            handler.close()
         logging.shutdown()
         if cleanup_tree_on_exit:
             shutil.rmtree(self.options.tmpdir)


### PR DESCRIPTION
Close #2025.

Reference: https://stackoverflow.com/questions/15435652/python-does-not-release-filehandles-to-logfile

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2029)
<!-- Reviewable:end -->
