### PR TITLE
Raise error in cfx_getEpochReceipts if there is a pivot hash mismatch

### DIFF
--- a/client/src/rpc/error_codes.rs
+++ b/client/src/rpc/error_codes.rs
@@ -17,6 +17,7 @@
 
 //! RPC Error codes and error objects
 
+use cfx_types::H256;
 use jsonrpc_core::{Error, ErrorCode, Value};
 use rustc_hex::ToHex;
 use std::fmt;
@@ -170,5 +171,16 @@ pub fn request_rejected_in_catch_up_mode(details: Option<String>) -> Error {
         code: ErrorCode::ServerError(codes::REQUEST_REJECTED_IN_CATCH_UP),
         message: "Request rejected due to still in the catch up mode.".into(),
         data: details.map(Value::String),
+    }
+}
+
+pub fn pivot_assumption_failed(expected: H256, got: H256) -> Error {
+    Error {
+        code: ErrorCode::ServerError(codes::CONFLUX_PIVOT_CHAIN_UNSTABLE),
+        message: "Pivot assumption failed".into(),
+        data: Some(Value::String(format!(
+            "pivot assumption: {:?}, actual pivot hash: {:?}",
+            expected, got
+        ))),
     }
 }

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -1439,6 +1439,15 @@ impl RpcImpl {
                 self.consensus.get_block_hashes_by_epoch(e.into())?
             }
             BlockHashOrEpochNumber::BlockHash(h) => {
+                if self
+                    .consensus
+                    .get_data_manager()
+                    .block_header_by_hash(&h)
+                    .is_none()
+                {
+                    bail!(invalid_params("block_hash", "block not found"));
+                }
+
                 let e = match self.get_block_epoch_number(&h) {
                     Some(e) => e,
                     None => return Ok(None), // not executed
@@ -1452,7 +1461,6 @@ impl RpcImpl {
                 let pivot_hash = *hashes.last().ok_or("Inconsistent state")?;
 
                 if h != pivot_hash {
-                    // assume client provided a known pivot hash
                     bail!(pivot_assumption_failed(h, pivot_hash));
                 }
 

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -42,7 +42,7 @@ use crate::{
     common::delegate_convert,
     rpc::{
         error_codes::{
-            call_execution_error, invalid_params,
+            call_execution_error, invalid_params, pivot_assumption_failed,
             request_rejected_in_catch_up_mode,
         },
         impls::{
@@ -787,16 +787,19 @@ impl RpcImpl {
     }
 
     fn prepare_block_receipts(
-        &self, block_hash: H256, maybe_pivot_hash: Option<H256>,
+        &self, block_hash: H256, pivot_assumption: H256,
     ) -> RpcResult<Option<Vec<RpcReceipt>>> {
         let exec_info = match self.get_block_execution_info(&block_hash)? {
-            None => return Ok(None),
+            None => return Ok(None), // not executed
             Some(res) => res,
         };
 
         // pivot chain reorg
-        if matches!(maybe_pivot_hash, Some(h) if h != exec_info.pivot_hash) {
-            return Ok(None);
+        if pivot_assumption != exec_info.pivot_hash {
+            bail!(pivot_assumption_failed(
+                pivot_assumption,
+                exec_info.pivot_hash
+            ));
         }
 
         let mut rpc_receipts = vec![];
@@ -1416,6 +1419,16 @@ impl RpcImpl {
         Ok(())
     }
 
+    fn get_block_epoch_number(&self, h: &H256) -> Option<u64> {
+        // try to get from memory
+        if let Some(e) = self.consensus.get_block_epoch_number(h) {
+            return Some(e);
+        }
+
+        // try to get from db
+        self.consensus.get_data_manager().block_epoch_number(h)
+    }
+
     fn epoch_receipts(
         &self, epoch: BlockHashOrEpochNumber,
     ) -> RpcResult<Option<Vec<Vec<RpcReceipt>>>> {
@@ -1426,18 +1439,21 @@ impl RpcImpl {
                 self.consensus.get_block_hashes_by_epoch(e.into())?
             }
             BlockHashOrEpochNumber::BlockHash(h) => {
-                let e = match self.consensus.get_block_epoch_number(&h) {
+                let e = match self.get_block_epoch_number(&h) {
                     Some(e) => e,
-                    None => return Ok(None),
+                    None => return Ok(None), // not executed
                 };
 
                 let hashes = self.consensus.get_block_hashes_by_epoch(
                     primitives::EpochNumber::Number(e),
                 )?;
 
-                // if the provided hash is not a pivot hash, return null
-                if hashes.last() != Some(&h) {
-                    return Ok(None);
+                // if the provided hash is not the pivot hash, abort
+                let pivot_hash = *hashes.last().ok_or("Inconsistent state")?;
+
+                if h != pivot_hash {
+                    // assume client provided a known pivot hash
+                    bail!(pivot_assumption_failed(h, pivot_hash));
                 }
 
                 hashes
@@ -1449,11 +1465,8 @@ impl RpcImpl {
 
         for h in hashes {
             epoch_receipts.push(
-                match self.prepare_block_receipts(h, Some(pivot_hash))? {
-                    // if the block is not executed yet, or there was a chain
-                    // reorg during processing that might cause inconsistency,
-                    // we return `null` and expect the client to retry
-                    None => return Ok(None),
+                match self.prepare_block_receipts(h, pivot_hash)? {
+                    None => return Ok(None), // not executed
                     Some(rs) => rs,
                 },
             );

--- a/tests/rpc/test_tx_receipt_by_hash.py
+++ b/tests/rpc/test_tx_receipt_by_hash.py
@@ -6,7 +6,7 @@ from conflux.address import b32_address_to_hex
 from conflux.rpc import RpcClient
 from conflux.utils import sha3 as keccak
 from test_framework.blocktools import encode_hex_0x
-from test_framework.util import assert_equal, assert_ne
+from test_framework.util import assert_equal, assert_ne, assert_raises_rpc_error
 
 CONTRACT_PATH = "../contracts/simple_storage.dat"
 NUM_TXS = 10
@@ -97,6 +97,11 @@ class TestGetTxReceiptByHash(RpcClient):
         block_c = self.generate_custom_block(parent_hash = block_a, referee = [], txs = [])
         block_d = self.generate_custom_block(parent_hash = block_c, referee = [block_b], txs = txs2)
 
+        # not executed yet, no epoch receipts
+        epoch_d = self.block_by_hash(block_d)['height']
+        assert_equal(self.node.cfx_getEpochReceipts(epoch_d), None)
+        assert_equal(self.node.cfx_getEpochReceipts(f'hash:{block_d}'), None)
+
         # make sure transactions have been executed
         parent_hash = block_d
 
@@ -105,8 +110,7 @@ class TestGetTxReceiptByHash(RpcClient):
             parent_hash = block
 
         # retrieve epoch receipts
-        epoch = self.block_by_hash(block_d)['height']
-        receipts = self.node.cfx_getEpochReceipts(epoch)
+        receipts = self.node.cfx_getEpochReceipts(epoch_d)
 
         assert_ne(receipts, None)
         assert_equal(len(receipts), 2)
@@ -117,5 +121,5 @@ class TestGetTxReceiptByHash(RpcClient):
         receipts2 = self.node.cfx_getEpochReceipts(f'hash:{block_d}')
         assert_equal(receipts2, receipts)
 
-        receipts3 = self.node.cfx_getEpochReceipts(f'hash:{block_b}')
-        assert_equal(receipts3, None)
+        # request with non-pivot block hash should fail
+        assert_raises_rpc_error(None, None, self.node.cfx_getEpochReceipts, f'hash:{block_b}')

--- a/tests/rpc/test_tx_receipt_by_hash.py
+++ b/tests/rpc/test_tx_receipt_by_hash.py
@@ -123,3 +123,6 @@ class TestGetTxReceiptByHash(RpcClient):
 
         # request with non-pivot block hash should fail
         assert_raises_rpc_error(None, None, self.node.cfx_getEpochReceipts, f'hash:{block_b}')
+
+        # request with nonexistent block hash should fail
+        assert_raises_rpc_error(None, None, self.node.cfx_getEpochReceipts, f'hash:0x66e365b5bbd53bc26fd306fd7c65290b2b13c165d7cae816b651e7fcf2646f37')


### PR DESCRIPTION
Currently, `cfx_getEpochReceipts` returns `null` if (1) the epoch is not executed, or (2) if there is a pivot chain mismatch. In order to better differentiate between these two cases, this PR changes the behavior of (2) to raise an error instead.

This PR also fixes incorrect usage of `get_block_epoch_number` which would probably have lead to this RPC returning `null` for all old-era blocks when used with a pivot hash parameter. After this PR, we try to get this value from DB if it's not present in consensus.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2201)
<!-- Reviewable:end -->
