### PR TITLE
Automatic proxy `eth_*` RPCs to eth endpoint.

### DIFF
--- a/tests/evm_space/log_filtering_test.py
+++ b/tests/evm_space/log_filtering_test.py
@@ -57,7 +57,7 @@ class CrossSpaceLogFilteringTest(ConfluxTestFramework):
         self.evmAccount = self.w3.eth.account.privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
         print(f'Using EVM account {self.evmAccount.address}')
         self.cross_space_transfer(self.evmAccount.address, 1 * 10 ** 18)
-        assert_equal(self.nodes[0].ethrpc.eth_getBalance(self.evmAccount.address), hex(1 * 10 ** 18))
+        assert_equal(self.nodes[0].eth_getBalance(self.evmAccount.address), hex(1 * 10 ** 18))
 
         # deploy Conflux space contract
         confluxContractAddr = self.deploy_conflux_space(CONFLUX_CONTRACT_PATH)
@@ -166,7 +166,7 @@ class CrossSpaceLogFilteringTest(ConfluxTestFramework):
         # check EVM events
         # we expect 4 events: #12, #13, #15, #16
         filter = { "topics": [TEST_EVENT_TOPIC], "fromBlock": epoch_a, "toBlock": epoch_b }
-        logs = self.nodes[0].ethrpc.eth_getLogs(filter)
+        logs = self.nodes[0].eth_getLogs(filter)
         assert_equal(len(logs), 4)
 
         # emitBoth: TestEvent(12)
@@ -218,7 +218,7 @@ class CrossSpaceLogFilteringTest(ConfluxTestFramework):
         # check EVM events
         # we expect 4 events: #22, #23, #25, #26
         filter = { "topics": [TEST_EVENT_TOPIC], "fromBlock": epoch_e, "toBlock": epoch_e }
-        logs = self.nodes[0].ethrpc.eth_getLogs(filter)
+        logs = self.nodes[0].eth_getLogs(filter)
         assert_equal(len(logs), 4)
 
         # emitBoth: TestEvent(22)
@@ -269,37 +269,37 @@ class CrossSpaceLogFilteringTest(ConfluxTestFramework):
         # --------------- other fields ---------------
         # filter by block hash
         filter = { "topics": [TEST_EVENT_TOPIC], "blockHash": block_c }
-        logs_2 = self.nodes[0].ethrpc.eth_getLogs(filter)
+        logs_2 = self.nodes[0].eth_getLogs(filter)
         assert_equal(logs_2, [])
 
         filter = { "topics": [TEST_EVENT_TOPIC], "blockHash": block_d } # from EVM perspective, D does not exist
         assert_raises_rpc_error(None, None, self.nodes[0].eth_getLogs, filter)
 
         filter = { "topics": [TEST_EVENT_TOPIC], "blockHash": block_e }
-        logs_2 = self.nodes[0].ethrpc.eth_getLogs(filter)
+        logs_2 = self.nodes[0].eth_getLogs(filter)
         assert_equal(logs_2, logs)
 
         # filter limit
         filter = { "topics": [TEST_EVENT_TOPIC], "blockHash": block_e, "limit": 1 }
-        logs_2 = self.nodes[0].ethrpc.eth_getLogs(filter)
+        logs_2 = self.nodes[0].eth_getLogs(filter)
         assert_equal(logs_2, [logs[-1]])
 
         # "earliest", "latest"
         filter = { "topics": [TEST_EVENT_TOPIC], "fromBlock": "earliest", "toBlock": "latest" }
-        logs_2 = self.nodes[0].ethrpc.eth_getLogs(filter)
+        logs_2 = self.nodes[0].eth_getLogs(filter)
         assert_equal(len(logs_2), 8)
 
         filter = { "topics": [TEST_EVENT_TOPIC], "fromBlock": "earliest", "toBlock": "latest", "limit": 4 }
-        logs_2 = self.nodes[0].ethrpc.eth_getLogs(filter)
+        logs_2 = self.nodes[0].eth_getLogs(filter)
         assert_equal(logs_2, logs)
 
         # address
         filter = { "address": confluxContractAddr }
-        logs_2 = self.nodes[0].ethrpc.eth_getLogs(filter)
+        logs_2 = self.nodes[0].eth_getLogs(filter)
         assert_equal(logs_2, [])
 
         filter = { "address": evmContractAddr}
-        logs_2 = self.nodes[0].ethrpc.eth_getLogs(filter)
+        logs_2 = self.nodes[0].eth_getLogs(filter)
         assert_equal(len(logs_2), 8)
 
         self.log.info("Pass")

--- a/tests/test_framework/test_node.py
+++ b/tests/test_framework/test_node.py
@@ -108,7 +108,10 @@ class TestNode:
         """Dispatches any unrecognised messages to the RPC connection."""
         assert self.rpc_connected and self.rpc is not None, self._node_msg(
             "Error: no RPC connection")
-        return getattr(self.rpc, name)
+        if name.startswith("eth_"):
+            return getattr(self.ethrpc, name)
+        else:
+            return getattr(self.rpc, name)
 
     def best_block_hash(self) -> str:
         return self.cfx_getBestBlockHash()


### PR DESCRIPTION
Other eth RPCs that do not start with `eth` still need to use `ethrpc`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2380)
<!-- Reviewable:end -->
