### PR TITLE
Add new field offset to cfx_getLogs filters

### DIFF
--- a/changelogs/CHANGELOG-1.1.x.md
+++ b/changelogs/CHANGELOG-1.1.x.md
@@ -1,3 +1,8 @@
+# 1.1.3
+
+## Improvements
+- Add new field `offset` in log filters used in `cfx_getLogs`. If specified, the response will skip the **last** `offset` logs. For instance, with 10 matching logs (`0..9`) and `offset=0x1, limit=0x5`, the response will contain logs `4..8`. Note: Even if you specify `offset`, the corresponding logs still need to be processed by the node, so a filter with `offset=10000, limit=10` has about the same performance as a filter with `offset=0, limit=100010`.
+
 # 1.1.2
 
 ## Improvements

--- a/client/src/rpc/types/filter.rs
+++ b/client/src/rpc/types/filter.rs
@@ -39,10 +39,17 @@ pub struct LogFilter {
     /// topic. If None, match all.
     pub topics: Option<Vec<VariadicValue<H256>>>,
 
+    /// Logs offset
+    ///
+    /// If None, return all logs
+    /// If specified, should skip the *last* `n` logs.
+    pub offset: Option<U64>,
+
     /// Logs limit
     ///
     /// If None, return all logs
-    /// If specified, should only return *last* `n` logs.
+    /// If specified, should only return *last* `n` logs
+    /// after the offset has been applied.
     pub limit: Option<U64>,
 }
 
@@ -103,6 +110,7 @@ impl LogFilter {
             }
         };
 
+        let offset = self.offset.map(|x| x.as_u64() as usize);
         let limit = self.limit.map(|x| x.as_u64() as usize);
 
         Ok(PrimitiveFilter {
@@ -111,6 +119,7 @@ impl LogFilter {
             block_hashes,
             address,
             topics,
+            offset,
             limit,
         })
     }
@@ -136,6 +145,7 @@ mod tests {
             block_hashes: None,
             address: None,
             topics: None,
+            offset: None,
             limit: None,
         };
 
@@ -149,6 +159,7 @@ mod tests {
              \"blockHashes\":null,\
              \"address\":null,\
              \"topics\":null,\
+             \"offset\":null,\
              \"limit\":null\
              }"
         );
@@ -171,6 +182,7 @@ mod tests {
                     H256::from_str("d397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5").unwrap(),
                 ]),
             ]),
+            offset: Some(U64::from(1)),
             limit: Some(U64::from(2)),
         };
 
@@ -187,6 +199,7 @@ mod tests {
                 \"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5\",\
                 [\"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5\",\"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5\"]\
              ],\
+             \"offset\":\"0x1\",\
              \"limit\":\"0x2\"\
              }"
         );
@@ -202,6 +215,7 @@ mod tests {
             block_hashes: None,
             address: None,
             topics: None,
+            offset: None,
             limit: None,
         };
 
@@ -218,6 +232,7 @@ mod tests {
                 \"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5\",\
                 [\"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5\",\"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5\"]\
              ],\
+             \"offset\":\"0x1\",\
              \"limit\":\"0x2\"\
         }";
 
@@ -239,6 +254,7 @@ mod tests {
                     H256::from_str("d397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5").unwrap(),
                 ]),
             ]),
+            offset: Some(U64::from(1)),
             limit: Some(U64::from(2)),
         };
 
@@ -267,6 +283,7 @@ mod tests {
                     H256::from_str("d397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5").unwrap(),
                 ]),
             ]),
+            offset: Some(U64::from(1)),
             limit: Some(U64::from(2)),
         };
 
@@ -290,6 +307,7 @@ mod tests {
                 None,
                 None,
             ],
+            offset: Some(1),
             limit: Some(2),
         };
 

--- a/core/src/light_protocol/query_service.rs
+++ b/core/src/light_protocol/query_service.rs
@@ -896,6 +896,7 @@ impl QueryService {
         };
 
         // set maximum to number of logs returned
+        let offset = filter.offset.unwrap_or(0);
         let limit = filter.limit.unwrap_or(::std::usize::MAX);
 
         // construct a stream object for log filtering
@@ -989,6 +990,7 @@ impl QueryService {
             // --> TryStream<LocalizedLogEntry>
 
             // limit number of entries we need
+            .skip(offset)
             .take(limit)
             // --> TryStream<LocalizedLogEntry>
 

--- a/primitives/src/filter.rs
+++ b/primitives/src/filter.rs
@@ -172,10 +172,17 @@ pub struct LogFilter {
     /// If specified, log must contain one of these topics.
     pub topics: Vec<Option<Vec<H256>>>,
 
+    /// Logs offset
+    ///
+    /// If None, return all logs
+    /// If specified, should skip the *last* `n` logs.
+    pub offset: Option<usize>,
+
     /// Logs limit
     ///
     /// If None, return all logs
-    /// If specified, should only return *last* `n` logs.
+    /// If specified, should only return *last* `n` logs
+    /// after the offset has been applied.
     pub limit: Option<usize>,
 }
 
@@ -192,6 +199,7 @@ impl Clone for LogFilter {
             block_hashes: self.block_hashes.clone(),
             address: self.address.clone(),
             topics: topics[..].to_vec(),
+            offset: self.offset,
             limit: self.limit,
         }
     }
@@ -205,6 +213,7 @@ impl Default for LogFilter {
             block_hashes: None,
             address: None,
             topics: vec![None, None, None, None],
+            offset: None,
             limit: None,
         }
     }

--- a/tests/conflux/filter.py
+++ b/tests/conflux/filter.py
@@ -3,7 +3,7 @@ from conflux.address import hex_to_b32_address
 
 class Filter():
     def __init__(self, from_epoch="earliest", to_epoch="latest_state", block_hashes = None, address = None, topics = [],
-                 limit = None, encode_address=True):
+                 offset = None, limit = None, encode_address=True):
         if encode_address and address is not None:
             if isinstance(address, list):
                 base32_address = []
@@ -17,4 +17,5 @@ class Filter():
         self.blockHashes = block_hashes
         self.address = address
         self.topics = topics
+        self.offset = offset
         self.limit = limit

--- a/tests/light/log_filtering_test.py
+++ b/tests/light/log_filtering_test.py
@@ -118,6 +118,10 @@ class LogFilteringTest(ConfluxTestFramework):
         self.log.info("testing filter limit...")
         self.check_filter(Filter(limit=("0x%x" % (NUM_CALLS // 2))))
 
+        # apply filter with offset and limit
+        self.log.info("testing filter offset and limit...")
+        self.check_filter(Filter(offset=("0x%x" % (NUM_CALLS // 4)), limit=("0x%x" % (NUM_CALLS // 2))))
+
         # apply filter for specific contract address
         self.log.info("testing address filtering...")
         self.check_filter(Filter(address=[contractAddr]))

--- a/tests/rpc/test_get_logs.py
+++ b/tests/rpc/test_get_logs.py
@@ -59,6 +59,10 @@ class TestGetLogs(RpcClient):
         filter = Filter(topics=[NULL_H256] * 5)
         assert_raises_rpc_error(None, None, self.get_logs, filter)
 
+        # invalid `offset` type
+        filter = Filter(offset=1)
+        assert_raises_rpc_error(None, None, self.get_logs, filter)
+
         # invalid `limit` type
         filter = Filter(limit=1)
         assert_raises_rpc_error(None, None, self.get_logs, filter)
@@ -111,6 +115,7 @@ class TestGetLogs(RpcClient):
             block_hashes = [self.blocks[0]],
             address=[NULL_H160],
             topics=[NULL_H256, [NULL_H256, NULL_H256]],
+            offset="0x0",
             limit="0x1"
         )
         logs = self.get_logs(filter)


### PR DESCRIPTION
**Overview**

When executing a `cfx_getLogs` query, the client has no way to know the amount of data (number of logs) returned in advance. This can be controlled by `filter.limit` but currently there is no way to continue requesting the remaining the logs.

This PR adds a new filter field `offset` which can be used for paging by clients. For instance, a client could request logs in batches of 100 like this (negative indices signify indexing from the end of the collection of all matching logs):

```
offset =  0x0, limit = 0x64  // -100..
offset = 0x64, limit = 0x64  // -200..-100
offset = 0xc8, limit = 0x64  // -300..-200
...
```

**Caveats**

There is no reliable way to know which blocks/epoch to skip without actually reading the corresponding receipts from DB and processing them. So a filter like `offset = 10000, limit = 10` that looks cheap can actually be very expensive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2113)
<!-- Reviewable:end -->
