### PR TITLE
Fix several bugs in state proof

### DIFF
--- a/core/storage/src/impls/state_proof.rs
+++ b/core/storage/src/impls/state_proof.rs
@@ -42,6 +42,14 @@ impl StateProof {
         maybe_intermediate_padding: Option<DeltaMptKeyPadding>,
     ) -> bool
     {
+        // Something is wrong when intermediate_proof exists but we are not able
+        // to get a intermediate padding.
+        if self.intermediate_proof.is_some()
+            && maybe_intermediate_padding.is_none()
+        {
+            return false;
+        }
+
         let delta_root = &root.delta_root;
         let intermediate_root = &root.intermediate_delta_root;
         let snapshot_root = &root.snapshot_root;
@@ -95,10 +103,9 @@ impl StateProof {
         // Now check intermediate_proof since it's required. Same logic applies.
         match &self.intermediate_proof {
             Some(proof) => {
-                if maybe_intermediate_mpt_key.is_none() {
-                    return false;
-                }
                 if proof.is_valid_kv(
+                    // It's guaranteed that
+                    // maybe_intermediate_mpt_key.is_some().
                     maybe_intermediate_mpt_key.as_ref().unwrap(),
                     delta_value,
                     intermediate_root,

--- a/core/storage/src/tests/proofs.rs
+++ b/core/storage/src/tests/proofs.rs
@@ -376,8 +376,15 @@ fn test_invalid_state_proof() {
             Some(padding.clone())
         ));
 
-        // checking proof with invalid padding should fail
+        // checking proof with invalid intermediate mpt existence should fail.
         if proof.intermediate_proof.is_some() {
+            assert!(!proof.is_valid_kv(key, value, root.clone(), None));
+
+            // Existence proof with invalid padding can be fine when delta proof
+            // combined with snapshot proof prove the key-value and the change
+            // of intermediate padding results into non-existence key in
+            // the intermediate mpt.
+            /*
             let invalid_padding = get_invalid_delta_padding(&padding);
 
             assert!(!proof.is_valid_kv(
@@ -386,8 +393,7 @@ fn test_invalid_state_proof() {
                 root.clone(),
                 Some(invalid_padding),
             ));
-
-            assert!(!proof.is_valid_kv(key, value, root.clone(), None));
+             */
         }
 
         // checking valid existence proof as non-existence proof should fail

--- a/core/storage/src/tests/proofs.rs
+++ b/core/storage/src/tests/proofs.rs
@@ -115,11 +115,6 @@ fn generate_random_state(
     let root_1 = state_1.compute_state_root().unwrap();
     state_1.commit(epoch_id_1).unwrap();
 
-    let intermediate_padding = StorageKey::delta_mpt_padding(
-        &root_1.state_root.snapshot_root,
-        &root_1.state_root.intermediate_delta_root,
-    );
-
     // insert 2nd, 3rd, 5th, 6th 1/7 portions into state-2
     let mut state_2 = state_manager
         .get_state_for_next_epoch(StateIndex::new_for_next_epoch(
@@ -157,12 +152,27 @@ fn generate_random_state(
 
     let mut epoch_id_2 = H256::default();
     epoch_id_2.as_bytes_mut()[0] = 3;
-    let _root_2 = state_2.compute_state_root().unwrap();
+    let root_2 = state_2.compute_state_root().unwrap();
     state_2.commit(epoch_id_2).unwrap();
 
     keys.shuffle(rng);
 
-    (state_manager, state_2, intermediate_padding, keys)
+    let intermediate_padding = StorageKey::delta_mpt_padding(
+        &root_2.state_root.snapshot_root,
+        &root_2.state_root.intermediate_delta_root,
+    );
+
+    let new_state = state_manager
+        .get_state_for_next_epoch(StateIndex::new_for_next_epoch(
+            &epoch_id_2,
+            &root_2,
+            3,
+            snapshot_epoch_count,
+        ))
+        .unwrap()
+        .unwrap();
+
+    (state_manager, new_state, intermediate_padding, keys)
 }
 
 fn select_keys(


### PR DESCRIPTION
- Fix a bug in test util function where a committed state is returned. A committed state isn't supposed to be operated on any more.
- Fix bug in proof test, which made wrong assumption that an incorrect intermediate padding invalidates the proof.
- Remove optimistic short-circuit logic in state_proof to be more rigorous.
- Add a TODO item for useless state proof removal from the return value of get_with_proof.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2056)
<!-- Reviewable:end -->
