### PR TITLE
Remove deprecated setting of sync_state.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "cfxcore"
-version = "1.1.2"
+version = "1.1.3-debug"
 dependencies = [
  "bit-set",
  "bn",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "1.1.2"
+version = "1.1.3-debug"
 dependencies = [
  "app_dirs",
  "bigdecimal",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "conflux"
-version = "1.1.2"
+version = "1.1.3-debug"
 dependencies = [
  "app_dirs",
  "blockgen",

--- a/client/src/common/mod.rs
+++ b/client/src/common/mod.rs
@@ -201,17 +201,7 @@ pub fn initialize_common_modules(
         }
     };
 
-    let mut consensus_conf = conf.consensus_config();
-    match node_type {
-        NodeType::Archive => {
-            consensus_conf.sync_state_starting_epoch = Some(0);
-        }
-        NodeType::Full | NodeType::Light => {
-            consensus_conf.sync_state_epoch_gap =
-                Some(CATCH_UP_EPOCH_LAG_THRESHOLD);
-        }
-        NodeType::Unknown => {}
-    }
+    let consensus_conf = conf.consensus_config();
     let vm = VmFactory::new(1024 * 32);
     let machine = Arc::new(new_machine_with_builtin(conf.common_params(), vm));
 
@@ -723,7 +713,6 @@ use crate::{
     GENESIS_VERSION,
 };
 use blockgen::BlockGenerator;
-use cfx_parameters::sync::CATCH_UP_EPOCH_LAG_THRESHOLD;
 use cfx_storage::StorageManager;
 use cfx_types::{address_util::AddressUtil, Address, U256};
 use cfxcore::{


### PR DESCRIPTION
It should have been replaced by the code below. 

https://github.com/Conflux-Chain/conflux-rust/blob/48f73cc2fb70006bc9dea36d77cc977d26bf1449/client/src/configuration.rs#L550-L562

And the deprecated code will overwrite the setting of `sync_state_starting_epoch` for archive nodes unexpectedly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2154)
<!-- Reviewable:end -->
