### PR TITLE
Enable gzip and background_rotation for log4rs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,6 +951,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
+name = "crc32fast"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "criterion"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1440,6 +1449,18 @@ name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
+name = "flate2"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -2433,6 +2454,7 @@ dependencies = [
  "arc-swap",
  "chrono",
  "derivative",
+ "flate2",
  "fnv",
  "humantime 2.0.1",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ blockgen = { path = "blockgen" }
 txgen = { path = "transactiongen" }
 secret-store = { path = "secret_store" }
 primitives = { path = "primitives" }
-log4rs = "1.0.0"
+log4rs = { version = "1.0.0", features = ["background_rotation", "gzip"] }
 rlp = "0.4.0"
 keccak-hash = "0.5"
 rand = "0.7"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -46,7 +46,7 @@ blockgen = { path = "../blockgen" }
 txgen = { path = "../transactiongen" }
 secret-store = { path = "../secret_store" }
 primitives = { path = "../primitives" }
-log4rs = "1.0.0"
+log4rs = { version = "1.0.0", features = ["background_rotation", "gzip"] }
 rlp = "0.4.0"
 keccak-hash = "0.5"
 rand = "0.7.2"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -37,7 +37,7 @@ kvdb-rocksdb = {path="../db/src/kvdb-rocksdb"}
 lazy_static = "1.4"
 link-cut-tree = { path = "../util/link-cut-tree" }
 log = "0.4"
-log4rs = "1.0.0"
+log4rs = { version = "1.0.0", features = ["background_rotation", "gzip"] }
 lru_time_cache = "0.9.0"
 malloc_size_of = {path = "../util/malloc_size_of"}
 malloc_size_of_derive = {path = "../util/malloc_size_of_derive"}

--- a/core/benchmark/consensus/Cargo.toml
+++ b/core/benchmark/consensus/Cargo.toml
@@ -14,7 +14,7 @@ primitives = { path = "../../../primitives" }
 db = { path = "../../../db" }
 threadpool = "1.0"
 parking_lot = "0.11"
-log4rs = "1.0.0"
+log4rs = { version = "1.0.0", features = ["background_rotation", "gzip"] }
 log = "0.4"
 
 [dev-dependencies]

--- a/core/storage/Cargo.toml
+++ b/core/storage/Cargo.toml
@@ -23,7 +23,7 @@ kvdb = "0.4"
 kvdb-rocksdb = {path="../../db/src/kvdb-rocksdb"}
 lazy_static = "1.4"
 log = "0.4"
-log4rs = "1.0.0"
+log4rs = { version = "1.0.0", features = ["background_rotation", "gzip"] }
 malloc_size_of = {path = "../../util/malloc_size_of"}
 malloc_size_of_derive = {path = "../../util/malloc_size_of_derive"}
 memoffset = "0.5.1"


### PR DESCRIPTION
`gzip` was disabled by default in v1.0.0, which makes our log rotation configuration in `log.yaml` fail.

Check https://github.com/estk/log4rs/blob/master/README.md#warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2051)
<!-- Reviewable:end -->
