### PR TITLE
Remove the deprecated `pos retire` command.

### DIFF
--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -875,13 +875,6 @@ subcommands:
                                         long: power
                                         required: true
                                         takes_value: true
-
-                            - retire:
-                                  about: Send a PoS transaction to retire this Conflux node.
-                                  args:
-                                      - rpc-method:
-                                            default_value: pos_retire_self
-                                            hidden: true
                             - stop_election:
                                   about: Stop sending PoS election transactions.
                                   args:


### PR DESCRIPTION
Now retire has been processed as a PoW transaction.
The corresponding RPC has been removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2455)
<!-- Reviewable:end -->
