### PR TITLE
Reduce the chance of random failure in invalid_block_sync_test.

### DIFF
--- a/core/src/sync/request_manager/request_batcher.rs
+++ b/core/src/sync/request_manager/request_batcher.rs
@@ -17,6 +17,7 @@ const DEFAULT_REQUEST_EPOCH_BATCH_SIZE: usize = 10;
 /// Resent requests include: `GetBlockHeaders`, `GetBlockTxn`,
 /// `GetBlockHashesByEpoch`, and `GetBlocks`. `GetBlockTxn` only includes one
 /// block so cannot be batched.
+/// TODO: Exclude failing peers for requests and batch based on peers.
 pub struct RequestBatcher {
     /// Hashes in header requests
     headers: DelayBucket<H256>,

--- a/tests/invalid_block_sync_test.py
+++ b/tests/invalid_block_sync_test.py
@@ -92,7 +92,7 @@ class InvalidBodySyncTest(ConfluxTestFramework):
         conn0.wait_for_status()
         connect_nodes(self.nodes, 0, 1)
 
-        self.nodes[0].wait_for_phase(["NormalSyncPhase"])
+        self.nodes[0].wait_for_phase(["NormalSyncPhase"], wait_time=120)
         wait_until(lambda: int(self.nodes[0].cfx_getStatus()["epochNumber"], 0) == CHAIN_LEN)
 
 


### PR DESCRIPTION
The cause is that when we resend a GetBlocks request, the RequestBatcher
does not take previous information of failing peers into consideration.

Only one of the two peers can provide all blocks, but it's possible that
the node always choose the wrong one to request. Increasing the timeout
to 120 s is a quick fix to reduce the failure probability to about
1/2^15 (the delay of a request is increased by 1 second for each failure),
which is small enough for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2076)
<!-- Reviewable:end -->
