### PR TITLE
Do not prune staking events for now to avoid OOM issues.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "cfx-types"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ethereum-types 0.9.2",
  "rlp",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "cfxcore"
-version = "1.1.4"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "async-oneshot",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "1.1.4"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "app_dirs",
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "conflux"
-version = "1.1.4"
+version = "2.0.0"
 dependencies = [
  "app_dirs",
  "base64ct",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "primitives"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "byteorder",
  "cfx-bytes",

--- a/core/src/pos/consensus/block_storage/block_store.rs
+++ b/core/src/pos/consensus/block_storage/block_store.rs
@@ -226,8 +226,6 @@ impl BlockStore {
     ) -> anyhow::Result<()> {
         let block_id_to_commit =
             finality_proof.ledger_info().consensus_block_id();
-        let pivot_decision_to_commit =
-            finality_proof.ledger_info().pivot_decision().cloned();
         diem_debug!("BlockStore::commit: id={}", block_id_to_commit);
         let block_to_commit = self
             .get_block(block_id_to_commit)
@@ -278,9 +276,8 @@ impl BlockStore {
         // After a block is committed, we will never need to execute a block
         // with an earlier pivot decision, so we can safely prune all
         // staking events before.
-        if let Some(pivot_decision) = pivot_decision_to_commit {
-            self.storage.prune_staking_events(&pivot_decision)?;
-        }
+        // TODO: Delete range causes OOM now. Prune staking events after the
+        // rocksdb issue is solved.
         Ok(())
     }
 


### PR DESCRIPTION
Currently calling `delete_range` seems to cause the rocksdb memory usage to exceed our expected value, so just disable this to see if the memory usage returns to normal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2342)
<!-- Reviewable:end -->
