### PR TITLE
Add more information to the client version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd4865004a46a0aafb2a0a5eb19d3c9fc46ee5f063a6cfc605c69ac9ecf5263d"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -373,12 +373,6 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
-name = "bitflags"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 
 [[package]]
 name = "bitflags"
@@ -494,7 +488,7 @@ dependencies = [
  "rand 0.7.3",
  "rlp",
  "secret-store",
- "toml 0.5.8",
+ "toml",
  "txgen",
 ]
 
@@ -749,7 +743,7 @@ dependencies = [
  "rlp_derive",
  "serde",
  "serde_derive",
- "toml 0.5.8",
+ "toml",
 ]
 
 [[package]]
@@ -991,7 +985,7 @@ dependencies = [
  "tokio 1.17.0",
  "tokio-stream",
  "tokio-timer",
- "toml 0.5.8",
+ "toml",
  "unexpected",
 ]
 
@@ -1052,7 +1046,7 @@ dependencies = [
  "serde_json",
  "smallvec 1.8.0",
  "tempdir",
- "time",
+ "time 0.1.44",
  "tiny-keccak 1.5.0",
 ]
 
@@ -1077,7 +1071,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
+ "time 0.1.44",
  "winapi 0.3.9",
 ]
 
@@ -1124,7 +1118,7 @@ checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags 1.3.2",
+ "bitflags",
  "strsim 0.8.0",
  "textwrap 0.11.0",
  "unicode-width",
@@ -1227,7 +1221,7 @@ dependencies = [
  "tokio 1.17.0",
  "tokio-stream",
  "tokio-timer",
- "toml 0.5.8",
+ "toml",
  "transient-hashmap",
  "txgen",
 ]
@@ -1238,7 +1232,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
 ]
 
 [[package]]
@@ -1293,6 +1287,7 @@ dependencies = [
  "move-core-types",
  "network",
  "panic_hook",
+ "parity-version",
  "parity-wordlist",
  "parking_lot 0.11.2",
  "pos-ledger-db",
@@ -1311,7 +1306,7 @@ dependencies = [
  "tempdir",
  "textwrap 0.9.0",
  "threadpool",
- "toml 0.5.8",
+ "toml",
  "txgen",
 ]
 
@@ -1377,7 +1372,7 @@ dependencies = [
  "backtrace",
  "diem-logger",
  "serde",
- "toml 0.5.8",
+ "toml",
 ]
 
 [[package]]
@@ -2138,6 +2133,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "enum-iterator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
+dependencies = [
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.87",
+]
+
+[[package]]
 name = "enum-map"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2493,7 +2508,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "fuchsia-zircon-sys",
 ]
 
@@ -2703,6 +2718,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.87",
+]
+
+[[package]]
 name = "ghash"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2717,6 +2744,19 @@ name = "gimli"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
+
+[[package]]
+name = "git2"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3826a6e0e2215d7a41c2bfc7c9244123969273f3476b939a226aac0ab56e9e3c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log 0.4.14",
+ "url 2.2.2",
+]
 
 [[package]]
 name = "glob"
@@ -3034,7 +3074,7 @@ dependencies = [
  "log 0.3.9",
  "mime",
  "num_cpus",
- "time",
+ "time 0.1.44",
  "traitobject",
  "typeable",
  "unicase 1.4.2",
@@ -3059,7 +3099,7 @@ dependencies = [
  "log 0.4.14",
  "net2",
  "rustc_version 0.2.3",
- "time",
+ "time 0.1.44",
  "tokio 0.1.22",
  "tokio-buf",
  "tokio-executor",
@@ -3233,7 +3273,7 @@ dependencies = [
  "num_cpus",
  "parking_lot 0.11.2",
  "slab",
- "time",
+ "time 0.1.44",
  "timer",
 ]
 
@@ -3552,6 +3592,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libgit2-sys"
+version = "0.13.2+1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a42de9a51a5c12e00fc0e4ca6bc2ea43582fc6418488e8f615e905d886f258b"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3821,7 +3873,7 @@ dependencies = [
  "log 0.4.14",
  "parking_lot 0.11.2",
  "rand 0.7.3",
- "time",
+ "time 0.1.44",
  "timer",
 ]
 
@@ -4165,6 +4217,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4213,7 +4274,7 @@ version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -4358,9 +4419,8 @@ dependencies = [
 name = "parity-version"
 version = "3.3.3"
 dependencies = [
- "rustc_version 0.2.3",
+ "anyhow",
  "target_info",
- "toml 0.4.10",
  "vergen",
 ]
 
@@ -4876,7 +4936,31 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml 0.5.8",
+ "toml",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.87",
+ "version_check 0.9.4",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -4931,7 +5015,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
 dependencies = [
  "bit-set 0.5.2",
- "bitflags 1.3.2",
+ "bitflags",
  "byteorder",
  "lazy_static",
  "num-traits",
@@ -5186,7 +5270,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
 ]
 
 [[package]]
@@ -5367,6 +5451,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5542,7 +5632,7 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -6046,6 +6136,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07fa4c84a5305909b0eedfcc8d1f2fafdbede645bb700a45ecaafe681a0ac5d6"
+dependencies = [
+ "cfg-if 1.0.0",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6166,7 +6270,7 @@ dependencies = [
  "malloc_size_of",
  "malloc_size_of_derive",
  "parking_lot 0.11.2",
- "toml 0.5.8",
+ "toml",
 ]
 
 [[package]]
@@ -6178,6 +6282,17 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "time"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+dependencies = [
+ "itoa 1.0.1",
+ "libc",
+ "num_threads",
 ]
 
 [[package]]
@@ -6540,15 +6655,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
@@ -6611,7 +6717,7 @@ dependencies = [
  "serde",
  "serde_json",
  "termcolor",
- "toml 0.5.8",
+ "toml",
 ]
 
 [[package]]
@@ -6636,7 +6742,7 @@ dependencies = [
  "rlp",
  "rustc-hex",
  "secret-store",
- "toml 0.5.8",
+ "toml",
 ]
 
 [[package]]
@@ -6807,12 +6913,20 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"
-version = "0.1.1"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3365f36c57e5df714a34be40902b27a992eeddb9996eca52d0584611cf885d"
+checksum = "4db743914c971db162f35bf46601c5a63ec4452e61461937b4c1ab817a60c12e"
 dependencies = [
- "bitflags 0.7.0",
- "time",
+ "anyhow",
+ "cfg-if 1.0.0",
+ "enum-iterator",
+ "getset",
+ "git2",
+ "rustc_version 0.4.0",
+ "rustversion",
+ "sysinfo",
+ "thiserror",
+ "time 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ bcs = "0.1.3"
 tempdir = "0.3.7"
 hex = "0.3.0"
 base64ct = "=1.1.1"
+parity-version = {path = "./util/version"}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies.jemallocator]
 version = "0.3.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,8 @@ fn main() -> Result<(), String> {
     } // only for #[cfg]
 
     let yaml = load_yaml!("cli.yaml");
-    let matches = App::from_yaml(yaml).version(crate_version!()).get_matches();
+    let version = parity_version::version(crate_version!());
+    let matches = App::from_yaml(yaml).version(version.as_str()).get_matches();
 
     if let Some(output) = handle_sub_command(&matches)? {
         println!("{}", output);
@@ -150,7 +151,7 @@ fn main() -> Result<(), String> {
 :......::::.......:::..::::..::..::::::::........:::.......:::..:::::..::
 Current Version: {}
 ",
-        crate_version!()
+        version
     );
 
     let client_handle: Box<dyn ClientTrait>;

--- a/util/version/Cargo.toml
+++ b/util/version/Cargo.toml
@@ -11,9 +11,5 @@ build = "build.rs"
 target_info = "0.1"
 
 [build-dependencies]
-vergen = "0.1"
-rustc_version = "0.2"
-toml = "0.4"
-
-[features]
-final = []
+anyhow = "1.0"
+vergen = "7.0.0"

--- a/util/version/build.rs
+++ b/util/version/build.rs
@@ -1,50 +1,12 @@
-// Copyright 2015-2020 Parity Technologies (UK) Ltd.
-// This file is part of OpenEthereum.
-
-// OpenEthereum is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-
-// OpenEthereum is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
-
-extern crate rustc_version;
-extern crate toml;
+extern crate anyhow;
 extern crate vergen;
 
-use std::{env, fs::File, io::Write, path::Path};
-use vergen::{vergen, OutputFns};
+use anyhow::Result;
+use vergen::{vergen, Config, ShaKind, TimestampKind};
 
-const ERROR_MSG: &'static str = "Failed to generate metadata files";
-
-fn main() {
-    vergen(OutputFns::all()).expect(ERROR_MSG);
-
-    let version = rustc_version::version().expect(ERROR_MSG);
-
-    create_file(
-        "meta.rs",
-        format!(
-            "
-			/// Returns compiler version.
-			pub fn rustc_version() -> &'static str {{
-				\"{version}\"
-			}}
-		",
-            version = version,
-        ),
-    );
-}
-
-fn create_file(filename: &str, data: String) {
-    let out_dir = env::var("OUT_DIR").expect(ERROR_MSG);
-    let dest_path = Path::new(&out_dir).join(filename);
-    let mut f = File::create(&dest_path).expect(ERROR_MSG);
-    f.write_all(data.as_bytes()).expect(ERROR_MSG);
+fn main() -> Result<()> {
+    let mut config = Config::default();
+    *config.git_mut().commit_timestamp_kind_mut() = TimestampKind::DateOnly;
+    *config.git_mut().sha_kind_mut() = ShaKind::Short;
+    vergen(config)
 }

--- a/util/version/src/lib.rs
+++ b/util/version/src/lib.rs
@@ -24,15 +24,6 @@ extern crate target_info;
 
 use target_info::Target;
 
-mod vergen {
-    #![allow(unused)]
-    include!(concat!(env!("OUT_DIR"), "/version.rs"));
-}
-
-mod generated {
-    include!(concat!(env!("OUT_DIR"), "/meta.rs"));
-}
-
 /// Get the platform identifier.
 pub fn platform() -> String {
     let env = Target::env();
@@ -42,9 +33,9 @@ pub fn platform() -> String {
 
 /// Get the standard version string for this software.
 pub fn version(crate_version: &str) -> String {
-    let sha3 = vergen::short_sha();
+    let sha3 = env!("VERGEN_GIT_SHA_SHORT");
     let sha3_dash = if sha3.is_empty() { "" } else { "-" };
-    let commit_date = vergen::commit_date().replace("-", "");
+    let commit_date = env!("VERGEN_GIT_COMMIT_DATE").replace("-", "");
     let date_dash = if commit_date.is_empty() { "" } else { "-" };
     format!(
         "conflux-rust/v{}{}{}{}{}/{}/rustc{}",
@@ -54,6 +45,6 @@ pub fn version(crate_version: &str) -> String {
         date_dash,
         commit_date,
         platform(),
-        generated::rustc_version()
+        env!("VERGEN_RUSTC_SEMVER"),
     )
 }


### PR DESCRIPTION
Originally the version is `conflux 2.0.0`, now it's like `conflux conflux-rust/v2.0.0-8d131d5-20220325/aarch64-macos/rustc1.59.0`.

`vergen` is updated for an automatic rerun if the git commit changes.

`cfx_clientVersion` remains unchanged for compatibility reason. We will add an announcement in this release and change it in the version v2.0.3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2475)
<!-- Reviewable:end -->
