### PR TITLE
Fix cfx space trace transacion_position.

### DIFF
--- a/client/src/rpc/impls/trace.rs
+++ b/client/src/rpc/impls/trace.rs
@@ -348,8 +348,7 @@ impl EthTrace for EthTraceHandler {
                                             subtraces: 0,
                                             // FIXME(lpl): follow the value of
                                             // tx index?
-                                            transaction_position: tx_index
-                                                .rpc_index,
+                                            transaction_position: None,
                                             transaction_hash: None,
                                             block_number: pivot_epoch_number,
                                             block_hash: pivot_hash,

--- a/client/src/rpc/impls/trace.rs
+++ b/client/src/rpc/impls/trace.rs
@@ -58,14 +58,12 @@ impl TraceHandler {
         &self, block_hash: H256,
     ) -> RpcResult<Option<LocalizedBlockTrace>> {
         // Note: an alternative to `into_jsonrpc_result` is the delegate! macro.
-        let transaction_hashes = match self
+        let block = match self
             .data_man
             .block_by_hash(&block_hash, true /* update_cache */)
         {
             None => return Ok(None),
-            Some(block) => {
-                block.transactions.iter().map(|tx| tx.hash()).collect()
-            }
+            Some(block) => block,
         };
 
         match self.data_man.block_traces_by_hash(&block_hash) {
@@ -81,7 +79,7 @@ impl TraceHandler {
                     block_hash,
                     pivot_hash,
                     epoch_number,
-                    transaction_hashes,
+                    &block.transactions,
                     self.network,
                 ) {
                     Ok(t) => Ok(Some(t)),
@@ -154,9 +152,9 @@ impl TraceHandler {
                                                 .into(),
                                         ),
                                         block_hash: Some(tx_index.block_hash),
-                                        transaction_position: Some(
-                                            tx_index.real_index.into(),
-                                        ),
+                                        transaction_position: tx_index
+                                            .rpc_index
+                                            .map(Into::into),
                                         transaction_hash: Some(*tx_hash),
                                     })
                                     .collect()

--- a/client/src/rpc/types/eth/trace.rs
+++ b/client/src/rpc/types/eth/trace.rs
@@ -220,10 +220,8 @@ impl TryFrom<RpcCfxLocalizedTrace> for LocalizedTrace {
             trace_address: vec![],
             subtraces: 0,
             // FIXME(lpl): Use the correct index in cfx/eth space.
-            transaction_position: cfx_trace
-                .transaction_position
-                .map(|p| p.as_usize()),
-            transaction_hash: cfx_trace.transaction_hash,
+            transaction_position: None,
+            transaction_hash: None,
             block_number: cfx_trace
                 .epoch_number
                 .map(|en| en.as_u64())

--- a/tests/evm_space/trace_test.py
+++ b/tests/evm_space/trace_test.py
@@ -79,13 +79,19 @@ class TraceTest(Web3Base):
         traces = self.nodes[0].ethrpc.trace_filter(filter)
         assert_equal(len(traces), 1)
         assert_ne(traces[0]["result"], None)
+        assert_equal(traces[0]["transactionHash"], None)
+        assert_equal(traces[0]["transactionPosition"], None)
         traces = self.nodes[0].ethrpc.trace_block(epoch_a)
         assert_equal(len(traces), 1)
         assert_ne(traces[0]["result"], None)
+        assert_equal(traces[0]["transactionHash"], None)
+        assert_equal(traces[0]["transactionPosition"], None)
         block_a_txs_evm = self.nodes[0].eth_getBlockByHash(block_a, False)["transactions"]
         traces = self.nodes[0].ethrpc.trace_transaction(block_a_txs_evm[0])
         assert_equal(len(traces), 1)
         assert_ne(traces[0]["result"], None)
+        assert_equal(traces[0]["transactionHash"], None)
+        assert_equal(traces[0]["transactionPosition"], None)
 
         self.log.info("Pass")
 


### PR DESCRIPTION
Return `None` for eth space transaction position and hash instead of false values for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2415)
<!-- Reviewable:end -->
