### PR TITLE
Fix #2472: Accept requests with zero as sender in eth_call

### DIFF
--- a/client/src/rpc/impls/eth.rs
+++ b/client/src/rpc/impls/eth.rs
@@ -88,7 +88,7 @@ pub fn sign_call(
         chain_id: Some(chain_id),
         data: request.data.unwrap_or_default().into_vec(),
     }
-    .fake_sign(from.with_evm_space()))
+    .fake_sign_rpc(from.with_evm_space()))
 }
 
 fn block_tx_by_index(

--- a/core/src/executive/internal_contract/impls/cross_space.rs
+++ b/core/src/executive/internal_contract/impls/cross_space.rs
@@ -540,7 +540,7 @@ impl PhantomTransaction {
             value: self.value,
         };
 
-        tx.fake_sign(self.from.with_space(Space::Ethereum))
+        tx.fake_sign_phantom(self.from.with_space(Space::Ethereum))
     }
 
     pub fn into_receipt(self, accumulated_gas_used: U256) -> Receipt {

--- a/tests/evm_space/tx_and_receipt_test.py
+++ b/tests/evm_space/tx_and_receipt_test.py
@@ -39,8 +39,11 @@ class EvmTx2ReceiptTest(Web3Base):
         tx = self.w3.eth.get_transaction(return_tx_hash)
         assert_equal(receipt["status"], 1)
 
-        # eth_call with unknown extra fields should work
+        # eth_call with unknown extra fields should work (#2471)
         self.nodes[0].eth_call({ "accessList": [] })
+
+        # eth_call with zero sender should work (#2472)
+        self.nodes[0].eth_call({ "from": "0x0000000000000000000000000000000000000000" })
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2474)
<!-- Reviewable:end -->
