### PR TITLE
Set subtraces of Eth traces for `trace_block` and `trace_transaction`.

### DIFF
--- a/core/src/observer/trace.rs
+++ b/core/src/observer/trace.rs
@@ -515,8 +515,11 @@ impl TransactionExecTraces {
         for trace in self.0 {
             match &trace.action {
                 Action::Call(call) => {
-                    if let Some(parent_subtraces) = sublen_stack.last_mut() {
-                        *parent_subtraces += 1;
+                    if call.space == filter.space {
+                        if let Some(parent_subtraces) = sublen_stack.last_mut()
+                        {
+                            *parent_subtraces += 1;
+                        }
                     }
                     sublen_stack.push(0);
                     if call.space == filter.space
@@ -532,8 +535,11 @@ impl TransactionExecTraces {
                     }
                 }
                 Action::Create(create) => {
-                    if let Some(parent_subtraces) = sublen_stack.last_mut() {
-                        *parent_subtraces += 1;
+                    if create.space == filter.space {
+                        if let Some(parent_subtraces) = sublen_stack.last_mut()
+                        {
+                            *parent_subtraces += 1;
+                        }
                     }
                     sublen_stack.push(0);
                     if create.space == filter.space
@@ -560,6 +566,8 @@ impl TransactionExecTraces {
                         let subtraces =
                             sublen_stack.pop().expect("stack_index matches");
                         trace_pairs[index].2 = subtraces;
+                    } else {
+                        sublen_stack.pop();
                     }
                 }
                 Action::InternalTransferAction(_) => {}

--- a/tests/evm_space/phantom_trace_test.py
+++ b/tests/evm_space/phantom_trace_test.py
@@ -155,7 +155,7 @@ class PhantomTransactionTest(Web3Base):
                 "gasUsed": "0x0",
                 "output": number_to_topic(1),
             },
-            "subtraces": 0,
+            "subtraces": 1,
             "traceAddress": [],
             "blockHash": phantom1["blockHash"],
             "blockNumber": int(phantom1["blockNumber"], 16),


### PR DESCRIPTION
`trace_filter` has not been updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2442)
<!-- Reviewable:end -->
