### PR TITLE
Limit EVM Space tx at the tx pool

### DIFF
--- a/blockgen/src/lib.rs
+++ b/blockgen/src/lib.rs
@@ -309,6 +309,7 @@ impl BlockGenerator {
         let transactions = self.txpool.pack_transactions(
             num_txs,
             block_gas_limit,
+            U256::zero(),
             block_size_limit,
             best_info.best_epoch_number,
             best_info.best_block_number,

--- a/core/parameters/src/lib.rs
+++ b/core/parameters/src/lib.rs
@@ -199,11 +199,11 @@ pub mod block {
     // The following parameter controls how many blocks are allowed to
     // contain EVM Space transactions. Setting it to N means that one block
     // must has a height of the multiple of N to contain EVM transactions.
-    pub const EVM_TRANSACTION_BLOCK_RATIO: usize = 10;
+    pub const EVM_TRANSACTION_BLOCK_RATIO: u64 = 10;
     // The following parameter controls the ratio of gas limit allowed for
     // EVM space transactions. Setting it to N means that only 1/N of th
     // block gas limit can be used for EVM transaction enabled blocks.
-    pub const EVM_TRANSACTION_GAS_RATIO: usize = 2;
+    pub const EVM_TRANSACTION_GAS_RATIO: u64 = 2;
 }
 
 pub mod staking {

--- a/core/parameters/src/lib.rs
+++ b/core/parameters/src/lib.rs
@@ -196,6 +196,14 @@ pub mod block {
     // FIXME: a block generator parameter only. We should remove this later
     pub const MAX_TRANSACTION_COUNT_PER_BLOCK: usize = 20000;
     pub const DEFAULT_TARGET_BLOCK_GAS_LIMIT: u64 = GENESIS_GAS_LIMIT;
+    // The following parameter controls how many blocks are allowed to
+    // contain EVM Space transactions. Setting it to N means that one block
+    // must has a height of the multiple of N to contain EVM transactions.
+    pub const EVM_TRANSACTION_BLOCK_RATIO: usize = 10;
+    // The following parameter controls the ratio of gas limit allowed for
+    // EVM space transactions. Setting it to N means that only 1/N of th
+    // block gas limit can be used for EVM transaction enabled blocks.
+    pub const EVM_TRANSACTION_GAS_RATIO: usize = 2;
 }
 
 pub mod staking {

--- a/core/src/transaction_pool/mod.rs
+++ b/core/src/transaction_pool/mod.rs
@@ -606,8 +606,9 @@ impl TransactionPool {
     }
 
     pub fn pack_transactions<'a>(
-        &self, num_txs: usize, block_gas_limit: U256, block_size_limit: usize,
-        mut best_epoch_height: u64, mut best_block_number: u64,
+        &self, num_txs: usize, block_gas_limit: U256, evm_gas_limit: U256,
+        block_size_limit: usize, mut best_epoch_height: u64,
+        mut best_block_number: u64,
     ) -> Vec<Arc<SignedTransaction>>
     {
         let mut inner = self.inner.write_with_metric(&PACK_TRANSACTION_LOCK);
@@ -617,6 +618,7 @@ impl TransactionPool {
         inner.pack_transactions(
             num_txs,
             block_gas_limit,
+            evm_gas_limit,
             block_size_limit,
             best_epoch_height,
             best_block_number,
@@ -787,10 +789,17 @@ impl TransactionPool {
 
         let target_gas_limit = self.config.target_block_gas_limit.into();
         let self_gas_limit = min(max(target_gas_limit, gas_lower), gas_upper);
+        let evm_gas_limit =
+            if (consensus_best_info_clone.best_epoch_number + 1) % 10 == 0 {
+                self_gas_limit / 2
+            } else {
+                U256::zero()
+            };
 
         let transactions_from_pool = self.pack_transactions(
             num_txs,
             self_gas_limit.clone(),
+            evm_gas_limit,
             block_size_limit,
             consensus_best_info_clone.best_epoch_number,
             consensus_best_info_clone.best_block_number,

--- a/core/src/transaction_pool/transaction_pool_inner.rs
+++ b/core/src/transaction_pool/transaction_pool_inner.rs
@@ -912,7 +912,7 @@ impl TransactionPoolInner {
 
     /// pack at most num_txs transactions randomly
     pub fn pack_transactions<'a>(
-        &mut self, num_txs: usize, block_gas_limit: U256,
+        &mut self, num_txs: usize, block_gas_limit: U256, evm_gas_limit: U256,
         block_size_limit: usize, best_epoch_height: u64,
         best_block_number: u64, verification_config: &VerificationConfig,
         machine: &Machine,
@@ -924,15 +924,23 @@ impl TransactionPoolInner {
         }
 
         let mut total_tx_gas_limit: U256 = 0.into();
+        let mut eth_total_tx_gas_limit: U256 = 0.into();
         let mut total_tx_size: usize = 0;
 
         let mut big_tx_resample_times_limit = 10;
+        let mut eth_tx_resample_times_limit = 10;
+
+        let mut sample_eth_tx = (evm_gas_limit > U256::zero());
         let mut recycle_txs = Vec::new();
 
         let spec = machine.spec(best_block_number);
         let transitions = &machine.params().transition_heights;
 
-        'out: while let Some(tx) = self.ready_account_pool.pop() {
+        'out: while let Some(tx) = if sample_eth_tx {
+            self.ready_account_pool.pop()
+        } else {
+            self.ready_account_pool.pop_native()
+        } {
             let tx_size = tx.rlp_size();
             if block_gas_limit - total_tx_gas_limit < *tx.gas_limit()
                 || block_size_limit - total_tx_size < tx_size
@@ -943,6 +951,17 @@ impl TransactionPoolInner {
                     continue 'out;
                 } else {
                     break 'out;
+                }
+            }
+            if tx.space() == Space::Ethereum {
+                if eth_gas_limit - eth_total_tx_gas_limit < *tx.gas_limit() {
+                    recycle_txs.push(tx.clone());
+                    if eth_tx_resample_times_limit > 0 {
+                        eth_tx_resample_times_limit -= 1;
+                    } else {
+                        sample_eth_tx = false;
+                    }
+                    continue 'out;
                 }
             }
 
@@ -964,6 +983,9 @@ impl TransactionPoolInner {
             }
 
             total_tx_gas_limit += *tx.gas_limit();
+            if tx.space() == Space::Ethereum {
+                eth_total_tx_gas_limit += *tx.gas_limit();
+            }
             total_tx_size += tx_size;
 
             packed_transactions.push(tx.clone());

--- a/core/src/transaction_pool/transaction_pool_inner.rs
+++ b/core/src/transaction_pool/transaction_pool_inner.rs
@@ -930,7 +930,7 @@ impl TransactionPoolInner {
         let mut big_tx_resample_times_limit = 10;
         let mut eth_tx_resample_times_limit = 10;
 
-        let mut sample_eth_tx = (evm_gas_limit > U256::zero());
+        let mut sample_eth_tx = evm_gas_limit > U256::zero();
         let mut recycle_txs = Vec::new();
 
         let spec = machine.spec(best_block_number);
@@ -954,7 +954,7 @@ impl TransactionPoolInner {
                 }
             }
             if tx.space() == Space::Ethereum {
-                if eth_gas_limit - eth_total_tx_gas_limit < *tx.gas_limit() {
+                if evm_gas_limit - eth_total_tx_gas_limit < *tx.gas_limit() {
                     recycle_txs.push(tx.clone());
                     if eth_tx_resample_times_limit > 0 {
                         eth_tx_resample_times_limit -= 1;

--- a/tests/web3_test.py
+++ b/tests/web3_test.py
@@ -89,7 +89,7 @@ class Web3Test(ConfluxTestFramework):
 
         client = RpcClient(self.nodes[0])
         client.generate_block(1)
-        client.generate_blocks(10)
+        client.generate_blocks(20, 1)
         receipt = self.w3.eth.waitForTransactionReceipt(tx_hash)
         assert_equal(receipt["status"], 1)
 


### PR DESCRIPTION
Only 1/10 blocks can pack EVM space tx.
Only half of the block gas for these blocks can be used.

All configurable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2331)
<!-- Reviewable:end -->
