### PR TITLE
Do not move mpt around among the path nodes.

### DIFF
--- a/core/storage/src/impls/merkle_patricia_trie/mpt_merger.rs
+++ b/core/storage/src/impls/merkle_patricia_trie/mpt_merger.rs
@@ -20,10 +20,7 @@
 // TODO(yz): In future merge can be made into multiple threads easily by merging
 // different children in parallel then combine the root node.
 pub struct MptMerger<'a> {
-    rw_cursor: MptCursorRw<
-        MergeMptsInRequest<'a>,
-        ReadWritePathNode<MergeMptsInRequest<'a>>,
-    >,
+    rw_cursor: MptCursorRw<MergeMptsInRequest<'a>, ReadWritePathNode>,
 }
 
 impl<'a> MptMerger<'a> {

--- a/core/storage/src/impls/merkle_patricia_trie/simple_mpt.rs
+++ b/core/storage/src/impls/merkle_patricia_trie/simple_mpt.rs
@@ -88,10 +88,10 @@ pub fn simple_mpt_merkle_root(simple_mpt: &mut SimpleMpt) -> MerkleHash {
 pub fn simple_mpt_proof(
     simple_mpt: &mut SimpleMpt, access_key: &[u8],
 ) -> TrieProof {
-    let mut cursor = MptCursor::<
-        &mut dyn SnapshotMptTraitRead,
-        BasicPathNode<&mut dyn SnapshotMptTraitRead>,
-    >::new(simple_mpt);
+    let mut cursor =
+        MptCursor::<&mut dyn SnapshotMptTraitRead, BasicPathNode>::new(
+            simple_mpt,
+        );
 
     cursor.load_root().expect("load_root should succeed");
 
@@ -115,7 +115,7 @@ pub fn simple_mpt_proof(
 
 use crate::{
     impls::merkle_patricia_trie::{
-        mpt_cursor::{BasicPathNode, MptCursor},
+        mpt_cursor::{BasicPathNode, MptCursor, MptCursorPathOps},
         trie_node::TrieNodeTrait,
         walk::GetChildTrait,
         CompressedPathRaw, MptMerger, TrieProof,

--- a/core/storage/src/impls/snapshot_sync/restoration/slice_restore_read_write_path_node.rs
+++ b/core/storage/src/impls/snapshot_sync/restoration/slice_restore_read_write_path_node.rs
@@ -2,65 +2,84 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-pub struct SliceVerifyReadWritePathNode<Mpt>(Option<ReadWritePathNode<Mpt>>);
+pub struct SliceVerifyReadWritePathNode(Option<ReadWritePathNode>);
 
-impl<Mpt> SliceVerifyReadWritePathNode<Mpt> {
-    fn take(mut self) -> ReadWritePathNode<Mpt> { self.0.take().unwrap() }
+impl SliceVerifyReadWritePathNode {
+    fn take(mut self) -> ReadWritePathNode { self.0.take().unwrap() }
 
-    pub fn as_ref(&self) -> &ReadWritePathNode<Mpt> { self.0.as_ref().unwrap() }
+    pub fn as_ref(&self) -> &ReadWritePathNode { self.0.as_ref().unwrap() }
 
-    fn as_mut(&mut self) -> &mut ReadWritePathNode<Mpt> {
-        self.0.as_mut().unwrap()
-    }
+    fn as_mut(&mut self) -> &mut ReadWritePathNode { self.0.as_mut().unwrap() }
 }
 
-impl<Mpt> Drop for SliceVerifyReadWritePathNode<Mpt> {
+impl Drop for SliceVerifyReadWritePathNode {
     fn drop(&mut self) {}
 }
 
-impl<Mpt> TakeMpt<Mpt> for SliceVerifyReadWritePathNode<Mpt> {
-    fn take_mpt(&mut self) -> Option<Mpt> { self.as_mut().take_mpt() }
-}
-
-impl<Mpt: GetReadMpt> CursorLoadNodeWrapper<Mpt>
-    for SliceVerifyReadWritePathNode<Mpt>
-{
-    fn load_node_wrapper<'a>(
+impl LoadNodeWrapper for SliceVerifyReadWritePathNode {
+    fn load_node_wrapper<Mpt: GetReadMpt>(
         &self, mpt: &mut Mpt, path: &CompressedPathRaw,
     ) -> Result<SnapshotMptNode> {
         self.as_ref().load_node_wrapper(mpt, path)
     }
 }
 
-impl<Mpt: GetRwMpt> PathNodeTrait<Mpt> for SliceVerifyReadWritePathNode<Mpt> {
-    fn new_loaded(basic_node: BasicPathNode<Mpt>, parent_node: &Self) -> Self {
-        let mut rw_path_node = ReadWritePathNode::<Mpt>::new_loaded(
-            basic_node,
-            parent_node.as_ref(),
-        );
+impl PathNodeTrait for SliceVerifyReadWritePathNode {
+    fn new_loaded(basic_node: BasicPathNode, parent_node: &Self) -> Self {
+        let mut rw_path_node =
+            ReadWritePathNode::new_loaded(basic_node, parent_node.as_ref());
         // Disable path compression for boundary nodes of MptSliceVerifier.
         rw_path_node.disable_path_compression();
         SliceVerifyReadWritePathNode(Some(rw_path_node))
     }
 
-    fn commit(self, parent_node: &mut Self) -> Result<Option<Mpt>> {
-        self.take().commit(parent_node.as_mut())
-    }
-
-    fn commit_root(self, mpt_taken: &mut Option<Mpt>) -> Result<MerkleHash> {
-        self.take().commit_root(mpt_taken)
-    }
-
-    fn get_basic_path_node(&self) -> &BasicPathNode<Mpt> {
+    fn get_basic_path_node(&self) -> &BasicPathNode {
         self.as_ref().get_basic_path_node()
     }
 
-    fn get_basic_path_node_mut(&mut self) -> &mut BasicPathNode<Mpt> {
+    fn get_basic_path_node_mut(&mut self) -> &mut BasicPathNode {
         self.as_mut().get_basic_path_node_mut()
     }
 
-    fn open_child_index(&mut self, child_index: u8) -> Result<Option<Self>> {
-        match self.as_mut().open_child_index(child_index) {
+    fn open_child_index_ro<Mpt: GetReadMpt>(
+        &mut self, _mpt: &mut Mpt, _child_index: u8,
+    ) -> Result<Option<Self>> {
+        unreachable!();
+    }
+}
+
+impl RwPathNodeTrait for SliceVerifyReadWritePathNode {
+    fn new(
+        basic_node: BasicPathNode, parent_node: &Self, value_size: usize,
+    ) -> Self {
+        // Do not disable path compression for non-boundary nodes.
+        SliceVerifyReadWritePathNode(Some(ReadWritePathNode::new(
+            basic_node,
+            parent_node.as_ref(),
+            value_size,
+        )))
+    }
+
+    fn get_read_write_path_node(&mut self) -> &mut ReadWritePathNode {
+        self.as_mut()
+    }
+
+    fn get_read_only_path_node(&self) -> &ReadWritePathNode { self.as_ref() }
+
+    fn commit<Mpt: GetRwMpt>(
+        self, mpt: &mut Mpt, parent_node: &mut Self,
+    ) -> Result<()> {
+        self.take().commit(mpt, parent_node.as_mut())
+    }
+
+    fn commit_root<Mpt: GetRwMpt>(self, mpt: &mut Mpt) -> Result<MerkleHash> {
+        self.take().commit_root(mpt)
+    }
+
+    fn open_child_index<Mpt: GetRwMpt>(
+        &mut self, mpt: &mut Mpt, child_index: u8,
+    ) -> Result<Option<Self>> {
+        match self.as_mut().open_child_index(mpt, child_index) {
             Err(e) => Err(e),
             Ok(Some(mut node)) => {
                 // Disable path compression for boundary nodes of
@@ -72,34 +91,14 @@ impl<Mpt: GetRwMpt> PathNodeTrait<Mpt> for SliceVerifyReadWritePathNode<Mpt> {
             Ok(None) => Ok(None),
         }
     }
-}
 
-impl<Mpt: GetRwMpt> RwPathNodeTrait<Mpt> for SliceVerifyReadWritePathNode<Mpt> {
-    fn new(
-        basic_node: BasicPathNode<Mpt>, parent_node: &Self, value_size: usize,
-    ) -> Self {
-        // Do not disable path compression for non-boundary nodes.
-        SliceVerifyReadWritePathNode(Some(ReadWritePathNode::new(
-            basic_node,
-            parent_node.as_ref(),
-            value_size,
-        )))
-    }
-
-    fn get_read_write_path_node(&mut self) -> &mut ReadWritePathNode<Mpt> {
-        self.as_mut()
-    }
-
-    fn get_read_only_path_node(&self) -> &ReadWritePathNode<Mpt> {
-        self.as_ref()
-    }
-
-    fn unmatched_child_node_for_path_diversion(
-        self, new_path_db_key: CompressedPathRaw,
+    fn unmatched_child_node_for_path_diversion<Mpt: GetRwMpt>(
+        self, mpt: &mut Mpt, new_path_db_key: CompressedPathRaw,
         new_compressed_path: CompressedPathRaw,
-    ) -> Result<ReadWritePathNode<Mpt>>
+    ) -> Result<ReadWritePathNode>
     {
         self.take().unmatched_child_node_for_path_diversion(
+            mpt,
             new_path_db_key,
             new_compressed_path,
         )
@@ -115,14 +114,14 @@ impl<Mpt: GetRwMpt> RwPathNodeTrait<Mpt> for SliceVerifyReadWritePathNode<Mpt> {
 }
 
 impl<Mpt: GetRwMpt, Cursor: CursorLoadNodeWrapper<Mpt> + CursorSetIoError>
-    CursorToRootNode<Mpt, SliceVerifyReadWritePathNode<Mpt>> for Cursor
+    CursorToRootNode<Mpt, SliceVerifyReadWritePathNode> for Cursor
 {
     fn new_root(
-        &self, basic_node: BasicPathNode<Mpt>, mpt_is_empty: bool,
-    ) -> SliceVerifyReadWritePathNode<Mpt> {
+        &self, basic_node: BasicPathNode, mpt_is_empty: bool,
+    ) -> SliceVerifyReadWritePathNode {
         let mut root_node = <Self as CursorToRootNode<
             Mpt,
-            ReadWritePathNode<Mpt>,
+            ReadWritePathNode,
         >>::new_root(self, basic_node, mpt_is_empty);
         root_node.disable_path_compression();
         SliceVerifyReadWritePathNode(Some(root_node))
@@ -135,8 +134,8 @@ use crate::{
         merkle_patricia_trie::{
             mpt_cursor::{
                 BasicPathNode, CursorLoadNodeWrapper, CursorSetIoError,
-                CursorToRootNode, GetReadMpt, GetRwMpt, PathNodeTrait,
-                ReadWritePathNode, RwPathNodeTrait, TakeMpt,
+                CursorToRootNode, GetReadMpt, GetRwMpt, LoadNodeWrapper,
+                PathNodeTrait, ReadWritePathNode, RwPathNodeTrait,
             },
             CompressedPathRaw,
         },

--- a/core/storage/src/impls/state.rs
+++ b/core/storage/src/impls/state.rs
@@ -140,7 +140,7 @@ impl State {
                 let mut mpt = self.snapshot_db.open_snapshot_mpt_shared()?;
                 let mut cursor = MptCursor::<
                     &mut dyn SnapshotMptTraitRead,
-                    BasicPathNode<&mut dyn SnapshotMptTraitRead>,
+                    BasicPathNode,
                 >::new(&mut mpt);
                 cursor.load_root()?;
                 cursor.open_path_for_key::<access_mode::Read>(access_key)?;
@@ -606,7 +606,7 @@ impl StateTraitExt for State {
         let mut mpt = self.snapshot_db.open_snapshot_mpt_shared()?;
         let mut cursor = MptCursor::<
             &mut dyn SnapshotMptTraitRead,
-            BasicPathNode<&mut dyn SnapshotMptTraitRead>,
+            BasicPathNode,
         >::new(&mut mpt);
         cursor.load_root()?;
         let snapshot =
@@ -897,7 +897,10 @@ use crate::{
         delta_mpt::{node_memory_manager::ActualSlabIndex, *},
         errors::*,
         merkle_patricia_trie::{
-            mpt_cursor::{BasicPathNode, CursorOpenPathTerminal, MptCursor},
+            mpt_cursor::{
+                BasicPathNode, CursorOpenPathTerminal, MptCursor,
+                MptCursorPathOps,
+            },
             KVInserter, MptKeyValue, TrieProof, VanillaChildrenTable,
         },
         node_merkle_proof::NodeMerkleProof,

--- a/core/storage/src/impls/storage_db/snapshot_db_sqlite/test_lib.rs
+++ b/core/storage/src/impls/storage_db/snapshot_db_sqlite/test_lib.rs
@@ -39,10 +39,10 @@ pub fn check_key_value_load<Value: MptValueKind>(
     let mut checker_count = 0;
     let mut mpt = snapshot_db.open_snapshot_mpt_shared()?;
 
-    let mut cursor = MptCursor::<
-        &mut dyn SnapshotMptTraitRead,
-        BasicPathNode<&mut dyn SnapshotMptTraitRead>,
-    >::new(&mut mpt);
+    let mut cursor =
+        MptCursor::<&mut dyn SnapshotMptTraitRead, BasicPathNode>::new(
+            &mut mpt,
+        );
     cursor.load_root()?;
     while let Some((access_key, expected_value)) = kv_iter.next()? {
         let terminal =
@@ -73,7 +73,10 @@ use crate::{
     impls::{
         errors::*,
         merkle_patricia_trie::{
-            mpt_cursor::{BasicPathNode, CursorOpenPathTerminal, MptCursor},
+            mpt_cursor::{
+                BasicPathNode, CursorOpenPathTerminal, MptCursor,
+                MptCursorPathOps,
+            },
             TrieNodeTrait,
         },
         storage_db::snapshot_db_sqlite::SnapshotDbSqlite,


### PR DESCRIPTION
Make it an argument instead. This improves readability, and might improve performance slightly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2234)
<!-- Reviewable:end -->
