### PR TITLE
Change BLS Pubkey to uncompressed encoding and decrease peer count.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,7 +480,7 @@ dependencies = [
 [[package]]
 name = "bls-signatures"
 version = "0.11.1"
-source = "git+https://github.com/Conflux-Chain/bls-signatures.git?rev=3fba9589b0413a10db9c88b46de61956673d7cf8#3fba9589b0413a10db9c88b46de61956673d7cf8"
+source = "git+https://github.com/Conflux-Chain/bls-signatures.git?rev=d9b1d575c15bc63b502beddcb7d470c35343af41#d9b1d575c15bc63b502beddcb7d470c35343af41"
 dependencies = [
  "bls12_381",
  "blst",

--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -198,7 +198,7 @@ build_config! {
         (max_chunk_number_in_manifest, (usize), 500)
         (max_downloading_chunks, (usize), 8)
         (max_handshakes, (usize), 64)
-        (max_incoming_peers, (usize), 64)
+        (max_incoming_peers, (usize), 48)
         (max_inflight_request_count, (u64), 64)
         (max_outgoing_peers, (usize), 8)
         (max_outgoing_peers_archive, (Option<usize>), None)

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -92,7 +92,7 @@ strum_macros = "0.20"
 smart-default = "0.6.0"
 #bls-signatures = {path = "/Users/lipeilun/conflux/bls-signatures"}
 #bls-signatures = {path = "/Users/lipeilun/conflux/bls-signatures",default-features = false, features = ["blst", "multicore"]}
-bls-signatures = {git = "https://github.com/Conflux-Chain/bls-signatures.git", rev = "3fba9589b0413a10db9c88b46de61956673d7cf8", default-features = false, features = ["multicore"]}
+bls-signatures = {git = "https://github.com/Conflux-Chain/bls-signatures.git", rev = "d9b1d575c15bc63b502beddcb7d470c35343af41", default-features = false, features = ["multicore"]}
 tiny-keccak = {version = "2.0",  features = ["keccak"]}
 bcs = "0.1.2"
 async-trait = "0.1"

--- a/core/src/pos/crypto/crypto/Cargo.toml
+++ b/core/src/pos/crypto/crypto/Cargo.toml
@@ -36,7 +36,7 @@ diem-crypto-derive = { path = "../crypto-derive", version = "0.1.0" }
 bcs = "0.1.2"
 cfxkey = { path = "../../../../../accounts/cfxkey" }
 cfx-types = { path = "../../../../../cfx_types" }
-bls-signatures = {git = "https://github.com/Conflux-Chain/bls-signatures.git", rev = "3fba9589b0413a10db9c88b46de61956673d7cf8", default-features = false, features = ["multicore"]}
+bls-signatures = {git = "https://github.com/Conflux-Chain/bls-signatures.git", rev = "d9b1d575c15bc63b502beddcb7d470c35343af41", default-features = false, features = ["multicore"]}
 #bls-signatures = {path = "/Users/lipeilun/conflux/bls-signatures",default-features = false, features = ["blst", "multicore"]}
 #bls-signatures = {path = "/Users/lipeilun/conflux/bls-signatures"}
 vrf = "0.2.2"

--- a/core/src/pos/crypto/crypto/benches/bls.rs
+++ b/core/src/pos/crypto/crypto/benches/bls.rs
@@ -20,9 +20,14 @@ fn decode(c: &mut Criterion) {
     let msg = TestDiemCrypto("".to_string());
     let sig: BLSSignature = priv_key.sign(&msg);
     let sig_bytes = sig.to_bytes();
+    let pub_key = priv_key.public_key();
+    let pub_key_bytes = pub_key.to_bytes();
 
-    c.bench_function("bls signature decoding", move |b| {
+    c.bench_function("bls signature decode", move |b| {
         b.iter(|| BLSSignature::try_from(sig_bytes.as_slice()).unwrap())
+    });
+    c.bench_function("bls pubkey decode", move |b| {
+        b.iter(|| BLSPublicKey::try_from(pub_key_bytes.as_slice()).unwrap())
     });
 }
 

--- a/run/tethys.toml
+++ b/run/tethys.toml
@@ -224,7 +224,7 @@ jsonrpc_local_http_port=12539
 
 # Maximum number of incoming connections.
 #
-# max_incoming_peers = 64
+# max_incoming_peers = 48
 
 # Maximum number of outgoing connections.
 #


### PR DESCRIPTION
The deserializing time of `BLSPublicKey` is reduced by 25% while the size is doubled. However, since public keys are always kept with signatures in transactions, the total size increase for a transaction is small. And currently the CPU is more likely a bottleneck for running PoS instead of the disk space.

We also decrease the peer count from 64 to 48 to reduce the cost to process received redundant broadcasts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2271)
<!-- Reviewable:end -->
