### PR TITLE
Fix an archive node crash after several restarts.

### DIFF
--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -1736,6 +1736,15 @@ impl ConsensusGraphTrait for ConsensusGraph {
                 &self.data_man.get_cur_consensus_era_stable_hash(),
             )
             .expect("stable exists");
+
+        if self.best_epoch_number() < stable_genesis_height {
+            // For an archive node, if its terminals are overwritten with
+            // earlier blocks during recovery, it's possible to
+            // reach here with a pivot chain before stable era
+            // checkpoint. Here we wait for it to recover the missing headers
+            // after the overwritten terminals.
+            return false;
+        }
         if let Some(target_epoch) = self.config.sync_state_starting_epoch {
             if stable_genesis_height < target_epoch {
                 return false;

--- a/tests/crash_archive_era2000_test.py
+++ b/tests/crash_archive_era2000_test.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+import datetime
+
+from eth_utils import decode_hex
+from rlp.sedes import Binary, BigEndianInt
+
+from conflux import utils
+from conflux.utils import encode_hex, bytes_to_int, priv_to_addr, parse_as_int
+from conflux.rpc import RpcClient
+from test_framework.blocktools import create_block, create_transaction
+from test_framework.test_framework import ConfluxTestFramework
+from test_framework.mininode import *
+from test_framework.util import *
+
+
+# This test is the same as `crash_test.py` except that nodes are launched as archive nodes instead of full nodes
+class CrashArchiveNodeTest(ConfluxTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.conf_parameters["adaptive_weight_beta"] = "1"
+        self.conf_parameters["timer_chain_block_difficulty_ratio"] = "3"
+        self.conf_parameters["timer_chain_beta"] = "10"
+        self.conf_parameters["era_epoch_count"] = "2000"
+        self.conf_parameters["dev_snapshot_epoch_count"] = "20000"
+        self.conf_parameters["anticone_penalty_ratio"] = "8"
+        self.conf_parameters["dev_allow_phase_change_without_peer"] = "false"
+
+    def setup_nodes(self):
+        self.add_nodes(self.num_nodes)
+        for i in range(self.num_nodes):
+            self.start_node(i, phase_to_wait=None)
+
+    def setup_network(self):
+        self.setup_nodes()
+        # Make all nodes fully connected, so a crashed archive node can be connected to another
+        # archive node to catch up
+        connect_sample_nodes(self.nodes, self.log, sample=self.num_nodes - 1)
+        sync_blocks(self.nodes)
+        for node in self.nodes:
+            node.wait_for_recovery(["NormalSyncPhase"], 30)
+
+    def run_test(self):
+        self.nodes[0].generate_empty_blocks(5000)
+        self.stop_node(0)
+        self.start_node(0, phase_to_wait=None)
+        self.stop_node(0)
+        self.start_node(0)
+        self.log.info("Pass 1")
+
+
+if __name__ == "__main__":
+    CrashArchiveNodeTest().main()


### PR DESCRIPTION
If an archive node is stopped during `CatchUpRecoverBlockHeaderFromDbPhase` while restarting, it may fail to be restarted again because its terminals have been overwritten by an earlier value during recovery.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2244)
<!-- Reviewable:end -->
