### PR TITLE
Fix random failure in `crash_test.py` and `logs_test.py`

### DIFF
--- a/tests/crash_test.py
+++ b/tests/crash_test.py
@@ -27,7 +27,8 @@ class CrashTest(ConfluxTestFramework):
         for i in range(1, self.num_nodes):
             self.start_node(i, extra_args=self.node_extra_args)
         for i in range(self.num_nodes):
-            wait_until(lambda: len(self.nodes[i].getpeerinfo()) >= 2)
+            # Make sure the graph is connected even after we stop node 0.
+            wait_until(lambda: len(self.nodes[i].getpeerinfo()) >= 4)
 
     def run_test(self):
         block_number = 10

--- a/tests/pubsub/logs_test.py
+++ b/tests/pubsub/logs_test.py
@@ -29,7 +29,6 @@ NUM_CALLS = 20
 class PubSubTest(ConfluxTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
-        self.conf_parameters["log_level"] = '"trace"'
 
     def setup_network(self):
         self.add_nodes(self.num_nodes)
@@ -66,8 +65,8 @@ class PubSubTest(ConfluxTestFramework):
         _, contract2 = self.deploy_contract(sender, priv_key, bytecode)
 
         # subscribe
-        sub_all = await self.pubsub[FULLNODE1].subscribe("logs")
-        sub_one = await self.pubsub[FULLNODE1].subscribe("logs", Filter(address=[contract2]).__dict__)
+        sub_all = await self.pubsub[FULLNODE0].subscribe("logs")
+        sub_one = await self.pubsub[FULLNODE0].subscribe("logs", Filter(address=[contract2]).__dict__)
 
         # call contracts and collect receipts
         receipts = []

--- a/tests/pubsub/logs_test.py
+++ b/tests/pubsub/logs_test.py
@@ -29,6 +29,7 @@ NUM_CALLS = 20
 class PubSubTest(ConfluxTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
+        self.conf_parameters["log_level"] = '"trace"'
 
     def setup_network(self):
         self.add_nodes(self.num_nodes)


### PR DESCRIPTION
If every node only has 2 peers, there will be a small chance that the nodes are partitioned after stopping node 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2038)
<!-- Reviewable:end -->
