### PR TITLE
Add rich fail reason in estimate_gas_and_collateral

### DIFF
--- a/changelogs/CHANGELOG-1.1.x.md
+++ b/changelogs/CHANGELOG-1.1.x.md
@@ -2,6 +2,9 @@
 
 ### Bug fix
 - Fix a bug that causes repacking useless transactions.
+### RPC Improvements
+- Make VM tracer records reasons for a fail execution. 
+- Make `estimate_gas_and_collateral` return an error stack in case an error happens in sub-call.  
 
 # 1.1.3
 

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -10,8 +10,7 @@ use blockgen::BlockGenerator;
 use cfx_state::state_trait::StateOpsTrait;
 use cfx_statedb::{StateDbExt, StateDbGetOriginalMethods};
 use cfx_types::{
-    address_util::AddressUtil, BigEndianHash, H256, H520, U128, U256,
-    U64,
+    address_util::AddressUtil, BigEndianHash, H256, H520, U128, U256, U64,
 };
 use cfxcore::{
     executive::{ExecutionError, ExecutionOutcome, TxDropError},

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -10,7 +10,7 @@ use blockgen::BlockGenerator;
 use cfx_state::state_trait::StateOpsTrait;
 use cfx_statedb::{StateDbExt, StateDbGetOriginalMethods};
 use cfx_types::{
-    address_util::AddressUtil, Address, BigEndianHash, H256, H520, U128, U256,
+    address_util::AddressUtil, BigEndianHash, H256, H520, U128, U256,
     U64,
 };
 use cfxcore::{

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -72,6 +72,7 @@ use cfxcore::{
     spec::genesis::{
         genesis_contract_address_four_year, genesis_contract_address_two_year,
     },
+    trace::ErrorUnwind,
 };
 use lazy_static::lazy_static;
 use metrics::{register_timer_with_group, ScopeTimer, Timer};
@@ -1123,10 +1124,33 @@ impl RpcImpl {
                 ExecutionError::VmError(vm::Error::Reverted),
                 executed,
             ) => {
+                let errors = ErrorUnwind::from_traces(executed.trace).errors;
+
+                // When a revert exception happens, there is usually an error in the sub-calls.
+                // So we return the trace information for debugging contract.
+                let errors = errors.iter()
+                    .map(|(addr,error)| format!("{} {}",addr,error))
+                    .collect::<Vec<String>>();
+
+                // Decode revert error
+                let revert_error = revert_reason_decode(&executed.output);
+                let revert_error = if !revert_error.is_empty() {
+                    format!(": {}.",revert_error)
+                }else{
+                    format!(".")
+                };
+
+                // Try to fetch the innermost error.
+                let innermost_error = if errors.len()>0{
+                    format!("Triggered from {}.", errors[0])
+                }else{
+                    String::default()
+                };
+
                 bail!(call_execution_error(
-                    format!("Estimation isn't accurate: transaction is reverted. Execution output {}",
-                        revert_reason_decode(&executed.output)),
-                    [b"Reverted. Execution output: ", &*executed.output].concat(),
+                    format!("Estimation isn't accurate: transaction is reverted{}{}",
+                        revert_error, innermost_error),
+                    errors.join("\n").into_bytes(),
                 ))
             }
             ExecutionOutcome::ExecutionErrorBumpNonce(e, _) => {

--- a/core/src/evm/interpreter/mod.rs
+++ b/core/src/evm/interpreter/mod.rs
@@ -268,7 +268,7 @@ impl<Cost: 'static + CostType> vm::ResumeCall for Interpreter<Cost> {
                         ),
                     ));
                 }
-                MessageCallResult::Failed => {
+                MessageCallResult::Failed(_) => {
                     this.stack.push(U256::zero());
                     this.resume_result = Some(InstructionResult::Ok);
                 }
@@ -298,7 +298,7 @@ impl<Cost: 'static + CostType> vm::ResumeCreate for Interpreter<Cost> {
                         .expect("Gas left cannot be greater."),
                 ));
             }
-            ContractCreateResult::Failed => {
+            ContractCreateResult::Failed(_) => {
                 self.stack.push(U256::zero());
                 self.resume_result = Some(InstructionResult::Ok);
             }
@@ -809,7 +809,7 @@ impl<Cost: CostType> Interpreter<Cost> {
                                 .expect("Gas left cannot be greater."),
                         ))
                     }
-                    Ok(ContractCreateResult::Failed) => {
+                    Ok(ContractCreateResult::Failed(_)) => {
                         self.stack.push(U256::zero());
                         Ok(InstructionResult::Ok)
                     }
@@ -967,7 +967,7 @@ impl<Cost: CostType> Interpreter<Cost> {
                             ),
                         ))
                     }
-                    Ok(MessageCallResult::Failed) => {
+                    Ok(MessageCallResult::Failed(_)) => {
                         self.stack.push(U256::zero());
                         Ok(InstructionResult::Ok)
                     }

--- a/core/src/executive/context.rs
+++ b/core/src/executive/context.rs
@@ -11,8 +11,8 @@ use crate::{
     trace::{self, trace::ExecTrace, Tracer},
     vm::{
         self, ActionParams, ActionValue, CallType, Context as ContextTrait,
-        ContractCreateResult, CreateContractAddress, Env, MessageCallResult,
-        ReturnData, Spec, TrapKind,
+        ContractCreateResult, CreateContractAddress, Env, Error,
+        MessageCallResult, ReturnData, Spec, TrapKind,
     },
 };
 use cfx_parameters::staking::{
@@ -198,7 +198,8 @@ impl<
         // helps in future.
         if self.state.is_contract_with_code(&address)? {
             debug!("Contract address conflict!");
-            return Ok(Ok(ContractCreateResult::Failed));
+            let err = Error::ConflictAddress(address.clone());
+            return Ok(Ok(ContractCreateResult::Failed(err)));
         }
 
         // prepare the params

--- a/core/src/executive/executed.rs
+++ b/core/src/executive/executed.rs
@@ -107,8 +107,6 @@ pub enum ExecutionError {
         /// Maximum storage limit cost.
         max_storage_limit_cost: U256,
     },
-    /// Contract already exists in the specified address.
-    ContractAddressConflict,
     VmError(vm::Error),
 }
 

--- a/core/src/trace/error_unwind.rs
+++ b/core/src/trace/error_unwind.rs
@@ -35,6 +35,9 @@ impl ErrorUnwind {
         errors
     }
 
+    // If contract A calls contract B, contract B returns with an exception (vm error or reverted),
+    // but contract A makes another sub-call, we think contract A catches this error and clear the
+    // error list.
     fn accept_call(&mut self, call: &Call) {
         self.callstack.push(call.to);
         self.errors.clear();
@@ -49,7 +52,13 @@ impl ErrorUnwind {
             .expect("trace call and their results must be matched");
 
         match Self::error_message(&result.outcome, &result.return_data) {
+            // If contract A calls contract B, contract B returns with an exception (vm error or reverted),
+            // and contract A then also returns with an exception, we think contract A is propagating out
+            // the exception.
             Some(message) => self.errors.push((address, message)),
+            // If contract A calls contract B, contract B returns with an exception (vm error or reverted),
+            // but contract A returns with success, we think contract A catches this error and clear the
+            // error list.
             None => self.errors.clear(),
         }
     }
@@ -58,7 +67,13 @@ impl ErrorUnwind {
         let address = result.addr;
 
         match Self::error_message(&result.outcome, &result.return_data) {
+            // If contract A calls contract B, contract B returns with an exception (vm error or reverted),
+            // and contract A then also returns with an exception, we think contract A is propagating out
+            // the exception.
             Some(message) => self.errors.push((address, message)),
+            // If contract A calls contract B, contract B returns with an exception (vm error or reverted),
+            // but contract A returns with success, we think contract A catches this error and clear the
+            // error list.
             None => self.errors.clear(),
         }
     }

--- a/core/src/trace/error_unwind.rs
+++ b/core/src/trace/error_unwind.rs
@@ -35,9 +35,9 @@ impl ErrorUnwind {
         errors
     }
 
-    // If contract A calls contract B, contract B returns with an exception (vm error or reverted),
-    // but contract A makes another sub-call, we think contract A catches this error and clear the
-    // error list.
+    // If contract A calls contract B, contract B returns with an exception (vm
+    // error or reverted), but contract A makes another sub-call, we think
+    // contract A catches this error and clear the error list.
     fn accept_call(&mut self, call: &Call) {
         self.callstack.push(call.to);
         self.errors.clear();
@@ -52,13 +52,15 @@ impl ErrorUnwind {
             .expect("trace call and their results must be matched");
 
         match Self::error_message(&result.outcome, &result.return_data) {
-            // If contract A calls contract B, contract B returns with an exception (vm error or reverted),
-            // and contract A then also returns with an exception, we think contract A is propagating out
-            // the exception.
+            // If contract A calls contract B, contract B returns with an
+            // exception (vm error or reverted), and contract A then
+            // also returns with an exception, we think contract A is
+            // propagating out the exception.
             Some(message) => self.errors.push((address, message)),
-            // If contract A calls contract B, contract B returns with an exception (vm error or reverted),
-            // but contract A returns with success, we think contract A catches this error and clear the
-            // error list.
+            // If contract A calls contract B, contract B returns with an
+            // exception (vm error or reverted), but contract A
+            // returns with success, we think contract A catches this error and
+            // clear the error list.
             None => self.errors.clear(),
         }
     }
@@ -67,13 +69,15 @@ impl ErrorUnwind {
         let address = result.addr;
 
         match Self::error_message(&result.outcome, &result.return_data) {
-            // If contract A calls contract B, contract B returns with an exception (vm error or reverted),
-            // and contract A then also returns with an exception, we think contract A is propagating out
-            // the exception.
+            // If contract A calls contract B, contract B returns with an
+            // exception (vm error or reverted), and contract A then
+            // also returns with an exception, we think contract A is
+            // propagating out the exception.
             Some(message) => self.errors.push((address, message)),
-            // If contract A calls contract B, contract B returns with an exception (vm error or reverted),
-            // but contract A returns with success, we think contract A catches this error and clear the
-            // error list.
+            // If contract A calls contract B, contract B returns with an
+            // exception (vm error or reverted), but contract A
+            // returns with success, we think contract A catches this error and
+            // clear the error list.
             None => self.errors.clear(),
         }
     }

--- a/core/src/trace/error_unwind.rs
+++ b/core/src/trace/error_unwind.rs
@@ -8,8 +8,10 @@ use cfx_types::Address;
 
 /// An executive tracer only records errors during EVM unwind.
 ///
-/// - Which errors will be retained?
-
+/// When the first error happens, `ErrorUnwind` tries to maintain a list for
+/// error description and code address for triggering error. However, if the
+/// tracer met a successful result or a sub-call/create, it will regard this
+/// error as "caught" and clear the error list.
 #[derive(Default)]
 pub struct ErrorUnwind {
     callstack: Vec<Address>,
@@ -67,7 +69,7 @@ impl ErrorUnwind {
         match outcome {
             Outcome::Success => None,
             Outcome::Reverted => Some(format!(
-                "Vm reverted, {}",
+                "Vm reverted. {}",
                 revert_reason_decode(return_data)
             )),
             Outcome::Fail => Some(

--- a/core/src/trace/error_unwind.rs
+++ b/core/src/trace/error_unwind.rs
@@ -1,0 +1,79 @@
+use crate::{
+    executive::revert_reason_decode,
+    trace::trace::{
+        Action, Call, CallResult, Create, CreateResult, ExecTrace, Outcome,
+    },
+};
+use cfx_types::Address;
+
+/// An executive tracer only records errors during EVM unwind.
+///
+/// - Which errors will be retained?
+
+#[derive(Default)]
+pub struct ErrorUnwind {
+    callstack: Vec<Address>,
+    pub errors: Vec<(Address, String)>,
+}
+
+impl ErrorUnwind {
+    pub fn from_traces(traces: Vec<ExecTrace>) -> Self {
+        let mut errors = ErrorUnwind::default();
+        for trace in traces.iter() {
+            match &trace.action {
+                Action::Call(call) => errors.accept_call(call),
+                Action::Create(create) => errors.accept_create(create),
+                Action::CallResult(result) => errors.accept_call_result(result),
+                Action::CreateResult(result) => {
+                    errors.accept_create_result(result)
+                }
+                Action::InternalTransferAction(_) => {}
+            }
+        }
+        errors
+    }
+
+    fn accept_call(&mut self, call: &Call) {
+        self.callstack.push(call.to);
+        self.errors.clear();
+    }
+
+    fn accept_create(&mut self, _create: &Create) { self.errors.clear(); }
+
+    fn accept_call_result(&mut self, result: &CallResult) {
+        let address = self
+            .callstack
+            .pop()
+            .expect("trace call and their results must be matched");
+
+        match Self::error_message(&result.outcome, &result.return_data) {
+            Some(message) => self.errors.push((address, message)),
+            None => self.errors.clear(),
+        }
+    }
+
+    fn accept_create_result(&mut self, result: &CreateResult) {
+        let address = result.addr;
+
+        match Self::error_message(&result.outcome, &result.return_data) {
+            Some(message) => self.errors.push((address, message)),
+            None => self.errors.clear(),
+        }
+    }
+
+    fn error_message(
+        outcome: &Outcome, return_data: &Vec<u8>,
+    ) -> Option<String> {
+        match outcome {
+            Outcome::Success => None,
+            Outcome::Reverted => Some(format!(
+                "Vm reverted, {}",
+                revert_reason_decode(return_data)
+            )),
+            Outcome::Fail => Some(
+                String::from_utf8(return_data.clone())
+                    .expect("Return data is encoded from valid utf-8 string"),
+            ),
+        }
+    }
+}

--- a/core/src/trace/mod.rs
+++ b/core/src/trace/mod.rs
@@ -11,8 +11,11 @@ use crate::{
 };
 use cfx_types::{Address, U256};
 
+pub mod error_unwind;
 pub mod trace;
 pub mod trace_filter;
+
+pub use error_unwind::ErrorUnwind;
 
 /// This trait is used by executive to build traces.
 pub trait Tracer: Send {

--- a/core/src/trace/trace.rs
+++ b/core/src/trace/trace.rs
@@ -129,10 +129,10 @@ impl From<&MessageCallResult> for CallResult {
                 gas_left: gas_left.clone(),
                 return_data: return_data.to_vec(),
             },
-            MessageCallResult::Failed => CallResult {
+            MessageCallResult::Failed(err) => CallResult {
                 outcome: Outcome::Fail,
                 gas_left: U256::zero(),
-                return_data: vec![],
+                return_data: format!("{:?}", err).into(),
             },
         }
     }
@@ -203,11 +203,11 @@ impl From<&ContractCreateResult> for CreateResult {
                     return_data: return_data.to_vec(),
                 }
             }
-            ContractCreateResult::Failed => CreateResult {
+            ContractCreateResult::Failed(err) => CreateResult {
                 outcome: Outcome::Fail,
                 addr: Address::zero(),
                 gas_left: U256::zero(),
-                return_data: vec![],
+                return_data: format!("{:?}", err).into(),
             },
         }
     }

--- a/core/src/vm/context.rs
+++ b/core/src/vm/context.rs
@@ -26,6 +26,7 @@ use super::{
     error::{Result, TrapKind},
     return_data::ReturnData,
     spec::Spec,
+    Error,
 };
 use crate::trace::{trace::ExecTrace, Tracer};
 use cfx_bytes::Bytes;
@@ -39,8 +40,8 @@ pub enum ContractCreateResult {
     /// Contains an address of newly created contract and gas left.
     Created(Address, U256),
     /// Returned when contract creation failed.
-    /// VM doesn't have to know the reason.
-    Failed,
+    /// Returns the reason so block trace can record it.
+    Failed(Error),
     /// Reverted with REVERT.
     Reverted(U256, ReturnData),
 }
@@ -52,8 +53,8 @@ pub enum MessageCallResult {
     /// Contains gas left and output data.
     Success(U256, ReturnData),
     /// Returned when message call failed.
-    /// VM doesn't have to know the reason.
-    Failed,
+    /// Returns the reason so block trace can record it.
+    Failed(Error),
     /// Returned when message call was reverted.
     /// Contains gas left and output data.
     Reverted(U256, ReturnData),

--- a/core/src/vm/error.rs
+++ b/core/src/vm/error.rs
@@ -118,6 +118,8 @@ pub enum Error {
     Reverted,
     /// Invalid address
     InvalidAddress(Address),
+    /// Create a contract on an address with existing contract
+    ConflictAddress(Address),
 }
 
 #[derive(Debug)]
@@ -189,6 +191,9 @@ impl fmt::Display for Error {
             OutOfBounds => write!(f, "Out of bounds"),
             Reverted => write!(f, "Reverted by bytecode"),
             InvalidAddress(ref addr) => write!(f, "InvalidAddress: {}", addr),
+            ConflictAddress(ref addr) => {
+                write!(f, "Contract creation on an existing address: {}", addr)
+            }
         }
     }
 }

--- a/core/src/vm/tests.rs
+++ b/core/src/vm/tests.rs
@@ -160,7 +160,9 @@ impl Context for MockContext {
             code_address: None,
         });
         // TODO: support traps in testing.
-        Ok(Ok(ContractCreateResult::Failed))
+        // This code is for test only. So we pick an arbitrary revert reason
+        // here.
+        Ok(Ok(ContractCreateResult::Failed(Error::OutOfGas)))
     }
 
     fn call(


### PR DESCRIPTION
The `estimate_gas_and_collateral` will return inner error information. 

The main obstacle of returning error information in the sub-call is that the EVM catches the exceptions thrown from a sub-call and ignores them by default. Solidity has to trigger another exception in case the sub-call has an exception. So in the EVM view, if contract A calls contract B, contract B triggers an exception first, and contract A triggers an exception later, it is hard to infer the ausal relationship between the two exceptions.  

In this implementation, we assume contract A triggers an exception for propagating out the exception from contract B if contract A does not make another sub-call. And the rpc interface `estimate_gas_and_collateral` will return the whole call stack when an exception happens. 

**Note:** Here an exception refers to both reversion from `REVERT` opcode and VM errors such as "Not enough gas". 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2156)
<!-- Reviewable:end -->
