### PR TITLE
Try to fix random failure of `sponsored_tx_test.py`.

### DIFF
--- a/tests/sponsored_tx_test.py
+++ b/tests/sponsored_tx_test.py
@@ -233,6 +233,8 @@ class SponsoredTxTest(ConfluxTestFramework):
         assert_equal(tx_info['local_balance_enough'], False)
         assert_equal(tx_info['packed'], False)
 
+        # Wait for 2 seconds so previous asynchronous `txpool.notify_modified_accounts()` calls can finish.
+        time.sleep(2)
         # send 1025 * 10 ** 18 // 1024 CFX to addr1
         tx = client.new_tx(
             sender=genesis_addr,


### PR DESCRIPTION
`notify_modified_accounts` is called in a spawned thread after executing an epoch. If we are generating blocks fast, it's possible that they are not executed in order, and in this case tx pool will be updated with an old account state (like account nonce).

This is not an issue in production because tx pool account state is not assumed to be always correct, and is updated in many other cases, so we just add some wait time here so this is less likely to happen in the test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2358)
<!-- Reviewable:end -->
