### PR TITLE
Refactor substate

### DIFF
--- a/client/benches/benchmark.rs
+++ b/client/benches/benchmark.rs
@@ -10,7 +10,7 @@ use cfx_types::{H256, U256};
 use cfxcore::{
     executive::{Executive, InternalContractMap, TransactOptions},
     machine::new_machine_with_builtin,
-    state::State,
+    state::{CallStackInfo, State},
     vm::Env,
     vm_factory::VmFactory,
 };
@@ -19,7 +19,7 @@ use client::{archive::ArchiveClient, configuration::Configuration};
 use criterion::{criterion_group, criterion_main, Benchmark, Criterion};
 use parking_lot::{Condvar, Mutex};
 use primitives::{Action, Transaction};
-use std::{sync::Arc, time::Duration};
+use std::{cell::RefCell, sync::Arc, time::Duration};
 
 fn txexe_benchmark(c: &mut Criterion) {
     let mut conf = Configuration::default();
@@ -84,12 +84,14 @@ fn txexe_benchmark(c: &mut Criterion) {
             .expect("Failed to initialize state");
 
             let spec = machine.spec(env.number);
+            let call_stack = RefCell::new(CallStackInfo::default());
             let mut ex = Executive::new(
                 &mut state,
                 &env,
                 &machine,
                 &spec,
                 &internal_contract_map,
+                &call_stack,
             );
 
             b.iter(|| {

--- a/core/src/executive/context.rs
+++ b/core/src/executive/context.rs
@@ -79,7 +79,7 @@ pub struct Context<
     origin: &'a OriginInfo,
     substate: &'a mut Substate,
     machine: &'a Machine,
-    spec: &'a Substate::Spec,
+    spec: &'a Spec,
     output: OutputPolicy,
     static_flag: bool,
     internal_contract_map: &'a InternalContractMap,
@@ -87,14 +87,14 @@ pub struct Context<
 
 impl<
         'a,
-        Substate: SubstateTrait<CallStackInfo = CallStackInfo, Spec = Spec>,
+        Substate: SubstateTrait<CallStackInfo = CallStackInfo>,
         State: StateTrait<Substate = Substate>,
     > Context<'a, Substate, State>
 {
     /// Basic `Context` constructor.
     pub fn new(
         state: &'a mut State, env: &'a Env, machine: &'a Machine,
-        spec: &'a Substate::Spec, depth: usize, stack_depth: usize,
+        spec: &'a Spec, depth: usize, stack_depth: usize,
         origin: &'a OriginInfo, substate: &'a mut Substate,
         output: OutputPolicy, static_flag: bool,
         internal_contract_map: &'a InternalContractMap,
@@ -118,7 +118,7 @@ impl<
 
 impl<
         'a,
-        Substate: SubstateMngTrait<CallStackInfo = CallStackInfo, Spec = Spec>,
+        Substate: SubstateMngTrait<CallStackInfo = CallStackInfo>,
         State: StateTrait<Substate = Substate>,
     > ContextTrait for Context<'a, Substate, State>
 {

--- a/core/src/executive/internal_contract/contracts/admin.rs
+++ b/core/src/executive/internal_contract/contracts/admin.rs
@@ -15,7 +15,6 @@ use crate::{
     evm::{ActionParams, Spec},
     impl_function_type, make_function_table, make_solidity_contract,
     make_solidity_function,
-    state::CallStackInfo,
     trace::{trace::ExecTrace, Tracer},
     vm::{self, Env},
 };
@@ -41,7 +40,7 @@ impl ExecutionTrait for SetAdmin {
     fn execute_inner(
         &self, inputs: (Address, Address), params: &ActionParams, _env: &Env,
         _spec: &Spec, state: &mut dyn StateOpsTrait,
-        substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        substate: &mut dyn SubstateTrait,
         _tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<()>
     {
@@ -63,8 +62,7 @@ impl_function_type!(Destroy, "non_payable_write", gas: |spec: &Spec| spec.sstore
 impl ExecutionTrait for Destroy {
     fn execute_inner(
         &self, input: Address, params: &ActionParams, env: &Env, spec: &Spec,
-        state: &mut dyn StateOpsTrait,
-        substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        state: &mut dyn StateOpsTrait, substate: &mut dyn SubstateTrait,
         tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<()>
     {
@@ -80,8 +78,7 @@ impl_function_type!(GetAdmin, "query_with_default_gas");
 impl ExecutionTrait for GetAdmin {
     fn execute_inner(
         &self, input: Address, _: &ActionParams, _env: &Env, _: &Spec,
-        state: &mut dyn StateOpsTrait,
-        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        state: &mut dyn StateOpsTrait, _: &mut dyn SubstateTrait,
         _tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<Address>
     {

--- a/core/src/executive/internal_contract/contracts/admin.rs
+++ b/core/src/executive/internal_contract/contracts/admin.rs
@@ -41,10 +41,7 @@ impl ExecutionTrait for SetAdmin {
     fn execute_inner(
         &self, inputs: (Address, Address), params: &ActionParams, _env: &Env,
         _spec: &Spec, state: &mut dyn StateOpsTrait,
-        substate: &mut dyn SubstateTrait<
-            CallStackInfo = CallStackInfo,
-            Spec = Spec,
-        >,
+        substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         _tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<()>
     {
@@ -67,10 +64,7 @@ impl ExecutionTrait for Destroy {
     fn execute_inner(
         &self, input: Address, params: &ActionParams, env: &Env, spec: &Spec,
         state: &mut dyn StateOpsTrait,
-        substate: &mut dyn SubstateTrait<
-            CallStackInfo = CallStackInfo,
-            Spec = Spec,
-        >,
+        substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<()>
     {
@@ -87,7 +81,7 @@ impl ExecutionTrait for GetAdmin {
     fn execute_inner(
         &self, input: Address, _: &ActionParams, _env: &Env, _: &Spec,
         state: &mut dyn StateOpsTrait,
-        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo, Spec = Spec>,
+        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         _tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<Address>
     {

--- a/core/src/executive/internal_contract/contracts/sponsor.rs
+++ b/core/src/executive/internal_contract/contracts/sponsor.rs
@@ -15,7 +15,6 @@ use crate::{
     evm::{ActionParams, Spec},
     impl_function_type, make_function_table, make_solidity_contract,
     make_solidity_function,
-    state::CallStackInfo,
     trace::{trace::ExecTrace, Tracer},
     vm::{self, Env},
 };
@@ -55,7 +54,7 @@ impl ExecutionTrait for SetSponsorForGas {
     fn execute_inner(
         &self, inputs: (Address, U256), params: &ActionParams, _env: &Env,
         spec: &Spec, state: &mut dyn StateOpsTrait,
-        substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        substate: &mut dyn SubstateTrait,
         tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<()>
     {
@@ -80,8 +79,7 @@ impl_function_type!(SetSponsorForCollateral, "payable_write", gas: |spec: &Spec|
 impl ExecutionTrait for SetSponsorForCollateral {
     fn execute_inner(
         &self, input: Address, params: &ActionParams, _env: &Env, spec: &Spec,
-        state: &mut dyn StateOpsTrait,
-        substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        state: &mut dyn StateOpsTrait, substate: &mut dyn SubstateTrait,
         tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<()>
     {
@@ -115,8 +113,7 @@ impl UpfrontPaymentTrait for AddPrivilege {
 impl ExecutionTrait for AddPrivilege {
     fn execute_inner(
         &self, addresses: Vec<Address>, params: &ActionParams, _env: &Env,
-        _: &Spec, state: &mut dyn StateOpsTrait,
-        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        _: &Spec, state: &mut dyn StateOpsTrait, _: &mut dyn SubstateTrait,
         _: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<()>
     {
@@ -147,8 +144,7 @@ impl UpfrontPaymentTrait for RemovePrivilege {
 impl ExecutionTrait for RemovePrivilege {
     fn execute_inner(
         &self, addresses: Vec<Address>, params: &ActionParams, _env: &Env,
-        _: &Spec, state: &mut dyn StateOpsTrait,
-        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        _: &Spec, state: &mut dyn StateOpsTrait, _: &mut dyn SubstateTrait,
         _: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<()>
     {
@@ -170,8 +166,7 @@ impl_function_type!(GetSponsorForGas, "query_with_default_gas");
 impl ExecutionTrait for GetSponsorForGas {
     fn execute_inner(
         &self, input: Address, _: &ActionParams, _env: &Env, _: &Spec,
-        state: &mut dyn StateOpsTrait,
-        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        state: &mut dyn StateOpsTrait, _: &mut dyn SubstateTrait,
         _: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<Address>
     {
@@ -187,8 +182,7 @@ impl_function_type!(GetSponsoredBalanceForGas, "query_with_default_gas");
 impl ExecutionTrait for GetSponsoredBalanceForGas {
     fn execute_inner(
         &self, input: Address, _: &ActionParams, _env: &Env, _: &Spec,
-        state: &mut dyn StateOpsTrait,
-        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        state: &mut dyn StateOpsTrait, _: &mut dyn SubstateTrait,
         _: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<U256>
     {
@@ -204,8 +198,7 @@ impl_function_type!(GetSponsoredGasFeeUpperBound, "query_with_default_gas");
 impl ExecutionTrait for GetSponsoredGasFeeUpperBound {
     fn execute_inner(
         &self, input: Address, _: &ActionParams, _env: &Env, _: &Spec,
-        state: &mut dyn StateOpsTrait,
-        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        state: &mut dyn StateOpsTrait, _: &mut dyn SubstateTrait,
         _: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<U256>
     {
@@ -221,8 +214,7 @@ impl_function_type!(GetSponsorForCollateral, "query_with_default_gas");
 impl ExecutionTrait for GetSponsorForCollateral {
     fn execute_inner(
         &self, input: Address, _: &ActionParams, _env: &Env, _: &Spec,
-        state: &mut dyn StateOpsTrait,
-        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        state: &mut dyn StateOpsTrait, _: &mut dyn SubstateTrait,
         _: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<Address>
     {
@@ -238,8 +230,7 @@ impl_function_type!(GetSponsoredBalanceForCollateral, "query_with_default_gas");
 impl ExecutionTrait for GetSponsoredBalanceForCollateral {
     fn execute_inner(
         &self, input: Address, _: &ActionParams, _env: &Env, _: &Spec,
-        state: &mut dyn StateOpsTrait,
-        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        state: &mut dyn StateOpsTrait, _: &mut dyn SubstateTrait,
         _: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<U256>
     {
@@ -256,8 +247,7 @@ impl ExecutionTrait for IsWhitelisted {
     fn execute_inner(
         &self, (contract, user): (Address, Address), _: &ActionParams,
         _env: &Env, _: &Spec, state: &mut dyn StateOpsTrait,
-        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
-        _: &mut dyn Tracer<Output = ExecTrace>,
+        _: &mut dyn SubstateTrait, _: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<bool>
     {
         if contract.is_contract_address() {
@@ -276,8 +266,7 @@ impl_function_type!(IsAllWhitelisted, "query", gas: |spec: &Spec| spec.sload_gas
 impl ExecutionTrait for IsAllWhitelisted {
     fn execute_inner(
         &self, contract: Address, _: &ActionParams, _env: &Env, _: &Spec,
-        state: &mut dyn StateOpsTrait,
-        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        state: &mut dyn StateOpsTrait, _: &mut dyn SubstateTrait,
         _: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<bool>
     {
@@ -311,8 +300,7 @@ impl ExecutionTrait for AddPrivilegeByAdmin {
     fn execute_inner(
         &self, (contract, addresses): (Address, Vec<Address>),
         params: &ActionParams, _env: &Env, _: &Spec,
-        state: &mut dyn StateOpsTrait,
-        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        state: &mut dyn StateOpsTrait, _: &mut dyn SubstateTrait,
         _: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<()>
     {
@@ -344,8 +332,7 @@ impl ExecutionTrait for RemovePrivilegeByAdmin {
     fn execute_inner(
         &self, (contract, addresses): (Address, Vec<Address>),
         params: &ActionParams, _env: &Env, _: &Spec,
-        state: &mut dyn StateOpsTrait,
-        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        state: &mut dyn StateOpsTrait, _: &mut dyn SubstateTrait,
         _: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<()>
     {

--- a/core/src/executive/internal_contract/contracts/sponsor.rs
+++ b/core/src/executive/internal_contract/contracts/sponsor.rs
@@ -55,10 +55,7 @@ impl ExecutionTrait for SetSponsorForGas {
     fn execute_inner(
         &self, inputs: (Address, U256), params: &ActionParams, _env: &Env,
         spec: &Spec, state: &mut dyn StateOpsTrait,
-        substate: &mut dyn SubstateTrait<
-            CallStackInfo = CallStackInfo,
-            Spec = Spec,
-        >,
+        substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<()>
     {
@@ -84,10 +81,7 @@ impl ExecutionTrait for SetSponsorForCollateral {
     fn execute_inner(
         &self, input: Address, params: &ActionParams, _env: &Env, spec: &Spec,
         state: &mut dyn StateOpsTrait,
-        substate: &mut dyn SubstateTrait<
-            CallStackInfo = CallStackInfo,
-            Spec = Spec,
-        >,
+        substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<()>
     {
@@ -122,7 +116,7 @@ impl ExecutionTrait for AddPrivilege {
     fn execute_inner(
         &self, addresses: Vec<Address>, params: &ActionParams, _env: &Env,
         _: &Spec, state: &mut dyn StateOpsTrait,
-        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo, Spec = Spec>,
+        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         _: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<()>
     {
@@ -154,7 +148,7 @@ impl ExecutionTrait for RemovePrivilege {
     fn execute_inner(
         &self, addresses: Vec<Address>, params: &ActionParams, _env: &Env,
         _: &Spec, state: &mut dyn StateOpsTrait,
-        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo, Spec = Spec>,
+        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         _: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<()>
     {
@@ -177,7 +171,7 @@ impl ExecutionTrait for GetSponsorForGas {
     fn execute_inner(
         &self, input: Address, _: &ActionParams, _env: &Env, _: &Spec,
         state: &mut dyn StateOpsTrait,
-        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo, Spec = Spec>,
+        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         _: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<Address>
     {
@@ -194,7 +188,7 @@ impl ExecutionTrait for GetSponsoredBalanceForGas {
     fn execute_inner(
         &self, input: Address, _: &ActionParams, _env: &Env, _: &Spec,
         state: &mut dyn StateOpsTrait,
-        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo, Spec = Spec>,
+        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         _: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<U256>
     {
@@ -211,7 +205,7 @@ impl ExecutionTrait for GetSponsoredGasFeeUpperBound {
     fn execute_inner(
         &self, input: Address, _: &ActionParams, _env: &Env, _: &Spec,
         state: &mut dyn StateOpsTrait,
-        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo, Spec = Spec>,
+        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         _: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<U256>
     {
@@ -228,7 +222,7 @@ impl ExecutionTrait for GetSponsorForCollateral {
     fn execute_inner(
         &self, input: Address, _: &ActionParams, _env: &Env, _: &Spec,
         state: &mut dyn StateOpsTrait,
-        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo, Spec = Spec>,
+        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         _: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<Address>
     {
@@ -245,7 +239,7 @@ impl ExecutionTrait for GetSponsoredBalanceForCollateral {
     fn execute_inner(
         &self, input: Address, _: &ActionParams, _env: &Env, _: &Spec,
         state: &mut dyn StateOpsTrait,
-        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo, Spec = Spec>,
+        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         _: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<U256>
     {
@@ -262,7 +256,7 @@ impl ExecutionTrait for IsWhitelisted {
     fn execute_inner(
         &self, (contract, user): (Address, Address), _: &ActionParams,
         _env: &Env, _: &Spec, state: &mut dyn StateOpsTrait,
-        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo, Spec = Spec>,
+        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         _: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<bool>
     {
@@ -283,7 +277,7 @@ impl ExecutionTrait for IsAllWhitelisted {
     fn execute_inner(
         &self, contract: Address, _: &ActionParams, _env: &Env, _: &Spec,
         state: &mut dyn StateOpsTrait,
-        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo, Spec = Spec>,
+        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         _: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<bool>
     {
@@ -318,7 +312,7 @@ impl ExecutionTrait for AddPrivilegeByAdmin {
         &self, (contract, addresses): (Address, Vec<Address>),
         params: &ActionParams, _env: &Env, _: &Spec,
         state: &mut dyn StateOpsTrait,
-        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo, Spec = Spec>,
+        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         _: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<()>
     {
@@ -351,7 +345,7 @@ impl ExecutionTrait for RemovePrivilegeByAdmin {
         &self, (contract, addresses): (Address, Vec<Address>),
         params: &ActionParams, _env: &Env, _: &Spec,
         state: &mut dyn StateOpsTrait,
-        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo, Spec = Spec>,
+        _: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         _: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<()>
     {

--- a/core/src/executive/internal_contract/contracts/staking.rs
+++ b/core/src/executive/internal_contract/contracts/staking.rs
@@ -58,10 +58,7 @@ impl ExecutionTrait for Deposit {
     fn execute_inner(
         &self, input: U256, params: &ActionParams, env: &Env, _spec: &Spec,
         state: &mut dyn StateOpsTrait,
-        _substate: &mut dyn SubstateTrait<
-            CallStackInfo = CallStackInfo,
-            Spec = Spec,
-        >,
+        _substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<()>
     {
@@ -89,10 +86,7 @@ impl ExecutionTrait for Withdraw {
     fn execute_inner(
         &self, input: U256, params: &ActionParams, env: &Env, _spec: &Spec,
         state: &mut dyn StateOpsTrait,
-        _substate: &mut dyn SubstateTrait<
-            CallStackInfo = CallStackInfo,
-            Spec = Spec,
-        >,
+        _substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<()>
     {
@@ -120,10 +114,7 @@ impl ExecutionTrait for VoteLock {
     fn execute_inner(
         &self, inputs: (U256, U256), params: &ActionParams, env: &Env,
         _spec: &Spec, state: &mut dyn StateOpsTrait,
-        _substate: &mut dyn SubstateTrait<
-            CallStackInfo = CallStackInfo,
-            Spec = Spec,
-        >,
+        _substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         _tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<()>
     {
@@ -140,10 +131,7 @@ impl ExecutionTrait for GetStakingBalance {
     fn execute_inner(
         &self, input: Address, _: &ActionParams, _env: &Env, _spec: &Spec,
         state: &mut dyn StateOpsTrait,
-        _substate: &mut dyn SubstateTrait<
-            CallStackInfo = CallStackInfo,
-            Spec = Spec,
-        >,
+        _substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         _tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<U256>
     {
@@ -171,10 +159,7 @@ impl ExecutionTrait for GetLockedStakingBalance {
     fn execute_inner(
         &self, (address, block_number): (Address, U256), _: &ActionParams,
         env: &Env, _spec: &Spec, state: &mut dyn StateOpsTrait,
-        _substate: &mut dyn SubstateTrait<
-            CallStackInfo = CallStackInfo,
-            Spec = Spec,
-        >,
+        _substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         _tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<U256>
     {
@@ -207,10 +192,7 @@ impl ExecutionTrait for GetVotePower {
     fn execute_inner(
         &self, (address, block_number): (Address, U256), _: &ActionParams,
         env: &Env, _spec: &Spec, state: &mut dyn StateOpsTrait,
-        _substate: &mut dyn SubstateTrait<
-            CallStackInfo = CallStackInfo,
-            Spec = Spec,
-        >,
+        _substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         _tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<U256>
     {

--- a/core/src/executive/internal_contract/contracts/staking.rs
+++ b/core/src/executive/internal_contract/contracts/staking.rs
@@ -13,7 +13,6 @@ use crate::{
     evm::{ActionParams, Spec},
     impl_function_type, make_function_table, make_solidity_contract,
     make_solidity_function,
-    state::CallStackInfo,
     trace::{trace::ExecTrace, Tracer},
     vm::{self, Env},
 };
@@ -57,8 +56,7 @@ impl UpfrontPaymentTrait for Deposit {
 impl ExecutionTrait for Deposit {
     fn execute_inner(
         &self, input: U256, params: &ActionParams, env: &Env, _spec: &Spec,
-        state: &mut dyn StateOpsTrait,
-        _substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        state: &mut dyn StateOpsTrait, _substate: &mut dyn SubstateTrait,
         tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<()>
     {
@@ -85,8 +83,7 @@ impl UpfrontPaymentTrait for Withdraw {
 impl ExecutionTrait for Withdraw {
     fn execute_inner(
         &self, input: U256, params: &ActionParams, env: &Env, _spec: &Spec,
-        state: &mut dyn StateOpsTrait,
-        _substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        state: &mut dyn StateOpsTrait, _substate: &mut dyn SubstateTrait,
         tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<()>
     {
@@ -114,7 +111,7 @@ impl ExecutionTrait for VoteLock {
     fn execute_inner(
         &self, inputs: (U256, U256), params: &ActionParams, env: &Env,
         _spec: &Spec, state: &mut dyn StateOpsTrait,
-        _substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        _substate: &mut dyn SubstateTrait,
         _tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<()>
     {
@@ -130,8 +127,7 @@ impl_function_type!(GetStakingBalance, "query_with_default_gas");
 impl ExecutionTrait for GetStakingBalance {
     fn execute_inner(
         &self, input: Address, _: &ActionParams, _env: &Env, _spec: &Spec,
-        state: &mut dyn StateOpsTrait,
-        _substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        state: &mut dyn StateOpsTrait, _substate: &mut dyn SubstateTrait,
         _tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<U256>
     {
@@ -159,7 +155,7 @@ impl ExecutionTrait for GetLockedStakingBalance {
     fn execute_inner(
         &self, (address, block_number): (Address, U256), _: &ActionParams,
         env: &Env, _spec: &Spec, state: &mut dyn StateOpsTrait,
-        _substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        _substate: &mut dyn SubstateTrait,
         _tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<U256>
     {
@@ -192,7 +188,7 @@ impl ExecutionTrait for GetVotePower {
     fn execute_inner(
         &self, (address, block_number): (Address, U256), _: &ActionParams,
         env: &Env, _spec: &Spec, state: &mut dyn StateOpsTrait,
-        _substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        _substate: &mut dyn SubstateTrait,
         _tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<U256>
     {

--- a/core/src/executive/internal_contract/function.rs
+++ b/core/src/executive/internal_contract/function.rs
@@ -35,10 +35,7 @@ impl<
     fn execute(
         &self, input: &[u8], params: &ActionParams, env: &Env, spec: &Spec,
         state: &mut dyn StateOpsTrait,
-        substate: &mut dyn SubstateTrait<
-            Spec = Spec,
-            CallStackInfo = CallStackInfo,
-        >,
+        substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<GasLeft>
     {
@@ -88,10 +85,7 @@ pub trait InterfaceTrait {
 pub trait PreExecCheckTrait: Send + Sync {
     fn pre_execution_check(
         &self, params: &ActionParams,
-        substate: &dyn SubstateTrait<
-            Spec = Spec,
-            CallStackInfo = CallStackInfo,
-        >,
+        substate: &dyn SubstateTrait<CallStackInfo = CallStackInfo>,
     ) -> vm::Result<()>;
 }
 
@@ -99,10 +93,7 @@ pub trait ExecutionTrait: Send + Sync + InterfaceTrait {
     fn execute_inner(
         &self, input: Self::Input, params: &ActionParams, env: &Env,
         spec: &Spec, state: &mut dyn StateOpsTrait,
-        substate: &mut dyn SubstateTrait<
-            Spec = Spec,
-            CallStackInfo = CallStackInfo,
-        >,
+        substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<<Self as InterfaceTrait>::Output>;
 }
@@ -124,10 +115,7 @@ pub trait PreExecCheckConfTrait: Send + Sync {
 impl<T: PreExecCheckConfTrait> PreExecCheckTrait for T {
     fn pre_execution_check(
         &self, params: &ActionParams,
-        substate: &dyn SubstateTrait<
-            Spec = Spec,
-            CallStackInfo = CallStackInfo,
-        >,
+        substate: &dyn SubstateTrait<CallStackInfo = CallStackInfo>,
     ) -> vm::Result<()>
     {
         if !Self::PAYABLE && !params.value.value().is_zero() {

--- a/core/src/executive/internal_contract/impls/admin.rs
+++ b/core/src/executive/internal_contract/impls/admin.rs
@@ -3,7 +3,7 @@
 // See http://www.gnu.org/licenses/
 
 use crate::{
-    state::CallStackInfo,
+    state::{cleanup_mode, CallStackInfo},
     trace::{trace::ExecTrace, Tracer},
     vm::{self, ActionParams, Env, Spec},
 };
@@ -20,10 +20,7 @@ use cfx_types::{address_util::AddressUtil, Address, U256};
 pub fn suicide(
     contract_address: &Address, refund_address: &Address,
     state: &mut dyn StateOpsTrait, spec: &Spec,
-    substate: &mut dyn SubstateTrait<
-        Spec = Spec,
-        CallStackInfo = CallStackInfo,
-    >,
+    substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
     tracer: &mut dyn Tracer<Output = ExecTrace>, account_start_nonce: U256,
 ) -> vm::Result<()>
 {
@@ -41,7 +38,7 @@ pub fn suicide(
         state.sub_balance(
             contract_address,
             &balance,
-            &mut substate.to_cleanup_mode(spec),
+            &mut cleanup_mode(substate, spec),
         )?;
         state.subtract_total_issued(balance);
     } else {
@@ -55,7 +52,7 @@ pub fn suicide(
             contract_address,
             refund_address,
             &balance,
-            substate.to_cleanup_mode(spec),
+            cleanup_mode(substate, spec),
             account_start_nonce,
         )?;
     }
@@ -100,10 +97,7 @@ pub fn set_admin(
 pub fn destroy(
     contract_address: Address, params: &ActionParams,
     state: &mut dyn StateOpsTrait, spec: &Spec,
-    substate: &mut dyn SubstateTrait<
-        Spec = Spec,
-        CallStackInfo = CallStackInfo,
-    >,
+    substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
     tracer: &mut dyn Tracer<Output = ExecTrace>, env: &Env,
 ) -> vm::Result<()>
 {

--- a/core/src/executive/internal_contract/impls/admin.rs
+++ b/core/src/executive/internal_contract/impls/admin.rs
@@ -3,7 +3,7 @@
 // See http://www.gnu.org/licenses/
 
 use crate::{
-    state::{cleanup_mode, CallStackInfo},
+    state::cleanup_mode,
     trace::{trace::ExecTrace, Tracer},
     vm::{self, ActionParams, Env, Spec},
 };
@@ -20,7 +20,7 @@ use cfx_types::{address_util::AddressUtil, Address, U256};
 pub fn suicide(
     contract_address: &Address, refund_address: &Address,
     state: &mut dyn StateOpsTrait, spec: &Spec,
-    substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+    substate: &mut dyn SubstateTrait,
     tracer: &mut dyn Tracer<Output = ExecTrace>, account_start_nonce: U256,
 ) -> vm::Result<()>
 {
@@ -97,7 +97,7 @@ pub fn set_admin(
 pub fn destroy(
     contract_address: Address, params: &ActionParams,
     state: &mut dyn StateOpsTrait, spec: &Spec,
-    substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+    substate: &mut dyn SubstateTrait,
     tracer: &mut dyn Tracer<Output = ExecTrace>, env: &Env,
 ) -> vm::Result<()>
 {

--- a/core/src/executive/internal_contract/impls/sponsor.rs
+++ b/core/src/executive/internal_contract/impls/sponsor.rs
@@ -3,7 +3,7 @@
 // See http://www.gnu.org/licenses/
 
 use crate::{
-    state::CallStackInfo,
+    state::{cleanup_mode, CallStackInfo},
     trace::{trace::ExecTrace, Tracer},
     vm::{self, ActionParams, Spec},
 };
@@ -15,10 +15,7 @@ use cfx_types::{address_util::AddressUtil, Address, U256};
 pub fn set_sponsor_for_gas(
     contract_address: Address, upper_bound: U256, params: &ActionParams,
     spec: &Spec, state: &mut dyn StateOpsTrait,
-    substate: &mut dyn SubstateTrait<
-        Spec = Spec,
-        CallStackInfo = CallStackInfo,
-    >,
+    substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
     tracer: &mut dyn Tracer<Output = ExecTrace>, account_start_nonce: U256,
 ) -> vm::Result<()>
 {
@@ -80,14 +77,14 @@ pub fn set_sponsor_for_gas(
             state.add_balance(
                 prev_sponsor.as_ref().unwrap(),
                 &prev_sponsor_balance,
-                substate.to_cleanup_mode(&spec),
+                cleanup_mode(substate, &spec),
                 account_start_nonce,
             )?;
         }
         state.sub_balance(
             &params.address,
             &sponsor_balance,
-            &mut substate.to_cleanup_mode(&spec),
+            &mut cleanup_mode(substate, &spec),
         )?;
         state.set_sponsor_for_gas(
             &contract_address,
@@ -109,7 +106,7 @@ pub fn set_sponsor_for_gas(
         state.sub_balance(
             &params.address,
             &sponsor_balance,
-            &mut substate.to_cleanup_mode(&spec),
+            &mut cleanup_mode(substate, &spec),
         )?;
         state.set_sponsor_for_gas(
             &contract_address,
@@ -126,10 +123,7 @@ pub fn set_sponsor_for_gas(
 pub fn set_sponsor_for_collateral(
     contract_address: Address, params: &ActionParams, spec: &Spec,
     state: &mut dyn StateOpsTrait,
-    substate: &mut dyn SubstateTrait<
-        Spec = Spec,
-        CallStackInfo = CallStackInfo,
-    >,
+    substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
     tracer: &mut dyn Tracer<Output = ExecTrace>, account_start_nonce: U256,
 ) -> vm::Result<()>
 {
@@ -182,14 +176,14 @@ pub fn set_sponsor_for_collateral(
             state.add_balance(
                 prev_sponsor.as_ref().unwrap(),
                 &(prev_sponsor_balance + collateral_for_storage),
-                substate.to_cleanup_mode(&spec),
+                cleanup_mode(substate, &spec),
                 account_start_nonce,
             )?;
         }
         state.sub_balance(
             &params.address,
             &sponsor_balance,
-            &mut substate.to_cleanup_mode(&spec),
+            &mut cleanup_mode(substate, &spec),
         )?;
         state.set_sponsor_for_collateral(
             &contract_address,
@@ -200,7 +194,7 @@ pub fn set_sponsor_for_collateral(
         state.sub_balance(
             &params.address,
             &sponsor_balance,
-            &mut substate.to_cleanup_mode(&spec),
+            &mut cleanup_mode(substate, &spec),
         )?;
         state.set_sponsor_for_collateral(
             &contract_address,

--- a/core/src/executive/internal_contract/impls/sponsor.rs
+++ b/core/src/executive/internal_contract/impls/sponsor.rs
@@ -3,7 +3,7 @@
 // See http://www.gnu.org/licenses/
 
 use crate::{
-    state::{cleanup_mode, CallStackInfo},
+    state::cleanup_mode,
     trace::{trace::ExecTrace, Tracer},
     vm::{self, ActionParams, Spec},
 };
@@ -15,7 +15,7 @@ use cfx_types::{address_util::AddressUtil, Address, U256};
 pub fn set_sponsor_for_gas(
     contract_address: Address, upper_bound: U256, params: &ActionParams,
     spec: &Spec, state: &mut dyn StateOpsTrait,
-    substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+    substate: &mut dyn SubstateTrait,
     tracer: &mut dyn Tracer<Output = ExecTrace>, account_start_nonce: U256,
 ) -> vm::Result<()>
 {
@@ -122,8 +122,7 @@ pub fn set_sponsor_for_gas(
 /// Implementation of `set_sponsor_for_collateral(address)`.
 pub fn set_sponsor_for_collateral(
     contract_address: Address, params: &ActionParams, spec: &Spec,
-    state: &mut dyn StateOpsTrait,
-    substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+    state: &mut dyn StateOpsTrait, substate: &mut dyn SubstateTrait,
     tracer: &mut dyn Tracer<Output = ExecTrace>, account_start_nonce: U256,
 ) -> vm::Result<()>
 {

--- a/core/src/executive/internal_contract/mod.rs
+++ b/core/src/executive/internal_contract/mod.rs
@@ -39,10 +39,7 @@ pub trait InternalContractTrait {
     fn execute(
         &self, params: &ActionParams, env: &Env, spec: &Spec,
         state: &mut dyn StateOpsTrait,
-        substate: &mut dyn SubstateTrait<
-            Spec = Spec,
-            CallStackInfo = CallStackInfo,
-        >,
+        substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<GasLeft>
     {
@@ -88,10 +85,7 @@ pub trait SolidityFunctionTrait: Send + Sync {
     fn execute(
         &self, input: &[u8], params: &ActionParams, env: &Env, spec: &Spec,
         state: &mut dyn StateOpsTrait,
-        substate: &mut dyn SubstateTrait<
-            Spec = Spec,
-            CallStackInfo = CallStackInfo,
-        >,
+        substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<GasLeft>;
 

--- a/core/src/executive/internal_contract/mod.rs
+++ b/core/src/executive/internal_contract/mod.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use cfx_state::{state_trait::StateOpsTrait, SubstateTrait};
 use cfx_types::{Address, H256};
-use std::sync::Arc;
+use std::{cell::RefCell, sync::Arc};
 
 lazy_static! {
     static ref INTERNAL_CONTRACT_CODE: Arc<Bytes> =
@@ -38,8 +38,8 @@ pub trait InternalContractTrait {
     /// execute this internal contract on the given parameters.
     fn execute(
         &self, params: &ActionParams, env: &Env, spec: &Spec,
-        state: &mut dyn StateOpsTrait,
-        substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        call_stack: &RefCell<CallStackInfo>, state: &mut dyn StateOpsTrait,
+        substate: &mut dyn SubstateTrait,
         tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<GasLeft>
     {
@@ -67,6 +67,7 @@ pub trait InternalContractTrait {
             params,
             env,
             spec,
+            call_stack,
             state,
             substate,
             tracer,
@@ -82,10 +83,13 @@ pub trait InternalContractTrait {
 
 /// Native implementation of a solidity-interface function.
 pub trait SolidityFunctionTrait: Send + Sync {
+    // TODO: there are too many parameters here. It should use context instead.
+    // However, context can not support all the requirements in internal
+    // contracts.
     fn execute(
         &self, input: &[u8], params: &ActionParams, env: &Env, spec: &Spec,
-        state: &mut dyn StateOpsTrait,
-        substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        call_stack: &RefCell<CallStackInfo>, state: &mut dyn StateOpsTrait,
+        substate: &mut dyn SubstateTrait,
         tracer: &mut dyn Tracer<Output = ExecTrace>,
     ) -> vm::Result<GasLeft>;
 

--- a/core/src/spec/genesis.rs
+++ b/core/src/spec/genesis.rs
@@ -8,7 +8,7 @@ use crate::{
         TransactOptions,
     },
     machine::Machine,
-    state::State,
+    state::{CallStackInfo, State},
     verification::{compute_receipts_root, compute_transaction_root},
     vm::{CreateContractAddress, Env},
 };
@@ -32,6 +32,7 @@ use primitives::{
 use rustc_hex::FromHex;
 use secret_store::SecretStore;
 use std::{
+    cell::RefCell,
     collections::HashMap,
     fs::File,
     io::{BufRead, BufReader, Read},
@@ -444,6 +445,7 @@ fn execute_genesis_transaction(
     let internal_contract_map = InternalContractMap::new();
 
     let options = TransactOptions::with_no_tracing();
+    let call_stack = RefCell::new(CallStackInfo::default());
     let r = {
         Executive::new(
             state,
@@ -451,6 +453,7 @@ fn execute_genesis_transaction(
             machine.as_ref(),
             &machine.spec(env.number),
             &internal_contract_map,
+            &call_stack,
         )
         .transact(transaction, options)
         .unwrap()

--- a/core/src/state/account_entry.rs
+++ b/core/src/state/account_entry.rs
@@ -698,10 +698,7 @@ impl OverlayAccount {
     /// account in current execution.
     pub fn commit_ownership_change<StateDbStorage: StorageStateTrait>(
         &mut self, db: &StateDbGeneric<StateDbStorage>,
-        substate: &mut dyn SubstateTrait<
-            CallStackInfo = CallStackInfo,
-            Spec = Spec,
-        >,
+        substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
     ) -> DbResult<()>
     {
         let storage_owner_lv1_write_cache: Vec<_> =

--- a/core/src/state/account_entry.rs
+++ b/core/src/state/account_entry.rs
@@ -5,8 +5,7 @@
 use crate::{
     bytes::Bytes,
     hash::{keccak, KECCAK_EMPTY},
-    state::{AccountEntryProtectedMethods, CallStackInfo, StateGeneric},
-    vm::Spec,
+    state::{AccountEntryProtectedMethods, StateGeneric},
 };
 use cfx_internal_common::debug::ComputeEpochDebugRecord;
 use cfx_parameters::staking::COLLATERAL_UNITS_PER_STORAGE_KEY;
@@ -698,7 +697,7 @@ impl OverlayAccount {
     /// account in current execution.
     pub fn commit_ownership_change<StateDbStorage: StorageStateTrait>(
         &mut self, db: &StateDbGeneric<StateDbStorage>,
-        substate: &mut dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        substate: &mut dyn SubstateTrait,
     ) -> DbResult<()>
     {
         let storage_owner_lv1_write_cache: Vec<_> =

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -4,13 +4,11 @@
 
 pub use self::{
     account_entry::{OverlayAccount, COMMISSION_PRIVILEGE_SPECIAL_KEY},
-    substate::{CallStackInfo, Substate},
+    substate::{cleanup_mode, CallStackInfo, Substate},
 };
 
 use self::account_entry::{AccountEntry, AccountState};
-use crate::{
-    hash::KECCAK_EMPTY, transaction_pool::SharedTransactionPool, vm::Spec,
-};
+use crate::{hash::KECCAK_EMPTY, transaction_pool::SharedTransactionPool};
 use cfx_bytes::Bytes;
 use cfx_internal_common::{
     debug::ComputeEpochDebugRecord, StateRootWithAuxInfo,
@@ -990,10 +988,7 @@ impl<StateDbStorage: StorageStateTrait> StateGeneric<StateDbStorage> {
     /// Charges or refund storage collateral and update `total_storage_tokens`.
     fn settle_collateral_for_address(
         &mut self, addr: &Address,
-        substate: &dyn SubstateTrait<
-            CallStackInfo = CallStackInfo,
-            Spec = Spec,
-        >,
+        substate: &dyn SubstateTrait<CallStackInfo = CallStackInfo>,
         account_start_nonce: U256,
     ) -> DbResult<CollateralCheckResult>
     {

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -987,8 +987,7 @@ impl<StateDbStorage: StorageStateTrait> StateGeneric<StateDbStorage> {
 
     /// Charges or refund storage collateral and update `total_storage_tokens`.
     fn settle_collateral_for_address(
-        &mut self, addr: &Address,
-        substate: &dyn SubstateTrait<CallStackInfo = CallStackInfo>,
+        &mut self, addr: &Address, substate: &dyn SubstateTrait,
         account_start_nonce: U256,
     ) -> DbResult<CollateralCheckResult>
     {

--- a/core/src/state/substate.rs
+++ b/core/src/state/substate.rs
@@ -25,7 +25,9 @@ pub struct CallStackInfo {
 
 impl CallStackInfo {
     fn push(&mut self, address: Address) {
-        if self.reentrancy_happens_when_push(&address) {
+        // We should still use the correct behaviour to check if reentrancy
+        // happens.
+        if self.last() != Some(address) && self.contains_key(&address) {
             self.first_reentrancy_depth
                 .get_or_insert(self.call_stack_recipient_addresses.len());
         }

--- a/core/src/state/substate.rs
+++ b/core/src/state/substate.rs
@@ -27,7 +27,7 @@ impl CallStackInfo {
     fn push(&mut self, address: Address) {
         // We should still use the correct behaviour to check if reentrancy
         // happens.
-        if self.last() != Some(address) && self.contains_key(&address) {
+        if self.last() != Some(&address) && self.contains_key(&address) {
             self.first_reentrancy_depth
                 .get_or_insert(self.call_stack_recipient_addresses.len());
         }

--- a/core/src/state/substate.rs
+++ b/core/src/state/substate.rs
@@ -55,7 +55,23 @@ impl CallStackInfo {
     }
 
     pub fn reentrancy_happens_when_push(&self, address: &Address) -> bool {
-        self.last() != Some(address) && self.contains_key(address)
+        // Consistent with old behaviour.
+        // The old (unexpected) behaviour is equivalent to the top element is
+        // lost.
+        let self_call = if let [.., second_last, _last] =
+            self.call_stack_recipient_addresses.as_slice()
+        {
+            second_last == address
+        } else {
+            false
+        };
+        // Check if the call stack except the last one contains key.
+        let contains_key = self.contains_key(address)
+            && (self.last() != Some(address)
+                || self.address_counter[address] > 1);
+        !self_call && contains_key
+        // Expected behaviour
+        // self.last() != Some(address) && self.contains_key(address)
     }
 
     pub fn last(&self) -> Option<&Address> {
@@ -67,7 +83,15 @@ impl CallStackInfo {
     }
 
     pub fn in_reentrancy(&self) -> bool {
-        self.first_reentrancy_depth.is_some()
+        // Consistent with old behaviour
+        // The old (unexpected) behaviour is equivalent to the top element is
+        // lost.
+        self.first_reentrancy_depth.map_or(false, |depth| {
+            (depth as isize)
+                < self.call_stack_recipient_addresses.len() as isize - 1
+        })
+        // Expected behaviour
+        // self.first_reentrancy_depth.is_some()
     }
 }
 
@@ -235,10 +259,7 @@ impl SubstateTrait for Substate {
     }
 
     fn in_reentrancy(&self) -> bool {
-        self.contracts_in_callstack
-            .borrow()
-            .first_reentrancy_depth
-            .is_some()
+        self.contracts_in_callstack.borrow().in_reentrancy()
     }
 
     fn sstore_clears_refund(&self) -> i128 { self.sstore_clears_refund }
@@ -256,10 +277,7 @@ impl SubstateTrait for Substate {
     fn reentrancy_happens_when_push(&self, address: &Address) -> bool {
         self.contracts_in_callstack
             .borrow()
-            .call_stack_recipient_addresses
-            .last()
-            != Some(address)
-            && self.contains_key(address)
+            .reentrancy_happens_when_push(address)
     }
 
     fn record_storage_release(&mut self, address: &Address, collaterals: u64) {
@@ -278,10 +296,7 @@ impl SubstateTrait for Substate {
     }
 
     fn contains_key(&self, key: &Address) -> bool {
-        self.contracts_in_callstack
-            .borrow()
-            .address_counter
-            .contains_key(key)
+        self.contracts_in_callstack.borrow().contains_key(key)
     }
 
     fn suicides(&self) -> &HashSet<Address> { &self.suicides }

--- a/core/state/src/substate_trait.rs
+++ b/core/state/src/substate_trait.rs
@@ -4,7 +4,6 @@
 
 pub trait SubstateTrait {
     type CallStackInfo;
-    type Spec;
 
     fn get_collateral_change(&self, address: &Address) -> (u64, u64);
 
@@ -23,7 +22,7 @@ pub trait SubstateTrait {
 
     fn record_storage_occupy(&mut self, address: &Address, collaterals: u64);
 
-    fn to_cleanup_mode(&mut self, spec: &Self::Spec) -> CleanupMode;
+    fn touched(&mut self) -> &mut HashSet<Address>;
 
     fn pop_callstack(&self);
 
@@ -72,7 +71,7 @@ pub trait SubstateMngTrait: SubstateTrait {
     ) -> Self;
 }
 
-use crate::{state_trait::StateOpsTrait, CleanupMode};
+use crate::state_trait::StateOpsTrait;
 use cfx_statedb::Result as DbResult;
 use cfx_types::{Address, U256};
 use primitives::LogEntry;

--- a/core/state/src/substate_trait.rs
+++ b/core/state/src/substate_trait.rs
@@ -3,8 +3,6 @@
 // See http://www.gnu.org/licenses/
 
 pub trait SubstateTrait {
-    type CallStackInfo;
-
     fn get_collateral_change(&self, address: &Address) -> (u64, u64);
 
     fn logs(&self) -> &[LogEntry];
@@ -24,14 +22,6 @@ pub trait SubstateTrait {
 
     fn touched(&mut self) -> &mut HashSet<Address>;
 
-    fn pop_callstack(&self);
-
-    fn push_callstack(&self, contract: Address);
-
-    fn contracts_in_callstack(&self) -> &Rc<RefCell<Self::CallStackInfo>>;
-
-    fn in_reentrancy(&self) -> bool;
-
     fn sstore_clears_refund(&self) -> i128;
 
     fn sstore_clears_refund_mut(&mut self) -> &mut i128;
@@ -39,13 +29,9 @@ pub trait SubstateTrait {
     fn contracts_created(&self) -> &[Address];
     fn contracts_created_mut(&mut self) -> &mut Vec<Address>;
 
-    fn reentrancy_happens_when_push(&self, address: &Address) -> bool;
-
     fn record_storage_release(&mut self, address: &Address, collaterals: u64);
 
     fn keys_for_collateral_changed(&self) -> HashSet<&Address>;
-
-    fn contains_key(&self, key: &Address) -> bool;
 
     fn suicides(&self) -> &HashSet<Address>;
 
@@ -55,8 +41,6 @@ pub trait SubstateTrait {
 }
 
 pub trait SubstateMngTrait: SubstateTrait {
-    fn with_call_stack(callstack: Rc<RefCell<Self::CallStackInfo>>) -> Self;
-
     fn accrue(&mut self, s: Self);
 
     fn new() -> Self;
@@ -75,4 +59,4 @@ use crate::state_trait::StateOpsTrait;
 use cfx_statedb::Result as DbResult;
 use cfx_types::{Address, U256};
 use primitives::LogEntry;
-use std::{cell::RefCell, collections::HashSet, rc::Rc};
+use std::collections::HashSet;


### PR DESCRIPTION
This PR relies #2180 

Remove two associate types of substate, including
- Remove associate type `Spec`. `Spec` is just a parameter of one function in Substate.
- Remove associate type `CallStackInfo`. We put `CallStackInfo` in `Substate` to save developing time. However, it breaks the intrinsic logic of `Substate`. We move `CallStackInfo` to the same place as `Env`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2183)
<!-- Reviewable:end -->
