### PR TITLE
Fix random failure in node_reputation_test.

### DIFF
--- a/tests/network_tests/node_reputation_test.py
+++ b/tests/network_tests/node_reputation_test.py
@@ -19,6 +19,8 @@ class NodeReputationTests(ConfluxTestFramework):
 
         self.conf_parameters = {
             "discovery_housekeeping_timeout_ms": str(self.test_house_keeping_ms),
+            # Enable ip_limit to make node sampling robuster.
+            "subnet_quota": "4",
         }
 
     def setup_network(self):


### PR DESCRIPTION
`subnet_quota` is set to 0 in python tests by default, so `ip_limit` remains disabled and we will use a deprecated node management mechanism where node sampling may fail with a relatively high probability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2060)
<!-- Reviewable:end -->
