### PR TITLE
Improve error message for pruned blocks during log filtering on full nodes

### DIFF
--- a/primitives/src/filter.rs
+++ b/primitives/src/filter.rs
@@ -61,6 +61,12 @@ pub enum FilterError {
         min: u64,
     },
 
+    /// Block cannot be served as it was already pruned from db on a full node
+    // Use this when the corresponding epoch is not known.
+    BlockAlreadyPruned {
+        block_hash: H256,
+    },
+
     /// Block has not been executed yet
     BlockNotExecutedYet {
         block_hash: H256,
@@ -119,6 +125,9 @@ impl fmt::Display for FilterError {
             EpochAlreadyPruned { epoch, min } => format! {
                 "Epoch is smaller than the earliest epoch stored (epoch: {}, min: {})",
                 epoch, min,
+            },
+            BlockAlreadyPruned { block_hash } => format! {
+                "Block {:?} has been pruned from db", block_hash,
             },
             BlockNotExecutedYet { block_hash } => format! {
                 "Block {:?} is not executed yet", block_hash,


### PR DESCRIPTION
When providing `blockHashes` in a filter for `cfx_getLogs`, we'd return the error "block not executed yet" for blocks that have been executed but were pruned already.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2098)
<!-- Reviewable:end -->
