### PR TITLE
Reconstruct consensus graph if we receive blocks with invalid bodies.

### DIFF
--- a/core/src/consensus/consensus_trait.rs
+++ b/core/src/consensus/consensus_trait.rs
@@ -100,6 +100,7 @@ pub trait ConsensusGraphTrait: Send + Sync {
     fn catch_up_completed(&self, peer_median_epoch: u64) -> bool;
 
     fn enter_normal_phase(&self);
+    fn reset(&self);
 }
 
 pub type SharedConsensusGraph =

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -1417,4 +1417,25 @@ impl ConsensusGraphTrait for ConsensusGraph {
             .notify_new_best_info(self.best_info.read_recursive().clone())
             .expect("No DB error")
     }
+
+    fn reset(&self) {
+        let old_consensus_inner = &mut *self.inner.write();
+
+        let cur_era_genesis_hash =
+            self.data_man.get_cur_consensus_era_genesis_hash();
+        let cur_era_stable_hash =
+            self.data_man.get_cur_consensus_era_stable_hash();
+        let new_consensus_inner = ConsensusGraphInner::with_era_genesis(
+            old_consensus_inner.pow_config.clone(),
+            old_consensus_inner.pow.clone(),
+            self.data_man.clone(),
+            old_consensus_inner.inner_conf.clone(),
+            &cur_era_genesis_hash,
+            &cur_era_stable_hash,
+        );
+        *old_consensus_inner = new_consensus_inner;
+        debug!("Build new consensus graph for sync-recovery with identified genesis {} stable block {}", cur_era_genesis_hash, cur_era_stable_hash);
+
+        self.confirmation_meter.clear();
+    }
 }

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -1418,6 +1418,8 @@ impl ConsensusGraphTrait for ConsensusGraph {
             .expect("No DB error")
     }
 
+    /// Reset the information in consensus graph with only checkpoint
+    /// information kept.
     fn reset(&self) {
         let old_consensus_inner = &mut *self.inner.write();
 

--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -1848,13 +1848,8 @@ impl SynchronizationGraph {
             // Send blocks in topological order.
             let sorted_blocks = inner.topological_sort(all_block_indices);
             for i in sorted_blocks {
-                self.consensus_unprocessed_count
-                    .fetch_add(1, Ordering::SeqCst);
-                assert!(
-                    self.new_block_hashes
-                        .send(inner.arena[i].block_header.hash()),
-                    "consensus receiver dropped"
-                );
+                self.consensus
+                    .on_new_block(&inner.arena[i].block_header.hash(), false);
             }
         }
         self.consensus.construct_pivot_state();

--- a/core/src/sync/synchronization_graph.rs
+++ b/core/src/sync/synchronization_graph.rs
@@ -1689,13 +1689,6 @@ impl SynchronizationGraph {
         if inner.locked_for_catchup {
             if inner.arena[me].graph_status == BLOCK_INVALID {
                 let invalid_set = self.propagate_graph_status(inner, vec![me]);
-                for i in &invalid_set {
-                    // We do not need to download the block body of invalid
-                    // blocks.
-                    inner
-                        .block_to_fill_set
-                        .remove(&inner.arena[*i].block_header.hash());
-                }
                 // Invalid blocks will also be removed from
                 // `block_to_fill_set`
                 // in `process_invalid_blocks`.

--- a/core/src/sync/synchronization_phases.rs
+++ b/core/src/sync/synchronization_phases.rs
@@ -412,10 +412,6 @@ impl SynchronizationPhaseTrait for CatchUpFillBlockBodyPhase {
     ) -> SyncPhaseType
     {
         if self.graph.is_fill_block_completed() {
-            debug_assert!(sync_handler
-                .request_manager
-                .in_flight_blocks()
-                .is_empty());
             if self.graph.complete_filling_block_bodies() {
                 return SyncPhaseType::CatchUpSyncBlock;
             } else {

--- a/tests/conflux/rpc.py
+++ b/tests/conflux/rpc.py
@@ -464,3 +464,9 @@ class RpcClient:
         signature = self.node.getnodeid(list(int_to_bytes(challenge)))
         node_id, _, _ = convert_to_nodeid(signature, challenge)
         return node_id
+
+    def current_sync_phase(self):
+        return self.node.current_sync_phase()
+
+    def get_status(self):
+        return self.node.cfx_getStatus()

--- a/tests/conflux/trie.py
+++ b/tests/conflux/trie.py
@@ -10,11 +10,13 @@ NULL_ROOT = utils.sha3(b'')
 # key value of (0, KECCAK_EMPTY).
 EMPTY_BLOCK_RECEIPT_ROOT = utils.sha3(b'n' + NULL_ROOT * 16 + b'v' + NULL_ROOT)
 
+
 def state_root(
         snapshot_root = NULL_ROOT,
         intermediate_delta_root = NULL_ROOT,
         delta_root = NULL_ROOT):
     return [snapshot_root, intermediate_delta_root, delta_root]
+
 
 def precompute_epoch_receipt_root_by_number_of_blocks():
     receipt_root_by_number_of_blocks = []
@@ -35,5 +37,14 @@ def precompute_epoch_receipt_root_by_number_of_blocks():
 
     return receipt_root_by_number_of_blocks
 
-UNINITIALIZED_STATE_ROOT = state_root()
+
+def compute_transaction_root_for_single_transaction(tx_hash):
+    node_hash = utils.sha3(b'n' + NULL_ROOT * 16 + b'v' + tx_hash)
+    path_bytes = bytearray()
+    path_bytes.extend([128 + 64 + 1, 0])
+    return utils.sha3(
+        bytes(path_bytes) + node_hash)
+
+
+UNINITIALIZED_STATE_ROOT = utils.sha3(rlp.encode(state_root()))
 EMPTY_EPOCH_RECEIPT_ROOT_BY_NUMBER_OF_BLOCKS = precompute_epoch_receipt_root_by_number_of_blocks()

--- a/tests/invalid_block_sync_test.py
+++ b/tests/invalid_block_sync_test.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+from rlp.sedes import Binary, BigEndianInt
+
+from conflux import utils, trie
+from conflux.rpc import RpcClient
+from conflux.trie import compute_transaction_root_for_single_transaction
+from conflux.utils import encode_hex, bytes_to_int, int_to_hex, str_to_bytes
+from test_framework.blocktools import create_block, create_transaction, create_chain_of_blocks
+from test_framework.test_framework import ConfluxTestFramework
+from test_framework.mininode import *
+from test_framework.util import *
+
+
+CHAIN_LEN = 400
+class InvalidBodyNode(DefaultNode):
+    def __init__(self):
+        super().__init__()
+        correct_chain = create_chain_of_blocks(parent_hash=self.genesis.hash, parent_height=0, count=CHAIN_LEN)
+        invalid_tx = create_transaction(chain_id=0)
+        invalid_body_block = create_block(parent_hash=self.genesis.hash, height=1, transactions=[invalid_tx],
+                                          transaction_root=compute_transaction_root_for_single_transaction(invalid_tx.hash))
+        invalid_chain_suffix = create_chain_of_blocks(parent_hash=invalid_body_block.hash, parent_height=1,
+                                                      count=CHAIN_LEN)
+        last_block = create_block(parent_hash=invalid_chain_suffix[-1].hash, height=CHAIN_LEN + 2,
+                                  referee_hashes=[correct_chain[-1].hash])
+        invalid_chain = [invalid_body_block] + invalid_chain_suffix + [last_block]
+        self.block_map = {self.genesis.hash: self.genesis}
+        self.epoch_map = {0: self.genesis.hash}
+        for i in range(1, CHAIN_LEN + 3):
+            b = invalid_chain[i-1]
+            self.block_map[b.hash] = b
+            self.epoch_map[i] = {b.hash}
+        for b in correct_chain:
+            self.block_map[b.hash] = b
+            self.epoch_map[CHAIN_LEN + 2].add(b.hash)
+        self.invalid_block = invalid_body_block.hash
+
+        self.set_callback(GET_BLOCK_HEADERS, self.__class__.on_get_block_headers)
+        self.best_block_hash = last_block.hash
+
+    def on_get_block_hashes_by_epoch(self, msg: GetBlockHashesByEpoch):
+        hashes = []
+        for epoch in msg.epochs:
+            hashes.extend(self.epoch_map[epoch])
+        resp = BlockHashes(reqid=msg.reqid, hashes=hashes)
+        self.send_protocol_msg(resp)
+
+    def on_get_blocks(self, msg: GetBlocks):
+        blocks = []
+        for h in msg.hashes:
+            blocks.append(self.block_map[h])
+        resp = Blocks(reqid=msg.reqid, blocks=blocks)
+        self.send_protocol_msg(resp)
+
+    def on_get_block_headers(self, msg: GetBlockHeaders):
+        blocks = []
+        for h in msg.hashes:
+            blocks.append(self.block_map[h].block_header)
+        resp = BlockHeaders(reqid=msg.reqid, headers=blocks)
+        self.send_protocol_msg(resp)
+
+    def send_status(self):
+        status = Status(
+            ChainIdParams(self.chain_id),
+            self.genesis.block_header.hash, CHAIN_LEN + 2, 0, [self.best_block_hash])
+        self.send_protocol_msg(status)
+
+class InvalidBodySyncTest(ConfluxTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.conf_parameters["dev_allow_phase_change_without_peer"] = "false"
+
+    def setup_network(self):
+        self.add_nodes(self.num_nodes)
+        for i in range(self.num_nodes):
+            self.nodes[i].start(extra_args=["--full"])
+            self.nodes[i].wait_for_rpc_connection()
+            self.nodes[i].wait_for_nodeid()
+
+    def run_test(self):
+        conn0 = InvalidBodyNode()
+        conn1 = DefaultNode()
+        self.nodes[1].add_p2p_connection(conn1)
+        network_thread_start()
+        conn1.wait_for_status()
+        for (h, b) in conn0.block_map.items():
+            if h != conn0.invalid_block:
+                conn1.send_protocol_msg(NewBlock(block=b))
+        wait_for_block_count(self.nodes[1], CHAIN_LEN + 1)
+
+        self.nodes[0].add_p2p_connection(conn0)
+        conn0.wait_for_status()
+        connect_nodes(self.nodes, 0, 1)
+
+        self.nodes[0].wait_for_phase(["NormalSyncPhase"])
+        wait_until(lambda: int(self.nodes[0].cfx_getStatus()["epochNumber"], 0) == CHAIN_LEN)
+
+
+if __name__ == "__main__":
+    InvalidBodySyncTest().main()

--- a/tests/invalid_message_test.py
+++ b/tests/invalid_message_test.py
@@ -6,6 +6,7 @@ from conflux.utils import encode_hex, bytes_to_int, int_to_hex, str_to_bytes
 from test_framework.blocktools import create_block, create_transaction
 from test_framework.test_framework import ConfluxTestFramework
 from test_framework.mininode import *
+from test_framework.test_node import TestNode
 from test_framework.util import *
 
 
@@ -26,12 +27,16 @@ class InvalidMessageTest(ConfluxTestFramework):
         self._test_invalid_packet()
         self._test_new_block()
 
-        print("pass")
-        while True:
-            pass
-
     def send_msg(self, msg):
         self.nodes[0].p2p.send_protocol_msg(msg)
+
+    def reconnect(self, node: TestNode):
+        node.disconnect_p2ps()
+        # Wait for disconnection
+        time.sleep(0.5)
+        node.add_p2p_connection(DefaultNode())
+        network_thread_start()
+        node.p2p.wait_for_status()
 
     def _test_invalid_packet(self):
         self.log.info("Test invalid packet")
@@ -49,6 +54,7 @@ class InvalidMessageTest(ConfluxTestFramework):
         h = WaitHandler(self.nodes[0].p2p, GET_BLOCK_HEADERS_RESPONSE, assert_length)
         self.nodes[0].p2p.send_protocol_msg(GetBlockHeaders(hashes=[self.nodes[0].p2p.genesis.hash]))
         h.wait()
+        self.reconnect(self.nodes[0])
 
     def _test_new_block(self):
         self.log.info("Test New Block")
@@ -58,10 +64,11 @@ class InvalidMessageTest(ConfluxTestFramework):
         wait_until(lambda: self.nodes[0].best_block_hash() == new_block.hash_hex())
 
         # Wrong payload
-        self.nodes[0].p2p.send_protocol_packet(int_to_bytes(NEW_BLOCK) + rlp.encode([0]))
+        self.nodes[0].p2p.send_protocol_packet(rlp.encode([0]) + int_to_bytes(NEW_BLOCK))
         time.sleep(1)
         assert_equal(self.nodes[0].best_block_hash(), new_block.hash_hex())
         assert_equal(self.nodes[0].getblockcount(), 2)
+        self.reconnect(self.nodes[0])
 
         # Wrong-length parent hash
         invalid_block = create_block(parent_hash=b'', height=2)
@@ -69,6 +76,7 @@ class InvalidMessageTest(ConfluxTestFramework):
         time.sleep(1)
         assert_equal(self.nodes[0].best_block_hash(), new_block.hash_hex())
         assert_equal(self.nodes[0].getblockcount(), 2)
+        self.reconnect(self.nodes[0])
 
         # Wrong-length author
         invalid_block = create_block(author=b'', height=2)
@@ -76,6 +84,7 @@ class InvalidMessageTest(ConfluxTestFramework):
         time.sleep(1)
         assert_equal(self.nodes[0].best_block_hash(), new_block.hash_hex())
         assert_equal(self.nodes[0].getblockcount(), 2)
+        self.reconnect(self.nodes[0])
 
         # Wrong-length root
         invalid_block = create_block(deferred_state_root=b'', height=2, deferred_receipts_root=b'')
@@ -83,6 +92,7 @@ class InvalidMessageTest(ConfluxTestFramework):
         time.sleep(1)
         assert_equal(self.nodes[0].best_block_hash(), new_block.hash_hex())
         assert_equal(self.nodes[0].getblockcount(), 2)
+        self.reconnect(self.nodes[0])
 
         # Nonexistent parent
         invalid_block = create_block(parent_hash=b'\x00' * 32, height=2)
@@ -90,6 +100,7 @@ class InvalidMessageTest(ConfluxTestFramework):
         time.sleep(1)
         assert_equal(self.nodes[0].best_block_hash(), new_block.hash_hex())
         assert_equal(self.nodes[0].getblockcount(), 2)
+        self.reconnect(self.nodes[0])
 
         # Invalid height
         invalid_block = create_block(new_block.hash, 1)
@@ -97,24 +108,8 @@ class InvalidMessageTest(ConfluxTestFramework):
         time.sleep(1)
         assert_equal(self.nodes[0].best_block_hash(), new_block.hash_hex())
         assert_equal(self.nodes[0].getblockcount(), 2)
+        self.reconnect(self.nodes[0])
 
-        # Invalid state root
-        partial_invalid_block = create_block(new_block.hash, 2, deferred_state_root=trie.UNINITIALIZED_STATE_ROOT)
-        self.send_msg(NewBlock(block=partial_invalid_block))
-        time.sleep(1)
-        assert_equal(self.nodes[0].best_block_hash(), new_block.hash_hex())
-        assert_equal(self.nodes[0].getblockcount(), 3)
-
-        # Generate some random partial invalid blocks
-        self.log.info("Start generating 1000 blocks with random partial invalid")
-        for i in range(1000):
-            r = random.randint(0, self.num_nodes)
-            if r < self.num_nodes:
-                self.nodes[r].generate_empty_blocks(1)
-            else:
-                partial_invalid_block = create_block(new_block.hash, 2, deferred_state_root=trie.UNINITIALIZED_STATE_ROOT, timestamp=i)
-                self.send_msg(NewBlock(block=partial_invalid_block))
-        wait_until(lambda: self.nodes[0].getblockcount() == 1003)
         sync_blocks(self.nodes)
 
         # TODO Generate some random blocks that have wrong ref edges
@@ -123,5 +118,4 @@ class InvalidMessageTest(ConfluxTestFramework):
 
 if __name__ == "__main__":
     # FIXME fix this failed test
-    # InvalidMessageTest().main()
-    pass
+    InvalidMessageTest().main()

--- a/tests/test_framework/blocktools.py
+++ b/tests/test_framework/blocktools.py
@@ -78,6 +78,17 @@ def create_block_with_nonce(
     return block
 
 
+def create_chain_of_blocks(parent_hash, parent_height, count):
+    chain = []
+    for i in range(count):
+        b = create_block(parent_hash, parent_height + 1)
+        chain.append(b)
+        parent_hash = b.hash
+        parent_height += 1
+    return chain
+
+
+
 def create_transaction(nonce=0, gas_price=1, gas=21000, value=0, receiver=default_config['GENESIS_COINBASE'],
                        data=b'', pri_key=default_config["GENESIS_PRI_KEY"], storage_limit=0, epoch_height = 0, chain_id = DEFAULT_PY_TEST_CHAIN_ID, node=None):
     transaction = UnsignedTransaction(nonce, gas_price, gas, receiver, value, data, storage_limit, epoch_height, chain_id)


### PR DESCRIPTION
If a block is invalid because of the block body, it should not enter the consensus graph. We will process them after downloading all the block bodies and reconstruct the consensus graph (insert blocks of sync graph into consensus in topological order) after that.

It's probably more effective to remove these invalid blocks from the consensus graph directly, but it is tricky to correctly implement block deletion in the consensus graph...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2073)
<!-- Reviewable:end -->
