### PR TITLE
Add env vairable `CFX_POS_KEY_ENCRYPTION_PASSWORD` to config pos passwd.

### DIFF
--- a/client/src/common/mod.rs
+++ b/client/src/common/mod.rs
@@ -245,6 +245,9 @@ pub fn initialize_common_modules(
             conf.raw_conf
                 .dev_pos_private_key_encryption_password
                 .clone()
+                // If the password is not set in the config file, read it from
+                // the environment variable.
+                .or(std::env::var("CFX_POS_KEY_ENCRYPTION_PASSWORD").ok())
                 .map(|s| s.into_bytes())
         };
         if key_path.exists() {


### PR DESCRIPTION
Close #2457 .

Now the pos private key encryption password is read in the following order:
1. The configuration file entry `dev_pos_private_key_encryption_password`. (This is not suggested if the node may vote in the future)
2. The environment variable `CFX_POS_KEY_ENCRYPTION_PASSWORD`.
3. The command line prompt.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2464)
<!-- Reviewable:end -->
