### PR TITLE
Consider phantom transactions in eth_getLogs

### DIFF
--- a/client/src/rpc/types/eth/block.rs
+++ b/client/src/rpc/types/eth/block.rs
@@ -202,10 +202,7 @@ impl Block {
                 .unwrap_or_default(),
             gas_limit: pb.pivot_header.gas_limit().into(),
             extra_data: Default::default(),
-            logs_bloom: pb.receipts.iter().fold(H2048::zero(), |mut acc, r| {
-                acc.accrue_bloom(&r.log_bloom);
-                acc
-            }),
+            logs_bloom: pb.bloom,
             timestamp: pb.pivot_header.timestamp().into(),
             difficulty: pb.pivot_header.difficulty().into(),
             total_difficulty: 0.into(),
@@ -217,9 +214,11 @@ impl Block {
             nonce: pb.pivot_header.nonce().low_u64().to_be_bytes().into(),
             mix_hash: H256::default(),
             transactions,
-            // FIXME(thegaram): should we recalculate size?
-            // size: blocks.iter().map(|b| b.size()).sum::<usize>().into(),
-            size: 0.into(),
+            size: pb
+                .transactions
+                .iter()
+                .fold(0, |acc, tx| acc + tx.rlp_size())
+                .into(),
         }
     }
 

--- a/client/src/rpc/types/eth/block.rs
+++ b/client/src/rpc/types/eth/block.rs
@@ -24,21 +24,13 @@ use cfx_types::{
 };
 use cfxcore::consensus::ConsensusGraphInner;
 use primitives::{
-    receipt::EVM_SPACE_SUCCESS, Block as PrimitiveBlock, BlockHeader, Receipt,
-    SignedTransaction,
+    receipt::EVM_SPACE_SUCCESS, Block as PrimitiveBlock, PhantomBlock,
 };
 use serde::{Serialize, Serializer};
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 const SHA3_HASH_OF_EMPTY_UNCLE: &str =
     "1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347";
-
-pub struct PhantomBlock {
-    pub pivot_header: BlockHeader,
-    pub transactions: Vec<Arc<SignedTransaction>>,
-    pub receipts: Vec<Receipt>,
-    pub errors: Vec<String>,
-}
 
 /// Block Transactions
 #[derive(Debug)]

--- a/client/src/rpc/types/eth/filter.rs
+++ b/client/src/rpc/types/eth/filter.rs
@@ -131,7 +131,7 @@ impl EthRpcLogFilter {
             offset: None,
             limit: self.limit,
             trusted: false,
-            space: Some(Space::Ethereum),
+            space: Space::Ethereum,
         };
 
         match (&self.from_block, &self.to_block, &self.block_hash) {

--- a/client/src/rpc/types/eth/mod.rs
+++ b/client/src/rpc/types/eth/mod.rs
@@ -12,7 +12,7 @@ mod sync;
 mod transaction;
 
 pub use self::{
-    block::{Block, PhantomBlock},
+    block::Block,
     block_number::BlockNumber,
     call_request::CallRequest,
     filter::{EthRpcLogFilter, FilterChanges},

--- a/client/src/rpc/types/filter.rs
+++ b/client/src/rpc/types/filter.rs
@@ -135,7 +135,7 @@ impl CfxRpcLogFilter {
             offset,
             limit,
             trusted: false,
-            space: Some(Space::Native),
+            space: Space::Native,
         };
 
         // choose filter type based on fields
@@ -387,7 +387,7 @@ mod tests {
                 offset: Some(1),
                 limit: Some(2),
                 trusted: false,
-                space: Some(Space::Native),
+                space: Space::Native,
             },
         };
 
@@ -436,7 +436,7 @@ mod tests {
                 offset: Some(1),
                 limit: Some(2),
                 trusted: false,
-                space: Some(Space::Native),
+                space: Space::Native,
             },
         };
 
@@ -493,7 +493,7 @@ mod tests {
                 offset: Some(1),
                 limit: Some(2),
                 trusted: false,
-                space: Some(Space::Native),
+                space: Space::Native,
             },
         };
 

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -1650,9 +1650,11 @@ impl ConsensusGraph {
 
                             // note: phantom txs consume no gas
                             let phantom_receipt = p.into_receipt(gas_used);
+
                             phantom_block
                                 .bloom
                                 .accrue_bloom(&phantom_receipt.log_bloom);
+
                             phantom_block.receipts.push(phantom_receipt);
 
                             // FIXME(thegaram): handle errors for phantom txs

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -6,7 +6,7 @@ use crate::{
     BlockHeader, Receipt, SignedTransaction, TransactionWithSignature,
 };
 use byteorder::{ByteOrder, LittleEndian};
-use cfx_types::{Space, H256, U256};
+use cfx_types::{Bloom, Space, H256, U256};
 use keccak_hash::keccak;
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use rand::Rng;
@@ -367,4 +367,5 @@ pub struct PhantomBlock {
     pub transactions: Vec<Arc<SignedTransaction>>,
     pub receipts: Vec<Receipt>,
     pub errors: Vec<String>,
+    pub bloom: Bloom,
 }

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -2,7 +2,9 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use crate::{BlockHeader, SignedTransaction, TransactionWithSignature};
+use crate::{
+    BlockHeader, Receipt, SignedTransaction, TransactionWithSignature,
+};
 use byteorder::{ByteOrder, LittleEndian};
 use cfx_types::{Space, H256, U256};
 use keccak_hash::keccak;
@@ -358,4 +360,11 @@ impl Decodable for CompactBlock {
             reconstructed_txns: Vec::new(),
         })
     }
+}
+
+pub struct PhantomBlock {
+    pub pivot_header: BlockHeader,
+    pub transactions: Vec<Arc<SignedTransaction>>,
+    pub receipts: Vec<Receipt>,
+    pub errors: Vec<String>,
 }

--- a/primitives/src/filter.rs
+++ b/primitives/src/filter.rs
@@ -218,9 +218,8 @@ pub struct LogFilterParams {
 
     /// Space: Conflux or Ethereum.
     ///
-    /// If None, match all.
-    /// If specified, log must be produced in this space.
-    pub space: Option<Space>,
+    /// Log must be produced in this space.
+    pub space: Space,
 }
 
 impl Default for LogFilterParams {
@@ -231,7 +230,7 @@ impl Default for LogFilterParams {
             offset: None,
             limit: None,
             trusted: false,
-            space: Some(Space::Native),
+            space: Space::Native,
         }
     }
 }
@@ -301,10 +300,8 @@ impl LogFilterParams {
 
     /// Returns true if given log entry matches filter.
     pub fn matches(&self, log: &LogEntry) -> bool {
-        if let Some(filter_space) = self.space {
-            if log.space != filter_space {
-                return false;
-            }
+        if log.space != self.space {
+            return false;
         }
 
         let matches = match self.address {

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -36,7 +36,7 @@ pub use crate::{
         Account, CodeInfo, DepositInfo, DepositList, SponsorInfo,
         VoteStakeInfo, VoteStakeList,
     },
-    block::{Block, BlockNumber},
+    block::{Block, BlockNumber, PhantomBlock},
     block_header::{BlockHeader, BlockHeaderBuilder},
     block_number::compute_block_number,
     epoch::{BlockHashOrEpochNumber, EpochId, EpochNumber, NULL_EPOCH},

--- a/tests/evm_space/log_filtering_test.py
+++ b/tests/evm_space/log_filtering_test.py
@@ -19,6 +19,8 @@ CONFLUX_CONTRACT_PATH = "../contracts/CrossSpaceEventTest/CrossSpaceEventTestCon
 EVM_CONTRACT_PATH = "../contracts/CrossSpaceEventTest/CrossSpaceEventTestEVMSide.bytecode"
 
 TEST_EVENT_TOPIC = encode_hex_0x(keccak(b"TestEvent(uint256)"))
+CALL_EVENT_TOPIC = encode_hex_0x(keccak(b"Call(bytes20,bytes20,uint256,uint256,bytes)"))
+OUTCOME_EVENT_TOPIC = encode_hex_0x(keccak(b"Outcome(bool)"))
 
 def encode_u256(number):
     return ("%x" % number).zfill(64)
@@ -144,6 +146,14 @@ class CrossSpaceLogFilteringTest(Web3Base):
         filter = Filter(from_epoch=epoch_a, to_epoch=epoch_e)
         logs = self.rpc.get_logs(filter)
         assert_equal(len(logs), 16)
+
+        filter = Filter(topics=[CALL_EVENT_TOPIC], from_epoch=epoch_a, to_epoch=epoch_e)
+        logs = self.rpc.get_logs(filter)
+        assert_equal(len(logs), 4)
+
+        filter = Filter(topics=[OUTCOME_EVENT_TOPIC], from_epoch=epoch_a, to_epoch=epoch_e)
+        logs = self.rpc.get_logs(filter)
+        assert_equal(len(logs), 4)
 
         filter = Filter(topics=[TEST_EVENT_TOPIC], from_epoch=epoch_a, to_epoch=epoch_e)
         logs = self.rpc.get_logs(filter)

--- a/tests/evm_space/log_filtering_test.py
+++ b/tests/evm_space/log_filtering_test.py
@@ -140,27 +140,88 @@ class CrossSpaceLogFilteringTest(Web3Base):
             assert_equal(receipt["status"], 1)
 
         # check Conflux events
+        # 11, 12, X, X, 14, 15, X, X, 21, 22, X, X, 24, 25, X, X   (X ~ internal contract event)
+        filter = Filter(from_epoch=epoch_a, to_epoch=epoch_e)
+        logs = self.rpc.get_logs(filter)
+        assert_equal(len(logs), 16)
+
         filter = Filter(topics=[TEST_EVENT_TOPIC], from_epoch=epoch_a, to_epoch=epoch_e)
         logs = self.rpc.get_logs(filter)
         assert_equal(len(logs), 8)
 
+        assert_equal(logs[0]["data"], number_to_topic(11))
+        assert_equal(logs[0]["blockHash"], block_a)
+        assert_equal(logs[0]["logIndex"], '0x0')
+        assert_equal(logs[0]["transactionIndex"], '0x0')
+        assert_equal(logs[0]["transactionLogIndex"], '0x0')
+
+        assert_equal(logs[1]["data"], number_to_topic(12))
+        assert_equal(logs[1]["blockHash"], block_a)
+        assert_equal(logs[1]["logIndex"], '0x1')
+        assert_equal(logs[1]["transactionIndex"], '0x1')
+        assert_equal(logs[1]["transactionLogIndex"], '0x0')
+
+        assert_equal(logs[2]["data"], number_to_topic(14))
+        assert_equal(logs[2]["blockHash"], block_b)
+        assert_equal(logs[2]["logIndex"], '0x0')
+        assert_equal(logs[2]["transactionIndex"], '0x0')
+        assert_equal(logs[2]["transactionLogIndex"], '0x0')
+
+        assert_equal(logs[3]["data"], number_to_topic(15))
+        assert_equal(logs[3]["blockHash"], block_b)
+        assert_equal(logs[3]["logIndex"], '0x1')
+        assert_equal(logs[3]["transactionIndex"], '0x1')
+        assert_equal(logs[3]["transactionLogIndex"], '0x0')
+
+        assert_equal(logs[4]["data"], number_to_topic(21))
+        assert_equal(logs[4]["blockHash"], block_d)
+        assert_equal(logs[4]["logIndex"], '0x0')
+        assert_equal(logs[4]["transactionIndex"], '0x0')
+        assert_equal(logs[4]["transactionLogIndex"], '0x0')
+
+        assert_equal(logs[5]["data"], number_to_topic(22))
+        assert_equal(logs[5]["blockHash"], block_d)
+        assert_equal(logs[5]["logIndex"], '0x1')
+        assert_equal(logs[5]["transactionIndex"], '0x1')
+        assert_equal(logs[5]["transactionLogIndex"], '0x0')
+
+        assert_equal(logs[6]["data"], number_to_topic(24))
+        assert_equal(logs[6]["blockHash"], block_e)
+        assert_equal(logs[6]["logIndex"], '0x0')
+        assert_equal(logs[6]["transactionIndex"], '0x0')
+        assert_equal(logs[6]["transactionLogIndex"], '0x0')
+
+        assert_equal(logs[7]["data"], number_to_topic(25))
+        assert_equal(logs[7]["blockHash"], block_e)
+        assert_equal(logs[7]["logIndex"], '0x1')
+        assert_equal(logs[7]["transactionIndex"], '0x1')
+        assert_equal(logs[7]["transactionLogIndex"], '0x0')
+
 
         # --------------- 1 block per epoch ---------------
         # check EVM events
-        # we expect 4 events: #12, #13, #15, #16
+        # block A
+        #   3 transactions: phantom (balance), phantom (cross-call), evm
+        #   2 events: #12, #13
+        # block B
+        #   3 transactions: phantom (balance), phantom (cross-call), evm
+        #   2 events: #15, #16
         filter = { "topics": [TEST_EVENT_TOPIC], "fromBlock": epoch_a, "toBlock": epoch_b }
         logs = self.nodes[0].eth_getLogs(filter)
         assert_equal(len(logs), 4)
+
+        block_a_txs_evm = self.nodes[0].eth_getBlockByHash(block_a, False)["transactions"]
+        block_b_txs_evm = self.nodes[0].eth_getBlockByHash(block_b, False)["transactions"]
 
         # emitBoth: TestEvent(12)
         assert_equal(logs[0]["data"], number_to_topic(12))
         assert_equal(logs[0]["address"], evmContractAddr.lower())
         assert_equal(logs[0]["blockHash"], block_a)
         assert_equal(logs[0]["blockNumber"], epoch_a)
-        assert_equal(logs[0]["transactionHash"], cfx_tx_hashes[1]) # TODO: should use phantom tx here
-        # assert_equal(logs[0]["logIndex"], '0x0')
-        # assert_equal(logs[0]["transactionIndex"], '0x0')
-        # assert_equal(logs[0]["transactionLogIndex"], '0x0')
+        assert_equal(logs[0]["transactionHash"], block_a_txs_evm[1]) # NOTE: #0 is balance transfer
+        assert_equal(logs[0]["logIndex"], '0x0')
+        assert_equal(logs[0]["transactionIndex"], '0x1')
+        assert_equal(logs[0]["transactionLogIndex"], '0x0')
         assert_equal(logs[0]["removed"], False)
 
         # emitEVM: TestEvent(13)
@@ -168,9 +229,9 @@ class CrossSpaceLogFilteringTest(Web3Base):
         assert_equal(logs[1]["address"], evmContractAddr.lower())
         assert_equal(logs[1]["blockHash"], block_a)
         assert_equal(logs[1]["blockNumber"], epoch_a)
-        assert_equal(logs[1]["transactionHash"], evm_tx_hashes[0].hex())
-        # assert_equal(logs[1]["logIndex"], '0x1')
-        # assert_equal(logs[1]["transactionIndex"], '0x1')
+        assert_equal(logs[1]["transactionHash"], block_a_txs_evm[2])
+        assert_equal(logs[1]["logIndex"], '0x1')
+        assert_equal(logs[1]["transactionIndex"], '0x2')
         assert_equal(logs[1]["transactionLogIndex"], '0x0')
         assert_equal(logs[1]["removed"], False)
 
@@ -179,10 +240,10 @@ class CrossSpaceLogFilteringTest(Web3Base):
         assert_equal(logs[2]["address"], evmContractAddr.lower())
         assert_equal(logs[2]["blockHash"], block_b)
         assert_equal(logs[2]["blockNumber"], epoch_b)
-        assert_equal(logs[2]["transactionHash"], cfx_tx_hashes[3]) # TODO: should use phantom tx here
-        # assert_equal(logs[2]["logIndex"], '0x0')
-        # assert_equal(logs[2]["transactionIndex"], '0x0')
-        # assert_equal(logs[2]["transactionLogIndex"], '0x0')
+        assert_equal(logs[2]["transactionHash"], block_b_txs_evm[1])
+        assert_equal(logs[2]["logIndex"], '0x0')
+        assert_equal(logs[2]["transactionIndex"], '0x1')
+        assert_equal(logs[2]["transactionLogIndex"], '0x0')
         assert_equal(logs[2]["removed"], False)
 
         # emitEVM: TestEvent(16)
@@ -190,29 +251,33 @@ class CrossSpaceLogFilteringTest(Web3Base):
         assert_equal(logs[3]["address"], evmContractAddr.lower())
         assert_equal(logs[3]["blockHash"], block_b)
         assert_equal(logs[3]["blockNumber"], epoch_b)
-        assert_equal(logs[3]["transactionHash"], evm_tx_hashes[1].hex())
-        # assert_equal(logs[3]["logIndex"], '0x1')
-        # assert_equal(logs[3]["transactionIndex"], '0x1')
+        assert_equal(logs[3]["transactionHash"], block_b_txs_evm[2])
+        assert_equal(logs[3]["logIndex"], '0x1')
+        assert_equal(logs[3]["transactionIndex"], '0x2')
         assert_equal(logs[3]["transactionLogIndex"], '0x0')
         assert_equal(logs[3]["removed"], False)
 
 
         # --------------- 2 blocks per epoch ---------------
         # check EVM events
-        # we expect 4 events: #22, #23, #25, #26
+        # block E
+        #   6 transactions: phantom (balance), phantom (cross-call), evm, phantom (balance), phantom (cross-call), evm
+        #   4 events: #22, #23, #25, #26
         filter = { "topics": [TEST_EVENT_TOPIC], "fromBlock": epoch_e, "toBlock": epoch_e }
         logs = self.nodes[0].eth_getLogs(filter)
         assert_equal(len(logs), 4)
+
+        block_e_txs_evm = self.nodes[0].eth_getBlockByHash(block_e, False)["transactions"]
 
         # emitBoth: TestEvent(22)
         assert_equal(logs[0]["data"], number_to_topic(22))
         assert_equal(logs[0]["address"], evmContractAddr.lower())
         assert_equal(logs[0]["blockHash"], block_e)
         assert_equal(logs[0]["blockNumber"], epoch_e)
-        assert_equal(logs[0]["transactionHash"], cfx_tx_hashes[5]) # TODO: should use phantom tx here
-        # assert_equal(logs[0]["logIndex"], '0x0')
-        # assert_equal(logs[0]["transactionIndex"], '0x0')
-        # assert_equal(logs[0]["transactionLogIndex"], '0x0')
+        assert_equal(logs[0]["transactionHash"], block_e_txs_evm[1]) # NOTE: #0 is balance transfer
+        assert_equal(logs[0]["logIndex"], '0x0')
+        assert_equal(logs[0]["transactionIndex"], '0x1')
+        assert_equal(logs[0]["transactionLogIndex"], '0x0')
         assert_equal(logs[0]["removed"], False)
 
         # emitEVM: TestEvent(23)
@@ -220,9 +285,9 @@ class CrossSpaceLogFilteringTest(Web3Base):
         assert_equal(logs[1]["address"], evmContractAddr.lower())
         assert_equal(logs[1]["blockHash"], block_e)
         assert_equal(logs[1]["blockNumber"], epoch_e)
-        assert_equal(logs[1]["transactionHash"], evm_tx_hashes[2].hex())
-        # assert_equal(logs[1]["logIndex"], '0x1')
-        # assert_equal(logs[1]["transactionIndex"], '0x1')
+        assert_equal(logs[1]["transactionHash"], block_e_txs_evm[2])
+        assert_equal(logs[1]["logIndex"], '0x1')
+        assert_equal(logs[1]["transactionIndex"], '0x2')
         assert_equal(logs[1]["transactionLogIndex"], '0x0')
         assert_equal(logs[1]["removed"], False)
 
@@ -231,10 +296,10 @@ class CrossSpaceLogFilteringTest(Web3Base):
         assert_equal(logs[2]["address"], evmContractAddr.lower())
         assert_equal(logs[2]["blockHash"], block_e)
         assert_equal(logs[2]["blockNumber"], epoch_e)
-        assert_equal(logs[2]["transactionHash"], cfx_tx_hashes[7]) # TODO: should use phantom tx here
-        # assert_equal(logs[2]["logIndex"], '0x2')
-        # assert_equal(logs[2]["transactionIndex"], '0x2')
-        # assert_equal(logs[2]["transactionLogIndex"], '0x0')
+        assert_equal(logs[2]["transactionHash"], block_e_txs_evm[4]) # NOTE: #3 is balance transfer
+        assert_equal(logs[2]["logIndex"], '0x2')
+        assert_equal(logs[2]["transactionIndex"], '0x4')
+        assert_equal(logs[2]["transactionLogIndex"], '0x0')
         assert_equal(logs[2]["removed"], False)
 
         # emitEVM: TestEvent(26)
@@ -242,9 +307,9 @@ class CrossSpaceLogFilteringTest(Web3Base):
         assert_equal(logs[3]["address"], evmContractAddr.lower())
         assert_equal(logs[3]["blockHash"], block_e)
         assert_equal(logs[3]["blockNumber"], epoch_e)
-        assert_equal(logs[3]["transactionHash"], evm_tx_hashes[3].hex())
-        # assert_equal(logs[3]["logIndex"], '0x3')
-        # assert_equal(logs[3]["transactionIndex"], '0x3')
+        assert_equal(logs[3]["transactionHash"], block_e_txs_evm[5])
+        assert_equal(logs[3]["logIndex"], '0x3')
+        assert_equal(logs[3]["transactionIndex"], '0x5')
         assert_equal(logs[3]["transactionLogIndex"], '0x0')
         assert_equal(logs[3]["removed"], False)
 

--- a/tests/evm_space/phantom_transaction_test.py
+++ b/tests/evm_space/phantom_transaction_test.py
@@ -258,6 +258,10 @@ class PhantomTransactionTest(ConfluxTestFramework):
 
         logIndex = 0
 
+        filter = { "fromBlock": epoch_a, "toBlock": epoch_a }
+        logsFiltered = self.nodes[0].eth_getLogs(filter)
+        assert_equal(len(logsFiltered), 4)
+
         for idx, receipt in enumerate(receipts):
             assert_equal(receipt["blockHash"], block_a)
             assert_equal(receipt["blockNumber"], epoch_a)
@@ -280,6 +284,7 @@ class PhantomTransactionTest(ConfluxTestFramework):
                 assert_equal(log["logIndex"], hex(logIndex))
                 assert_equal(log["transactionLogIndex"], hex(idx2))
                 assert_equal(log["removed"], False)
+                assert_equal(log, logsFiltered[logIndex])
                 logIndex += 1
 
         assert_equal(len(receipts[0]["logs"]), 1)
@@ -335,6 +340,10 @@ class PhantomTransactionTest(ConfluxTestFramework):
 
         logIndex = 0
 
+        filter = { "fromBlock": epoch_e, "toBlock": epoch_e }
+        logsFiltered = self.nodes[0].eth_getLogs(filter)
+        assert_equal(len(logsFiltered), 8)
+
         for idx, receipt in enumerate(receipts):
             assert_equal(receipt["blockHash"], block_e)
             assert_equal(receipt["blockNumber"], epoch_e)
@@ -357,6 +366,7 @@ class PhantomTransactionTest(ConfluxTestFramework):
                 assert_equal(log["logIndex"], hex(logIndex))
                 assert_equal(log["transactionLogIndex"], hex(idx2))
                 assert_equal(log["removed"], False)
+                assert_equal(log, logsFiltered[logIndex])
                 logIndex += 1
 
         assert_equal(len(receipts[0]["logs"]), 1)


### PR DESCRIPTION
This PR fixes the following fields in `eth_getLogs` and `cfx_getLogs`: `transactionHash`, `transactionIndex`, `transactionLogIndex`, `logIndex`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2408)
<!-- Reviewable:end -->
