### PR TITLE
Replace `Instant::elapsed` with `saturating_duration_since` in metrics.

### DIFF
--- a/util/metrics/src/histogram.rs
+++ b/util/metrics/src/histogram.rs
@@ -27,7 +27,11 @@ pub trait Histogram: Send + Sync {
     fn update(&self, _v: u64) {}
     fn variance(&self) -> f64 { 0.0 }
     fn update_since(&self, start_time: Instant) {
-        self.update(start_time.elapsed().as_nanos() as u64);
+        self.update(
+            Instant::now()
+                .saturating_duration_since(start_time)
+                .as_nanos() as u64,
+        );
     }
 }
 

--- a/util/metrics/src/timer.rs
+++ b/util/metrics/src/timer.rs
@@ -16,7 +16,7 @@ pub trait Timer: Send + Sync {
     fn update(&self, _d: Duration) {}
 
     fn update_since(&self, start_time: Instant) {
-        self.update(start_time.elapsed());
+        self.update(Instant::now().saturating_duration_since(start_time));
     }
 }
 


### PR DESCRIPTION
Close #2428.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2429)
<!-- Reviewable:end -->
