### PR TITLE
Only set tx packed after catching up.

### DIFF
--- a/changelogs/CHANGELOG-1.1.x.md
+++ b/changelogs/CHANGELOG-1.1.x.md
@@ -24,6 +24,7 @@
   
 ## Bug Fixes
 - Fix a possible OOM error when a full node is catching up.
+- Fix a possible OOM error in transaction pool when an archive node is catching up.
 - Return correct `block_number` in `cfx_getStatus`.
 - Fix a bug that makes the configuration `mining_author` require extra quotes to use a CIP-37 base32 address.
 - Fix a bug that the block traces may be incorrect if the pivot chain switches frequently.

--- a/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
+++ b/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
@@ -2010,6 +2010,9 @@ impl ConsensusNewBlockHandler {
     ) {
         if let Some(me) = inner.hash_to_arena_indices.get(hash) {
             let parent = inner.arena[*me].parent;
+            if parent == NULL {
+                return;
+            }
             let era_genesis_height =
                 inner.get_era_genesis_height(inner.arena[parent].height);
             let cur_pivot_era_block = if inner

--- a/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
+++ b/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
@@ -1561,20 +1561,8 @@ impl ConsensusNewBlockHandler {
                 )
                 // FIXME: propogate error.
                 .expect(&concat!(file!(), ":", line!(), ":", column!()));
-
-            if inner.pivot_chain.len() > RECYCLE_TRANSACTION_DELAY as usize {
-                let recycle_pivot_index = inner.pivot_chain.len()
-                    - RECYCLE_TRANSACTION_DELAY as usize
-                    - 1;
-                let recycle_arena_index =
-                    inner.pivot_chain[recycle_pivot_index];
-                let skipped_blocks = inner
-                    .get_or_compute_skipped_epoch_blocks(recycle_arena_index)
-                    .clone();
-                for idx in &skipped_blocks {
-                    self.recycle_tx_in_block(inner, idx);
-                }
-            }
+            self.set_block_tx_packed(inner, me);
+            self.delayed_tx_recycle_in_skipped_blocks(inner);
 
             let to_state_pos = if inner
                 .pivot_index_to_height(inner.pivot_chain.len())
@@ -2005,38 +1993,62 @@ impl ConsensusNewBlockHandler {
         }
     }
 
-    pub fn set_block_tx_packed(
-        &self, inner: &ConsensusGraphInner, hash: &H256,
-    ) {
-        if let Some(me) = inner.hash_to_arena_indices.get(hash) {
-            let parent = inner.arena[*me].parent;
-            if parent == NULL {
-                return;
-            }
-            let era_genesis_height =
-                inner.get_era_genesis_height(inner.arena[parent].height);
-            let cur_pivot_era_block = if inner
-                .pivot_index_to_height(inner.pivot_chain.len())
-                > era_genesis_height
-            {
-                inner.get_pivot_block_arena_index(era_genesis_height)
-            } else {
-                NULL
-            };
-            let era_block = inner.get_era_genesis_block_with_parent(parent);
+    fn set_block_tx_packed(&self, inner: &ConsensusGraphInner, me: usize) {
+        if !self.txpool.ready_for_mining() {
+            // Skip tx pool operation before catching up.
+            return;
+        }
+        let parent = inner.arena[me].parent;
+        if parent == NULL {
+            return;
+        }
+        let era_genesis_height =
+            inner.get_era_genesis_height(inner.arena[parent].height);
+        let cur_pivot_era_block = if inner
+            .pivot_index_to_height(inner.pivot_chain.len())
+            > era_genesis_height
+        {
+            inner.get_pivot_block_arena_index(era_genesis_height)
+        } else {
+            NULL
+        };
+        let era_block = inner.get_era_genesis_block_with_parent(parent);
 
-            // It's only correct to set tx stale after the block is considered
-            // terminal for mining.
-            // Note that we conservatively only mark those blocks inside the
-            // current pivot era
-            if era_block == cur_pivot_era_block {
-                self.txpool.set_tx_packed(
-                    &self
-                        .data_man
-                        .block_by_hash(&hash, true /* update_cache */)
-                        .expect("Already checked")
-                        .transactions,
-                );
+        // It's only correct to set tx stale after the block is considered
+        // terminal for mining.
+        // Note that we conservatively only mark those blocks inside the
+        // current pivot era
+        if era_block == cur_pivot_era_block {
+            self.txpool.set_tx_packed(
+                &self
+                    .data_man
+                    .block_by_hash(
+                        &inner.arena[me].hash,
+                        true, /* update_cache */
+                    )
+                    .expect("Already checked")
+                    .transactions,
+            );
+        }
+    }
+
+    fn delayed_tx_recycle_in_skipped_blocks(
+        &self, inner: &mut ConsensusGraphInner,
+    ) {
+        if !self.txpool.ready_for_mining() {
+            // Skip tx pool operation before catching up.
+            return;
+        }
+        if inner.pivot_chain.len() > RECYCLE_TRANSACTION_DELAY as usize {
+            let recycle_pivot_index = inner.pivot_chain.len()
+                - RECYCLE_TRANSACTION_DELAY as usize
+                - 1;
+            let recycle_arena_index = inner.pivot_chain[recycle_pivot_index];
+            let skipped_blocks = inner
+                .get_or_compute_skipped_epoch_blocks(recycle_arena_index)
+                .clone();
+            for h in &skipped_blocks {
+                self.recycle_tx_in_block(inner, h);
             }
         }
     }

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -196,7 +196,7 @@ pub struct ConsensusGraph {
     /// any inconsistency
     best_info: RwLock<Arc<BestInformation>>,
     /// Set to `true` when we enter NormalPhase
-    ready_for_mining: Arc<AtomicBool>,
+    ready_for_mining: AtomicBool,
 
     /// The epoch id of the remotely synchronized state.
     /// This is always `None` for archive nodes.
@@ -247,7 +247,6 @@ impl ConsensusGraph {
         );
         let confirmation_meter = ConfirmationMeter::new();
 
-        let ready_for_mining = Arc::new(AtomicBool::new(false));
         let graph = ConsensusGraph {
             inner,
             txpool: txpool.clone(),
@@ -265,7 +264,7 @@ impl ConsensusGraph {
             ),
             confirmation_meter,
             best_info: RwLock::new(Arc::new(Default::default())),
-            ready_for_mining,
+            ready_for_mining: AtomicBool::new(false),
             synced_epoch_id: Default::default(),
             config: conf,
         };

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -1258,6 +1258,8 @@ impl ConsensusGraphTrait for ConsensusGraph {
         let ready_for_mining = self.ready_for_mining.load(Ordering::SeqCst);
         self.update_best_info(ready_for_mining);
         if ready_for_mining {
+            self.new_block_handler
+                .set_block_tx_packed(&*self.inner.read(), hash);
             self.txpool
                 .notify_new_best_info(self.best_info.read().clone())
                 // FIXME: propogate error.


### PR DESCRIPTION
Otherwise, `set_tx_requests` will keep growing and cause OOM for catching-up archive nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2107)
<!-- Reviewable:end -->
