### PR TITLE
Fix auto block generation in `dev` mode.

### DIFF
--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -745,9 +745,11 @@ impl Configuration {
             sync_expire_block_timeout: Duration::from_secs(
                 self.raw_conf.sync_expire_block_timeout_s,
             ),
-            allow_phase_change_without_peer: self
-                .raw_conf
-                .dev_allow_phase_change_without_peer,
+            allow_phase_change_without_peer: if self.is_dev_mode() {
+                true
+            } else {
+                self.raw_conf.dev_allow_phase_change_without_peer
+            },
         }
     }
 


### PR DESCRIPTION
Without this, even in `mode="dev"`, we still need to set
`dev_allow_phase_change_without_peer=true` to make it work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2120)
<!-- Reviewable:end -->
