### PR TITLE
Fix #2471: accept unknown fields in eth_call

### DIFF
--- a/client/src/rpc/types/eth/call_request.rs
+++ b/client/src/rpc/types/eth/call_request.rs
@@ -23,7 +23,6 @@ use cfx_types::{H160, U256};
 
 /// Call request
 #[derive(Debug, Default, PartialEq, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct CallRequest {
     /// From

--- a/tests/evm_space/tx_and_receipt_test.py
+++ b/tests/evm_space/tx_and_receipt_test.py
@@ -39,6 +39,9 @@ class EvmTx2ReceiptTest(Web3Base):
         tx = self.w3.eth.get_transaction(return_tx_hash)
         assert_equal(receipt["status"], 1)
 
+        # eth_call with unknown extra fields should work
+        self.nodes[0].eth_call({ "accessList": [] })
+
 
 if __name__ == "__main__":
     EvmTx2ReceiptTest().main()


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2473)
<!-- Reviewable:end -->
