### PR TITLE
Reduce compute_epoch during node startup

### DIFF
--- a/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
+++ b/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
@@ -1931,21 +1931,95 @@ impl ConsensusNewBlockHandler {
         if inner.pivot_chain.len() < DEFERRED_STATE_EPOCH_COUNT as usize {
             return;
         }
-        for pivot_index in start_pivot_index + 1
-            ..inner.pivot_chain.len() - DEFERRED_STATE_EPOCH_COUNT as usize + 1
-        {
+
+        let end_index =
+            inner.pivot_chain.len() - DEFERRED_STATE_EPOCH_COUNT as usize + 1;
+        for pivot_index in start_pivot_index + 1..end_index {
+            let pivot_arena_index = inner.pivot_chain[pivot_index];
+            let pivot_hash = inner.arena[pivot_arena_index].hash;
+
+            // Ensure that the commitments for the blocks on
+            // pivot_chain after cur_era_stable_genesis are kept in memory.
+            if self
+                .data_man
+                .load_epoch_execution_commitment_from_db(&pivot_hash)
+                .is_none()
+            {
+                break;
+            }
+        }
+
+        let mut force_compute_index = start_pivot_index;
+        let mut epoch_count = 0;
+        for pivot_index in (start_pivot_index + 1..end_index).rev() {
+            let pivot_arena_index = inner.pivot_chain[pivot_index];
+            let pivot_hash = inner.arena[pivot_arena_index].hash;
+
+            let maybe_epoch_execution_commitment =
+                self.data_man.get_epoch_execution_commitment(&pivot_hash);
+            if let Some(commitment) = *maybe_epoch_execution_commitment {
+                if self
+                    .data_man
+                    .storage_manager
+                    .get_state_no_commit(
+                        StateIndex::new_for_readonly(
+                            &pivot_hash,
+                            &commitment.state_root_with_aux_info,
+                        ),
+                        /* try_open = */ false,
+                    )
+                    .expect("DB Error")
+                    .is_some()
+                {
+                    epoch_count += 1;
+
+                    // force to recompute last 5 epochs in case state database
+                    // is not ready in last shutdown
+                    if epoch_count > DEFERRED_STATE_EPOCH_COUNT {
+                        let reward_execution_info =
+                            self.executor.get_reward_execution_info(
+                                inner,
+                                pivot_arena_index,
+                            );
+
+                        let pivot_block_height = self
+                            .data_man
+                            .block_header_by_hash(&pivot_hash)
+                            .expect("must exists")
+                            .height();
+
+                        // ensure current epoch is new executed whether there
+                        // is a fork or not
+                        if self.executor.epoch_executed_and_recovered(
+                            &pivot_hash,
+                            &inner.get_epoch_block_hashes(pivot_arena_index),
+                            true,
+                            &reward_execution_info,
+                            pivot_block_height,
+                        ) {
+                            force_compute_index = pivot_index;
+                            debug!(
+                                "Force compute start index {}",
+                                force_compute_index
+                            );
+                            break;
+                        }
+                    }
+                } else {
+                    epoch_count = 0;
+                }
+            }
+        }
+
+        let mut pre_epoch_state_exist = true;
+
+        for pivot_index in start_pivot_index + 1..end_index {
             let pivot_arena_index = inner.pivot_chain[pivot_index];
             let pivot_hash = inner.arena[pivot_arena_index].hash;
             let height = inner.arena[pivot_arena_index].height;
-            let mut has_storage = true;
 
             let mut compute_epoch = false;
-            // Ensure that the commitments for the blocks on
-            // pivot_chain after cur_era_stable_genesis are kept in memory.
-            let maybe_epoch_execution_commitment = self
-                .data_man
-                .load_epoch_execution_commitment_from_db(&pivot_hash);
-            match maybe_epoch_execution_commitment {
+            match *self.data_man.get_epoch_execution_commitment(&pivot_hash) {
                 None => {
                     // We should recompute the epochs that should have been
                     // executed but fail to persist their
@@ -1984,7 +2058,10 @@ impl ConsensusNewBlockHandler {
                             // last shutdown the snapshotting process wasn't
                             // finished yet. In this case, we must trigger the
                             // snapshotting process by computing epoch again.
-                            compute_epoch = true;
+
+                            if pre_epoch_state_exist {
+                                compute_epoch = true;
+                            }
                         }
                     }
 
@@ -2001,11 +2078,9 @@ impl ConsensusNewBlockHandler {
                         .expect("DB Error")
                         .is_none()
                     {
-                        // The commitment exists but the state is missing.
-                        // This is possible after a crash because commitments
-                        // and states are stored in different databases.
-                        compute_epoch = true;
-                        has_storage = false;
+                        pre_epoch_state_exist = false;
+                    } else {
+                        pre_epoch_state_exist = true;
                     }
 
                     self.data_man
@@ -2014,12 +2089,13 @@ impl ConsensusNewBlockHandler {
                         .upper_bound += 1;
                 }
             }
+
             info!(
-                "construct_pivot_state: index {} height {} compute_epoch {} has_storage {}.",
-                pivot_index, height, compute_epoch, has_storage,
+                "construct_pivot_state: index {} height {} compute_epoch {}.",
+                pivot_index, height, compute_epoch,
             );
 
-            if compute_epoch {
+            if compute_epoch || pivot_index > force_compute_index {
                 let reward_execution_info = self
                     .executor
                     .get_reward_execution_info(inner, pivot_arena_index);
@@ -2033,6 +2109,7 @@ impl ConsensusNewBlockHandler {
                     ),
                     None,
                 );
+                pre_epoch_state_exist = true;
             }
         }
     }

--- a/core/src/sync/synchronization_phases.rs
+++ b/core/src/sync/synchronization_phases.rs
@@ -26,11 +26,7 @@ use std::{
     time::{self, Instant},
 };
 
-///
-/// Archive node goes through the following phases:
-///     CatchUpFillBlockBody --> CatchUpSyncBlock --> Normal
-///
-/// Full node goes through the following phases:
+/// Both Archive and Full node go through the following phases:
 ///     CatchUpRecoverBlockHeaderFromDB --> CatchUpSyncBlockHeader -->
 ///     CatchUpCheckpoint --> CatchUpFillBlockBody -->
 ///     CatchUpSyncBlock --> Normal
@@ -292,6 +288,7 @@ impl SynchronizationPhaseTrait for CatchUpSyncBlockHeaderPhase {
         *sync_handler.latest_epoch_requested.lock() =
             (cur_era_genesis_height, Instant::now(), 0, 0);
 
+        // sync block headers from peers
         sync_handler.request_epochs(io);
     }
 }
@@ -433,11 +430,11 @@ impl SynchronizationPhaseTrait for CatchUpFillBlockBodyPhase {
     {
         info!("start phase {:?}", self.name());
         {
-            // For archive node, this will be `None`.
-            // For full node, this is `None` when the state of checkpoint is
-            // already in disk and we didn't sync it from peer.
-            // In both cases, we should set `state_availability_boundary` to
-            // `[cur_era_stable_height, cur_era_stable_height]`.
+            // For both archive and full node, synced_epoch_id possible be
+            // `None`. It wil be nont when stable epoch is equal to
+            // true genesis In both cases, we should set
+            // `state_availability_boundary` to
+            // `[cur_era_stable_hash, cur_era_stable_height]`.
             if let Some(epoch_synced) = &*sync_handler.synced_epoch_id.lock() {
                 let epoch_synced_height = self
                     .graph

--- a/core/src/sync/synchronization_phases.rs
+++ b/core/src/sync/synchronization_phases.rs
@@ -431,7 +431,7 @@ impl SynchronizationPhaseTrait for CatchUpFillBlockBodyPhase {
         info!("start phase {:?}", self.name());
         {
             // For both archive and full node, synced_epoch_id possible be
-            // `None`. It wil be nont when stable epoch is equal to
+            // `None`. It wil be none when stable epoch is equal to
             // true genesis In both cases, we should set
             // `state_availability_boundary` to
             // `[cur_era_stable_hash, cur_era_stable_height]`.

--- a/core/src/sync/synchronization_phases.rs
+++ b/core/src/sync/synchronization_phases.rs
@@ -434,7 +434,7 @@ impl SynchronizationPhaseTrait for CatchUpFillBlockBodyPhase {
             // `None`. It wil be none when stable epoch is equal to
             // true genesis In both cases, we should set
             // `state_availability_boundary` to
-            // `[cur_era_stable_hash, cur_era_stable_height]`.
+            // `[cur_era_stable_height, cur_era_stable_height]`.
             if let Some(epoch_synced) = &*sync_handler.synced_epoch_id.lock() {
                 let epoch_synced_height = self
                     .graph

--- a/tests/example_test.py
+++ b/tests/example_test.py
@@ -14,7 +14,6 @@ class ExampleTest(ConfluxTestFramework):
         self.setup_nodes()
 
     def run_test(self):
-        time.sleep(7)
         genesis = self.nodes[0].best_block_hash()
         self.log.info(genesis)
 

--- a/tests/reboot_with_pivot_change_test.py
+++ b/tests/reboot_with_pivot_change_test.py
@@ -36,8 +36,6 @@ class ExampleTest(ConfluxTestFramework):
 
 
     def run_test(self):
-        time.sleep(7)
-
         client1 = RpcClient(self.nodes[0])
         client2 = RpcClient(self.nodes[1])
 
@@ -63,8 +61,8 @@ class ExampleTest(ConfluxTestFramework):
 
         # pack tx in node 1
         # pivot chain in node 1
-        tx_hash1 = client1.send_tx(tx)
-        self.log.info("Node 1 tx hash {}".format(tx_hash1))
+        tx_hash = client1.send_tx(tx)
+        self.log.info("Node 1 tx hash {}".format(tx_hash))
 
         block_hash1 = client1.generate_block(1)
         self.log.info("Node 1 block hash {}".format(block_hash1))
@@ -72,7 +70,7 @@ class ExampleTest(ConfluxTestFramework):
         blocks = self.nodes[0].generate_empty_blocks(6)
         last_block = blocks[-1]
 
-        tx_info = client1.get_tx(tx_hash1)
+        tx_info = client1.get_tx(tx_hash)
         block_contains_tx1 = tx_info["blockHash"]
 
         assert_equal(block_contains_tx1, block_hash1)
@@ -82,15 +80,16 @@ class ExampleTest(ConfluxTestFramework):
         
         # pack tx in node2
         # pivot chain in node 2
-        tx_hash2 = client2.send_tx(tx)
-        self.log.info("Node 2 tx hash {}".format(tx_hash2))
+        tx_hash_new = client2.send_tx(tx)
+        self.log.info("Node 2 tx hash {}".format(tx_hash_new))
+        assert_equal(tx_hash, tx_hash_new)
 
         block_hash2 = client2.generate_block(1)
         self.log.info("Node 2 block hash {}".format(block_hash2))
 
         self.nodes[1].generate_empty_blocks(12)
 
-        tx_info = client2.get_tx(tx_hash1)
+        tx_info = client2.get_tx(tx_hash)
         block_contains_tx2 = tx_info["blockHash"]
 
         assert_equal(block_contains_tx2, block_hash2)
@@ -108,8 +107,8 @@ class ExampleTest(ConfluxTestFramework):
         self.log.info("Node 1 epoch {}".format(client1.epoch_number()))
         self.log.info("Node 2 epoch {}".format(client2.epoch_number()))
 
-        b1 = client1.get_tx(tx_hash1)["blockHash"]
-        b2 = client2.get_tx(tx_hash2)["blockHash"]
+        b1 = client1.get_tx(tx_hash)["blockHash"]
+        b2 = client2.get_tx(tx_hash)["blockHash"]
        
         assert_equal(b1, block_hash2)
         assert_equal(b2, block_hash2)
@@ -128,13 +127,12 @@ class ExampleTest(ConfluxTestFramework):
         self.nodes[0].wait_for_nodeid()
         self.nodes[0].wait_for_recovery(["NormalSyncPhase"], 100)
 
-        time.sleep(7)
         self.log.info("Node 1 epoch {}".format(client1.epoch_number()))
         self.log.info("Node 2 epoch {}".format(client2.epoch_number()))
 
         # pivot chain in node 1 changed
-        b1 = client1.get_tx(tx_hash1)["blockHash"]
-        b2 = client2.get_tx(tx_hash2)["blockHash"]
+        b1 = client1.get_tx(tx_hash)["blockHash"]
+        b2 = client2.get_tx(tx_hash)["blockHash"]
        
         assert_equal(b1, block_hash1)
         assert_equal(b2, block_hash1)

--- a/tests/reboot_with_pivot_change_test.py
+++ b/tests/reboot_with_pivot_change_test.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Pivot chain changed during reboot node
+1. Node 1 generate chain 1
+2. Node 2 generate chain 2, longer than chain 1
+3. Node 1, node 2 synced, pivot chain is chain 2
+4. Node 1 stoped
+5. Node 2 changed pivot chain to chain 1
+6. Node 1 start
+7. Blocks in node 1 since fork point should be reexecuted
+"""
+
+from test_framework.test_framework import ConfluxTestFramework
+from test_framework.util import *
+from conflux.rpc import RpcClient
+
+
+class ExampleTest(ConfluxTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+
+    def setup_network(self):
+        self.setup_nodes()
+
+    def run_test(self):
+        time.sleep(7)
+
+        client1 = RpcClient(self.nodes[0])
+        client2 = RpcClient(self.nodes[1])
+
+        genesis = self.nodes[0].best_block_hash()
+        self.log.info("genesis {}".format(genesis))
+        self.log.info("Node 1 epoch {}".format(client1.epoch_number()))
+
+        # generate blocks to slow down node startup to wait nodes connected
+        self.nodes[0].generate_empty_blocks(10000)
+        connect_nodes(self.nodes, 0, 1)
+        sync_blocks(self.nodes[0:2])
+
+        e1 = client1.epoch_number()
+        e2 = client2.epoch_number()
+        self.log.info("Node 1 epoch {}".format(e1))
+        self.log.info("Node 2 epoch {}".format(e2))
+        assert_equal(e1, 10000)
+        assert_equal(e2, 10000)
+
+        self.log.info("Disconnect nodes")
+        disconnect_nodes(self.nodes, 0, 1)
+
+        tx = client1.new_tx()
+
+        # pack tx in node 1
+        # pivot chain in node 1
+        tx_hash1 = client1.send_tx(tx)
+        self.log.info("Node 1 tx hash {}".format(tx_hash1))
+
+        block_hash1 = client1.generate_block(1)
+        self.log.info("Node 1 block hash {}".format(block_hash1))
+
+        blocks = self.nodes[0].generate_empty_blocks(6)
+        last_block = blocks[-1]
+
+        tx_info = client1.get_tx(tx_hash1)
+        block_contains_tx1 = tx_info["blockHash"]
+
+        assert_equal(block_contains_tx1, block_hash1)
+
+        self.log.info("Node 1 block info {}".format(client1.block_by_hash(block_hash1, True)))
+        self.log.info("Node 1 tx info {}".format(tx_info))
+        
+        # pack tx in node2
+        # pivot chain in node 2
+        tx_hash2 = client2.send_tx(tx)
+        self.log.info("Node 2 tx hash {}".format(tx_hash2))
+
+        block_hash2 = client2.generate_block(1)
+        self.log.info("Node 2 block hash {}".format(block_hash2))
+
+        self.nodes[1].generate_empty_blocks(12)
+
+        tx_info = client2.get_tx(tx_hash1)
+        block_contains_tx2 = tx_info["blockHash"]
+
+        assert_equal(block_contains_tx2, block_hash2)
+
+        self.log.info("Node 2 block info {}".format(client2.block_by_hash(block_hash2, True)))
+        self.log.info("Node 2 tx info {}".format(tx_info))
+
+        self.log.info("Node 1 epoch {}".format(client1.epoch_number()))
+        self.log.info("Node 2 epoch {}".format(client2.epoch_number()))
+
+        # sync blocks, pivot chain in node 1 changed
+        connect_nodes(self.nodes, 0, 1)
+        sync_blocks(self.nodes[0:2])
+
+        self.log.info("Node 1 epoch {}".format(client1.epoch_number()))
+        self.log.info("Node 2 epoch {}".format(client2.epoch_number()))
+
+        b1 = client1.get_tx(tx_hash1)["blockHash"]
+        b2 = client2.get_tx(tx_hash2)["blockHash"]
+       
+        assert_equal(b1, block_hash2)
+        assert_equal(b2, block_hash2)
+
+        self.log.info("==== Stop node 1 ====")
+        self.nodes[0].stop_node()
+        self.nodes[0].wait_until_stopped()
+
+        # change pivot chain in node 2, must more than 20 (CATCH_UP_EPOCH_LAG_THRESHOLD)
+        for i in range(30):
+            last_block = client2.generate_block_with_parent(last_block)
+
+        self.log.info("==== Start node 1 ====")
+        self.nodes[0].start()
+        self.nodes[0].wait_for_rpc_connection()
+        self.nodes[0].wait_for_nodeid()
+        self.nodes[0].wait_for_recovery(["NormalSyncPhase"], 100)
+
+        time.sleep(7)
+        self.log.info("Node 1 epoch {}".format(client1.epoch_number()))
+        self.log.info("Node 2 epoch {}".format(client2.epoch_number()))
+
+        # pivot chain in node 1 changed
+        b1 = client1.get_tx(tx_hash1)["blockHash"]
+        b2 = client2.get_tx(tx_hash2)["blockHash"]
+       
+        assert_equal(b1, block_hash1)
+        assert_equal(b2, block_hash1)
+
+
+if __name__ == '__main__':
+    ExampleTest().main()


### PR DESCRIPTION
Rerun compute_epoch during startup is time consuming due to most snapshots (InfoOnly) since stable checkpoint is deleted and state is missing. To speed up startup, rerun compute_epoch from latest commit state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2533)
<!-- Reviewable:end -->
