### PR TITLE
Enable block number index by default

### DIFF
--- a/changelogs/CHANGELOG-1.1.x.md
+++ b/changelogs/CHANGELOG-1.1.x.md
@@ -1,5 +1,10 @@
 # 1.1.6
 
+## Improvements
+
+### Configuration Improvements
+- Enable `persist_block_number_index` on all nodes by default.
+
 ## Bug fixes
 - Fix issue where the block number index is not updated after repeated pivot chain switches. This issue results in `cfx_getBlockByBlockNumber` returning incorrect blocks occasionally. Similarly, log filtering (`cfx_getLogs`) using block numbers is also affected. For this fix to take effect for blocks executed previously, please re-sync the blockchain.
 

--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -278,7 +278,7 @@ build_config! {
         (get_logs_epoch_batch_size, (usize), 32)
         (max_trans_count_received_in_catch_up, (u64), 60_000)
         (persist_tx_index, (bool), false)
-        (persist_block_number_index, (bool), false)
+        (persist_block_number_index, (bool), true)
         (print_memory_usage_period_s, (Option<u64>), None)
         (target_block_gas_limit, (u64), DEFAULT_TARGET_BLOCK_GAS_LIMIT)
         (executive_trace, (bool), false)

--- a/run/tethys.toml
+++ b/run/tethys.toml
@@ -362,7 +362,7 @@ jsonrpc_local_http_port=12539
 # Whether to persist block number indices.
 # This only needs to be enabled if you want to use RPCs that take block numbers as an input.
 #
-# persist_block_number_index = false
+# persist_block_number_index = true
 
 # ---------------- Transaction Cache Parameters -----------------
 


### PR DESCRIPTION
Rationale: As RPCs relying on this parameter become available, more and more dapps will rely on them. Specifically, all dapps developed using Reach need these APIs. I think it's better to enable them by default and allow node operators to opt out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2241)
<!-- Reviewable:end -->
