### PR TITLE
Add `cfx_getAccountPendingTransactions` to get pending transactions of a given account.

### DIFF
--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -583,7 +583,7 @@ impl RpcImpl {
     {
         info!("RPC Request: cfx_getAccountPendingInfo({:?})", address);
 
-        let (pending_txs, tx_status) =
+        let (pending_txs, tx_status, pending_count) =
             self.tx_pool.get_account_pending_transactions(
                 &(address.into()),
                 maybe_start_nonce,
@@ -601,6 +601,7 @@ impl RpcImpl {
                 })
                 .collect::<Result<Vec<RpcTransaction>, String>>()?,
             first_tx_status: tx_status,
+            pending_count: pending_count.into(),
         })
     }
 

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -559,6 +559,7 @@ impl RpcImpl {
         &self, address: RpcAddress,
     ) -> RpcResult<Option<AccountPendingInfo>> {
         info!("RPC Request: cfx_getAccountPendingInfo({:?})", address);
+        self.check_address_network(address.network)?;
 
         match self.tx_pool.get_account_pending_info(&(address.into())) {
             None => Ok(None),
@@ -581,7 +582,9 @@ impl RpcImpl {
         maybe_limit: Option<U64>,
     ) -> RpcResult<AccountPendingTransactions>
     {
-        info!("RPC Request: cfx_getAccountPendingInfo({:?})", address);
+        info!("RPC Request: cfx_getAccountPendingTransactions(addr={:?}, start_nonce={:?}, limit={:?})",
+              address, maybe_start_nonce, maybe_limit);
+        self.check_address_network(address.network)?;
 
         let (pending_txs, tx_status, pending_count) =
             self.tx_pool.get_account_pending_transactions(

--- a/client/src/rpc/impls/light.rs
+++ b/client/src/rpc/impls/light.rs
@@ -52,6 +52,7 @@ use crate::{
 use cfx_addr::Network;
 use cfxcore::{
     light_protocol::QueryService, rpc_errors::ErrorKind::LightProtocol,
+    transaction_pool::TransactionStatus,
 };
 
 // macro for reducing boilerplate for unsupported methods
@@ -1073,6 +1074,7 @@ impl Cfx for CfxHandler {
         fn estimate_gas_and_collateral(&self, request: CallRequest, epoch_num: Option<EpochNumber>) -> JsonRpcResult<EstimateGasAndCollateralResponse>;
         fn get_block_reward_info(&self, num: EpochNumber) -> JsonRpcResult<Vec<RpcRewardInfo>>;
         fn get_supply_info(&self, epoch_num: Option<EpochNumber>) -> JsonRpcResult<TokenSupplyInfo>;
+        fn account_pending_transactions(&self, address: RpcAddress, maybe_start_nonce: Option<U256>, maybe_limit: Option<U64>) -> BoxFuture<(Vec<RpcTransaction>, Option<TransactionStatus>)>;
     }
 }
 

--- a/client/src/rpc/impls/light.rs
+++ b/client/src/rpc/impls/light.rs
@@ -37,8 +37,9 @@ use crate::{
         },
         traits::{cfx::Cfx, debug::LocalRpc, test::TestRpc},
         types::{
-            Account as RpcAccount, AccountPendingInfo, BlameInfo,
-            Block as RpcBlock, BlockHashOrEpochNumber, Bytes, CallRequest,
+            Account as RpcAccount, AccountPendingInfo,
+            AccountPendingTransactions, BlameInfo, Block as RpcBlock,
+            BlockHashOrEpochNumber, Bytes, CallRequest,
             CheckBalanceAgainstTransactionResponse, ConsensusGraphStates,
             EpochNumber, EstimateGasAndCollateralResponse, Log as RpcLog,
             LogFilter as RpcFilter, Receipt as RpcReceipt,
@@ -52,7 +53,6 @@ use crate::{
 use cfx_addr::Network;
 use cfxcore::{
     light_protocol::QueryService, rpc_errors::ErrorKind::LightProtocol,
-    transaction_pool::TransactionStatus,
 };
 
 // macro for reducing boilerplate for unsupported methods
@@ -1074,7 +1074,7 @@ impl Cfx for CfxHandler {
         fn estimate_gas_and_collateral(&self, request: CallRequest, epoch_num: Option<EpochNumber>) -> JsonRpcResult<EstimateGasAndCollateralResponse>;
         fn get_block_reward_info(&self, num: EpochNumber) -> JsonRpcResult<Vec<RpcRewardInfo>>;
         fn get_supply_info(&self, epoch_num: Option<EpochNumber>) -> JsonRpcResult<TokenSupplyInfo>;
-        fn account_pending_transactions(&self, address: RpcAddress, maybe_start_nonce: Option<U256>, maybe_limit: Option<U64>) -> BoxFuture<(Vec<RpcTransaction>, Option<TransactionStatus>)>;
+        fn account_pending_transactions(&self, address: RpcAddress, maybe_start_nonce: Option<U256>, maybe_limit: Option<U64>) -> BoxFuture<AccountPendingTransactions>;
     }
 }
 

--- a/client/src/rpc/traits/cfx.rs
+++ b/client/src/rpc/traits/cfx.rs
@@ -9,9 +9,10 @@ use super::super::types::{
     Receipt as RpcReceipt, RewardInfo as RpcRewardInfo, SponsorInfo,
     Status as RpcStatus, TokenSupplyInfo, Transaction,
 };
-use crate::rpc::types::{BlockHashOrEpochNumber, RpcAddress};
+use crate::rpc::types::{
+    AccountPendingTransactions, BlockHashOrEpochNumber, RpcAddress,
+};
 use cfx_types::{H256, U256, U64};
-use cfxcore::transaction_pool::TransactionStatus;
 use jsonrpc_core::{BoxFuture, Result as JsonRpcResult};
 use jsonrpc_derive::rpc;
 use primitives::{DepositInfo, StorageRoot, VoteStakeInfo};
@@ -178,7 +179,7 @@ pub trait Cfx {
     fn account_pending_transactions(
         &self, address: RpcAddress, maybe_start_nonce: Option<U256>,
         maybe_limit: Option<U64>,
-    ) -> BoxFuture<(Vec<Transaction>, Option<TransactionStatus>)>;
+    ) -> BoxFuture<AccountPendingTransactions>;
 
     /// Return estimated gas and collateral usage.
     #[rpc(name = "cfx_estimateGasAndCollateral")]

--- a/client/src/rpc/traits/cfx.rs
+++ b/client/src/rpc/traits/cfx.rs
@@ -11,6 +11,7 @@ use super::super::types::{
 };
 use crate::rpc::types::{BlockHashOrEpochNumber, RpcAddress};
 use cfx_types::{H256, U256, U64};
+use cfxcore::transaction_pool::TransactionStatus;
 use jsonrpc_core::{BoxFuture, Result as JsonRpcResult};
 use jsonrpc_derive::rpc;
 use primitives::{DepositInfo, StorageRoot, VoteStakeInfo};
@@ -171,6 +172,13 @@ pub trait Cfx {
     fn account_pending_info(
         &self, address: RpcAddress,
     ) -> BoxFuture<Option<AccountPendingInfo>>;
+
+    /// Get transaction pending info by account address
+    #[rpc(name = "cfx_getAccountPendingTransactions")]
+    fn account_pending_transactions(
+        &self, address: RpcAddress, maybe_start_nonce: Option<U256>,
+        maybe_limit: Option<U64>,
+    ) -> BoxFuture<(Vec<Transaction>, Option<TransactionStatus>)>;
 
     /// Return estimated gas and collateral usage.
     #[rpc(name = "cfx_estimateGasAndCollateral")]

--- a/client/src/rpc/types.rs
+++ b/client/src/rpc/types.rs
@@ -53,7 +53,7 @@ pub use self::{
     },
     trace_filter::TraceFilter,
     transaction::{
-        AccountPendingInfo, PackedOrExecuted, Transaction, TxPoolPendingInfo,
-        TxWithPoolInfo,
+        AccountPendingInfo, AccountPendingTransactions, PackedOrExecuted,
+        Transaction, TxPoolPendingInfo, TxWithPoolInfo,
     },
 };

--- a/client/src/rpc/types/transaction.rs
+++ b/client/src/rpc/types/transaction.rs
@@ -5,6 +5,7 @@
 use crate::rpc::types::{receipt::Receipt, Bytes, RpcAddress};
 use cfx_addr::Network;
 use cfx_types::{H256, U256, U64};
+use cfxcore::transaction_pool::TransactionStatus;
 use cfxkey::Error;
 use primitives::{
     transaction::Action, SignedTransaction,
@@ -173,4 +174,11 @@ pub struct AccountPendingInfo {
     pub pending_count: U256,
     pub pending_nonce: U256,
     pub next_pending_tx: H256,
+}
+
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountPendingTransactions {
+    pub pending_transactions: Vec<Transaction>,
+    pub first_tx_status: Option<TransactionStatus>,
 }

--- a/client/src/rpc/types/transaction.rs
+++ b/client/src/rpc/types/transaction.rs
@@ -181,4 +181,5 @@ pub struct AccountPendingInfo {
 pub struct AccountPendingTransactions {
     pub pending_transactions: Vec<Transaction>,
     pub first_tx_status: Option<TransactionStatus>,
+    pub pending_count: U64,
 }

--- a/core/src/transaction_pool/mod.rs
+++ b/core/src/transaction_pool/mod.rs
@@ -14,7 +14,7 @@ mod transaction_pool_inner;
 
 extern crate rand;
 
-pub use self::impls::TreapMap;
+pub use self::{impls::TreapMap, transaction_pool_inner::TransactionStatus};
 use crate::{
     block_data_manager::BlockDataManager, consensus::BestInformation,
     machine::Machine, state::State, verification::VerificationConfig,
@@ -207,6 +207,18 @@ impl TransactionPool {
         &self, address: &Address,
     ) -> Option<(U256, U256, U256, H256)> {
         self.inner.read().get_account_pending_info(address)
+    }
+
+    pub fn get_account_pending_transactions(
+        &self, address: &Address, maybe_start_nonce: Option<U256>,
+        maybe_limit: Option<usize>,
+    ) -> (Vec<Arc<SignedTransaction>>, Option<TransactionStatus>)
+    {
+        self.inner.read().get_account_pending_transactions(
+            address,
+            maybe_start_nonce,
+            maybe_limit,
+        )
     }
 
     pub fn get_state_account_info(

--- a/core/src/transaction_pool/mod.rs
+++ b/core/src/transaction_pool/mod.rs
@@ -209,10 +209,15 @@ impl TransactionPool {
         self.inner.read().get_account_pending_info(address)
     }
 
+    /// Return `(pending_txs, first_tx_status, pending_count)`.
     pub fn get_account_pending_transactions(
         &self, address: &Address, maybe_start_nonce: Option<U256>,
         maybe_limit: Option<usize>,
-    ) -> (Vec<Arc<SignedTransaction>>, Option<TransactionStatus>)
+    ) -> (
+        Vec<Arc<SignedTransaction>>,
+        Option<TransactionStatus>,
+        usize,
+    )
     {
         self.inner.read().get_account_pending_transactions(
             address,

--- a/tests/rpc/test_send_tx.py
+++ b/tests/rpc/test_send_tx.py
@@ -307,6 +307,5 @@ class TestSendTx(RpcClient):
         r = self.node.cfx_getAccountPendingTransactions(addr)
         pending_txs = r["pendingTransactions"]
         tx_status = r["firstTxStatus"]
-        print(r)
         assert_equal(len(pending_txs), 1)
         assert_equal(tx_status, {'pending': 'notEnoughCash'})

--- a/tests/rpc/test_send_tx.py
+++ b/tests/rpc/test_send_tx.py
@@ -253,6 +253,10 @@ class TestSendTx(RpcClient):
         assert_equal(pending_info["pendingNonce"], hex(cur_nonce))
         assert_equal(pending_info["nextPendingTx"], tx0.hash_hex())
 
+        pending_txs, pending_reason = self.node.cfx_getAccountPendingTransactions(addr)
+        assert_equal(len(pending_txs), 3)
+        assert_equal(pending_reason, "ready")
+
 
         # generate a block to pack above txs.
         self.generate_blocks_to_state(num_txs=4)


### PR DESCRIPTION
Close #2143.
The API is defined as 
```
fn cfx_getAccountPendingTransactions(&self, address: RpcAddress, start_nonce: Option<U256>, limit: Option<U64>)
```

And the response is like:
```
{
    'firstTxStatus': {
        'pending': 'notEnoughCash'
    },
    'pendingCount': '0x1',
    'pendingTransactions': [{
        'blockHash': None,
        'chainId': '0xa',
        'contractCreated': None,
        'data': '0x',
        'epochHeight': '0x0',
        'from': 'NET10:TYPE.USER:AAR8JZYBZV0FHZREAV49SYXNZUT8S0JT1ASMXX99XH',
        'gas': '0x5208',
        'gasPrice': '0x1',
        'hash': '0xb7ffe7402b7f922477c85e2c452ae1266f3a7aac52d73808b9bd2c7e2b4a9309',
        'nonce': '0x15',
        'r': '0xafed6be26c46bec4855d8e5cd1240d00c9dbc8e25325cc93592ca52459a47427',
        's': '0x7e2c257387e241f643ff41c01939aef121e17aea3f03e051761d7d853d1f384d',
        'status': None,
        'storageLimit': '0x0',
        'to': 'NET10:TYPE.USER:AAJBAEAUCAJBAEAUCAJBAEAUCAJBAEAUCA902UEXYP',
        'transactionIndex': None,
        'v': '0x0',
        'value': '0xf684df56c3e01bc6c73200000000'
    }]
}
```

`firstTxStatus` can be `'ready'`, `{'pending': 'notEnoughCash'}`, or `{'pending': 'futureNonce'}`.
`pending_count` is the total number of pending transactions from `start_nonce` without taking the provided `limit`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2149)
<!-- Reviewable:end -->
