### PR TITLE
Encode transaction outcome as enum

### DIFF
--- a/client/src/rpc/types/block.rs
+++ b/client/src/rpc/types/block.rs
@@ -12,13 +12,8 @@ use cfxcore::{
 };
 use jsonrpc_core::Error as RpcError;
 use primitives::{
-    receipt::{
-        TRANSACTION_OUTCOME_EXCEPTION_WITHOUT_NONCE_BUMPING,
-        TRANSACTION_OUTCOME_EXCEPTION_WITH_NONCE_BUMPING,
-        TRANSACTION_OUTCOME_SUCCESS,
-    },
     Block as PrimitiveBlock, BlockHeader as PrimitiveBlockHeader,
-    BlockHeaderBuilder, TransactionIndex,
+    BlockHeaderBuilder, TransactionIndex, TransactionOutcome,
 };
 use serde::{
     de::{Deserialize, Deserializer, Error, Unexpected},
@@ -227,8 +222,7 @@ impl Block {
                                         execution_result.block_receipts.receipts[idx - 1].accumulated_gas_used
                                     };
                                     match receipt.outcome_status {
-                                        TRANSACTION_OUTCOME_SUCCESS
-                                        | TRANSACTION_OUTCOME_EXCEPTION_WITH_NONCE_BUMPING => {
+                                        TransactionOutcome::Success | TransactionOutcome::Failure => {
                                             let tx_index = TransactionIndex {
                                                 block_hash: b.hash(),
                                                 index: idx,
@@ -254,11 +248,8 @@ impl Block {
                                                 network,
                                             )
                                         }
-                                        TRANSACTION_OUTCOME_EXCEPTION_WITHOUT_NONCE_BUMPING => {
+                                        TransactionOutcome::Skipped => {
                                             Transaction::from_signed(tx, None, network)
-                                        }
-                                        _ => {
-                                            unreachable!();
                                         }
                                     }
                                 })

--- a/client/src/rpc/types/eth/block.rs
+++ b/client/src/rpc/types/eth/block.rs
@@ -259,7 +259,8 @@ impl Block {
                         .filter(|(_, tx)| tx.space() == Space::Ethereum)
                         .map(|(idx, tx)| {
                             let status = res.block_receipts.receipts[idx]
-                                .evm_space_status();
+                                .outcome_status
+                                .in_space(Space::Ethereum);
                             // save tx contract_address to address_map
                             let contract_address =
                                 Transaction::deployed_contract_address(tx);

--- a/client/src/rpc/types/receipt.rs
+++ b/client/src/rpc/types/receipt.rs
@@ -12,6 +12,7 @@ use primitives::{
     },
     transaction::Action,
     SignedTransaction as PrimitiveTransaction, Transaction, TransactionIndex,
+    TransactionOutcome,
 };
 use serde_derive::Serialize;
 
@@ -106,7 +107,9 @@ impl Receipt {
         } else {
             bail!(format!("Does not support EIP-155 transaction in Conflux space RPC. get_receipt for tx: {:?}",transaction));
         };
-        if Action::Create == unsigned.action && outcome_status == 0 {
+        if Action::Create == unsigned.action
+            && outcome_status == TransactionOutcome::Success
+        {
             let (created_address, _) = contract_address(
                 CreateContractAddress::FromSenderNonceAndCodeHash,
                 block_number.into(),
@@ -141,7 +144,7 @@ impl Receipt {
                     Some(RpcAddress::try_from_h160(address.clone(), network)?)
                 }
             },
-            outcome_status: U64::from(outcome_status),
+            outcome_status: U64::from(outcome_status.in_space(Space::Native)),
             contract_created: address,
             logs: logs
                 .into_iter()

--- a/core/src/block_data_manager/mod.rs
+++ b/core/src/block_data_manager/mod.rs
@@ -19,10 +19,7 @@ use malloc_size_of_derive::MallocSizeOf as DeriveMallocSizeOf;
 use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockUpgradableReadGuard};
 use primitives::{
     block::CompactBlock,
-    receipt::{
-        BlockReceipts, TRANSACTION_OUTCOME_EXCEPTION_WITH_NONCE_BUMPING,
-        TRANSACTION_OUTCOME_SUCCESS,
-    },
+    receipt::{BlockReceipts, TransactionOutcome},
     Block, BlockHeader, EpochId, SignedTransaction, TransactionIndex,
     TransactionWithSignature, NULL_EPOCH,
 };
@@ -1271,8 +1268,8 @@ impl BlockDataManager {
                         .unwrap()
                         .outcome_status
                     {
-                        TRANSACTION_OUTCOME_SUCCESS
-                        | TRANSACTION_OUTCOME_EXCEPTION_WITH_NONCE_BUMPING => {
+                        TransactionOutcome::Success
+                        | TransactionOutcome::Failure => {
                             self.insert_transaction_index(
                                 &tx.hash,
                                 &TransactionIndex {

--- a/core/src/light_protocol/handler/sync/tx_infos.rs
+++ b/core/src/light_protocol/handler/sync/tx_infos.rs
@@ -30,7 +30,9 @@ use futures::future::FutureExt;
 use lru_time_cache::LruCache;
 use network::{node_table::NodeId, NetworkContext};
 use parking_lot::RwLock;
-use primitives::{Receipt, SignedTransaction, TransactionIndex};
+use primitives::{
+    Receipt, SignedTransaction, TransactionIndex, TransactionOutcome,
+};
 use std::{future::Future, sync::Arc};
 
 #[derive(Debug)]
@@ -214,10 +216,12 @@ impl TxInfos {
 
         // only executed instances of the transaction are acceptable;
         // receipts belonging to non-executed instances should not be sent
-        if receipt.outcome_status != 0 && receipt.outcome_status != 1 {
+        if receipt.outcome_status != TransactionOutcome::Success
+            && receipt.outcome_status != TransactionOutcome::Failure
+        {
             bail!(ErrorKind::InvalidTxInfo {
                 reason: format!(
-                    "Unexpected outcome status in tx info: {}",
+                    "Unexpected outcome status in tx info: {:?}",
                     receipt.outcome_status
                 )
             });

--- a/primitives/src/block_header.rs
+++ b/primitives/src/block_header.rs
@@ -600,6 +600,7 @@ mod tests {
     use crate::{
         hash::keccak,
         receipt::{BlockReceipts, Receipt},
+        TransactionOutcome,
     };
     use cfx_types::{Bloom, KECCAK_EMPTY_BLOOM, U256};
     use std::{str::FromStr, sync::Arc};
@@ -631,7 +632,7 @@ mod tests {
             gas_fee: U256::zero(),
             gas_sponsor_paid: false,
             logs: vec![],
-            outcome_status: 0,
+            outcome_status: TransactionOutcome::Success,
             log_bloom: Bloom::zero(),
             storage_sponsor_paid: false,
             storage_collateralized: vec![],
@@ -662,7 +663,7 @@ mod tests {
                     gas_fee: 0.into(),
                     gas_sponsor_paid: false,
                     logs: vec![],
-                    outcome_status: 0,
+                    outcome_status: TransactionOutcome::Success,
                     log_bloom: Bloom::from_str(
                         "11111111111111111111111111111111\
                          00000000000000000000000000000000\
@@ -691,7 +692,7 @@ mod tests {
                     gas_fee: U256::zero(),
                     gas_sponsor_paid: false,
                     logs: vec![],
-                    outcome_status: 0,
+                    outcome_status: TransactionOutcome::Success,
                     log_bloom: Bloom::from_str(
                         "00000000000000000000000000000000\
                          22222222222222222222222222222222\
@@ -727,7 +728,7 @@ mod tests {
                 gas_fee: U256::zero(),
                 gas_sponsor_paid: false,
                 logs: vec![],
-                outcome_status: 0,
+                outcome_status: TransactionOutcome::Success,
                 log_bloom: Bloom::from_str(
                     "44444444444444440000000000000000\
                      44444444444444440000000000000000\

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -41,7 +41,7 @@ pub use crate::{
     block_number::compute_block_number,
     epoch::{BlockHashOrEpochNumber, EpochId, EpochNumber, NULL_EPOCH},
     log_entry::LogEntry,
-    receipt::{BlockReceipts, Receipt},
+    receipt::{BlockReceipts, Receipt, TransactionOutcome},
     state_root::*,
     static_bool::StaticBool,
     storage::{

--- a/primitives/src/receipt.rs
+++ b/primitives/src/receipt.rs
@@ -3,8 +3,9 @@
 // See http://www.gnu.org/licenses/
 
 use crate::log_entry::LogEntry;
-use cfx_types::{Address, Bloom, U256, U64};
+use cfx_types::{Address, Bloom, Space, U256, U64};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
+use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 use rlp_derive::{RlpDecodable, RlpEncodable};
 
 pub const TRANSACTION_OUTCOME_SUCCESS: u8 = 0;
@@ -13,6 +14,67 @@ pub const TRANSACTION_OUTCOME_EXCEPTION_WITHOUT_NONCE_BUMPING: u8 = 2; // no gas
 
 pub const EVM_SPACE_FAIL: u8 = 0;
 pub const EVM_SPACE_SUCCESS: u8 = 1;
+
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransactionOutcome {
+    Success = 0,
+    Failure = 1,
+    Skipped = 2,
+}
+
+impl TransactionOutcome {
+    fn into_u8(&self) -> u8 {
+        match self {
+            TransactionOutcome::Success => 0,
+            TransactionOutcome::Failure => 1,
+            TransactionOutcome::Skipped => 2,
+        }
+    }
+}
+
+impl Encodable for TransactionOutcome {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        s.append_internal(&self.into_u8());
+    }
+}
+
+impl Decodable for TransactionOutcome {
+    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+        match rlp.as_val::<u8>()? {
+            0 => Ok(TransactionOutcome::Success),
+            1 => Ok(TransactionOutcome::Failure),
+            2 => Ok(TransactionOutcome::Skipped),
+            _ => Err(DecoderError::Custom("Unrecognized outcome status")),
+        }
+    }
+}
+
+impl Default for TransactionOutcome {
+    fn default() -> Self { TransactionOutcome::Success }
+}
+
+impl TransactionOutcome {
+    pub fn in_space(&self, space: Space) -> u8 {
+        match (space, self) {
+            // Conflux
+            (Space::Native, TransactionOutcome::Success) => {
+                TRANSACTION_OUTCOME_SUCCESS
+            }
+            (Space::Native, TransactionOutcome::Failure) => {
+                TRANSACTION_OUTCOME_EXCEPTION_WITH_NONCE_BUMPING
+            }
+            (Space::Native, TransactionOutcome::Skipped) => {
+                TRANSACTION_OUTCOME_EXCEPTION_WITHOUT_NONCE_BUMPING
+            }
+
+            // EVM
+            (Space::Ethereum, TransactionOutcome::Success) => EVM_SPACE_SUCCESS,
+            (Space::Ethereum, TransactionOutcome::Failure) => EVM_SPACE_FAIL,
+            (Space::Ethereum, TransactionOutcome::Skipped) => 0xff,
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, RlpDecodable, RlpEncodable)]
 pub struct StorageChange {
@@ -37,8 +99,7 @@ pub struct Receipt {
     /// The logs stemming from this transaction.
     pub logs: Vec<LogEntry>,
     /// Transaction outcome.
-    // TODO: use enum variants for Conflux / Ethereum
-    pub outcome_status: u8,
+    pub outcome_status: TransactionOutcome,
     /// The designated account to bear the storage fee, if any.
     pub storage_sponsor_paid: bool,
     pub storage_collateralized: Vec<StorageChange>,
@@ -47,7 +108,7 @@ pub struct Receipt {
 
 impl Receipt {
     pub fn new(
-        outcome: u8, accumulated_gas_used: U256, gas_fee: U256,
+        outcome: TransactionOutcome, accumulated_gas_used: U256, gas_fee: U256,
         gas_sponsor_paid: bool, logs: Vec<LogEntry>, log_bloom: Bloom,
         storage_sponsor_paid: bool, storage_collateralized: Vec<StorageChange>,
         storage_released: Vec<StorageChange>,
@@ -63,15 +124,6 @@ impl Receipt {
             storage_sponsor_paid,
             storage_collateralized,
             storage_released,
-        }
-    }
-
-    // conflux receipt status code is different with EVM
-    pub fn evm_space_status(&self) -> u8 {
-        if self.outcome_status == TRANSACTION_OUTCOME_SUCCESS {
-            EVM_SPACE_SUCCESS
-        } else {
-            EVM_SPACE_FAIL
         }
     }
 }
@@ -107,4 +159,11 @@ impl MallocSizeOf for BlockReceipts {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         self.receipts.size_of(ops)
     }
+}
+
+#[test]
+fn test_transaction_outcome_rlp() {
+    assert_eq!(rlp::encode(&TransactionOutcome::Success), rlp::encode(&0u8));
+    assert_eq!(rlp::encode(&TransactionOutcome::Failure), rlp::encode(&1u8));
+    assert_eq!(rlp::encode(&TransactionOutcome::Skipped), rlp::encode(&2u8));
 }


### PR DESCRIPTION
Use abstract representation `TransactionOutcome` in transaction receipts. Encode according to `Space::Native` or `Space::Ethereum` in RPC layer. This way, we can avoid confusion caused by the different use of `outcome_status` in the two spaces.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2392)
<!-- Reviewable:end -->
