### PR TITLE
Accept pivot hash in cfx_getEpochReceipts

### DIFF
--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -1417,13 +1417,30 @@ impl RpcImpl {
     }
 
     fn epoch_receipts(
-        &self, epoch: EpochNumber,
+        &self, epoch: BlockHashOrEpochNumber,
     ) -> RpcResult<Option<Vec<Vec<RpcReceipt>>>> {
         info!("RPC Request: cfx_getEpochReceipts({:?})", epoch);
 
-        let hashes = self.consensus.get_block_hashes_by_epoch(epoch.into())?;
-        let pivot_hash = *hashes.last().ok_or("Inconsistent state")?;
+        let hashes = match epoch {
+            BlockHashOrEpochNumber::EpochNumber(e) => {
+                self.consensus.get_block_hashes_by_epoch(e.into())?
+            }
+            BlockHashOrEpochNumber::BlockHash(h) => {
+                let e = self.consensus.get_block_epoch_number(&h).unwrap();
+                let hashes = self.consensus.get_block_hashes_by_epoch(
+                    primitives::EpochNumber::Number(e),
+                )?;
 
+                // if the provided hash is not a pivot hash, return null
+                if hashes.last() != Some(&h) {
+                    return Ok(None);
+                }
+
+                hashes
+            }
+        };
+
+        let pivot_hash = *hashes.last().ok_or("Inconsistent state")?;
         let mut epoch_receipts = vec![];
 
         for h in hashes {
@@ -1619,7 +1636,7 @@ impl LocalRpc for LocalRpcImpl {
         to self.rpc_impl {
             fn current_sync_phase(&self) -> JsonRpcResult<String>;
             fn consensus_graph_state(&self) -> JsonRpcResult<ConsensusGraphStates>;
-            fn epoch_receipts(&self, epoch: EpochNumber) -> JsonRpcResult<Option<Vec<Vec<RpcReceipt>>>>;
+            fn epoch_receipts(&self, epoch: BlockHashOrEpochNumber) -> JsonRpcResult<Option<Vec<Vec<RpcReceipt>>>>;
             fn sync_graph_state(&self) -> JsonRpcResult<SyncGraphStates>;
             fn send_transaction(
                 &self, tx: SendTxRequest, password: Option<String>) -> BoxFuture<H256>;

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -1426,7 +1426,11 @@ impl RpcImpl {
                 self.consensus.get_block_hashes_by_epoch(e.into())?
             }
             BlockHashOrEpochNumber::BlockHash(h) => {
-                let e = self.consensus.get_block_epoch_number(&h).unwrap();
+                let e = match self.consensus.get_block_epoch_number(&h) {
+                    Some(e) => e,
+                    None => return Ok(None),
+                };
+
                 let hashes = self.consensus.get_block_hashes_by_epoch(
                     primitives::EpochNumber::Number(e),
                 )?;

--- a/client/src/rpc/impls/light.rs
+++ b/client/src/rpc/impls/light.rs
@@ -1166,7 +1166,7 @@ impl LocalRpc for DebugRpcImpl {
     not_supported! {
         fn consensus_graph_state(&self) -> JsonRpcResult<ConsensusGraphStates>;
         fn current_sync_phase(&self) -> JsonRpcResult<String>;
-        fn epoch_receipts(&self, epoch: EpochNumber) -> JsonRpcResult<Option<Vec<Vec<RpcReceipt>>>>;
+        fn epoch_receipts(&self, epoch: BlockHashOrEpochNumber) -> JsonRpcResult<Option<Vec<Vec<RpcReceipt>>>>;
         fn sign_transaction(&self, tx: SendTxRequest, password: Option<String>) -> JsonRpcResult<String>;
         fn sync_graph_state(&self) -> JsonRpcResult<SyncGraphStates>;
     }

--- a/client/src/rpc/traits/debug.rs
+++ b/client/src/rpc/traits/debug.rs
@@ -3,7 +3,7 @@
 // See http://www.gnu.org/licenses/
 
 use super::super::types::{
-    Bytes as RpcBytes, ConsensusGraphStates, EpochNumber,
+    BlockHashOrEpochNumber, Bytes as RpcBytes, ConsensusGraphStates,
     Receipt as RpcReceipt, RpcAddress, SyncGraphStates,
     Transaction as RpcTransaction, TxPoolPendingInfo, TxWithPoolInfo,
 };
@@ -117,6 +117,6 @@ pub trait LocalRpc {
 
     #[rpc(name = "cfx_getEpochReceipts")]
     fn epoch_receipts(
-        &self, epoch: EpochNumber,
+        &self, epoch: BlockHashOrEpochNumber,
     ) -> JsonRpcResult<Option<Vec<Vec<RpcReceipt>>>>;
 }

--- a/tests/rpc/test_tx_receipt_by_hash.py
+++ b/tests/rpc/test_tx_receipt_by_hash.py
@@ -112,3 +112,10 @@ class TestGetTxReceiptByHash(RpcClient):
         assert_equal(len(receipts), 2)
         assert_equal(len(receipts[0]), NUM_TXS//2)
         assert_equal(len(receipts[1]), NUM_TXS//2)
+
+        # retrieve epoch receipts by pivot hash
+        receipts2 = self.node.cfx_getEpochReceipts(f'hash:{block_d}')
+        assert_equal(receipts2, receipts)
+
+        receipts3 = self.node.cfx_getEpochReceipts(f'hash:{block_b}')
+        assert_equal(receipts3, None)


### PR DESCRIPTION
To get an epoch's data, one could execute the following steps:

```
1. blocks = cfx_getBlocksByEpoch(epoch)

2. for block in blocks {
    blockWithTxs = cfx_getBlockByHash(block)
}

3. epochReceipts = cfx_getEpochReceipts(epoch)
```

However, there might be a pivot chain reorg between 2. and 3. which would make the data retrieved inconsistent. In some cases, this is impossible to detect. This PR changes `cfx_getEpochReceipts` so that it also accepts a pivot hash (with the format `hash:0x...`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2193)
<!-- Reviewable:end -->
