### PR TITLE
Do not crash in StorageKey::from_key_bytes::<CheckInput>

### DIFF
--- a/primitives/src/storage_key.rs
+++ b/primitives/src/storage_key.rs
@@ -318,6 +318,16 @@ where FromKeyBytesResult<ShouldCheckInput>: ConditionalReturnValue<'a>{
 
             let extension_bit: bool = bytes[Self::ACCOUNT_BYTES] & 0x80 != 0;
             let bytes = if extension_bit {
+                // check for incorrect extension byte
+                if ShouldCheckInput::value() == CheckInput::value()
+                    && bytes[Self::ACCOUNT_BYTES] != Self::EVM_SPACE_TYPE[0]
+                {
+                    return <FromKeyBytesResult<ShouldCheckInput> as ConditionalReturnValue<'a>>::from_result(
+                        Err(format!("Unexpected extension byte: {:?}", bytes[Self::ACCOUNT_BYTES]))
+                    );
+                }
+
+                // with `SkipInputCheck`, crash on incorrect extension byte
                 assert_eq!(bytes[Self::ACCOUNT_BYTES], Self::EVM_SPACE_TYPE[0]);
                 &bytes[(Self::ACCOUNT_BYTES + 1)..]
             } else {


### PR DESCRIPTION
When calling `StorageKey::from_key_bytes::<CheckInput>`, the caller assumes that this call will not crash but returns an error instead. Currently, errors can only be triggered on light nodes that might receive the raw key from their peers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2336)
<!-- Reviewable:end -->
