### PR TITLE
Fixes issue #2225

### DIFF
--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -1054,33 +1054,30 @@ impl RpcImpl {
             epoch
         );
         let epoch_number = match epoch {
-            EpochNumber::Num(number) => {
-                number
-            }
+            EpochNumber::Num(number) => number,
             _ => {
-                let epoch_hash = self.consensus.get_hash_from_epoch_number(
-                    epoch.clone().into())?;
-                match self.consensus
-                    .get_block_epoch_number(&epoch_hash)
-                {
+                let epoch_hash = self
+                    .consensus
+                    .get_hash_from_epoch_number(epoch.clone().into())?;
+                match self.consensus.get_block_epoch_number(&epoch_hash) {
                     None => {
-                        bail!(invalid_params("epoch", "get_block_epoch_number returns none!"));
+                        bail!(invalid_params(
+                            "epoch",
+                            "get_block_epoch_number returns none!"
+                        ));
                     }
-                    Some(epoch_number) => {
-                        epoch_number.into()
-                    }
+                    Some(epoch_number) => epoch_number.into(),
                 }
             }
         };
-        let epoch_later_number = epoch_number
-            .overflowing_add(12.into());
+        let epoch_later_number = epoch_number.overflowing_add(12.into());
         if epoch_later_number.1 {
             bail!(invalid_params("epoch", "Epoch number overflows!"));
         }
         let epoch_later_number = epoch_later_number.0;
-        let epoch_later = self.consensus
-            .get_hash_from_epoch_number(
-                EpochNumber::Num(epoch_later_number).into_primitive())?;
+        let epoch_later = self.consensus.get_hash_from_epoch_number(
+            EpochNumber::Num(epoch_later_number).into_primitive(),
+        )?;
 
         let blocks = self.consensus.get_block_hashes_by_epoch(epoch.into())?;
 
@@ -1090,7 +1087,11 @@ impl RpcImpl {
                 .consensus
                 .get_data_manager()
                 .block_reward_result_by_hash_with_epoch(
-                    &b, &epoch_later, false, true)
+                    &b,
+                    &epoch_later,
+                    false,
+                    true,
+                )
             {
                 if let Some(block_header) =
                     self.consensus.get_data_manager().block_header_by_hash(&b)

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -1067,7 +1067,8 @@ impl RpcImpl {
             EpochNumber::Num(epoch_later_number).into_primitive(),
         ) {
             Ok(hash) => hash,
-            Err(_) => {
+            Err(e) => {
+                debug!("get_block_reward_info: get_hash_from_epoch_number returns error: {}", e);
                 bail!(invalid_params("epoch", "Reward not calculated yet!"))
             }
         };

--- a/core/benchmark/consensus/Cargo.toml
+++ b/core/benchmark/consensus/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2018"
 [dependencies]
 cfxcore = { path = "../../../core" }
 cfx-types = { path = "../../../cfx_types" }
-cfx-storage = { path = "../../../core/storage" }
 primitives = { path = "../../../primitives" }
 db = { path = "../../../db" }
 threadpool = "1.0"

--- a/core/src/block_data_manager/block_data_types.rs
+++ b/core/src/block_data_manager/block_data_types.rs
@@ -67,6 +67,18 @@ impl Default for BlockRewardResult {
     }
 }
 
+pub type BlockRewardResultWithEpoch =
+    DataVersionTuple<H256, BlockRewardResult>;
+impl BlockRewardResultWithEpoch {
+    pub fn new(pivot_hash: H256, reward_result: BlockRewardResult) -> Self {
+        DataVersionTuple(pivot_hash, reward_result)
+    }
+}
+
+pub type BlockRewardsInfo =
+    BlockDataWithMultiVersion<H256, BlockRewardResult>;
+
+
 #[derive(Clone, Debug, DeriveMallocSizeOf)]
 pub struct DataVersionTuple<Version, T>(pub Version, pub T);
 

--- a/core/src/block_data_manager/block_data_types.rs
+++ b/core/src/block_data_manager/block_data_types.rs
@@ -67,17 +67,14 @@ impl Default for BlockRewardResult {
     }
 }
 
-pub type BlockRewardResultWithEpoch =
-    DataVersionTuple<H256, BlockRewardResult>;
+pub type BlockRewardResultWithEpoch = DataVersionTuple<H256, BlockRewardResult>;
 impl BlockRewardResultWithEpoch {
     pub fn new(pivot_hash: H256, reward_result: BlockRewardResult) -> Self {
         DataVersionTuple(pivot_hash, reward_result)
     }
 }
 
-pub type BlockRewardsInfo =
-    BlockDataWithMultiVersion<H256, BlockRewardResult>;
-
+pub type BlockRewardsInfo = BlockDataWithMultiVersion<H256, BlockRewardResult>;
 
 #[derive(Clone, Debug, DeriveMallocSizeOf)]
 pub struct DataVersionTuple<Version, T>(pub Version, pub T);

--- a/core/src/block_data_manager/block_data_types.rs
+++ b/core/src/block_data_manager/block_data_types.rs
@@ -67,13 +67,6 @@ impl Default for BlockRewardResult {
     }
 }
 
-pub type BlockRewardResultWithEpoch = DataVersionTuple<H256, BlockRewardResult>;
-impl BlockRewardResultWithEpoch {
-    pub fn new(pivot_hash: H256, reward_result: BlockRewardResult) -> Self {
-        DataVersionTuple(pivot_hash, reward_result)
-    }
-}
-
 pub type BlockRewardsInfo = BlockDataWithMultiVersion<H256, BlockRewardResult>;
 
 #[derive(Clone, Debug, DeriveMallocSizeOf)]

--- a/core/src/block_data_manager/db_manager.rs
+++ b/core/src/block_data_manager/db_manager.rs
@@ -523,10 +523,7 @@ impl DBManager {
     ) -> Option<V>
     where V: DatabaseDecodable {
         let encoded = self.load_from_db(table, db_key)?;
-        match V::db_decode(&encoded) {
-            Ok(res) => Some(res),
-            Err(_) => None,
-        }
+        V::db_decode(&encoded).ok()
     }
 
     fn load_decodable_list<V>(

--- a/core/src/block_data_manager/db_manager.rs
+++ b/core/src/block_data_manager/db_manager.rs
@@ -1,10 +1,9 @@
 use crate::{
     block_data_manager::{
         db_decode_list, db_encode_list, BlamedHeaderVerifiedRoots,
-        BlockExecutionResultWithEpoch,
-        BlockRewardResultWithEpoch,
-        BlockTracesWithEpoch,
-        CheckpointHashes, EpochExecutionContext, LocalBlockInfo,
+        BlockExecutionResultWithEpoch, BlockRewardResultWithEpoch,
+        BlockTracesWithEpoch, CheckpointHashes, EpochExecutionContext,
+        LocalBlockInfo,
     },
     db::{
         COL_BLAMED_HEADER_VERIFIED_ROOTS, COL_BLOCKS, COL_BLOCK_TRACES,
@@ -316,7 +315,10 @@ impl DBManager {
     pub fn block_reward_result_from_db(
         &self, hash: &H256,
     ) -> Option<BlockRewardResultWithEpoch> {
-        self.load_might_decodable_val(DBTable::Blocks, &block_reward_result_key(hash))
+        self.load_might_decodable_val(
+            DBTable::Blocks,
+            &block_reward_result_key(hash),
+        )
     }
 
     pub fn remove_block_execution_result_from_db(&self, hash: &H256) {
@@ -522,8 +524,8 @@ impl DBManager {
     where V: DatabaseDecodable {
         let encoded = self.load_from_db(table, db_key)?;
         match V::db_decode(&encoded) {
-            Ok(res) => { Some(res) }
-            Err(_) => { None }
+            Ok(res) => Some(res),
+            Err(_) => None,
         }
     }
 

--- a/core/src/block_data_manager/db_manager.rs
+++ b/core/src/block_data_manager/db_manager.rs
@@ -1,8 +1,8 @@
 use crate::{
     block_data_manager::{
         db_decode_list, db_encode_list, BlamedHeaderVerifiedRoots,
-        BlockExecutionResultWithEpoch, BlockRewardResultWithEpoch,
-        BlockTracesWithEpoch, CheckpointHashes, EpochExecutionContext,
+        BlockExecutionResultWithEpoch, BlockRewardResult, BlockTracesWithEpoch,
+        CheckpointHashes, DataVersionTuple, EpochExecutionContext,
         LocalBlockInfo,
     },
     db::{
@@ -294,7 +294,7 @@ impl DBManager {
     }
 
     pub fn insert_block_reward_result_to_db(
-        &self, hash: &H256, value: &BlockRewardResultWithEpoch,
+        &self, hash: &H256, value: &DataVersionTuple<H256, BlockRewardResult>,
     ) {
         self.insert_encodable_val(
             DBTable::Blocks,
@@ -314,7 +314,7 @@ impl DBManager {
 
     pub fn block_reward_result_from_db(
         &self, hash: &H256,
-    ) -> Option<BlockRewardResultWithEpoch> {
+    ) -> Option<DataVersionTuple<H256, BlockRewardResult>> {
         self.load_might_decodable_val(
             DBTable::Blocks,
             &block_reward_result_key(hash),

--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -1455,7 +1455,7 @@ impl ConsensusExecutionHandler {
                 .block_execution_result_by_hash_with_epoch(
                     &block_hash,
                     &reward_epoch_hash,
-                    true, /* update_pivot_assumption */
+                    false, /* update_pivot_assumption */
                     true, /* update_cache */
                 ) {
                 Some(block_exec_result) => block_exec_result.block_receipts,

--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -1456,7 +1456,7 @@ impl ConsensusExecutionHandler {
                     &block_hash,
                     &reward_epoch_hash,
                     false, /* update_pivot_assumption */
-                    true, /* update_cache */
+                    true,  /* update_cache */
                 ) {
                 Some(block_exec_result) => block_exec_result.block_receipts,
                 None => {

--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -1456,7 +1456,7 @@ impl ConsensusExecutionHandler {
                     &block_hash,
                     &reward_epoch_hash,
                     true, /* update_pivot_assumption */
-                    true,  /* update_cache */
+                    true, /* update_cache */
                 ) {
                 Some(block_exec_result) => block_exec_result.block_receipts,
                 None => {

--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -912,6 +912,7 @@ impl ConsensusExecutionHandler {
                 &epoch_block_hashes,
                 on_local_pivot,
                 self.config.executive_trace,
+                reward_execution_info,
             )
         {
             let pivot_block_header = self
@@ -1015,6 +1016,7 @@ impl ConsensusExecutionHandler {
             self.process_rewards_and_fees(
                 &mut state,
                 &reward_execution_info,
+                epoch_hash,
                 on_local_pivot,
                 debug_record.as_deref_mut(),
                 self.machine.spec(start_block_number).account_start_nonce,
@@ -1331,7 +1333,7 @@ impl ConsensusExecutionHandler {
     /// anticone difficulty
     fn process_rewards_and_fees(
         &self, state: &mut State, reward_info: &RewardExecutionInfo,
-        on_local_pivot: bool,
+        epoch_later: &H256, on_local_pivot: bool,
         mut debug_record: Option<&mut ComputeEpochDebugRecord>,
         account_start_nonce: U256,
     )
@@ -1453,7 +1455,7 @@ impl ConsensusExecutionHandler {
                 .block_execution_result_by_hash_with_epoch(
                     &block_hash,
                     &reward_epoch_hash,
-                    false, /* update_pivot_assumption */
+                    true, /* update_pivot_assumption */
                     true,  /* update_cache */
                 ) {
                 Some(block_exec_result) => block_exec_result.block_receipts,
@@ -1584,6 +1586,7 @@ impl ConsensusExecutionHandler {
             if on_local_pivot {
                 self.data_man.insert_block_reward_result(
                     block_hash,
+                    epoch_later,
                     BlockRewardResult {
                         total_reward,
                         tx_fee,

--- a/tests/rpc/test_get_block_reward_info.py
+++ b/tests/rpc/test_get_block_reward_info.py
@@ -3,6 +3,7 @@ import time
 sys.path.append("..")
 
 from conflux.rpc import RpcClient
+from test_framework.util import *
 
 class TestGetBlockRewardInfo(RpcClient):
     def test_two_chains(self):
@@ -18,10 +19,12 @@ class TestGetBlockRewardInfo(RpcClient):
         time.sleep(1)
 
         epoch = self.epoch_number(self.EPOCH_LATEST_MINED)
-        res = self.get_block_reward_info(self.EPOCH_LATEST_MINED)
-        assert(len(res) == 0)
-        res = self.get_block_reward_info(self.EPOCH_NUM(epoch - 10))
-        assert(len(res) == 0)
+        assert_raises_rpc_error(-32602,
+            "Invalid parameters: epoch",
+            self.get_block_reward_info, self.EPOCH_LATEST_MINED)
+        assert_raises_rpc_error(-32602,
+            "Invalid parameters: epoch",
+            self.get_block_reward_info, self.EPOCH_NUM(epoch - 10))
 
         for i in range(0, 7):
             self.generate_block()


### PR DESCRIPTION
This PR fixes issue #2225. However, all clients that provide ```cfx_getBlockRewardInfo``` RPC service should be resynced, otherwise the RPC will return empty results for old epoches.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2226)
<!-- Reviewable:end -->
