### PR TITLE
Only return eth tx receipt after the state is available as LatestState.

### DIFF
--- a/client/src/rpc/impls/eth.rs
+++ b/client/src/rpc/impls/eth.rs
@@ -886,6 +886,12 @@ impl Eth for EthHandler {
                 Some(n) => n,
             };
 
+        if epoch_num > self.consensus_graph().best_executed_state_epoch_number()
+        {
+            // The receipt is only visible to optimistic execution.
+            return Ok(None);
+        }
+
         let maybe_block = self
             .consensus_graph()
             .get_phantom_block_by_number(EpochNumber::Number(epoch_num), None)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2414)
<!-- Reviewable:end -->
