### PR TITLE
Store block and net data in `conflux_data_dir` if they are not set.

### DIFF
--- a/client/src/common/mod.rs
+++ b/client/src/common/mod.rs
@@ -152,10 +152,9 @@ pub fn initialize_common_modules(
     let network_config = conf.net_config()?;
     let cache_config = conf.cache_config();
 
-    let db_config = conf.db_config();
-    let ledger_db =
-        db::open_database(conf.raw_conf.block_db_dir.as_str(), &db_config)
-            .map_err(|e| format!("Failed to open database {:?}", e))?;
+    let (db_path, db_config) = conf.db_config();
+    let ledger_db = db::open_database(db_path.to_str().unwrap(), &db_config)
+        .map_err(|e| format!("Failed to open database {:?}", e))?;
 
     let secret_store = Arc::new(SecretStore::new());
     let storage_manager = Arc::new(

--- a/client/src/tests/blockgen_tests.rs
+++ b/client/src/tests/blockgen_tests.rs
@@ -72,20 +72,6 @@ fn test_mining_10_epochs() {
     let tmp_dir = TempDir::new("conflux-test").unwrap();
     conf.raw_conf.conflux_data_dir =
         tmp_dir.path().to_str().unwrap().to_string() + "/";
-    conf.raw_conf.block_db_dir = tmp_dir
-        .path()
-        .join("db")
-        .into_os_string()
-        .into_string()
-        .unwrap();
-    conf.raw_conf.netconf_dir = Some(
-        tmp_dir
-            .path()
-            .join("config")
-            .into_os_string()
-            .into_string()
-            .unwrap(),
-    );
     conf.raw_conf.tcp_port = 13001;
     conf.raw_conf.jsonrpc_http_port = Some(18001);
     conf.raw_conf.mining_author =
@@ -112,20 +98,6 @@ fn test_mining_10_epochs_with_larger_pow_problem_window() {
     let tmp_dir = TempDir::new("conflux-test").unwrap();
     conf.raw_conf.conflux_data_dir =
         tmp_dir.path().to_str().unwrap().to_string() + "/";
-    conf.raw_conf.block_db_dir = tmp_dir
-        .path()
-        .join("db")
-        .into_os_string()
-        .into_string()
-        .unwrap();
-    conf.raw_conf.netconf_dir = Some(
-        tmp_dir
-            .path()
-            .join("config")
-            .into_os_string()
-            .into_string()
-            .unwrap(),
-    );
     conf.raw_conf.tcp_port = 13002;
     conf.raw_conf.jsonrpc_http_port = Some(18002);
     conf.raw_conf.mining_author =

--- a/client/src/tests/load_chain_tests.rs
+++ b/client/src/tests/load_chain_tests.rs
@@ -61,20 +61,6 @@ fn test_load_chain() {
     let tmp_dir = TempDir::new("conflux-test").unwrap();
     conf.raw_conf.conflux_data_dir =
         tmp_dir.path().to_str().unwrap().to_string() + "/";
-    conf.raw_conf.block_db_dir = tmp_dir
-        .path()
-        .join("db")
-        .into_os_string()
-        .into_string()
-        .unwrap();
-    conf.raw_conf.netconf_dir = Some(
-        tmp_dir
-            .path()
-            .join("config")
-            .into_os_string()
-            .into_string()
-            .unwrap(),
-    );
     conf.raw_conf.tcp_port = 13000;
     conf.raw_conf.jsonrpc_http_port = Some(18000);
     conf.raw_conf.chain_id = Some(10);

--- a/run/tethys.toml
+++ b/run/tethys.toml
@@ -302,6 +302,9 @@ jsonrpc_local_http_port=12539
 # `netconf_dir` is the directory to store network related persistent data, including `net_key`,
 # a list of trusted nodes and a list of untrusted nodes.
 #
+# By default, it is stored under the directory configured with `conflux_data_dir` with the directory name `net_config`.
+# If set, the directory path will not be related to `conflux_data_dir` anymore.
+#
 # netconf_dir="./blockchain_data/net_config"
 
 # `net_key` is the 256-bit private key to generate a unique node id for this node.
@@ -385,11 +388,14 @@ jsonrpc_local_http_port=12539
 #
 # block_db_type = "rocksdb"
 
-# The root directory of all data (block data, state data, log files, node database).
+# The root directory of all data (block data, state data, and node database).
 #
 # conflux_data_dir = "./blockchain_data"
 
 # The directory to store block-related data.
+#
+# By default, it is stored under the directory configured with `conflux_data_dir` with the directory name `blockchain_db`.
+# If set, the directory path will not be related to `conflux_data_dir` anymore.
 #
 # block_db_dir = "./blockchain_data/blockchain_db"
 


### PR DESCRIPTION
In the old implementation, they will still be kept under
`./blockchain_data` even if `conflux_data_dir` is set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2083)
<!-- Reviewable:end -->
