### PR TITLE
Remove default dev mode ports to fix flasky test dev-mode-test

### DIFF
--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -97,9 +97,8 @@ build_config! {
         //
         // `dev` mode is for users to run a single node that automatically
         //     generates blocks with fixed intervals
-        //     * Open port 12535 for ws rpc if `jsonrpc_ws_port` is not provided.
-        //     * Open port 12536 for tcp rpc if `jsonrpc_tcp_port` is not provided.
-        //     * Open port 12537 for http rpc if `jsonrpc_http_port` is not provided.
+        //     * You are expected to also set `jsonrpc_ws_port`, `jsonrpc_tcp_port`,
+        //       and `jsonrpc_http_port` if you want RPC functionalities.
         //     * generate blocks automatically without PoW.
         //     * Skip catch-up mode even there is no peer
         //
@@ -371,17 +370,6 @@ impl Configuration {
         let mut config = Configuration::default();
         config.raw_conf = RawConfiguration::parse(matches)?;
 
-        if config.is_dev_mode() {
-            if config.raw_conf.jsonrpc_ws_port.is_none() {
-                config.raw_conf.jsonrpc_ws_port = Some(12535);
-            }
-            if config.raw_conf.jsonrpc_tcp_port.is_none() {
-                config.raw_conf.jsonrpc_tcp_port = Some(12536);
-            }
-            if config.raw_conf.jsonrpc_http_port.is_none() {
-                config.raw_conf.jsonrpc_http_port = Some(12537);
-            }
-        };
         if matches.is_present("archive") {
             config.raw_conf.node_type = Some(NodeType::Archive);
         } else if matches.is_present("full") {

--- a/run/tethys.toml
+++ b/run/tethys.toml
@@ -27,9 +27,8 @@ bootnodes="cfxnode://dc79bc70833e797ba41eff5bda67c0484abca4918ef38289b5f96acd3da
 #
 # `dev` mode is for users to run a single node that automatically
 #     generates blocks with fixed intervals
-#     * Open port 12535 for ws rpc if `jsonrpc_ws_port` is not provided.
-#     * Open port 12536 for tcp rpc if `jsonrpc_tcp_port` is not provided.
-#     * Open port 12537 for http rpc if `jsonrpc_http_port` is not provided.
+#     * You are expected to also set `jsonrpc_ws_port`, `jsonrpc_tcp_port`,
+#       and `jsonrpc_http_port` if you want RPC functionalities.
 #     * generate blocks without PoW (either after receiving a transaction or
 #       in fixed period, see ``dev_block_interval_ms'')
 #     * Skip catch-up mode even there is no peer

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -40,6 +40,7 @@ def run_single_test(py, script, test_dir, index, port_min, port_max):
     except subprocess.CalledProcessError as err:
         color = RED
         glyph = CROSS
+        print(color[1] + glyph + " Testcase " + script + color[0])
         print("Output of " + script + "\n" + err.output.decode("utf-8"))
         raise err
     print(color[1] + glyph + " Testcase " + script + color[0])


### PR DESCRIPTION
In future, just set JSONRPC configurations when use dev mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2328)
<!-- Reviewable:end -->
