### PR TITLE
Update CHANGELOG for 1.1.2 and the start script.

### DIFF
--- a/changelogs/CHANGELOG-1.1.x.md
+++ b/changelogs/CHANGELOG-1.1.x.md
@@ -1,8 +1,3 @@
-# 1.1.3
-## Improvements
-- Add new trace RPC `trace_transaction`.
-- Use hex encoding for the returned bytes in trace-related RPCs.
-
 # 1.1.2
 
 ## Improvements
@@ -21,6 +16,8 @@
 ### RPC Improvements
 - Add new local RPC `cfx_getEpochReceipts` to allow querying receipts based on an epoch number.
 - Add new trace RPC `trace_filter` to allow querying traces based on epochs/types/offset.
+- Add new trace RPC `trace_transaction`.
+- Use hex encoding for the returned bytes in trace-related RPCs.
 - Add new fields `latestCheckpoint`, `latestConfirmed`, and `latestState` in `cfx_getStatus`.
 - Improve some RPC error reporting.
   

--- a/run/start.bat
+++ b/run/start.bat
@@ -1,2 +1,2 @@
 set RUST_BACKTRACE=1
-conflux.exe --config tethys.toml --full 2> stderr.txt
+conflux.exe --config tethys.toml 2> stderr.txt

--- a/run/start.sh
+++ b/run/start.sh
@@ -1,2 +1,2 @@
 export RUST_BACKTRACE=1
-./conflux --config tethys.toml --full 2> stderr.txt
+./conflux --config tethys.toml 2> stderr.txt


### PR DESCRIPTION
Now we start full nodes by default. Adding `--full` in the command line
parameter will overwrite `node_type` in the configuration file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2109)
<!-- Reviewable:end -->
