### PR TITLE
Fix test case fail incurred by branch merge

### DIFF
--- a/tests/rpc/test_trace.py
+++ b/tests/rpc/test_trace.py
@@ -34,7 +34,7 @@ class TestTrace(RpcClient):
                     "action": {
                         "gasLeft": "0x0",
                         "outcome": "success",
-                        "returnData": []
+                        "returnData": "0x"
                     },
                     "type": "call_result"
                 }],
@@ -96,7 +96,7 @@ class TestTrace(RpcClient):
             "action": {
                 "gasLeft": "0x0",
                 "outcome": "success",
-                "returnData": []
+                "returnData": "0x"
             },
             "blockHash": receipt["blockHash"],
             "epochHash": receipt["blockHash"],
@@ -133,7 +133,7 @@ class TestTrace(RpcClient):
             "action": {
                 "gasLeft": "0x0",
                 "outcome": "success",
-                "returnData": []
+                "returnData": "0x"
             },
             "blockHash": block_hash,
             "epochHash": block_hash,


### PR DESCRIPTION
#2185 changes the format of trace returned by rpc and #2184 adds old-format new trace to test code. This results in a test error after two branches are merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2197)
<!-- Reviewable:end -->
