### PR TITLE
Do not exit process in case of a thread panic.

### DIFF
--- a/core/src/pos/common/crash-handler/src/lib.rs
+++ b/core/src/pos/common/crash-handler/src/lib.rs
@@ -11,10 +11,7 @@
 use backtrace::Backtrace;
 use diem_logger::prelude::*;
 use serde::Serialize;
-use std::{
-    panic::{self, PanicInfo},
-    process,
-};
+use std::panic::{self, PanicInfo};
 
 #[derive(Debug, Serialize)]
 pub struct CrashInfo {
@@ -46,7 +43,4 @@ fn handle_panic(panic_info: &PanicInfo<'_>) {
 
     // Wait till the logs have been flushed
     diem_logger::flush();
-
-    // Kill the process
-    process::exit(12);
 }


### PR DESCRIPTION
This prevents RPC thread panics to crash the whole process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2396)
<!-- Reviewable:end -->
