### PR TITLE
Remove use of ForceCreate cleanup mode from production.

### DIFF
--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -1599,7 +1599,7 @@ impl ConsensusExecutionHandler {
                 .add_balance(
                     &address,
                     &reward,
-                    CleanupMode::ForceCreate,
+                    CleanupMode::NoEmpty,
                     account_start_nonce,
                 )
                 .unwrap();


### PR DESCRIPTION
This change should be backward compatible. But for this kind of changes I'm always afraid of any unexpected effects, it's better to run the blockchain history just before the release cut.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2118)
<!-- Reviewable:end -->
