### PR TITLE
Add base32 address type to RPC layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,6 +455,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfx-addr"
+version = "0.1.0"
+dependencies = [
+ "cfx-types",
+ "lazy_static",
+ "rustc-hex",
+]
+
+[[package]]
 name = "cfx-bytes"
 version = "0.1.0"
 dependencies = [
@@ -767,6 +776,7 @@ dependencies = [
  "app_dirs",
  "bigdecimal",
  "blockgen",
+ "cfx-addr",
  "cfx-bytes",
  "cfx-internal-common",
  "cfx-parameters",

--- a/cfx_addr/rust/src/consts.rs
+++ b/cfx_addr/rust/src/consts.rs
@@ -40,7 +40,7 @@ pub const SIZE_384: u8 = 0x05;
 pub const SIZE_448: u8 = 0x06;
 pub const SIZE_512: u8 = 0x07;
 
-#[derive(PartialEq, Eq, Clone, Debug, Hash)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash)]
 pub enum Network {
     /// Main network.
     Main,
@@ -131,7 +131,7 @@ impl AddressType {
     }
 
     pub fn from_address(address_hex: &Address) -> Result<Self, EncodingError> {
-        match *address_hex.type_byte() {
+        match address_hex.address_type_bits() {
             address_util::TYPE_BITS_BUILTIN => {
                 if address_hex.is_null_address() {
                     Ok(Self::Null)

--- a/cfx_addr/rust/src/lib.rs
+++ b/cfx_addr/rust/src/lib.rs
@@ -19,7 +19,7 @@ mod tests;
 
 use cfx_types::Address;
 use checksum::polymod;
-use consts::{AddressType, Network};
+pub use consts::{AddressType, Network};
 use errors::*;
 
 const BASE32_CHARS: &str = "0123456789abcdefghijklmnopqrstuvwxyz";

--- a/cfx_addr/rust/src/lib.rs
+++ b/cfx_addr/rust/src/lib.rs
@@ -124,7 +124,6 @@ pub fn cfx_addr_decode(addr_str: &str) -> Result<UserAddress, DecodingError> {
         return Err(DecodingError::MixedCase);
     }
     let lowercase = addr_str.to_lowercase();
-    drop(addr_str);
 
     // Delimit and extract prefix
     let parts: Vec<&str> = lowercase.split(':').collect();
@@ -289,13 +288,7 @@ fn convert_bits(
         // If there's some bits left, figure out if we need to remove padding
         // and add it
         let padding = ((data.len() * inbits as usize) % outbits as usize) as u8;
-        if num >= inbits {
-            return Err(DecodingError::InvalidPadding {
-                from_bits: inbits,
-                padding_bits: padding,
-                padding: acc,
-            });
-        } else if acc != 0 {
+        if num >= inbits || acc != 0 {
             return Err(DecodingError::InvalidPadding {
                 from_bits: inbits,
                 padding_bits: padding,

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -35,6 +35,7 @@ error-chain = { version = "0.12" }
 lazy_static = "1.4"
 log = "0.4"
 cfx-types = { path = "../cfx_types" }
+cfx-addr = { path = "../cfx_addr/rust" }
 cfx-bytes = { path = "../cfx_bytes" }
 runtime = { path = "../util/runtime" }
 slab = "0.4"

--- a/client/src/rpc/types.rs
+++ b/client/src/rpc/types.rs
@@ -3,6 +3,7 @@
 // See http://www.gnu.org/licenses/
 
 mod account;
+mod address;
 mod blame_info;
 mod block;
 mod bytes;
@@ -25,6 +26,7 @@ pub mod pubsub;
 
 pub use self::{
     account::Account,
+    address::Address,
     blame_info::BlameInfo,
     block::{Block, BlockTransactions, Header},
     bytes::Bytes,

--- a/client/src/rpc/types/address.rs
+++ b/client/src/rpc/types/address.rs
@@ -1,0 +1,128 @@
+// Copyright 2021 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use cfx_addr::{cfx_addr_decode, cfx_addr_encode, Network, UserAddress};
+use cfx_types::H160;
+use serde::{de, ser, Deserialize, Deserializer, Serialize, Serializer};
+use std::{convert::TryInto, ops::Deref};
+
+#[derive(Debug)]
+pub struct Address(UserAddress);
+
+impl Deref for Address {
+    type Target = UserAddress;
+
+    fn deref(&self) -> &Self::Target { &self.0 }
+}
+
+impl TryInto<H160> for Address {
+    type Error = String;
+
+    fn try_into(self) -> Result<H160, Self::Error> {
+        match self.hex_address {
+            Some(h) => Ok(h),
+            None => Err("Not a hex address".into()),
+        }
+    }
+}
+
+impl<'a> Deserialize<'a> for Address {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where D: Deserializer<'a> {
+        let s: String = Deserialize::deserialize(deserializer)?;
+
+        let inner = cfx_addr_decode(&s).map_err(|e| {
+            de::Error::custom(format!("Invalid base32 address: {}", e))
+        })?;
+
+        Ok(Address(inner))
+    }
+}
+
+impl Serialize for Address {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where S: Serializer {
+        let addr_str = cfx_addr_encode(&self.0.body[..], self.0.network)
+            .map_err(|e| {
+                ser::Error::custom(format!("Failed to encode address: {}", e))
+            })?;
+
+        serializer.serialize_str(&addr_str)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    fn check_deserialize(raw: &str, hex: &str, network: Network) {
+        let addr_hex = hex.trim_start_matches("0x").parse().unwrap();
+        let parsed: Address = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed.network, network);
+        assert_eq!(parsed.hex_address, Some(addr_hex));
+        assert_eq!(parsed.try_into(), Ok(addr_hex));
+    }
+
+    #[test]
+    fn test_deserialize_address() {
+        check_deserialize(
+            "\"cfx:022xg0j5vg1fba4nh7gz372we6740puptms36cm58c\"",
+            "0x85d80245dc02f5a89589e1f19c5c718e405b56cd",
+            Network::Main,
+        );
+
+        check_deserialize(
+            "\"cfxtest:022xg0j5vg1fba4nh7gz372we6740puptmj8nwjfc6\"",
+            "0x85d80245dc02f5a89589e1f19c5c718e405b56cd",
+            Network::Test,
+        );
+
+        check_deserialize(
+            "\"cfxtest:type.contract:022xg0j5vg1fba4nh7gz372we6740puptmj8nwjfc6\"",
+            "0x85d80245dc02f5a89589e1f19c5c718e405b56cd",
+            Network::Test,
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_deserialize_incorrect_network_prefix() {
+        check_deserialize(
+            "\"cfy:022xg0j5vg1fba4nh7gz372we6740puptmj8nwjfc6\"",
+            "0x85d80245dc02f5a89589e1f19c5c718e405b56cd",
+            Network::Main,
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_deserialize_no_network_prefix() {
+        check_deserialize(
+            "\"022xg0j5vg1fba4nh7gz372we6740puptmj8nwjfc6\"",
+            "0x85d80245dc02f5a89589e1f19c5c718e405b56cd",
+            Network::Main,
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_deserialize_incorrect_type() {
+        check_deserialize(
+            "\"cfx:type.user:022xg0j5vg1fba4nh7gz372we6740puptmj8nwjfc6\"",
+            "0x85d80245dc02f5a89589e1f19c5c718e405b56cd",
+            Network::Main,
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_deserialize_incorrect_checksum() {
+        check_deserialize(
+            "\"cfx:022xg0j5vg1fba4nh7gz372we6740puptmj8nwjfc7\"",
+            "0x85d80245dc02f5a89589e1f19c5c718e405b56cd",
+            Network::Main,
+        );
+    }
+}

--- a/client/src/rpc/types/address.rs
+++ b/client/src/rpc/types/address.rs
@@ -2,7 +2,7 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use cfx_addr::{cfx_addr_decode, cfx_addr_encode, Network, UserAddress};
+use cfx_addr::{cfx_addr_decode, cfx_addr_encode, UserAddress};
 use cfx_types::H160;
 use serde::{de, ser, Deserialize, Deserializer, Serialize, Serializer};
 use std::{convert::TryInto, ops::Deref};
@@ -54,8 +54,10 @@ impl Serialize for Address {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::Address;
+    use cfx_addr::Network;
     use serde_json;
+    use std::convert::TryInto;
 
     fn check_deserialize(raw: &str, hex: &str, network: Network) {
         let addr_hex = hex.trim_start_matches("0x").parse().unwrap();


### PR DESCRIPTION
This PR exposes the newly added base32 address type (`cfx_addr`) as an RPC type. RPC handlers will be updated in a separate PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2039)
<!-- Reviewable:end -->
