### PR TITLE
Allow configuring public RPC APIs.

### DIFF
--- a/changelogs/CHANGELOG-1.1.x.md
+++ b/changelogs/CHANGELOG-1.1.x.md
@@ -9,6 +9,9 @@
   transactions, block traces, state, e.t.c.). Check the `additional_maintained_*` entries in `run/tethys.toml`.
 - If `block_db_dir` or `netconf_dir` is not set, put the default directory in the one configured with `conflux_data_dir`.
   The old behavior is to be put in the hard-coded `./blockchain_data`.
+- Add a parameter `public_rpc_apis` to control the publicly available RPC interface sets. 
+  The access to `test` and `debug` RPCs is no longer related to `mode`.
+- Remove the parameter `enable_tracing` because it has been included in the new `public_rpc_apis`.
 
 ### RPC Improvements
 - Add new local RPC `cfx_getEpochReceipts` to allow querying receipts based on an epoch number.
@@ -23,6 +26,7 @@
 - Fix a possible OOM error when a full node is catching up.
 - Return correct `block_number` in `cfx_getStatus`.
 - Fix a bug that makes the configuration `mining_author` require extra quotes to use a CIP-37 base32 address.
+- Fix a bug that the block traces may be incorrect if the pivot chain switches frequently.
 
 # 1.1.1
 

--- a/client/src/common/mod.rs
+++ b/client/src/common/mod.rs
@@ -500,51 +500,29 @@ pub fn initialize_not_light_node_modules(
 
     let rpc_tcp_server = super::rpc::start_tcp(
         conf.tcp_config(),
-        if conf.is_test_or_dev_mode() {
-            setup_debug_rpc_apis(
-                common_impl.clone(),
-                rpc_impl.clone(),
-                pubsub.clone(),
-                &conf,
-            )
-        } else {
-            setup_public_rpc_apis(
-                common_impl.clone(),
-                rpc_impl.clone(),
-                pubsub.clone(),
-                &conf,
-            )
-        },
+        setup_public_rpc_apis(
+            common_impl.clone(),
+            rpc_impl.clone(),
+            pubsub.clone(),
+            &conf,
+        ),
         RpcExtractor,
     )?;
 
     let rpc_ws_server = super::rpc::start_ws(
         conf.ws_config(),
-        if conf.is_test_or_dev_mode() {
-            setup_debug_rpc_apis(
-                common_impl.clone(),
-                rpc_impl.clone(),
-                pubsub.clone(),
-                &conf,
-            )
-        } else {
-            setup_public_rpc_apis(
-                common_impl.clone(),
-                rpc_impl.clone(),
-                pubsub.clone(),
-                &conf,
-            )
-        },
+        setup_public_rpc_apis(
+            common_impl.clone(),
+            rpc_impl.clone(),
+            pubsub.clone(),
+            &conf,
+        ),
         RpcExtractor,
     )?;
 
     let rpc_http_server = super::rpc::start_http(
         conf.http_config(),
-        if conf.is_test_or_dev_mode() {
-            setup_debug_rpc_apis(common_impl, rpc_impl, pubsub, &conf)
-        } else {
-            setup_public_rpc_apis(common_impl, rpc_impl, pubsub, &conf)
-        },
+        setup_public_rpc_apis(common_impl, rpc_impl, pubsub, &conf),
     )?;
 
     Ok((

--- a/client/src/common/mod.rs
+++ b/client/src/common/mod.rs
@@ -493,7 +493,7 @@ pub fn initialize_not_light_node_modules(
         setup_debug_rpc_apis(
             common_impl.clone(),
             rpc_impl.clone(),
-            None,
+            pubsub.clone(),
             &conf,
         ),
     )?;
@@ -504,14 +504,14 @@ pub fn initialize_not_light_node_modules(
             setup_debug_rpc_apis(
                 common_impl.clone(),
                 rpc_impl.clone(),
-                Some(pubsub.clone()),
+                pubsub.clone(),
                 &conf,
             )
         } else {
             setup_public_rpc_apis(
                 common_impl.clone(),
                 rpc_impl.clone(),
-                Some(pubsub.clone()),
+                pubsub.clone(),
                 &conf,
             )
         },
@@ -524,14 +524,14 @@ pub fn initialize_not_light_node_modules(
             setup_debug_rpc_apis(
                 common_impl.clone(),
                 rpc_impl.clone(),
-                Some(pubsub.clone()),
+                pubsub.clone(),
                 &conf,
             )
         } else {
             setup_public_rpc_apis(
                 common_impl.clone(),
                 rpc_impl.clone(),
-                Some(pubsub.clone()),
+                pubsub.clone(),
                 &conf,
             )
         },
@@ -541,11 +541,12 @@ pub fn initialize_not_light_node_modules(
     let rpc_http_server = super::rpc::start_http(
         conf.http_config(),
         if conf.is_test_or_dev_mode() {
-            setup_debug_rpc_apis(common_impl, rpc_impl, None, &conf)
+            setup_debug_rpc_apis(common_impl, rpc_impl, pubsub, &conf)
         } else {
-            setup_public_rpc_apis(common_impl, rpc_impl, None, &conf)
+            setup_public_rpc_apis(common_impl, rpc_impl, pubsub, &conf)
         },
     )?;
+
     Ok((
         data_man,
         pow,

--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -3,8 +3,8 @@
 // See http://www.gnu.org/licenses/
 
 use crate::rpc::{
-    impls::RpcImplConfiguration, HttpConfiguration, TcpConfiguration,
-    WsConfiguration,
+    impls::RpcImplConfiguration, rpc_apis::ApiSet, HttpConfiguration,
+    TcpConfiguration, WsConfiguration,
 };
 use cfx_addr::{cfx_addr_decode, Network};
 use cfx_internal_common::{ChainIdParams, ChainIdParamsInner};
@@ -318,6 +318,7 @@ build_config! {
             vec![ProvideExtraSnapshotSyncConfig::StableCheckpoint],
             ProvideExtraSnapshotSyncConfig::parse_config_list)
         (node_type, (Option<NodeType>), None, NodeType::from_str)
+        (public_rpc_apis, (ApiSet), ApiSet::Safe, ApiSet::from_str)
     }
 }
 

--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -165,7 +165,6 @@ build_config! {
         (public_tcp_port, (Option<u16>), None)
         (public_address, (Option<String>), None)
         (udp_port, (Option<u16>), Some(32323))
-        (enable_tracing, (bool), false)
 
         // Network parameters section.
         (blocks_request_timeout_ms, (u64), 20_000)

--- a/client/src/light/mod.rs
+++ b/client/src/light/mod.rs
@@ -93,7 +93,8 @@ impl LightClient {
             setup_debug_rpc_apis_light(
                 common_impl.clone(),
                 rpc_impl.clone(),
-                None,
+                pubsub.clone(),
+                &conf,
             ),
         )?;
 
@@ -103,13 +104,14 @@ impl LightClient {
                 setup_debug_rpc_apis_light(
                     common_impl.clone(),
                     rpc_impl.clone(),
-                    Some(pubsub.clone()),
+                    pubsub.clone(),
+                    &conf,
                 )
             } else {
                 setup_public_rpc_apis_light(
                     common_impl.clone(),
                     rpc_impl.clone(),
-                    Some(pubsub.clone()),
+                    pubsub.clone(),
                     &conf,
                 )
             },
@@ -122,13 +124,14 @@ impl LightClient {
                 setup_debug_rpc_apis_light(
                     common_impl.clone(),
                     rpc_impl.clone(),
-                    Some(pubsub),
+                    pubsub.clone(),
+                    &conf,
                 )
             } else {
                 setup_public_rpc_apis_light(
                     common_impl.clone(),
                     rpc_impl.clone(),
-                    Some(pubsub),
+                    pubsub.clone(),
                     &conf,
                 )
             },
@@ -138,9 +141,19 @@ impl LightClient {
         let rpc_http_server = super::rpc::start_http(
             conf.http_config(),
             if conf.is_test_mode() {
-                setup_debug_rpc_apis_light(common_impl, rpc_impl, None)
+                setup_debug_rpc_apis_light(
+                    common_impl,
+                    rpc_impl,
+                    pubsub.clone(),
+                    &conf,
+                )
             } else {
-                setup_public_rpc_apis_light(common_impl, rpc_impl, None, &conf)
+                setup_public_rpc_apis_light(
+                    common_impl,
+                    rpc_impl,
+                    pubsub.clone(),
+                    &conf,
+                )
             },
         )?;
 

--- a/client/src/light/mod.rs
+++ b/client/src/light/mod.rs
@@ -100,61 +100,34 @@ impl LightClient {
 
         let rpc_tcp_server = super::rpc::start_tcp(
             conf.tcp_config(),
-            if conf.is_test_mode() {
-                setup_debug_rpc_apis_light(
-                    common_impl.clone(),
-                    rpc_impl.clone(),
-                    pubsub.clone(),
-                    &conf,
-                )
-            } else {
-                setup_public_rpc_apis_light(
-                    common_impl.clone(),
-                    rpc_impl.clone(),
-                    pubsub.clone(),
-                    &conf,
-                )
-            },
+            setup_public_rpc_apis_light(
+                common_impl.clone(),
+                rpc_impl.clone(),
+                pubsub.clone(),
+                &conf,
+            ),
             RpcExtractor,
         )?;
 
         let rpc_ws_server = super::rpc::start_ws(
             conf.ws_config(),
-            if conf.is_test_mode() {
-                setup_debug_rpc_apis_light(
-                    common_impl.clone(),
-                    rpc_impl.clone(),
-                    pubsub.clone(),
-                    &conf,
-                )
-            } else {
-                setup_public_rpc_apis_light(
-                    common_impl.clone(),
-                    rpc_impl.clone(),
-                    pubsub.clone(),
-                    &conf,
-                )
-            },
+            setup_public_rpc_apis_light(
+                common_impl.clone(),
+                rpc_impl.clone(),
+                pubsub.clone(),
+                &conf,
+            ),
             RpcExtractor,
         )?;
 
         let rpc_http_server = super::rpc::start_http(
             conf.http_config(),
-            if conf.is_test_mode() {
-                setup_debug_rpc_apis_light(
-                    common_impl,
-                    rpc_impl,
-                    pubsub.clone(),
-                    &conf,
-                )
-            } else {
-                setup_public_rpc_apis_light(
-                    common_impl,
-                    rpc_impl,
-                    pubsub.clone(),
-                    &conf,
-                )
-            },
+            setup_public_rpc_apis_light(
+                common_impl,
+                rpc_impl,
+                pubsub.clone(),
+                &conf,
+            ),
         )?;
 
         Ok(Box::new(ClientComponents {

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -29,6 +29,7 @@ pub mod impls;
 pub mod informant;
 mod interceptor;
 pub mod metadata;
+pub mod rpc_apis;
 mod traits;
 pub mod types;
 

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -153,6 +153,7 @@ pub fn setup_public_rpc_apis(
         rpc,
         pubsub,
         &conf.raw_conf.throttling_conf,
+        "rpc",
         conf.raw_conf.public_rpc_apis.list_apis(),
     )
 }
@@ -167,13 +168,15 @@ pub fn setup_debug_rpc_apis(
         rpc,
         pubsub,
         &conf.raw_conf.throttling_conf,
+        "rpc_local",
         ApiSet::All.list_apis(),
     )
 }
 
 fn setup_rpc_apis(
     common: Arc<CommonImpl>, rpc: Arc<RpcImpl>, pubsub: PubSubClient,
-    throttling_conf: &Option<String>, apis: HashSet<Api>,
+    throttling_conf: &Option<String>, throttling_section: &str,
+    apis: HashSet<Api>,
 ) -> MetaIoHandler<Metadata>
 {
     let mut handler = MetaIoHandler::default();
@@ -182,8 +185,10 @@ fn setup_rpc_apis(
             Api::Cfx => {
                 let cfx =
                     CfxHandler::new(common.clone(), rpc.clone()).to_delegate();
-                let interceptor =
-                    ThrottleInterceptor::new(throttling_conf, "rpc");
+                let interceptor = ThrottleInterceptor::new(
+                    throttling_conf,
+                    throttling_section,
+                );
                 handler.extend_with(RpcProxy::new(cfx, interceptor));
             }
             Api::Debug => {
@@ -205,8 +210,10 @@ fn setup_rpc_apis(
                     rpc.consensus.clone(),
                 )
                 .to_delegate();
-                let interceptor =
-                    ThrottleInterceptor::new(throttling_conf, "rpc");
+                let interceptor = ThrottleInterceptor::new(
+                    throttling_conf,
+                    throttling_section,
+                );
                 handler.extend_with(RpcProxy::new(trace, interceptor));
             }
         }
@@ -224,6 +231,7 @@ pub fn setup_public_rpc_apis_light(
         rpc,
         pubsub,
         &conf.raw_conf.throttling_conf,
+        "rpc",
         conf.raw_conf.public_rpc_apis.list_apis(),
     )
 }
@@ -240,13 +248,15 @@ pub fn setup_debug_rpc_apis_light(
         rpc,
         pubsub,
         &conf.raw_conf.throttling_conf,
+        "rpc_local",
         light_debug_apis,
     )
 }
 
 fn setup_rpc_apis_light(
     common: Arc<CommonImpl>, rpc: Arc<LightImpl>, pubsub: PubSubClient,
-    throttling_conf: &Option<String>, apis: HashSet<Api>,
+    throttling_conf: &Option<String>, throttling_section: &str,
+    apis: HashSet<Api>,
 ) -> MetaIoHandler<Metadata>
 {
     let mut handler = MetaIoHandler::default();
@@ -255,8 +265,10 @@ fn setup_rpc_apis_light(
             Api::Cfx => {
                 let cfx = LightCfxHandler::new(common.clone(), rpc.clone())
                     .to_delegate();
-                let interceptor =
-                    ThrottleInterceptor::new(throttling_conf, "rpc");
+                let interceptor = ThrottleInterceptor::new(
+                    throttling_conf,
+                    throttling_section,
+                );
                 handler.extend_with(RpcProxy::new(cfx, interceptor));
             }
             Api::Debug => {

--- a/client/src/rpc/rpc_apis.rs
+++ b/client/src/rpc/rpc_apis.rs
@@ -37,7 +37,7 @@ pub enum ApiSet {
 }
 
 impl ApiSet {
-    fn list_apis(&self) -> HashSet<Api> {
+    pub fn list_apis(&self) -> HashSet<Api> {
         match *self {
             ApiSet::List(ref apis) => apis.clone(),
             ApiSet::All => {

--- a/client/src/rpc/rpc_apis.rs
+++ b/client/src/rpc/rpc_apis.rs
@@ -1,0 +1,83 @@
+// Copyright 2021 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use std::{collections::HashSet, str::FromStr};
+
+#[derive(Debug, PartialEq, Clone, Eq, Hash)]
+pub enum Api {
+    Cfx,
+    Debug,
+    Pubsub,
+    Test,
+    Trace,
+}
+
+impl FromStr for Api {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        use self::Api::*;
+        match s {
+            "cfx" => Ok(Cfx),
+            "debug" => Ok(Debug),
+            "pubsub" => Ok(Pubsub),
+            "test" => Ok(Test),
+            "trace" => Ok(Trace),
+            _ => Err("Unknown api type".into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ApiSet {
+    All,
+    Safe,
+    List(HashSet<Api>),
+}
+
+impl ApiSet {
+    fn list_apis(&self) -> HashSet<Api> {
+        match *self {
+            ApiSet::List(ref apis) => apis.clone(),
+            ApiSet::All => {
+                [Api::Cfx, Api::Debug, Api::Pubsub, Api::Test, Api::Trace]
+                    .iter()
+                    .cloned()
+                    .collect()
+            }
+            ApiSet::Safe => [Api::Cfx, Api::Pubsub].iter().cloned().collect(),
+        }
+    }
+}
+
+impl FromStr for ApiSet {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut apis = HashSet::new();
+
+        for api in s.split(',') {
+            match api {
+                "all" => {
+                    apis.extend(ApiSet::All.list_apis());
+                }
+                "safe" => {
+                    // Safe APIs are those that are safe even in UnsafeContext.
+                    apis.extend(ApiSet::Safe.list_apis());
+                }
+                // Remove the API
+                api if api.starts_with("-") => {
+                    let api = api[1..].parse()?;
+                    apis.remove(&api);
+                }
+                api => {
+                    let api = api.parse()?;
+                    apis.insert(api);
+                }
+            }
+        }
+
+        Ok(ApiSet::List(apis))
+    }
+}

--- a/run/tethys.toml
+++ b/run/tethys.toml
@@ -16,7 +16,6 @@ bootnodes="cfxnode://dc79bc70833e797ba41eff5bda67c0484abca4918ef38289b5f96acd3da
 #
 # For both `test` and `dev` modes, we will
 #     * Set initial difficulty to 4
-#     * Allow calling test and debug rpc from public port
 #
 # `test` mode is for Conflux testing and debugging, we will
 #     * Add latency to peer connections
@@ -143,6 +142,13 @@ log_conf="log.yaml"
 # jsonrpc_http_port=12537
 # jsonrpc_local_tcp_port=12538
 jsonrpc_local_http_port=12539
+
+# Specify the APIs available through the public JSON-RPC interfaces (HTTP, TCP, WebSocket)
+# using a comma-delimited list of API names.
+# Possible names are: all, safe, cfx, debug, pubsub, test, trace.
+# `safe` only includes `cfx` and `pubsub`.
+#
+# public_rpc_apis = "safe"
 
 # --------------- Performance-related Network Parameters ----------------------
 
@@ -462,11 +468,6 @@ jsonrpc_local_http_port=12539
 #
 # executive_trace = false
 
-# Whether to enable tracing RPC for public access. It works only if `executive_trace`
-# is set to `true`. On the other hand, once `executive_trace` is enabled, the tracing
-# RPC is always enabled for local access.
-#
-# enable_tracing = false
 
 # -------------------- Others -------------------
 

--- a/tests/network_tests/node_reputation_test.py
+++ b/tests/network_tests/node_reputation_test.py
@@ -121,7 +121,7 @@ class NodeReputationTests(ConfluxTestFramework):
         time.sleep((self.test_house_keeping_ms + 100) / 1000)
         peer0 = client3.get_peer(self.nodes[0].key)
         # refused during handshake or not handshaked yet
-        assert peer0 is None or len(peer0["caps"]) == 0
+        assert peer0 is None or len(peer0["protocols"]) == 0
 
 if __name__ == "__main__":
     NodeReputationTests().main()

--- a/tests/rpc_test.py
+++ b/tests/rpc_test.py
@@ -17,7 +17,7 @@ class RpcTest(ConfluxTestFramework):
         self.conf_parameters = {
             "log_level": "\"trace\"",
             "executive_trace": "true",
-            "enable_tracing": "true",
+            "public_rpc_apis": "\"cfx,debug,test,pubsub,trace\"",
         }
 
     def setup_network(self):

--- a/tests/throttle_test.py
+++ b/tests/throttle_test.py
@@ -22,6 +22,9 @@ class ThrottleRpcTests(ConfluxTestFramework):
             fp.write("[rpc_local]\n")
             fp.write("cfx_epochNumber=\"300,200,1,100,1\"\n")
             fp.write("cfx_gasPrice=\"5,5,2,1,0\"\n")
+            # In python tests, we will only call the local RPC interface,
+            # just add the public rpc section as a placeholder.
+            fp.write("[rpc]")
 
         self.conf_parameters["throttling_conf"] = "'{}'".format(throttle_conf)
 


### PR DESCRIPTION
Add a parameter `public_rpc_apis` to control the publicly available RPC interface sets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2093)
<!-- Reviewable:end -->
