### PR TITLE
Rpc receipts log doesn't fill in the correct network type.

### DIFF
--- a/client/src/rpc/types/receipt.rs
+++ b/client/src/rpc/types/receipt.rs
@@ -136,7 +136,7 @@ impl Receipt {
             contract_created: address,
             logs: logs
                 .into_iter()
-                .map(|l| Log::try_from(l, cfx_addr::Network::Main))
+                .map(|l| Log::try_from(l, network))
                 .collect::<Result<_, _>>()?,
             logs_bloom: log_bloom,
             state_root: maybe_state_root


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2064)
<!-- Reviewable:end -->
