### PR TITLE
Allow immediately packing sent transactions in `dev` mode.

### DIFF
--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -101,7 +101,7 @@ build_config! {
         (debug_dump_dir_invalid_state_root, (String), "./storage_db/debug_dump_invalid_state_root/".to_string())
         // Controls block generation speed.
         // Only effective in `dev` mode
-        (dev_block_interval_ms, (u64), 250)
+        (dev_block_interval_ms, (Option<u64>), None)
         (enable_state_expose, (bool), false)
         (generate_tx, (bool), false)
         (generate_tx_period_us, (Option<u64>), Some(100_000))
@@ -883,6 +883,8 @@ impl Configuration {
     pub fn rpc_impl_config(&self) -> RpcImplConfiguration {
         RpcImplConfiguration {
             get_logs_filter_max_limit: self.raw_conf.get_logs_filter_max_limit,
+            dev_pack_tx_immediately: self.is_dev_mode()
+                && self.raw_conf.dev_block_interval_ms.is_none(),
         }
     }
 

--- a/client/src/rpc/impls.rs
+++ b/client/src/rpc/impls.rs
@@ -5,6 +5,10 @@
 #[derive(Default)]
 pub struct RpcImplConfiguration {
     pub get_logs_filter_max_limit: Option<usize>,
+    /// If it's `true`, `DEFERRED_STATE_EPOCH_COUNT` blocks are generated after
+    /// receiving a new tx through RPC calling to pack and execute this
+    /// transaction.
+    pub dev_pack_tx_immediately: bool,
 }
 
 pub mod cfx;

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -66,6 +66,7 @@ use crate::{
 use cfx_addr::Network;
 use cfxcore::{
     consensus::{MaybeExecutedTxExtraInfo, TransactionInfo},
+    consensus_parameters::DEFERRED_STATE_EPOCH_COUNT,
     executive::revert_reason_decode,
     spec::genesis::{
         genesis_contract_address_four_year, genesis_contract_address_two_year,
@@ -384,7 +385,20 @@ impl RpcImpl {
         let tx =
             invalid_params_check("raw", Rlp::new(&raw.into_vec()).as_val())?;
 
-        self.send_transaction_with_signature(tx)
+        let r = self.send_transaction_with_signature(tx);
+        if r.is_ok() && self.config.dev_pack_tx_immediately {
+            // Try to pack and execute this new tx.
+            for _ in 0..DEFERRED_STATE_EPOCH_COUNT {
+                self.generate_one_block(
+                    1,
+                    self.sync
+                        .get_synchronization_graph()
+                        .verification_config
+                        .max_block_size_in_bytes,
+                )?;
+            }
+        }
+        r
     }
 
     fn storage_at(

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -390,7 +390,7 @@ impl RpcImpl {
             // Try to pack and execute this new tx.
             for _ in 0..DEFERRED_STATE_EPOCH_COUNT {
                 self.generate_one_block(
-                    1,
+                    1, /* num_txs */
                     self.sync
                         .get_synchronization_graph()
                         .verification_config

--- a/run/tethys.toml
+++ b/run/tethys.toml
@@ -30,7 +30,8 @@ bootnodes="cfxnode://dc79bc70833e797ba41eff5bda67c0484abca4918ef38289b5f96acd3da
 #     * Open port 12535 for ws rpc if `jsonrpc_ws_port` is not provided.
 #     * Open port 12536 for tcp rpc if `jsonrpc_tcp_port` is not provided.
 #     * Open port 12537 for http rpc if `jsonrpc_http_port` is not provided.
-#     * generate blocks automatically without PoW
+#     * generate blocks without PoW (either after receiving a transaction or
+#       in fixed period, see ``dev_block_interval_ms'')
 #     * Skip catch-up mode even there is no peer
 #
 # mode = ""
@@ -40,7 +41,10 @@ bootnodes="cfxnode://dc79bc70833e797ba41eff5bda67c0484abca4918ef38289b5f96acd3da
 #
 # mode = "dev"
 
-# Note that ``dev_block_interval_ms'' controls the mining rate in the dev mode.
+# ``dev_block_interval_ms'' controls the mining rate in the dev mode.
+#
+# If it's not set, blocks will only be generated after receiving a transaction.
+# Otherwise, blocks are automatically generated every ``dev_block_interval_ms'' ms.
 #
 # dev_block_interval_ms = 250
 

--- a/tests/dev_mode_test.py
+++ b/tests/dev_mode_test.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""An example functional test
+"""
+from conflux.rpc import RpcClient
+from test_framework.test_framework import ConfluxTestFramework
+from test_framework.util import *
+
+
+class DevModeTest(ConfluxTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.conf_parameters["mode"] = '"dev"'
+
+    def setup_network(self):
+        self.setup_nodes()
+
+    def run_test(self):
+        rpc = RpcClient(self.nodes[0])
+        tx = rpc.new_tx()
+        tx_hash = rpc.send_tx(tx)
+        wait_until(lambda: checktx(self.nodes[0], tx_hash))
+
+
+if __name__ == '__main__':
+    DevModeTest().main()


### PR DESCRIPTION
Keeping `dev_block_interval_ms` unset will use this behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2121)
<!-- Reviewable:end -->
