### PR TITLE
Enable rolling file writer for pos log.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "aead"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,6 +1809,8 @@ dependencies = [
  "erased-serde",
  "hostname",
  "once_cell",
+ "parking_lot 0.11.2",
+ "pipe-logger-lib",
  "prometheus 0.12.0",
  "serde",
  "serde_json",
@@ -3494,6 +3502,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
+name = "libflate"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16364af76ebb39b5869bb32c81fa93573267cd8c62bb3474e28d78fac3fb141e"
+dependencies = [
+ "adler32",
+ "crc32fast",
+ "libflate_lz77",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a734c0493409afcd49deee13c006a04e3586b9761a03543c6272c9c51f2f5a"
+dependencies = [
+ "rle-decode-fast",
+]
+
+[[package]]
 name = "libloading"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4412,6 +4440,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "path-absolutize"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b288298a7a3a7b42539e3181ba590d32f2d91237b0691ed5f103875c754b3bf5"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bfa72956f6be8524f7f7e2b07972dda393cb0008a6df4451f658b7e1bd1af80"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "path-slash"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4513,6 +4559,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pipe-logger-lib"
+version = "1.1.13"
+source = "git+https://github.com/aleksuss/pipe-logger-lib.git?rev=3ff3550fc7e46d6e530daf1a47471c6628baa43d#3ff3550fc7e46d6e530daf1a47471c6628baa43d"
+dependencies = [
+ "chrono",
+ "libflate",
+ "path-absolutize",
+ "regex",
+]
 
 [[package]]
 name = "pkcs5"
@@ -5124,6 +5181,12 @@ dependencies = [
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
+
+[[package]]
+name = "rle-decode-fast"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 
 [[package]]
 name = "rlp"

--- a/core/src/pos/common/logger/Cargo.toml
+++ b/core/src/pos/common/logger/Cargo.toml
@@ -22,3 +22,5 @@ once_cell = "1.7.2"
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 prometheus = { version = "0.12.0", default-features = false }
+pipe-logger-lib = {git = "https://github.com/aleksuss/pipe-logger-lib.git", rev = "3ff3550fc7e46d6e530daf1a47471c6628baa43d", default-features = false, features = ["gzip"]}
+parking_lot = "0.11"

--- a/core/src/pos/common/logger/src/lib.rs
+++ b/core/src/pos/common/logger/src/lib.rs
@@ -160,7 +160,7 @@
 pub mod prelude {
     pub use crate::{
         debug as diem_debug,
-        diem_logger::FileWriter,
+        diem_logger::{FileWriter, RollingFileWriter},
         error as diem_error, event, info as diem_info, sample as diem_sample,
         sample::{SampleRate, Sampling},
         security::SecurityEvent,

--- a/core/src/pos/config/src/config/logger_config.rs
+++ b/core/src/pos/config/src/config/logger_config.rs
@@ -19,6 +19,12 @@ pub struct LoggerConfig {
     // The default logging level for slog.
     pub level: Level,
     pub file: Option<PathBuf>,
+    // If this is None, we will not enable file rotation and
+    // `rotation_file_size_mb` will not be used.
+    pub rotation_count: Option<usize>,
+    // The maximal file size before rotation.
+    // The default value is set to 500MB.
+    pub rotation_file_size_mb: Option<usize>,
 }
 
 impl Default for LoggerConfig {
@@ -28,6 +34,8 @@ impl Default for LoggerConfig {
             is_async: true,
             level: Level::Info,
             file: None,
+            rotation_count: None,
+            rotation_file_size_mb: None,
         }
     }
 }


### PR DESCRIPTION
By default, pos log is written to a single file without compression.

This PR allows PoS logs to be rotated and compressed like PoW logs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2279)
<!-- Reviewable:end -->
