### PR TITLE
Improve some rpc error reporting.

### DIFF
--- a/client/src/rpc/error_codes.rs
+++ b/client/src/rpc/error_codes.rs
@@ -59,7 +59,7 @@ pub mod codes {
     pub const EXPERIMENTAL: i64 = -32071;
     /// The node is not able to serve the request due to configuration. e.g. Not
     /// mining, light node, not archive node.
-    pub const INCAPABLE: i64 = -32703;
+    pub const INCAPABLE: i64 = -32073;
 
     /* Rpc usage related error codes */
     /// When there are too many rpc requests. We limit the number of allowed rpc

--- a/client/src/rpc/impls/common.rs
+++ b/client/src/rpc/impls/common.rs
@@ -362,7 +362,10 @@ impl RpcImpl {
             address, num
         );
 
-        consensus_graph.next_nonce(address.hex_address, num.into())
+        // TODO: check if address is not in reserved address space.
+        // We pass "num" into next_nonce() function for the error reporting
+        // rpc_param_name because the user passed epoch number could be invalid.
+        consensus_graph.next_nonce(address.hex_address, num.into(), "num")
     }
 }
 
@@ -762,8 +765,7 @@ impl RpcImpl {
 
     pub fn accounts(&self) -> RpcResult<Vec<RpcAddress>> {
         let accounts: Vec<Address> = self.accounts.accounts().map_err(|e| {
-            warn!("Could not fetch accounts. With error {:?}", e);
-            RpcError::internal_error()
+            format!("Could not fetch accounts. With error {:?}", e)
         })?;
 
         Ok(accounts
@@ -780,8 +782,7 @@ impl RpcImpl {
     pub fn new_account(&self, password: String) -> RpcResult<RpcAddress> {
         let address =
             self.accounts.new_account(&password.into()).map_err(|e| {
-                warn!("Could not create account. With error {:?}", e);
-                RpcError::internal_error()
+                format!("Could not create account. With error {:?}", e)
             })?;
 
         Ok(RpcAddress::try_from_h160(

--- a/client/src/rpc/impls/trace.rs
+++ b/client/src/rpc/impls/trace.rs
@@ -3,11 +3,14 @@
 // See http://www.gnu.org/licenses/
 
 use super::super::types::LocalizedBlockTrace;
-use crate::rpc::traits::trace::Trace;
+use crate::{
+    common::delegate_convert::into_jsonrpc_result,
+    rpc::{traits::trace::Trace, RpcResult},
+};
 use cfx_addr::Network;
 use cfx_types::H256;
 use cfxcore::BlockDataManager;
-use jsonrpc_core::{Error as RpcError, Result as JsonRpcResult};
+use jsonrpc_core::Result as JsonRpcResult;
 use std::sync::Arc;
 
 pub struct TraceHandler {
@@ -19,21 +22,29 @@ impl TraceHandler {
     pub fn new(data_man: Arc<BlockDataManager>, network: Network) -> Self {
         TraceHandler { data_man, network }
     }
+
+    fn block_traces_impl(
+        &self, block_hash: H256,
+    ) -> RpcResult<Option<LocalizedBlockTrace>> {
+        // Note: an alternative to `into_jsonrpc_result` is the delegate! macro.
+
+        match self.data_man.block_traces_by_hash(&block_hash) {
+            None => Ok(None),
+            Some(t) => match LocalizedBlockTrace::from(t, self.network) {
+                Ok(t) => Ok(Some(t)),
+                Err(e) => bail!(format!(
+                    "Traces not found for block {:?}: {:?}",
+                    block_hash, e
+                )),
+            },
+        }
+    }
 }
 
 impl Trace for TraceHandler {
     fn block_traces(
         &self, block_hash: H256,
     ) -> JsonRpcResult<Option<LocalizedBlockTrace>> {
-        match self.data_man.block_traces_by_hash(&block_hash) {
-            None => Ok(None),
-            Some(t) => match LocalizedBlockTrace::from(t, self.network) {
-                Ok(t) => Ok(Some(t)),
-                Err(e) => Err(RpcError::invalid_params(format!(
-                    "Traces not found for block {:?}: {:?}",
-                    block_hash, e
-                ))),
-            },
-        }
+        into_jsonrpc_result(self.block_traces_impl(block_hash))
     }
 }

--- a/client/src/rpc/types/call_request.rs
+++ b/client/src/rpc/types/call_request.rs
@@ -126,6 +126,7 @@ impl SendTxRequest {
         let password = password.map(Password::from);
         let sig = accounts
             .sign(self.from.into(), password, tx.hash())
+            // TODO: sign error into secret store error codes.
             .map_err(|e| format!("failed to sign transaction: {:?}", e))?;
 
         Ok(tx.with_signature(sig))

--- a/core/src/consensus/consensus_trait.rs
+++ b/core/src/consensus/consensus_trait.rs
@@ -86,11 +86,11 @@ pub trait ConsensusGraphTrait: Send + Sync {
     fn set_initial_sequence_number(&self, initial_sn: u64);
 
     fn get_state_by_epoch_number(
-        &self, epoch_number: EpochNumber,
+        &self, epoch_number: EpochNumber, rpc_param_name: &str,
     ) -> RpcResult<State>;
 
     fn get_state_db_by_epoch_number(
-        &self, epoch_number: EpochNumber,
+        &self, epoch_number: EpochNumber, rpc_param_name: &str,
     ) -> RpcResult<StateDb>;
 
     fn get_blocks_needing_bodies(&self) -> HashSet<H256>;

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -668,6 +668,8 @@ impl<StateDbStorage: StorageStateTrait> StateGeneric<StateDbStorage> {
         ))
     }
 
+    // TODO: maybe return error for reserved address? Not sure where is the best
+    //  place to do the check.
     pub fn nonce(&self, address: &Address) -> DbResult<U256> {
         self.ensure_account_loaded(address, RequireCache::None, |acc| {
             acc.map_or(U256::zero(), |account| *account.nonce())


### PR DESCRIPTION
Fixed some cases of some typical wrong way of error reporting:
- report exception as invalid_params error;
- report exception as internal_error;
- report wrong parameter name for invalid_params error;
- report all kinds of errors as string. Some errors can be structured and mapped into more specific jsonrpc error.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2065)
<!-- Reviewable:end -->
