### PR TITLE
Use random key for p2p connection.

### DIFF
--- a/client/src/common/mod.rs
+++ b/client/src/common/mod.rs
@@ -41,7 +41,7 @@ use cfxkey::public_to_address;
 use diem_config::keys::ConfigKey;
 use diem_crypto::{
     key_file::{load_pri_key, save_pri_key},
-    Uniform,
+    PrivateKey, Uniform,
 };
 use diem_types::validator_config::{
     ConsensusPrivateKey, ConsensusVRFPrivateKey,
@@ -391,11 +391,14 @@ pub fn initialize_common_modules(
     ));
 
     let network = {
+        let mut rng = StdRng::from_rng(OsRng).unwrap();
+        let private_key = ConsensusPrivateKey::generate(&mut rng);
+        let vrf_private_key = ConsensusVRFPrivateKey::generate(&mut rng);
         let mut network = NetworkService::new(network_config.clone());
         network
             .initialize((
-                self_pos_private_key.public_key(),
-                self_vrf_private_key.public_key(),
+                private_key.public_key(),
+                vrf_private_key.public_key(),
             ))
             .unwrap();
         Arc::new(network)


### PR DESCRIPTION
Since we do not need to send any message to a specific PoS validator node, we do not need to maintain the map between a PoS validator account and the network session.

This PR allows #2438 to work. Otherwise, only one of the two nodes with the same PoS key can connect to the same peer. This PR also prepares us for allowing non-voter nodes to have no PoS key at all in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2439)
<!-- Reviewable:end -->
