### PR TITLE
Allow epoch subscriptions on latest_mined and latest_executed

### DIFF
--- a/changelogs/CHANGELOG-1.1.x.md
+++ b/changelogs/CHANGELOG-1.1.x.md
@@ -8,6 +8,8 @@ Note that the data format returned by `trace_block` is incompatible with old ver
   For instance, with 10 matching logs (`0..9`) and `offset=0x1, limit=0x5`, the response will contain logs `4..8`.
   Note: Even if you specify `offset`, the corresponding logs still need to be processed by the node,
   so a filter with `offset=10000, limit=10` has about the same performance as a filter with `offset=0, limit=100010`.
+- Add a new parameter `subscription_epoch` to the `epochs` pubsub.
+  The supported values are `"latest_mined"` (default) and `"latest_state"`.
 
 # 1.1.2
 

--- a/client/src/rpc/helpers/epoch_queue.rs
+++ b/client/src/rpc/helpers/epoch_queue.rs
@@ -22,6 +22,10 @@ impl<T> EpochQueue<T> {
     }
 
     pub fn push(&mut self, new: (u64, T)) -> Option<(u64, T)> {
+        if self.capacity == 0 {
+            return Some(new);
+        }
+
         // remove epochs from queue that are greater or equal to the new one
         while matches!(self.queue.back(), Some((e, _)) if *e >= new.0) {
             self.queue.pop_back();
@@ -53,6 +57,16 @@ impl<T> EpochQueue<T> {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn test_no_queue() {
+        let mut queue = EpochQueue::with_capacity(0);
+
+        assert_eq!(queue.push((0, 0)), Some((0, 0)));
+        assert_eq!(queue.push((1, 1)), Some((1, 1)));
+        assert_eq!(queue.push((2, 2)), Some((2, 2)));
+        assert_eq!(queue.push((3, 3)), Some((3, 3)));
+    }
 
     #[test]
     fn test_no_reorgs() {

--- a/client/src/rpc/impls/pubsub.rs
+++ b/client/src/rpc/impls/pubsub.rs
@@ -368,8 +368,8 @@ impl ChainNotificationHandler {
                 }
             }
 
-            // this should not happen
-            if ii > 100 {
+            // we assume that an epoch gets executed within 100 seconds
+            if ii > 1000 {
                 error!("Cannot find receipts with {:?}/{:?}", block, pivot);
                 return None;
             }

--- a/client/src/rpc/impls/pubsub.rs
+++ b/client/src/rpc/impls/pubsub.rs
@@ -381,7 +381,7 @@ impl ChainNotificationHandler {
     // wait until the execution results corresponding to `pivot` become
     // available in the database.
     async fn wait_for_epoch(&self, pivot: &H256) -> () {
-        let _ = self.retrieve_block_receipts(&pivot, &pivot);
+        let _ = self.retrieve_block_receipts(&pivot, &pivot).await;
     }
 
     async fn retrieve_epoch_logs(

--- a/client/src/rpc/impls/pubsub.rs
+++ b/client/src/rpc/impls/pubsub.rs
@@ -128,7 +128,7 @@ impl PubSubClient {
                 };
 
                 // wait for epoch to be executed
-                if sub_epoch == SubscriptionEpoch::LatestExecuted {
+                if sub_epoch == SubscriptionEpoch::LatestState {
                     let pivot = hashes.last().expect("empty epoch in pubsub");
                     handler.wait_for_epoch(&pivot).await;
                 }

--- a/client/src/rpc/types/pubsub.rs
+++ b/client/src/rpc/types/pubsub.rs
@@ -71,7 +71,7 @@ pub enum Kind {
 }
 
 /// Subscription epoch.
-#[derive(Debug, Deserialize, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, Deserialize, PartialEq, Eq, Hash, Clone, Copy)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
 pub enum SubscriptionEpoch {

--- a/client/src/rpc/types/pubsub.rs
+++ b/client/src/rpc/types/pubsub.rs
@@ -70,6 +70,17 @@ pub enum Kind {
     Epochs,
 }
 
+/// Subscription epoch.
+#[derive(Debug, Deserialize, PartialEq, Eq, Hash, Clone)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "snake_case")]
+pub enum SubscriptionEpoch {
+    /// Latest epoch available.
+    LatestMined,
+    /// Latest epoch executed.
+    LatestExecuted,
+}
+
 /// Subscription kind.
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum Params {
@@ -77,6 +88,8 @@ pub enum Params {
     None,
     /// Log parameters.
     Logs(LogFilter),
+    /// Epoch parameters.
+    Epochs(SubscriptionEpoch),
 }
 
 impl Default for Params {
@@ -94,7 +107,13 @@ impl<'a> Deserialize<'a> for Params {
             return Ok(Params::None);
         }
 
-        from_value(v).map(Params::Logs).map_err(|e| {
+        // try to interpret as a log filter
+        if let Ok(v) = from_value(v.clone()).map(Params::Logs) {
+            return Ok(v);
+        }
+
+        // otherwise, interpret as epoch
+        from_value(v).map(Params::Epochs).map_err(|e| {
             D::Error::custom(format!("Invalid Pub-Sub parameters: {}", e))
         })
     }

--- a/client/src/rpc/types/pubsub.rs
+++ b/client/src/rpc/types/pubsub.rs
@@ -78,7 +78,7 @@ pub enum SubscriptionEpoch {
     /// Latest epoch available.
     LatestMined,
     /// Latest epoch executed.
-    LatestExecuted,
+    LatestState,
 }
 
 /// Subscription kind.

--- a/tests/pubsub/epochs_test.py
+++ b/tests/pubsub/epochs_test.py
@@ -139,11 +139,11 @@ class PubSubTest(ConfluxTestFramework):
 
         self.log.info(f"Pass -- forks")
 
-    async def test_latest_executed(self):
+    async def test_latest_state(self):
         parent = self.nodes[FULLNODE0].best_block_hash()
 
         sub_mined = await self.pubsub[FULLNODE0].subscribe("epochs", "latest_mined")
-        sub_exec = await self.pubsub[FULLNODE0].subscribe("epochs", "latest_executed")
+        sub_exec = await self.pubsub[FULLNODE0].subscribe("epochs", "latest_state")
 
         for _ in range(4):
             parent = self.rpc[FULLNODE0].generate_block_with_parent(parent)
@@ -172,12 +172,12 @@ class PubSubTest(ConfluxTestFramework):
             msg = await sub_exec.next()
             assert_equal(msg['epochNumber'], hex(int(epoch, 0) - 4))
 
-        self.log.info(f"Pass -- latest_executed")
+        self.log.info(f"Pass -- latest_state")
 
     def run_test(self):
         assert(SHORT_FORK_LEN < LONG_FORK_LEN)
         asyncio.get_event_loop().run_until_complete(self.test_forks())
-        asyncio.get_event_loop().run_until_complete(self.test_latest_executed())
+        asyncio.get_event_loop().run_until_complete(self.test_latest_state())
 
     def generate_chain(self, parent, len):
         hashes = [parent]

--- a/tests/pubsub/epochs_test.py
+++ b/tests/pubsub/epochs_test.py
@@ -27,6 +27,7 @@ def flatten(l):
 class PubSubTest(ConfluxTestFramework):
     def set_test_params(self):
         self.num_nodes = 3
+        self.conf_parameters["enable_optimistic_execution"] = "false"
 
     def setup_network(self):
         self.add_nodes(self.num_nodes)
@@ -56,7 +57,7 @@ class PubSubTest(ConfluxTestFramework):
         self.nodes[FULLNODE0].wait_for_phase(["NormalSyncPhase"])
         self.nodes[FULLNODE1].wait_for_phase(["NormalSyncPhase"])
 
-    async def run_async(self):
+    async def test_forks(self):
         # Generate a chain with multiple forks like this:
         # 1 -- 2 -- 3 -- 4
         #       \-- 3 -- 4 -- 5 -- 6
@@ -136,9 +137,47 @@ class PubSubTest(ConfluxTestFramework):
 
             self.log.info(f"[{ii}] Pass")
 
+        self.log.info(f"Pass -- forks")
+
+    async def test_latest_executed(self):
+        parent = self.nodes[FULLNODE0].best_block_hash()
+
+        sub_mined = await self.pubsub[FULLNODE0].subscribe("epochs", "latest_mined")
+        sub_exec = await self.pubsub[FULLNODE0].subscribe("epochs", "latest_executed")
+
+        for _ in range(4):
+            parent = self.rpc[FULLNODE0].generate_block_with_parent(parent)
+            epoch = self.rpc[FULLNODE0].block_by_hash(parent)["height"]
+
+            msg = await sub_mined.next()
+            assert_equal(msg['epochNumber'], epoch)
+
+            # epoch received not executed yet, should timeout
+            try:
+                # do not use an overly large timeout here;
+                # if an epoch is not executed for 100s, this violates our
+                # asssumptions and the node will return invalid results.
+                msg = await sub_exec.next(timeout=2)
+                assert(False)
+            except:
+                pass
+
+        for _ in range(20):
+            parent = self.rpc[FULLNODE0].generate_block_with_parent(parent)
+            epoch = self.rpc[FULLNODE0].block_by_hash(parent)["height"]
+
+            msg = await sub_mined.next()
+            assert_equal(msg['epochNumber'], epoch)
+
+            msg = await sub_exec.next()
+            assert_equal(msg['epochNumber'], hex(int(epoch, 0) - 4))
+
+        self.log.info(f"Pass -- latest_executed")
+
     def run_test(self):
         assert(SHORT_FORK_LEN < LONG_FORK_LEN)
-        asyncio.get_event_loop().run_until_complete(self.run_async())
+        asyncio.get_event_loop().run_until_complete(self.test_forks())
+        asyncio.get_event_loop().run_until_complete(self.test_latest_executed())
 
     def generate_chain(self, parent, len):
         hashes = [parent]


### PR DESCRIPTION
A request from Infura is that clients should be able to subscribe to the latest executed epoch.

We expose an optional parameter for the `epochs` pubsub with the possible values of `latest_mined` and `latest_state`. When using `latest_mined`, the pubsub layer will publish epochs immediately after receiving them. When using `latest_state`, the pubsub layer will wait for execution before publishing an epoch.

~~I decided to call this `latest_executed` instead of `latest_state` as the semantics are somewhat different, this implementation will expose results of optimistic execution, while `latest_state` does not. That said, during a pivot chain reorg, the previous epochs are re-published even if they are not re-executed.~~

~~In my python tests the epochs just become available immediately, possibly because of optimistic execution, so I haven't been able to expose the different behavior in a test.~~ ~~In the tests the epochs become available non-deterministically, possible because of optimistic execution. @peilun-conflux do you have any suggestions as to how to test this?~~

Related issue: #2044.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2130)
<!-- Reviewable:end -->
