### PR TITLE
Fix reorg_test.

### DIFF
--- a/tests/reorg_test.py
+++ b/tests/reorg_test.py
@@ -74,6 +74,8 @@ class ReorgTest(ConfluxTestFramework):
                 nonce_map[sender_key] = nonce + 1
                 balance_map[sender_key] -= value + gas_price * 21000
                 time.sleep(random.random() / 10)
+            sync_blocks(shard_nodes)
+            rpc_clients[0].generate_blocks_to_state()
             for k in balance_map:
                 self.log.info("Check account sk:%s addr:%s", bytes_to_int(k), eth_utils.encode_hex(priv_to_addr(k)))
                 wait_until(lambda: self.check_account(k, balance_map, shard_nodes[0]))


### PR DESCRIPTION
Generate enough blocks so that the final balance can be accessed at the
latest state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2530)
<!-- Reviewable:end -->
