### PR TITLE
Fix MacOS 12.3 compilation issues.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3574,7 +3574,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=e62343e63be38284556b6610d75833217e3360b4#e62343e63be38284556b6610d75833217e3360b4"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=cac983ab886a0701c8458bce76a76f63de16e1bd#cac983ab886a0701c8458bce76a76f63de16e1bd"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -3591,7 +3591,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=e62343e63be38284556b6610d75833217e3360b4#e62343e63be38284556b6610d75833217e3360b4"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=cac983ab886a0701c8458bce76a76f63de16e1bd#cac983ab886a0701c8458bce76a76f63de16e1bd"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -5296,7 +5296,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=e62343e63be38284556b6610d75833217e3360b4#e62343e63be38284556b6610d75833217e3360b4"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=cac983ab886a0701c8458bce76a76f63de16e1bd#cac983ab886a0701c8458bce76a76f63de16e1bd"
 dependencies = [
  "libc",
  "librocksdb_sys",

--- a/core/src/pos/storage/schemadb/Cargo.toml
+++ b/core/src/pos/storage/schemadb/Cargo.toml
@@ -18,7 +18,7 @@ diem-metrics = { path = "../../common/metrics" }
 
 [dependencies.rocksdb]
 git = "https://github.com/Conflux-Chain/rust-rocksdb.git"
-rev = "e62343e63be38284556b6610d75833217e3360b4"
+rev = "cac983ab886a0701c8458bce76a76f63de16e1bd"
 
 [dev-dependencies]
 byteorder = "1.4.3"

--- a/db/src/kvdb-rocksdb/Cargo.toml
+++ b/db/src/kvdb-rocksdb/Cargo.toml
@@ -27,4 +27,4 @@ tempdir = "0.3.7"
 
 [dependencies.rocksdb]
 git = "https://github.com/Conflux-Chain/rust-rocksdb.git"
-rev = "e62343e63be38284556b6610d75833217e3360b4"
+rev = "cac983ab886a0701c8458bce76a76f63de16e1bd"


### PR DESCRIPTION
`rocksdb` and `titan` are manually edited to fix new warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2470)
<!-- Reviewable:end -->
