### PR TITLE
Increase request delay upper bound to tolerate corner cases.

### DIFF
--- a/core/src/sync/request_manager/mod.rs
+++ b/core/src/sync/request_manager/mod.rs
@@ -85,10 +85,16 @@ lazy_static! {
             "request_tx_from_inflight_pending_pool"
         );
 
-    /// Delay is increased by 1 second each time, so it costs at least 90*91/2 = 4095s to reach
+    /// Delay is increased by 1 second each time, so it costs at least 600*601/2 (about 50h) to reach
     /// this upper bound. And requests will be discarded after reaching this upper bound.
+    ///
+    /// This upper bound is set so that a block should have been before the current checkpoint
+    /// in our experience, so it will not be referred to by a new block and will likely not
+    /// affect the sync process.
+    /// TODO: We may want to decrease this dynamically in case some active attackers are
+    /// sending non-existent hashes to better limit the resource exhaustion.
     static ref DEFAULT_REQUEST_DELAY_UPPER_BOUND: Duration =
-        Duration::from_secs(90);
+        Duration::from_secs(600);
     static ref DEFAULT_REQUEST_BATCH_BUCKET_SIZE: Duration =
         Duration::from_secs(2);
 }


### PR DESCRIPTION
If a block is not received after this upper bound, the request will be
removed, and this will prevent all its futures from becoming graph-ready.
If some block is just sent before the final timeout boundary, it may
cause a temporary fork because some nodes will not receive it.

Now it's increased so that benign stale blocks are not likely to cause
this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2476)
<!-- Reviewable:end -->
