### PR TITLE
Remove checking of staking events in epoch execution update.

### DIFF
--- a/core/src/block_data_manager/mod.rs
+++ b/core/src/block_data_manager/mod.rs
@@ -49,7 +49,6 @@ use cfx_internal_common::{
     EpochExecutionCommitment, StateAvailabilityBoundary, StateRootWithAuxInfo,
 };
 use db_gc_manager::GCProgress;
-use diem_types::block_info::PivotBlockDecision;
 use metrics::{register_meter_with_group, Meter, MeterTimer};
 use primitives::pos::PosBlockId;
 use std::{hash::Hash, path::Path, time::Duration};
@@ -1307,34 +1306,18 @@ impl BlockDataManager {
             }
             let me_height = self.block_height_by_hash(epoch_hash).unwrap();
             if pos_verifier.pos_option().is_some() && me_height != 0 {
-                let parent_hash = *self
-                    .block_header_by_hash(epoch_hash)
-                    .unwrap()
-                    .parent_hash();
-                if let Err(e) = pos_verifier.consensus_db().get_staking_events(
-                    PivotBlockDecision {
-                        height: me_height - 1,
-                        block_hash: parent_hash,
-                    },
-                    PivotBlockDecision {
-                        height: me_height,
-                        block_hash: *epoch_hash,
-                    },
+                trace!(
+                    "staking events update: height={}, new={}",
+                    me_height,
+                    epoch_hash,
+                );
+                if let Err(e) = pos_verifier.consensus_db().put_staking_events(
+                    me_height,
+                    *epoch_hash,
+                    epoch_staking_events,
                 ) {
-                    debug!(
-                        "staking events update: height={}, new={}, err={:?}",
-                        me_height, epoch_hash, e
-                    );
-                    if let Err(e) =
-                        pos_verifier.consensus_db().put_staking_events(
-                            me_height,
-                            *epoch_hash,
-                            epoch_staking_events,
-                        )
-                    {
-                        error!("epoch_executed err={:?}", e);
-                        return false;
-                    }
+                    error!("epoch_executed err={:?}", e);
+                    return false;
                 }
             }
         }

--- a/core/src/block_data_manager/mod.rs
+++ b/core/src/block_data_manager/mod.rs
@@ -534,6 +534,7 @@ impl BlockDataManager {
         persistent: bool,
     )
     {
+        trace! {"insert_block_traces start pivot={:?}", pivot_hash};
         self.insert_version(
             hash,
             &pivot_hash,
@@ -545,6 +546,7 @@ impl BlockDataManager {
             CacheId::BlockTraces(hash),
             persistent,
         );
+        trace! {"insert_block_traces ends pivot={:?}", pivot_hash};
     }
 
     /// remove block traces in memory cache and db
@@ -675,6 +677,7 @@ impl BlockDataManager {
         persistent: bool,
     )
     {
+        trace! {"insert_block_traces start pivot={:?}", epoch};
         let bloom =
             block_receipts
                 .receipts
@@ -698,6 +701,7 @@ impl BlockDataManager {
             CacheId::BlockReceipts(hash),
             persistent,
         );
+        trace! {"insert_block_traces end pivot={:?}", epoch};
     }
 
     pub fn insert_block_reward_result(

--- a/core/src/consensus/consensus_inner/consensus_executor.rs
+++ b/core/src/consensus/consensus_inner/consensus_executor.rs
@@ -1359,7 +1359,7 @@ impl ConsensusExecutionHandler {
                         }
 
                         if self.pos_verifier.pos_option().is_some() {
-                            debug!("Check {} events", transaction_logs.len());
+                            trace!("Check {} events", transaction_logs.len());
                             for log in &transaction_logs {
                                 if let Some(staking_event) =
                                     decode_register_info(log)
@@ -1367,6 +1367,7 @@ impl ConsensusExecutionHandler {
                                     epoch_staking_events.push(staking_event);
                                 }
                             }
+                            trace!("Check events ends");
                         }
                     }
                 }

--- a/tests/pos/hard_fork_test.py
+++ b/tests/pos/hard_fork_test.py
@@ -92,7 +92,7 @@ class ExampleTest(ConfluxTestFramework):
         initialize_tg_config(self.options.tmpdir, len(self.nodes), len(self.nodes), DEFAULT_PY_TEST_CHAIN_ID, pkfile="public_keys")
 
         # generate blocks until pos start
-        self.nodes[0].generate_empty_blocks(400)
+        self.nodes[0].generate_empty_blocks(500)
         sync_blocks(self.nodes)
         pos_identifier, _ = client.wait_for_pos_register()
         client.generate_empty_blocks(400)


### PR DESCRIPTION
Writing staking events without checking first is more efficient since we have changed the put operation of staking events into async patterns.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2290)
<!-- Reviewable:end -->
