### PR TITLE
Add config `min_phase_change_normal_peer_count`.

### DIFF
--- a/changelogs/CHANGELOG-2.0.x.md
+++ b/changelogs/CHANGELOG-2.0.x.md
@@ -4,3 +4,4 @@
 
 - Add config parameter `get_logs_filter_max_block_number_range` for limiting the maximum gap between `from_block` and `to_block` during Core space log filtering (`cfx_getLogs`). Note: eSpace blocks correspond to epochs in Core space, so the range in `eth_getLogs` can be limited using `get_logs_filter_max_epoch_range`.
 - Report error in `cfx_getLogs` and `eth_getLogs` if `get_logs_filter_max_limit` is configured but the query would return more logs. The previous behavior of `cfx_getLogs` was to silently truncate the result. The previous behavior of `eth_getLogs` was to raise an error when `filter.limit` is too low, regardless of how many logs the query would result in.
+- Add config parameter `min_phase_change_normal_peer_count` to set the number of normal-phase peers needed for phase change. The default value is set to 3 to make it more robust.

--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -214,6 +214,7 @@ build_config! {
         (max_peers_tx_propagation, (usize), 128)
         (max_unprocessed_block_size_mb, (usize), (128))
         (min_peers_tx_propagation, (usize), 8)
+        (min_phase_change_normal_peer_count, (usize), 3)
         (received_tx_index_maintain_timeout_ms, (u64), 300_000)
         (request_block_with_public, (bool), false)
         (send_tx_period_ms, (u64), 1300)
@@ -792,6 +793,9 @@ impl Configuration {
             } else {
                 self.raw_conf.dev_allow_phase_change_without_peer
             },
+            min_phase_change_normal_peer_count: self
+                .raw_conf
+                .min_phase_change_normal_peer_count,
             pos_genesis_pivot_decision: self
                 .raw_conf
                 .pos_genesis_pivot_decision

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -421,6 +421,7 @@ pub struct ProtocolConfiguration {
     pub max_unprocessed_block_size: usize,
     pub max_chunk_number_in_manifest: usize,
     pub allow_phase_change_without_peer: bool,
+    pub min_phase_change_normal_peer_count: usize,
     pub pos_genesis_pivot_decision: H256,
     pub check_status_genesis: bool,
 
@@ -440,6 +441,7 @@ impl SynchronizationProtocolHandler {
             protocol_config.is_consortium,
             node_type,
             protocol_config.allow_phase_change_without_peer,
+            protocol_config.min_phase_change_normal_peer_count,
         ));
         let recover_public_queue = Arc::new(AsyncTaskQueue::new(
             SyncHandlerWorkType::RecoverPublic,

--- a/run/hydra.toml
+++ b/run/hydra.toml
@@ -255,6 +255,10 @@ jsonrpc_local_http_port=12539
 #
 # min_peers_tx_propagation = 8
 
+# Minimum number of normal-phase peers to estimate the current global latest epoch for phase change.
+#
+# min_phase_change_normal_peer_count = 3
+
 # The time to maintain received transactions to avoid duplicated requests.
 #
 # received_tx_index_maintain_timeout_ms = 300_000

--- a/tests/conflux/config.py
+++ b/tests/conflux/config.py
@@ -59,4 +59,5 @@ small_local_test_conf = dict(
     hydra_transition_height = 0,
     hydra_transition_number = 0,
     cip43_init_end_number = 2 ** 32 - 1,
+    min_phase_change_normal_peer_count = 1,
 )


### PR DESCRIPTION
The default value is set to 3 to avoid entering `NormalPhase` because
only unluckily connected to one node stuck in old epochs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2465)
<!-- Reviewable:end -->
