### PR TITLE
Update base32 address charset so that address usually starts with …

### DIFF
--- a/cfx_addr/rust/src/lib.rs
+++ b/cfx_addr/rust/src/lib.rs
@@ -23,7 +23,7 @@ pub use consts::{AddressType, Network};
 pub use errors::DecodingError;
 use errors::*;
 
-const BASE32_CHARS: &str = "0123456789abcdefghijklmnopqrstuvwxyz";
+const BASE32_CHARS: &str = "abcdefghijklmnopqrstuvwxyz0123456789";
 const EXCLUDE_CHARS: [char; 4] = ['o', 'i', 'l', 'q'];
 lazy_static! {
     // Regular expression for application to match string. This regex isn't strict,

--- a/cfx_addr/rust/src/tests.rs
+++ b/cfx_addr/rust/src/tests.rs
@@ -13,73 +13,73 @@ fn spec_test_vectors() {
     verify(
         Network::Main,
         "85d80245dc02f5a89589e1f19c5c718e405b56cd",
-        "cfx:022xg0j5vg1fba4nh7gz372we6740puptms36cm58c",
+        "cfx:acc7uawf5ubtnmezvhu9dhc6sghea0403y2dgpyfjp",
     );
 
     verify(
         Network::Test,
         "85d80245dc02f5a89589e1f19c5c718e405b56cd",
-        "cfxtest:022xg0j5vg1fba4nh7gz372we6740puptmj8nwjfc6",
+        "cfxtest:acc7uawf5ubtnmezvhu9dhc6sghea0403ywjz6wtpg",
     );
 
     verify(
         Network::Main,
         "1a2f80341409639ea6a35bbcab8299066109aa55",
-        "cfx:00d2z01m2g4p77n6mddvtaw2k43622daamm1867uk6",
+        "cfx:aarc9abycue0hhzgyrr53m6cxedgccrmmyybjgh4xg",
     );
 
     verify(
         Network::Test,
         "1a2f80341409639ea6a35bbcab8299066109aa55",
-        "cfxtest:00d2z01m2g4p77n6mddvtaw2k43622daamyavp1grc",
+        "cfxtest:aarc9abycue0hhzgyrr53m6cxedgccrmmy8m50bu1p",
     );
 
     verify(
         Network::Main,
         "19c742cec42b9e4eff3b84cdedcde2f58a36f44f",
-        "cfx:00cwegpesgntwkrz7e2cvvedwbusmdrm9wdsdks47x",
+        "cfx:aap6su0s2uz36x19hscp55sr6n42yr1yk6r2rx2eh7",
     );
 
     verify(
         Network::Test,
         "19c742cec42b9e4eff3b84cdedcde2f58a36f44f",
-        "cfxtest:00cwegpesgntwkrz7e2cvvedwbusmdrm9w7ky3ye3r",
+        "cfxtest:aap6su0s2uz36x19hscp55sr6n42yr1yk6hx8d8sd1",
     );
 
     verify(
         Network::Main,
         "84980a94d94f54ac335109393c08c866a21b1b0e",
-        "cfx:0229g2mmv57n9b1ka44kjf08t1ka46sv1s1vpcf0wh",
+        "cfx:acckucyy5fhzknbxmeexwtaj3bxmeg25b2b50pta6v",
     );
 
     verify(
         Network::Test,
         "84980a94d94f54ac335109393c08c866a21b1b0e",
-        "cfxtest:0229g2mmv57n9b1ka44kjf08t1ka46sv1sbg5w9asv",
+        "cfxtest:acckucyy5fhzknbxmeexwtaj3bxmeg25b2nuf6km25",
     );
 
     verify(
         Network::Main,
         "1cdf3969a428a750b89b33cf93c96560e2bd17d1",
-        "cfx:00edyeb9mgmaem5skctwz4y9cnge5f8ru42rbphk8r",
+        "cfx:aasr8snkyuymsyf2xp369e8kpzusftj14ec1n0vxj1",
     );
 
     verify(
         Network::Test,
         "1cdf3969a428a750b89b33cf93c96560e2bd17d1",
-        "cfxtest:00edyeb9mgmaem5skctwz4y9cnge5f8ru48ws6rtcx",
+        "cfxtest:aasr8snkyuymsyf2xp369e8kpzusftj14ej62g13p7",
     );
 
     verify(
         Network::Main,
         "0888000000000000000000000000000000000002",
-        "cfx:0048g00000000000000000000000000008djg2z8b1",
+        "cfx:aaejuaaaaaaaaaaaaaaaaaaaaaaaaaaaajrwuc9jnb",
     );
 
     verify(
         Network::Test,
         "0888000000000000000000000000000000000002",
-        "cfxtest:0048g000000000000000000000000000087t3jt2fb",
+        "cfxtest:aaejuaaaaaaaaaaaaaaaaaaaaaaaaaaaajh3dw3ctn",
     );
 }
 
@@ -98,36 +98,40 @@ fn encoding_errors() {
 #[test]
 #[rustfmt::skip]
 fn decoding_errors() {
+    let hex_addr = "85d80245dc02f5a89589e1f19c5c718e405b56cd".from_hex::<Vec<u8>>().unwrap();
+    let base32_addr = cfx_addr_encode(&hex_addr, Network::Main, EncodingOptions::Simple).unwrap();
+    assert_eq!(base32_addr, "cfx:acc7uawf5ubtnmezvhu9dhc6sghea0403y2dgpyfjp");
+
     // mixed case
-    assert!(cfx_addr_decode("cfx:022xg0j5vg1fba4nh7gz372we6740puptms36cm58c").is_ok());
-    assert!(cfx_addr_decode("CFX:022XG0J5VG1FBA4NH7GZ372WE6740PUPTMS36CM58C").is_ok());
-    assert!(cfx_addr_decode("Cfx:022xg0j5vg1fba4nh7gz372we6740puptms36cm58c").is_err());
-    assert!(cfx_addr_decode("cfx:022Xg0j5vg1fba4nh7gz372we6740puptms36cm58c").is_err());
+    assert!(cfx_addr_decode("cfx:acc7uawf5ubtnmezvhu9dhc6sghea0403y2dgpyfjp").is_ok());
+    assert!(cfx_addr_decode("CFX:ACC7UAWF5UBTNMEZVHU9DHC6SGHEA0403Y2DGPYFJP").is_ok());
+    assert!(cfx_addr_decode("Cfx:acc7uawf5ubtnmezvhu9dhc6sghea0403y2dgpyfjp").is_err());
+    assert!(cfx_addr_decode("cfx:acc7Uawf5ubtnmezvhu9dhc6sghea0403y2dgpyfjp").is_err());
 
     // prefix
-    assert!(cfx_addr_decode("022xg0j5vg1fba4nh7gz372we6740puptms36cm58c").is_err());
-    assert!(cfx_addr_decode("bch:022xg0j5vg1fba4nh7gz372we6740puptms36cm58c").is_err());
-    assert!(cfx_addr_decode("cfx1:022xg0j5vg1fba4nh7gz372we6740puptms36cm58c").is_err());
-    assert!(cfx_addr_decode("cfx1029:022xg0j5vg1fba4nh7gz372we6740puptms36cm58c").is_err());
+    assert!(cfx_addr_decode("acc7uawf5ubtnmezvhu9dhc6sghea0403y2dgpyfjp").is_err());
+    assert!(cfx_addr_decode("bch:acc7uawf5ubtnmezvhu9dhc6sghea0403y2dgpyfjp").is_err());
+    assert!(cfx_addr_decode("cfx1:acc7uawf5ubtnmezvhu9dhc6sghea0403y2dgpyfjp").is_err());
+    assert!(cfx_addr_decode("cfx1029:acc7uawf5ubtnmezvhu9dhc6sghea0403y2dgpyfjp").is_err());
 
     // optional address type
-    assert!(cfx_addr_decode("cfx:type.contract:022xg0j5vg1fba4nh7gz372we6740puptms36cm58c").is_ok());
-    assert!(cfx_addr_decode("cfx:type.contract:opt.random:022xg0j5vg1fba4nh7gz372we6740puptms36cm58c").is_ok());
-    assert!(cfx_addr_decode("cfx:type.user:022xg0j5vg1fba4nh7gz372we6740puptms36cm58c").is_err());
-    assert!(cfx_addr_decode("cfx:contract:022xg0j5vg1fba4nh7gz372we6740puptms36cm58c").is_err());
-    assert!(cfx_addr_decode("cfx:type.contract.2:022xg0j5vg1fba4nh7gz372we6740puptms36cm58c").is_err());
+    assert!(cfx_addr_decode("cfx:type.contract:acc7uawf5ubtnmezvhu9dhc6sghea0403y2dgpyfjp").is_ok());
+    assert!(cfx_addr_decode("cfx:type.contract:opt.random:acc7uawf5ubtnmezvhu9dhc6sghea0403y2dgpyfjp").is_ok());
+    assert!(cfx_addr_decode("cfx:type.user:acc7uawf5ubtnmezvhu9dhc6sghea0403y2dgpyfjp").is_err());
+    assert!(cfx_addr_decode("cfx:contract:acc7uawf5ubtnmezvhu9dhc6sghea0403y2dgpyfjp").is_err());
+    assert!(cfx_addr_decode("cfx:type.contract.2:acc7uawf5ubtnmezvhu9dhc6sghea0403y2dgpyfjp").is_err());
 
     // length check
     assert!(cfx_addr_decode("cfx:").is_err());
-    assert!(cfx_addr_decode("cfx:062xg0j5vg1fba4nh7gz372we6740puptmru39kknc").is_err()); // change length in version byte to 001
-    assert!(cfx_addr_decode("cfx:0022xg0j5vg1fba4nh7gz372we6740puptms36cm58c").is_err());
+    assert!(cfx_addr_decode("cfx:agc7uawf5ubtnmezvhu9dhc6sghea0403y2dgpyfjp").is_err()); // change length in version byte to 001
+    assert!(cfx_addr_decode("cfx:aacc7uawf5ubtnmezvhu9dhc6sghea0403y2dgpyfjp").is_err());
 
     // charset check
-    assert!(cfx_addr_decode("cfx:022xg0i5vg1fba4nh7gz372we6740puptms36cm58c").is_err()); // j --> i
+    assert!(cfx_addr_decode("cfx:acc7uawf5ubtnmezvhu9dhc6sghea0403y2dgpyfip").is_err()); // j --> i
 
     // checksum check
     for ii in 4..46 {
-        let mut x: String = "cfx:022xg0j5vg1fba4nh7gz372we6740puptms36cm58c".into();
+        let mut x = base32_addr.clone();
 
         // need unsafe to mutate utf-8
         unsafe {
@@ -141,11 +145,11 @@ fn decoding_errors() {
     }
 
     // version check
-    assert!(cfx_addr_decode("cfx:g22xg0j5vg1fba4nh7gz372we6740puptm91kazw6t").is_err()); // version byte: 0b10000000
-    assert!(cfx_addr_decode("cfx:822xg0j5vg1fba4nh7gz372we6740puptm42sf5xfj").is_err()); // version byte: 0b01000000
-    assert!(cfx_addr_decode("cfx:422xg0j5vg1fba4nh7gz372we6740puptmpr9t89z3").is_err()); // version byte: 0b00100000
-    assert!(cfx_addr_decode("cfx:222xg0j5vg1fba4nh7gz372we6740puptmz9nju3rz").is_err()); // version byte: 0b00010000
-    assert!(cfx_addr_decode("cfx:122xg0j5vg1fba4nh7gz372we6740puptmf6v3k6kh").is_err()); // version byte: 0b00001000
+    assert!(cfx_addr_decode("cfx:t22xg0j5vg1fba4nh7gz372we6740puptm91kazw6t").is_err()); // version byte: 0b10000000
+    assert!(cfx_addr_decode("cfx:jcc7uawf5ubtnmezvhu9dhc6sghea0403y2dgpyfjp").is_err()); // version byte: 0b01000000
+    assert!(cfx_addr_decode("cfx:ecc7uawf5ubtnmezvhu9dhc6sghea0403y2dgpyfjp").is_err()); // version byte: 0b00100000
+    assert!(cfx_addr_decode("cfx:ccc7uawf5ubtnmezvhu9dhc6sghea0403y2dgpyfjp").is_err()); // version byte: 0b00010000
+    assert!(cfx_addr_decode("cfx:bcc7uawf5ubtnmezvhu9dhc6sghea0403y2dgpyfjp").is_err()); // version byte: 0b00001000
 }
 
 #[test]
@@ -154,112 +158,112 @@ fn bch_tests() {
     verify(
         Network::Main,
         "F5BF48B397DAE70BE82B3CCA4793F8EB2B6CDAC9",
-        "cfx:03uvyj5kjzdee2z85cycmhwkz3njpv6ut404kg24d3",
+        "cfx:ad458wfxw9rssc9jfp8pyv6x9dzw05g43eaexucerd",
     );
 
     // 24-byte public key hash on mainnet
     verify(
         Network::Main,
         "7ADBF6C17084BC86C1706827B41A56F5CA32865925E946EA",
-        "cfx:05xdrxp1e22bt1p1e1m2fd0uavuwmcm6b4jyjhrah5yarrsk",
+        "cfx:af7r170bsccn3b0bsbyctra4m546ypygnew8wv1mvf8m112x",
     );
 
     // 28-byte public key hash on mainnet
     verify(
         Network::Main,
         "3A84F9CF51AAE98A3BB3A78BF16A6183790B18719126325BFC0C075B",
-        "cfx:08x89yefa6nek2hvpeksrwbac61rj2sse68jccjvzg60epsfkmp7pfx",
+        "cfx:aj7jk8stmgzsxcv50sx216nmpgb1wc22sgjwppw59ugas02txy0h0t7",
     );
 
     // 32-byte public key hash on mainnet
     verify(
         Network::Main,
         "3173EF6623C6B48FFD1A3DCC0CC6489B0A07BB47A37F47CFEF4FE69DE825C060",
-        "cfx:0csr7vv64f3b93zx38yws36692dgm1xv8yhryhyfxx7yd7f84r060ts1bh7b2",
+        "cfx:ap21h55getdnkd97dj862dggkcruyb75j8v18v8t77h8rhtje1aga32bnvhnc",
     );
 
     // 40-byte public key hash on mainnet
     verify(
         Network::Main,
         "C07138323E00FA4FC122D3B85B9628EA810B3F381706385E289B0B25631197D194B5C238BEB136FB",
-        "cfx:0k072e1j7s0fmky14b9vgpwp53n822tz70bgce2y52dgp9b326bx355ns8wbxc9pzc6wyh3134",
+        "cfx:axahcsbwh2atyx8benk5u060fdzjcc39hanupsc8fcru0kndcgn7dffz2j6n7pk09pg68vdbde",
     );
 
     // 48-byte public key hash on mainnet
     verify(
         Network::Main,
         "E361CA9A7F99107C17A622E047E3745D3E19CF804ED63C5C40C6BA763696B98241223D8CE62AD48D863F4CB18C930E4C",
-        "cfx:0rhp3jmufych0z0rmshe0hz3ehekw6efg17dcf2w833bmxhpjuws4g927p6ecapmhp33yk5hhj9gwk0p7j3465g",
+        "cfx:a1v0dwy4t8pva9a1y2vsav9dsvsx6gstubhrptc6jddny7v0w462eukch0gspm0yv0dd8xfvvwku6xa0hwdegfu",
     );
 
     // 56-byte public key hash on mainnet
     verify(
         Network::Main,
         "D9FA7C4C6EF56DC4FF423BAAE6D495DBFF663D034A72D1DC7D52CBFE7D1E6858F9D523AC0A7A5C34077638E4DD1A701BD017842789982041",
-        "cfx:0vczmz2cdvupvh7z88xuntpmjrdzythx0d575mewfn9crzkx3tm5hyen4ep0myjw6g3rce74vmd706yg2y22f2cs410gkuf22jyz",
+        "cfx:a5p9y9cpr5405vh9jj74z30yw1r983v7arfhfys6tzkp19x7d3yfv8szes0ay8w6gud1pshe5yrhag8uc8cctcp2ebaux4tccw89",
     );
 
     // 64-byte public key hash on mainnet
     verify(
         Network::Main,
         "D0F346310D5513D9E01E299978624BA883E6BDA8F4C60883C10F28C2967E67EC77ECC7EEEAEAFC6DA89FAD72D11AC961E164678B868AEEEC5F2C1DA08884175B",
-        "cfx:0z8f6hhh1nah7pf03smtjy329em87tnxn3ucc243s47jhgmpftkysxzcszrenurwdpm9zbbju4dcjsf1chksr1maxvp5yb0xm24885uvnjjgpguy",
+        "cfx:a9jtgvvvbzmvh0tad2y3w8dcksyjh3z7zd4ppced2ehwvuy0t3x8279p291sz416r0yk9nnw4erpw2tbpvx21bym750f8na7ycejjf45zwwu0u48",
     );
 
     // 20-byte public key hash on testnet
     verify(
         Network::Test,
         "F5BF48B397DAE70BE82B3CCA4793F8EB2B6CDAC9",
-        "cfxtest:03uvyj5kjzdee2z85cycmhwkz3njpv6ut4af004e99",
+        "cfxtest:ad458wfxw9rssc9jfp8pyv6x9dzw05g43emtaaeskk",
     );
 
     // 24-byte public key hash on testnet
     verify(
         Network::Test,
         "7ADBF6C17084BC86C1706827B41A56F5CA32865925E946EA",
-        "cfxtest:05xdrxp1e22bt1p1e1m2fd0uavuwmcm6b4jyjhratdxfn0t2",
+        "cfxtest:af7r170bsccn3b0bsbyctra4m546ypygnew8wv1m3r7tza3c",
     );
 
     // 28-byte public key hash on testnet
     verify(
         Network::Test,
         "3A84F9CF51AAE98A3BB3A78BF16A6183790B18719126325BFC0C075B",
-        "cfxtest:08x89yefa6nek2hvpeksrwbac61rj2sse68jccjvzg60epsjea27vyt",
+        "cfxtest:aj7jk8stmgzsxcv50sx216nmpgb1wc22sgjwppw59ugas02wsmch583",
     );
 
     // 32-byte public key hash on testnet
     verify(
         Network::Test,
         "3173EF6623C6B48FFD1A3DCC0CC6489B0A07BB47A37F47CFEF4FE69DE825C060",
-        "cfxtest:0csr7vv64f3b93zx38yws36692dgm1xv8yhryhyfxx7yd7f84r060hkzn7njc",
+        "cfxtest:ap21h55getdnkd97dj862dggkcruyb75j8v18v8t77h8rhtje1agavx9zhzwp",
     );
 
     // 40-byte public key hash on testnet
     verify(
         Network::Test,
         "C07138323E00FA4FC122D3B85B9628EA810B3F381706385E289B0B25631197D194B5C238BEB136FB",
-        "cfxtest:0k072e1j7s0fmky14b9vgpwp53n822tz70bgce2y52dgp9b326bx355ns8wbxc9pzck0f5wyv4",
+        "cfxtest:axahcsbwh2atyx8benk5u060fdzjcc39hanupsc8fcru0kndcgn7dffz2j6n7pk09pxatf685e",
     );
 
     // 48-byte public key hash on testnet
     verify(
         Network::Test,
         "E361CA9A7F99107C17A622E047E3745D3E19CF804ED63C5C40C6BA763696B98241223D8CE62AD48D863F4CB18C930E4C",
-        "cfxtest:0rhp3jmufych0z0rmshe0hz3ehekw6efg17dcf2w833bmxhpjuws4g927p6ecapmhp33yk5hhj9gwk08cxav3r7",
+        "cfxtest:a1v0dwy4t8pva9a1y2vsav9dsvsx6gstubhrptc6jddny7v0w462eukch0gspm0yv0dd8xfvvwku6xajp7m5d1h",
     );
 
     // 56-byte public key hash on testnet
     verify(
         Network::Test,
         "D9FA7C4C6EF56DC4FF423BAAE6D495DBFF663D034A72D1DC7D52CBFE7D1E6858F9D523AC0A7A5C34077638E4DD1A701BD017842789982041",
-        "cfxtest:0vczmz2cdvupvh7z88xuntpmjrdzythx0d575mewfn9crzkx3tm5hyen4ep0myjw6g3rce74vmd706yg2y22f2cs410g9cpne8en",
+        "cfxtest:a5p9y9cpr5405vh9jj74z30yw1r983v7arfhfys6tzkp19x7d3yfv8szes0ay8w6gud1pshe5yrhag8uc8cctcp2ebaukp0zsjsz",
     );
 
     // 64-byte public key hash on testnet
     verify(
         Network::Test,
         "D0F346310D5513D9E01E299978624BA883E6BDA8F4C60883C10F28C2967E67EC77ECC7EEEAEAFC6DA89FAD72D11AC961E164678B868AEEEC5F2C1DA08884175B",
-        "cfxtest:0z8f6hhh1nah7pf03smtjy329em87tnxn3ucc243s47jhgmpftkysxzcszrenurwdpm9zbbju4dcjsf1chksr1maxvp5yb0xm24885uv5wp01dyc",
+        "cfxtest:a9jtgvvvbzmvh0tad2y3w8dcksyjh3z7zd4ppced2ehwvuy0t3x8279p291sz416r0yk9nnw4erpw2tbpvx21bym750f8na7ycejjf45f60abr8p",
     );
 }
 

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -430,8 +430,7 @@ impl RpcImpl {
 
         if tx.nonce.is_none() {
             let nonce = consensus_graph.next_nonce(
-                // FIXME: check transaction input.
-                tx.from.clone().try_into()?,
+                tx.from.clone().into(),
                 BlockHashOrEpochNumber::EpochNumber(EpochNumber::LatestState)
                     .into_primitive(),
             )?;

--- a/client/src/rpc/impls/light.rs
+++ b/client/src/rpc/impls/light.rs
@@ -494,7 +494,7 @@ impl RpcImpl {
                 // TODO(thegaram): consider adding a light node specific tx pool
                 // to track the nonce
 
-                let address = tx.from.clone().try_into()?;
+                let address = tx.from.clone().into();
                 let epoch = EpochNumber::LatestState.into_primitive();
 
                 let nonce = light

--- a/client/src/rpc/types/block.rs
+++ b/client/src/rpc/types/block.rs
@@ -454,7 +454,7 @@ mod tests {
                 Transaction::default(Network::Main).unwrap()
             ]);
         let serialized = serde_json::to_string(&t).unwrap();
-        assert_eq!(serialized, r#"[{"hash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0","blockHash":null,"transactionIndex":null,"from":"CFX:TYPE.NULL:0000000000000000000000000000000000PE51B8AS","to":null,"value":"0x0","gasPrice":"0x0","gas":"0x0","contractCreated":null,"data":"0x","storageLimit":"0x0","epochHeight":"0x0","chainId":"0x0","status":null,"v":"0x0","r":"0x0","s":"0x0"}]"#);
+        assert_eq!(serialized, r#"[{"hash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0","blockHash":null,"transactionIndex":null,"from":"CFX:TYPE.NULL:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0SFBNJM2","to":null,"value":"0x0","gasPrice":"0x0","gas":"0x0","contractCreated":null,"data":"0x","storageLimit":"0x0","epochHeight":"0x0","chainId":"0x0","status":null,"v":"0x0","r":"0x0","s":"0x0"}]"#);
 
         let t = BlockTransactions::Hashes(vec![H256::default()]);
         let serialized = serde_json::to_string(&t).unwrap();
@@ -474,7 +474,7 @@ mod tests {
         let result_block_transactions = BlockTransactions::Full(vec![
             Transaction::default(Network::Main).unwrap(),
         ]);
-        let serialized = r#"[{"hash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0","blockHash":null,"blockNumber":null,"transactionIndex":null,"from":"cfx:0000000000000000000000000000000000pe51b8as","to":null,"value":"0x0","gasPrice":"0x0","gas":"0x0","data":"0x","storageLimit":"0x0","epochHeight":"0x0","chainId":"0x0","status":null,"v":"0x0","r":"0x0","s":"0x0"}]"#;
+        let serialized = r#"[{"hash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0","blockHash":null,"blockNumber":null,"transactionIndex":null,"from":"cfx:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0sfbnjm2","to":null,"value":"0x0","gasPrice":"0x0","gas":"0x0","data":"0x","storageLimit":"0x0","epochHeight":"0x0","chainId":"0x0","status":null,"v":"0x0","r":"0x0","s":"0x0"}]"#;
         let deserialized_block_transactions: BlockTransactions =
             serde_json::from_str(serialized).unwrap();
         assert_eq!(result_block_transactions, deserialized_block_transactions);
@@ -507,13 +507,13 @@ mod tests {
         };
         let serialized_block = serde_json::to_string(&block).unwrap();
 
-        assert_eq!(serialized_block, r#"{"hash":"0x0000000000000000000000000000000000000000000000000000000000000000","parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000","height":"0x0","miner":"CFX:TYPE.NULL:0000000000000000000000000000000000PE51B8AS","deferredStateRoot":"0x0000000000000000000000000000000000000000000000000000000000000000","deferredReceiptsRoot":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","deferredLogsBloomHash":"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5","blame":"0x0","transactionsRoot":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","epochNumber":null,"gasLimit":"0x0","gasUsed":null,"timestamp":"0x0","difficulty":"0x0","powQuality":null,"refereeHashes":[],"adaptive":false,"nonce":"0x0","transactions":[],"size":"0x45","custom":[]}"#);
+        assert_eq!(serialized_block, r#"{"hash":"0x0000000000000000000000000000000000000000000000000000000000000000","parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000","height":"0x0","miner":"CFX:TYPE.NULL:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0SFBNJM2","deferredStateRoot":"0x0000000000000000000000000000000000000000000000000000000000000000","deferredReceiptsRoot":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","deferredLogsBloomHash":"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5","blame":"0x0","transactionsRoot":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","epochNumber":null,"gasLimit":"0x0","gasUsed":null,"timestamp":"0x0","difficulty":"0x0","powQuality":null,"refereeHashes":[],"adaptive":false,"nonce":"0x0","transactions":[],"size":"0x45","custom":[]}"#);
     }
 
     #[test]
     #[serial] // TODO: remove
     fn test_deserialize_block() {
-        let serialized = r#"{"hash":"0x0000000000000000000000000000000000000000000000000000000000000000","parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000","height":"0x0","miner":"cfx:0000000000000000000000000000000000pe51b8as","deferredStateRoot":"0x0000000000000000000000000000000000000000000000000000000000000000","deferredReceiptsRoot":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","deferredLogsBloomHash":"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5","blame":"0x0","transactionsRoot":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","epochNumber":"0x0","gasLimit":"0x0","timestamp":"0x0","difficulty":"0x0","refereeHashes":[],"stable":null,"adaptive":false,"nonce":"0x0","transactions":[],"size":"0x45","custom":[]}"#;
+        let serialized = r#"{"hash":"0x0000000000000000000000000000000000000000000000000000000000000000","parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000","height":"0x0","miner":"cfx:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0sfbnjm2","deferredStateRoot":"0x0000000000000000000000000000000000000000000000000000000000000000","deferredReceiptsRoot":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","deferredLogsBloomHash":"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5","blame":"0x0","transactionsRoot":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","epochNumber":"0x0","gasLimit":"0x0","timestamp":"0x0","difficulty":"0x0","refereeHashes":[],"stable":null,"adaptive":false,"nonce":"0x0","transactions":[],"size":"0x45","custom":[]}"#;
         let result_block = Block {
             hash: H256::default(),
             parent_hash: H256::default(),
@@ -540,9 +540,6 @@ mod tests {
         let deserialized_block: Block =
             serde_json::from_str(serialized).unwrap();
         assert_eq!(deserialized_block, result_block);
-
-        println!("deserialized_block: {:?}", deserialized_block);
-        println!("result_block: {:?}", result_block);
     }
 
     #[test]
@@ -568,6 +565,6 @@ mod tests {
         };
         let serialized_header = serde_json::to_string(&header).unwrap();
 
-        assert_eq!(serialized_header, r#"{"hash":"0x0000000000000000000000000000000000000000000000000000000000000000","parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000","height":"0x0","miner":"CFX:TYPE.NULL:0000000000000000000000000000000000PE51B8AS","deferredStateRoot":"0x0000000000000000000000000000000000000000000000000000000000000000","deferredReceiptsRoot":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","deferredLogsBloomHash":"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5","blame":"0x0","transactionsRoot":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","epochNumber":null,"gasLimit":"0x0","timestamp":"0x0","difficulty":"0x0","powQuality":null,"refereeHashes":[],"adaptive":false,"nonce":"0x0"}"#);
+        assert_eq!(serialized_header, r#"{"hash":"0x0000000000000000000000000000000000000000000000000000000000000000","parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000","height":"0x0","miner":"CFX:TYPE.NULL:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0SFBNJM2","deferredStateRoot":"0x0000000000000000000000000000000000000000000000000000000000000000","deferredReceiptsRoot":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","deferredLogsBloomHash":"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5","blame":"0x0","transactionsRoot":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","epochNumber":null,"gasLimit":"0x0","timestamp":"0x0","difficulty":"0x0","powQuality":null,"refereeHashes":[],"adaptive":false,"nonce":"0x0"}"#);
     }
 }

--- a/client/src/rpc/types/filter.rs
+++ b/client/src/rpc/types/filter.rs
@@ -198,15 +198,15 @@ impl Filter {
 
 #[cfg(test)]
 mod tests {
-    use super::{EpochNumber, Filter, VariadicValue};
+    use super::{super::Address, EpochNumber, Filter, VariadicValue};
+    use cfx_addr::Network;
     use cfx_types::{H160, H256, U64};
     use primitives::{
         epoch::EpochNumber as PrimitiveEpochNumber,
         filter::Filter as PrimitiveFilter,
     };
     use serde_json;
-    use serial_test::serial;
-    use std::{convert::TryInto, str::FromStr};
+    use std::str::FromStr;
 
     #[test]
     fn test_serialize_variadic_value() {
@@ -286,8 +286,8 @@ mod tests {
                 H256::from_str("1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347").unwrap()
             ]),
             address: Some(VariadicValue::Multiple(vec![
-                "cfx:0000000000000000000000000000000000pe51b8as".try_into().unwrap(),
-                "cfx:000000000000000000000000000000000482u4m4mw".try_into().unwrap(),
+                Address::try_from_h160(H160::from_str("0000000000000000000000000000000000000000").unwrap(), Network::Main).unwrap(),
+                Address::try_from_h160(H160::from_str("0000000000000000000000000000000000000001").unwrap(), Network::Main).unwrap(),
             ])),
             topics: Some(vec![
                 VariadicValue::Single(H256::from_str("d397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5").unwrap()),
@@ -307,7 +307,7 @@ mod tests {
              \"fromEpoch\":\"0x3e8\",\
              \"toEpoch\":\"latest_state\",\
              \"blockHashes\":[\"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470\",\"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347\"],\
-             \"address\":[\"CFX:TYPE.NULL:0000000000000000000000000000000000PE51B8AS\",\"CFX:TYPE.BUILTIN:000000000000000000000000000000000482U4M4MW\"],\
+             \"address\":[\"CFX:TYPE.NULL:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0SFBNJM2\",\"CFX:TYPE.BUILTIN:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEJC4EYEY6\"],\
              \"topics\":[\
                 \"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5\",\
                 [\"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5\",\"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5\"]\
@@ -318,7 +318,6 @@ mod tests {
     }
 
     #[test]
-    #[serial] // TODO: remove
     fn test_deserialize_filter() {
         let serialized = "{}";
 
@@ -339,7 +338,7 @@ mod tests {
              \"fromEpoch\":\"0x3e8\",\
              \"toEpoch\":\"latest_state\",\
              \"blockHashes\":[\"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470\",\"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347\"],\
-             \"address\":[\"cfx:0000000000000000000000000000000000pe51b8as\",\"cfx:000000000000000000000000000000000482u4m4mw\"],\
+             \"address\":[\"cfx:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0sfbnjm2\",\"cfx:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaejc4eyey6\"],\
              \"topics\":[\
                 \"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5\",\
                 [\"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5\",\"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5\"]\
@@ -355,8 +354,8 @@ mod tests {
                 H256::from_str("1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347").unwrap()
             ]),
             address: Some(VariadicValue::Multiple(vec![
-                "cfx:0000000000000000000000000000000000pe51b8as".try_into().unwrap(),
-                "cfx:000000000000000000000000000000000482u4m4mw".try_into().unwrap(),
+                Address::try_from_h160(H160::from_str("0000000000000000000000000000000000000000").unwrap(), Network::Main).unwrap(),
+                Address::try_from_h160(H160::from_str("0000000000000000000000000000000000000001").unwrap(), Network::Main).unwrap(),
             ])),
             topics: Some(vec![
                 VariadicValue::Single(H256::from_str("d397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5").unwrap()),
@@ -383,8 +382,8 @@ mod tests {
                 H256::from_str("1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347").unwrap()
             ]),
             address: Some(VariadicValue::Multiple(vec![
-                "cfx:0000000000000000000000000000000000pe51b8as".try_into().unwrap(),
-                "cfx:000000000000000000000000000000000482u4m4mw".try_into().unwrap(),
+                Address::try_from_h160(H160::from_str("0000000000000000000000000000000000000000").unwrap(), Network::Main).unwrap(),
+                Address::try_from_h160(H160::from_str("0000000000000000000000000000000000000001").unwrap(), Network::Main).unwrap(),
             ])),
             topics: Some(vec![
                 VariadicValue::Single(H256::from_str("d397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5").unwrap()),
@@ -405,7 +404,7 @@ mod tests {
             ]),
             address: Some(vec![
                 H160::from_str("0000000000000000000000000000000000000000").unwrap(),
-                H160::from_str("0000000000000000000000000000000000000001").unwrap()
+                H160::from_str("0000000000000000000000000000000000000001").unwrap(),
             ]),
             topics: vec![
                 Some(vec![H256::from_str("d397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5").unwrap()]),

--- a/client/src/rpc/types/log.rs
+++ b/client/src/rpc/types/log.rs
@@ -78,17 +78,18 @@ impl Log {
 
 #[cfg(test)]
 mod tests {
-    use crate::rpc::types::Log;
-    use cfx_types::{H256, U256};
+    use crate::rpc::types::{Address, Log};
+    use cfx_addr::Network;
+    use cfx_types::{H160, H256, U256};
     use serde_json;
-    use std::{convert::TryInto, str::FromStr};
+    use std::str::FromStr;
 
     #[test]
     fn log_serialization() {
-        let s = r#"{"address":"CFXTEST:TYPE.USER:00CWEGPESGNTWKRZ7E2CVVEDWBUSMDRM9W7KY3YE3R","topics":["0xa6697e974e6a320f454390be03f74955e8978f1a6971ea6730542e37b66179bc","0x4861736852656700000000000000000000000000000000000000000000000000"],"data":"0x","blockHash":"0xed76641c68a1c641aee09a94b3b471f4dc0316efe5ac19cf488e2674cf8d05b5","epochNumber":"0x4510c","transactionHash":"0x0000000000000000000000000000000000000000000000000000000000000000","transactionIndex":"0x0","logIndex":"0x1","transactionLogIndex":"0x1"}"#;
+        let s = r#"{"address":"CFXTEST:TYPE.USER:AAK3WAKCPSF3CP0MFHDWHTTUG924VERHBUV9NMM3YC","topics":["0xa6697e974e6a320f454390be03f74955e8978f1a6971ea6730542e37b66179bc","0x4861736852656700000000000000000000000000000000000000000000000000"],"data":"0x","blockHash":"0xed76641c68a1c641aee09a94b3b471f4dc0316efe5ac19cf488e2674cf8d05b5","epochNumber":"0x4510c","transactionHash":"0x0000000000000000000000000000000000000000000000000000000000000000","transactionIndex":"0x0","logIndex":"0x1","transactionLogIndex":"0x1"}"#;
 
         let log = Log {
-            address: "cfxtest:00cwegpesgntwkrz7e2cvvedwbusmdrm9w7ky3ye3r".try_into().unwrap(),
+            address: Address::try_from_h160(H160::from_str("13990122638b9132ca29c723bdf037f1a891a70c").unwrap(), Network::Test).unwrap(),
             topics: vec![
                 H256::from_str("a6697e974e6a320f454390be03f74955e8978f1a6971ea6730542e37b66179bc").unwrap(),
                 H256::from_str("4861736852656700000000000000000000000000000000000000000000000000").unwrap(),

--- a/tests/address_test.py
+++ b/tests/address_test.py
@@ -1,4 +1,4 @@
 from conflux.address import hex_to_b32_address, b32_address_to_hex
 
-print(hex_to_b32_address("F5BF48B397DAE70BE82B3CCA4793F8EB2B6CDAC9") == "cfx:03uvyj5kjzdee2z85cycmhwkz3njpv6ut404kg24d3")
-print(b32_address_to_hex("cfx:03uvyj5kjzdee2z85cycmhwkz3njpv6ut404kg24d3") == "F5BF48B397DAE70BE82B3CCA4793F8EB2B6CDAC9".lower())
+print(hex_to_b32_address("F5BF48B397DAE70BE82B3CCA4793F8EB2B6CDAC9") == "cfx:ad458wfxw9rssc9jfp8pyv6x9dzw05g43eaexucerd")
+print(b32_address_to_hex("cfx:ad458wfxw9rssc9jfp8pyv6x9dzw05g43eaexucerd") == "F5BF48B397DAE70BE82B3CCA4793F8EB2B6CDAC9".lower())

--- a/tests/conflux/address_utils.py
+++ b/tests/conflux/address_utils.py
@@ -23,7 +23,7 @@ SOFTWARE.
 """
 
 
-BASE32_CHARS = '0123456789abcdefghijklmnopqrstuvwxyz'
+BASE32_CHARS = 'abcdefghijklmnopqrstuvwxyz0123456789'
 EXCLUDE_CHARS = {'o', 'i', 'l', 'q'}
 CHARSET = ''
 for c in BASE32_CHARS:


### PR DESCRIPTION
cfx:a... or cfxtest:a..., so that in Chrome like browser a double-click selects the whole address.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2057)
<!-- Reviewable:end -->
