### PR TITLE
Implement web3_clientVersion and fix eth_getUncleCount*

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd4865004a46a0aafb2a0a5eb19d3c9fc46ee5f063a6cfc605c69ac9ecf5263d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -373,6 +373,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 
 [[package]]
 name = "bitflags"
@@ -479,7 +485,7 @@ dependencies = [
  "rand 0.7.3",
  "rlp",
  "secret-store",
- "toml",
+ "toml 0.5.8",
  "txgen",
 ]
 
@@ -734,7 +740,7 @@ dependencies = [
  "rlp_derive",
  "serde",
  "serde_derive",
- "toml",
+ "toml 0.5.8",
 ]
 
 [[package]]
@@ -976,7 +982,7 @@ dependencies = [
  "tokio 1.13.0",
  "tokio-stream",
  "tokio-timer",
- "toml",
+ "toml 0.5.8",
  "unexpected",
 ]
 
@@ -1109,7 +1115,7 @@ checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "strsim 0.8.0",
  "textwrap 0.11.0",
  "unicode-width",
@@ -1181,6 +1187,7 @@ dependencies = [
  "network",
  "num-bigint",
  "order-stat",
+ "parity-version",
  "parking_lot 0.11.2",
  "pos-ledger-db",
  "pow-types",
@@ -1211,7 +1218,7 @@ dependencies = [
  "tokio 1.13.0",
  "tokio-stream",
  "tokio-timer",
- "toml",
+ "toml 0.5.8",
  "transient-hashmap",
  "txgen",
 ]
@@ -1222,7 +1229,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1295,7 +1302,7 @@ dependencies = [
  "tempdir",
  "textwrap 0.9.0",
  "threadpool",
- "toml",
+ "toml 0.5.8",
  "txgen",
 ]
 
@@ -1361,7 +1368,7 @@ dependencies = [
  "backtrace",
  "diem-logger",
  "serde",
- "toml",
+ "toml 0.5.8",
 ]
 
 [[package]]
@@ -2453,7 +2460,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "fuchsia-zircon-sys",
 ]
 
@@ -4162,7 +4169,7 @@ version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -4301,6 +4308,16 @@ dependencies = [
  "proc-macro2 1.0.32",
  "syn 1.0.81",
  "synstructure",
+]
+
+[[package]]
+name = "parity-version"
+version = "3.3.3"
+dependencies = [
+ "rustc_version 0.2.3",
+ "target_info",
+ "toml 0.4.10",
+ "vergen",
 ]
 
 [[package]]
@@ -4783,7 +4800,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml",
+ "toml 0.5.8",
 ]
 
 [[package]]
@@ -4850,7 +4867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
 dependencies = [
  "bit-set 0.5.2",
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "lazy_static",
  "num-traits",
@@ -5115,7 +5132,7 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -5471,7 +5488,7 @@ version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -5970,6 +5987,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "target_info"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"
+
+[[package]]
 name = "tempdir"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6078,7 +6101,7 @@ dependencies = [
  "malloc_size_of",
  "malloc_size_of_derive",
  "parking_lot 0.11.2",
- "toml",
+ "toml 0.5.8",
 ]
 
 [[package]]
@@ -6452,6 +6475,15 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
@@ -6514,7 +6546,7 @@ dependencies = [
  "serde",
  "serde_json",
  "termcolor",
- "toml",
+ "toml 0.5.8",
 ]
 
 [[package]]
@@ -6539,7 +6571,7 @@ dependencies = [
  "rlp",
  "rustc-hex",
  "secret-store",
- "toml",
+ "toml 0.5.8",
 ]
 
 [[package]]
@@ -6707,6 +6739,16 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "vergen"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3365f36c57e5df714a34be40902b27a992eeddb9996eca52d0584611cf885d"
+dependencies = [
+ "bitflags 0.7.0",
+ "time",
+]
 
 [[package]]
 name = "version_check"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -95,6 +95,7 @@ consensus-types = {path = "../core/src/pos/consensus/consensus-types"}
 anyhow = "1.0.38"
 rpassword = "5.0.1"
 static_assertions = "1.1.0"
+parity-version = {path = "../util/version"}
 
 [dev-dependencies]
 criterion = "0.3"

--- a/client/src/rpc/impls/eth.rs
+++ b/client/src/rpc/impls/eth.rs
@@ -543,12 +543,16 @@ impl Eth for EthHandler {
             Some(n) => n,
         };
 
-        let maybe_epoch = self
+        let maybe_pivot_hash = self
             .consensus
             .get_block_hashes_by_epoch(epoch_num.into())
-            .ok();
+            .ok()
+            .and_then(|hs| hs.last().cloned());
 
-        Ok(maybe_epoch.map(|_| 0.into()))
+        match maybe_pivot_hash {
+            Some(h) if h == hash => Ok(Some(0.into())),
+            _ => Ok(None),
+        }
     }
 
     fn block_uncles_count_by_number(

--- a/client/src/rpc/impls/eth.rs
+++ b/client/src/rpc/impls/eth.rs
@@ -354,9 +354,7 @@ impl Eth for EthHandler {
 
     fn accounts(&self) -> jsonrpc_core::Result<Vec<H160>> {
         info!("RPC Request: eth_accounts");
-        // TODO: EVM core: discussion: do we really need this? Maybe not,
-        // because EVM has enough dev tools and don't need dev mode.
-        // We do not expect people to use the ETH rpc to manage accounts
+        // Conflux eSpace does not manage accounts
         Ok(vec![])
     }
 

--- a/client/src/rpc/impls/eth.rs
+++ b/client/src/rpc/impls/eth.rs
@@ -282,8 +282,7 @@ impl EthHandler {
 impl Eth for EthHandler {
     fn client_version(&self) -> jsonrpc_core::Result<String> {
         info!("RPC Request: web3_clientVersion");
-        // TODO
-        Ok(format!("Conflux"))
+        Ok(parity_version::version(crate_version!()))
     }
 
     fn net_version(&self) -> jsonrpc_core::Result<String> {

--- a/client/src/rpc/impls/eth.rs
+++ b/client/src/rpc/impls/eth.rs
@@ -2,34 +2,6 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use std::{cmp::min, sync::Arc};
-
-use jsonrpc_core::{Error as RpcError, Result as RpcResult};
-use rlp::Rlp;
-
-use cfx_statedb::StateDbExt;
-use cfx_types::{
-    Address, AddressSpaceUtil, BigEndianHash, Space, H160, H256, U256, U64,
-};
-use cfxcore::{
-    executive::{
-        revert_reason_decode, ExecutionError, ExecutionOutcome, TxDropError,
-    },
-    observer::ErrorUnwind,
-    rpc_errors::{
-        invalid_params_check, Error as CfxRpcError, Result as CfxRpcResult,
-    },
-    vm, ConsensusGraph, SharedConsensusGraph, SharedSynchronizationService,
-    SharedTransactionPool,
-};
-use primitives::{
-    filter::LogFilter, receipt::EVM_SPACE_SUCCESS, Action, Block,
-    BlockHashOrEpochNumber, Eip155Transaction, EpochNumber, PhantomBlock,
-    SignedTransaction, StorageKey, StorageValue, TransactionOutcome,
-    TransactionWithSignature,
-};
-use std::convert::TryInto;
-
 use crate::rpc::{
     error_codes::{
         call_execution_error, internal_error, invalid_params,
@@ -45,6 +17,31 @@ use crate::rpc::{
         Bytes, Index, MAX_GAS_CALL_REQUEST,
     },
 };
+use cfx_statedb::StateDbExt;
+use cfx_types::{
+    Address, AddressSpaceUtil, BigEndianHash, Space, H160, H256, U256, U64,
+};
+use cfxcore::{
+    executive::{
+        revert_reason_decode, ExecutionError, ExecutionOutcome, TxDropError,
+    },
+    observer::ErrorUnwind,
+    rpc_errors::{
+        invalid_params_check, Error as CfxRpcError, Result as CfxRpcResult,
+    },
+    vm, ConsensusGraph, SharedConsensusGraph, SharedSynchronizationService,
+    SharedTransactionPool,
+};
+use clap::crate_version;
+use jsonrpc_core::{Error as RpcError, Result as RpcResult};
+use primitives::{
+    filter::LogFilter, receipt::EVM_SPACE_SUCCESS, Action,
+    BlockHashOrEpochNumber, Eip155Transaction, EpochNumber, PhantomBlock,
+    SignedTransaction, StorageKey, StorageValue, TransactionOutcome,
+    TransactionWithSignature,
+};
+use rlp::Rlp;
+use std::{cmp::min, convert::TryInto};
 
 pub struct EthHandler {
     config: RpcImplConfiguration,
@@ -124,36 +121,6 @@ fn block_tx_by_index(
 }
 
 impl EthHandler {
-    fn get_blocks_by_number(
-        &self, block_num: BlockNumber,
-    ) -> jsonrpc_core::Result<Option<Vec<Arc<Block>>>> {
-        let epoch_hashes = self
-            .consensus
-            .get_block_hashes_by_epoch(block_num.try_into()?)
-            .map_err(RpcError::invalid_params)?;
-
-        let epoch_blocks = self
-            .consensus
-            .get_data_manager()
-            .blocks_by_hash_list(&epoch_hashes, false /* update_cache */);
-
-        Ok(epoch_blocks)
-    }
-
-    // Get pivot block hash by epoch number
-    #[allow(dead_code)]
-    fn get_block_hash_by_number(
-        &self, block_number: BlockNumber,
-    ) -> Option<H256> {
-        match self.get_blocks_by_number(block_number) {
-            Ok(Some(blocks)) => match blocks.last() {
-                None => None,
-                Some(b) => Some(b.hash()),
-            },
-            _ => None,
-        }
-    }
-
     fn exec_transaction(
         &self, request: CallRequest, epoch: Option<BlockNumber>,
     ) -> CfxRpcResult<ExecutionOutcome> {
@@ -200,22 +167,30 @@ impl EthHandler {
         &self, b: &PhantomBlock, idx: usize, prior_log_index: &mut usize,
     ) -> jsonrpc_core::Result<Receipt> {
         if b.transactions.len() != b.receipts.len() {
-            return Err(internal_error("Inconsistent state"));
+            return Err(internal_error(
+                "Inconsistent state: transactions and receipts length mismatch",
+            ));
         }
 
         if b.transactions.len() != b.errors.len() {
-            return Err(internal_error("Inconsistent state"));
+            return Err(internal_error(
+                "Inconsistent state: transactions and errors length mismatch",
+            ));
         }
 
         if idx >= b.transactions.len() {
-            return Err(internal_error("Inconsistent state"));
+            return Err(internal_error(
+                "Inconsistent state: tx index out of bound",
+            ));
         }
 
         let tx = &b.transactions[idx];
         let receipt = &b.receipts[idx];
 
         if receipt.logs.iter().any(|l| l.space != Space::Ethereum) {
-            return Err(internal_error("Inconsistent state"));
+            return Err(internal_error(
+                "Inconsistent state: native tx in phantom block",
+            ));
         }
 
         let contract_address = match receipt.outcome_status {
@@ -566,13 +541,17 @@ impl Eth for EthHandler {
     ) -> jsonrpc_core::Result<Option<U256>> {
         info!("RPC Request: eth_getUncleCountByBlockHash hash={:?}", hash);
 
-        // TODO(thegaram): only return Some(_) for pivot block
-        let maybe_block = self
-            .consensus
-            .get_data_manager()
-            .block_by_hash(&hash, false);
+        let epoch_num = match self.consensus.get_block_epoch_number(&hash) {
+            None => return Ok(None),
+            Some(n) => n,
+        };
 
-        Ok(maybe_block.map(|_| 0.into()))
+        let maybe_epoch = self
+            .consensus
+            .get_block_hashes_by_epoch(epoch_num.into())
+            .ok();
+
+        Ok(maybe_epoch.map(|_| 0.into()))
     }
 
     fn block_uncles_count_by_number(
@@ -583,9 +562,12 @@ impl Eth for EthHandler {
             block_num
         );
 
-        // TODO(thegaram): enough to just check if pivot exists
-        let maybe_block = self.get_blocks_by_number(block_num)?;
-        Ok(maybe_block.map(|_| 0.into()))
+        let maybe_epoch = self
+            .consensus
+            .get_block_hashes_by_epoch(block_num.try_into()?)
+            .ok();
+
+        Ok(maybe_epoch.map(|_| 0.into()))
     }
 
     fn code_at(
@@ -915,6 +897,7 @@ impl Eth for EthHandler {
                 return Ok(Some(receipt));
             }
 
+            // if the if-branch was not entered, we do the bookeeping here
             prior_log_index += phantom_block.receipts[idx].logs.len();
         }
 

--- a/client/src/rpc/types/eth/log.rs
+++ b/client/src/rpc/types/eth/log.rs
@@ -49,7 +49,6 @@ pub struct Log {
     /// Transaction Index
     pub transaction_index: U256,
     /// Log Index in Block
-    // FIXME(thegaram): currently we're using the epoch log index here
     pub log_index: Option<U256>,
     /// Log Index in Transaction
     pub transaction_log_index: Option<U256>,

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -1570,7 +1570,7 @@ impl ConsensusGraph {
         // sanity check: epoch is not empty
         let pivot = match blocks.last() {
             Some(p) => p,
-            None => return Err("Inconsistent state".into()),
+            None => return Err("Inconsistent state: empty epoch".into()),
         };
 
         if matches!(pivot_assumption, Some(h) if h != pivot.hash()) {
@@ -1607,7 +1607,7 @@ impl ConsensusGraph {
 
             // sanity check: transaction and
             if b.transactions.len() != block_receipts.len() {
-                return Err("Inconsistent state".into());
+                return Err("Inconsistent state: transactions and receipts length mismatch".into());
             }
 
             let evm_chain_id = self.best_chain_id().in_evm_space();
@@ -1627,7 +1627,7 @@ impl ConsensusGraph {
 
                         // sanity check: gas price must be positive
                         if *tx.gas_price() == 0.into() {
-                            return Err("Inconsistent state".into());
+                            return Err("Inconsistent state: zero transaction gas price".into());
                         }
 
                         // FIXME(thegaram): is this correct?
@@ -1662,7 +1662,7 @@ impl ConsensusGraph {
 
                             phantom_block.receipts.push(phantom_receipt);
 
-                            // FIXME(thegaram): handle errors for phantom txs
+                            // note: phantom txs never fails
                             phantom_block.errors.push("".into());
                         }
                     }

--- a/util/version/Cargo.toml
+++ b/util/version/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "parity-version"
+# NOTE: this value is used for OpenEthereum version string (via env CARGO_PKG_VERSION)
+version = "3.3.3"
+authors = ["Parity Technologies <admin@parity.io>"]
+build = "build.rs"
+
+[package.metadata]
+
+[dependencies]
+target_info = "0.1"
+
+[build-dependencies]
+vergen = "0.1"
+rustc_version = "0.2"
+toml = "0.4"
+
+[features]
+final = []

--- a/util/version/build.rs
+++ b/util/version/build.rs
@@ -1,0 +1,50 @@
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of OpenEthereum.
+
+// OpenEthereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// OpenEthereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
+
+extern crate rustc_version;
+extern crate toml;
+extern crate vergen;
+
+use std::{env, fs::File, io::Write, path::Path};
+use vergen::{vergen, OutputFns};
+
+const ERROR_MSG: &'static str = "Failed to generate metadata files";
+
+fn main() {
+    vergen(OutputFns::all()).expect(ERROR_MSG);
+
+    let version = rustc_version::version().expect(ERROR_MSG);
+
+    create_file(
+        "meta.rs",
+        format!(
+            "
+			/// Returns compiler version.
+			pub fn rustc_version() -> &'static str {{
+				\"{version}\"
+			}}
+		",
+            version = version,
+        ),
+    );
+}
+
+fn create_file(filename: &str, data: String) {
+    let out_dir = env::var("OUT_DIR").expect(ERROR_MSG);
+    let dest_path = Path::new(&out_dir).join(filename);
+    let mut f = File::create(&dest_path).expect(ERROR_MSG);
+    f.write_all(data.as_bytes()).expect(ERROR_MSG);
+}

--- a/util/version/src/lib.rs
+++ b/util/version/src/lib.rs
@@ -1,0 +1,59 @@
+// Copyright 2022 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+// Copyright 2015-2020 Parity Technologies (UK) Ltd.
+// This file is part of OpenEthereum.
+
+// OpenEthereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// OpenEthereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Parity version specific information.
+
+extern crate target_info;
+
+use target_info::Target;
+
+mod vergen {
+    #![allow(unused)]
+    include!(concat!(env!("OUT_DIR"), "/version.rs"));
+}
+
+mod generated {
+    include!(concat!(env!("OUT_DIR"), "/meta.rs"));
+}
+
+/// Get the platform identifier.
+pub fn platform() -> String {
+    let env = Target::env();
+    let env_dash = if env.is_empty() { "" } else { "-" };
+    format!("{}-{}{}{}", Target::arch(), Target::os(), env_dash, env)
+}
+
+/// Get the standard version string for this software.
+pub fn version(crate_version: &str) -> String {
+    let sha3 = vergen::short_sha();
+    let sha3_dash = if sha3.is_empty() { "" } else { "-" };
+    let commit_date = vergen::commit_date().replace("-", "");
+    let date_dash = if commit_date.is_empty() { "" } else { "-" };
+    format!(
+        "conflux-rust/v{}{}{}{}{}/{}/rustc{}",
+        crate_version,
+        sha3_dash,
+        sha3,
+        date_dash,
+        commit_date,
+        platform(),
+        generated::rustc_version()
+    )
+}


### PR DESCRIPTION
Note: `web3_clientVersion` will return a version like this: `conflux-rust/v2.0.0-36cc40dd7-20220210/aarch64-macos/rustc1.55.0`. The commit hash is stored in a temporary build file. As a result, you will need to do a clean rebuild for this to be updated (or remove `target/release/build/parity-version-*` manually).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2417)
<!-- Reviewable:end -->
