### PR TITLE
Remove parameters limit and offset in cfx_getLogs and eth_getLogs

### DIFF
--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -591,6 +591,7 @@ impl Configuration {
             get_logs_epoch_batch_size: self.raw_conf.get_logs_epoch_batch_size,
             get_logs_filter_max_epoch_range: self.raw_conf.get_logs_filter_max_epoch_range,
             get_logs_filter_max_block_number_range: self.raw_conf.get_logs_filter_max_block_number_range,
+            get_logs_filter_max_limit: self.raw_conf.get_logs_filter_max_limit,
             sync_state_starting_epoch: self.raw_conf.sync_state_starting_epoch,
             sync_state_epoch_gap: self.raw_conf.sync_state_epoch_gap,
         };

--- a/client/src/light/mod.rs
+++ b/client/src/light/mod.rs
@@ -91,7 +91,6 @@ impl LightClient {
         sync_graph.recover_graph_from_db();
 
         let rpc_impl = Arc::new(RpcImpl::new(
-            conf.rpc_impl_config(),
             light.clone(),
             accounts,
             consensus.clone(),

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -1058,7 +1058,7 @@ impl RpcImpl {
         // If the results does not fit into `max_limit`, report an error
         if let Some(max_limit) = self.config.get_logs_filter_max_limit {
             if logs.len() > max_limit {
-                bail!(invalid_params("filter", format!("This query results in too many logs, please set filter.limit to {} or lower", max_limit)));
+                bail!(invalid_params("filter", format!("This query results in too many logs, max limitation is {}, please filter results by a smaller epoch/block range", max_limit)));
             }
         }
 

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -1041,19 +1041,7 @@ impl RpcImpl {
         let consensus_graph = self.consensus_graph();
 
         info!("RPC Request: cfx_getLogs({:?})", filter);
-        let mut filter: LogFilter = filter.into_primitive()?;
-
-        // If max_limit is set, the value in `filter` will be modified to
-        // satisfy this limitation to avoid loading too many blocks
-        if let Some(max_limit) = self.config.get_logs_filter_max_limit {
-            if filter.limit.is_none() || filter.limit.unwrap() > max_limit {
-                // Use `max_limit + 1` so that we can detect when the query
-                // results in more than `max_limit` logs.
-                // Note: it is possible that processing `max_limit + 1` takes
-                // much more time than `max_limit`, however, this is rare.
-                filter.limit = Some(max_limit + 1);
-            }
-        }
+        let filter: LogFilter = filter.into_primitive()?;
 
         let logs = consensus_graph
             .logs(filter)?

--- a/client/src/rpc/impls/eth.rs
+++ b/client/src/rpc/impls/eth.rs
@@ -989,7 +989,7 @@ impl Eth for EthHandler {
         // If the results does not fit into `max_limit`, report an error
         if let Some(max_limit) = self.config.get_logs_filter_max_limit {
             if logs.len() > max_limit {
-                bail!(invalid_params("filter", format!("This query results in too many logs, please use a smaller block range or set filter.limit to {} or lower", max_limit)));
+                bail!(invalid_params("filter", format!("This query results in too many logs, max limitation is {}, please use a smaller block range", max_limit)));
             }
         }
 

--- a/client/src/rpc/impls/eth.rs
+++ b/client/src/rpc/impls/eth.rs
@@ -978,20 +978,8 @@ impl Eth for EthHandler {
     fn logs(&self, filter: EthRpcLogFilter) -> jsonrpc_core::Result<Vec<Log>> {
         info!("RPC Request: eth_getLogs({:?})", filter);
 
-        let mut filter: LogFilter =
+        let filter: LogFilter =
             filter.into_primitive(self.consensus.clone())?;
-
-        // If max_limit is set, the value in `filter` will be modified to
-        // satisfy this limitation to avoid loading too many blocks
-        if let Some(max_limit) = self.config.get_logs_filter_max_limit {
-            if filter.limit.is_none() || filter.limit.unwrap() > max_limit {
-                // Use `max_limit + 1` so that we can detect when the query
-                // results in more than `max_limit` logs.
-                // Note: it is possible that processing `max_limit + 1` takes
-                // much more time than `max_limit`, however, this is rare.
-                filter.limit = Some(max_limit + 1);
-            }
-        }
 
         let logs = self
             .consensus_graph()

--- a/client/src/rpc/types/eth/filter.rs
+++ b/client/src/rpc/types/eth/filter.rs
@@ -112,8 +112,6 @@ pub struct EthRpcLogFilter {
     pub address: Option<FilterAddress>,
     /// Topics
     pub topics: Option<Vec<Topic>>,
-    /// Limit
-    pub limit: Option<usize>,
 }
 
 impl EthRpcLogFilter {
@@ -128,8 +126,6 @@ impl EthRpcLogFilter {
                 .into_iter()
                 .map(|t| t.to_opt())
                 .collect(),
-            offset: None,
-            limit: self.limit,
             trusted: false,
             space: Space::Ethereum,
         };

--- a/client/src/rpc/types/filter.rs
+++ b/client/src/rpc/types/filter.rs
@@ -45,19 +45,6 @@ pub struct CfxRpcLogFilter {
     /// logs with "0xA" as the 1st topic AND ("0xB" OR "0xC") as the 3rd
     /// topic. If None, match all.
     pub topics: Option<Vec<VariadicValue<H256>>>,
-
-    /// Logs offset
-    ///
-    /// If None, return all logs
-    /// If specified, should skip the *last* `n` logs.
-    pub offset: Option<U64>,
-
-    /// Logs limit
-    ///
-    /// If None, return all logs
-    /// If specified, should only return *last* `n` logs
-    /// after the offset has been applied.
-    pub limit: Option<U64>,
 }
 
 impl CfxRpcLogFilter {
@@ -126,14 +113,9 @@ impl CfxRpcLogFilter {
             }
         };
 
-        let offset = self.offset.map(|x| x.as_u64() as usize);
-        let limit = self.limit.map(|x| x.as_u64() as usize);
-
         let params = LogFilterParams {
             address,
             topics,
-            offset,
-            limit,
             trusted: false,
             space: Space::Native,
         };
@@ -214,8 +196,6 @@ mod tests {
             block_hashes: None,
             address: None,
             topics: None,
-            offset: None,
-            limit: None,
         };
 
         let serialized_filter = serde_json::to_string(&filter).unwrap();
@@ -229,9 +209,7 @@ mod tests {
              \"toBlock\":null,\
              \"blockHashes\":null,\
              \"address\":null,\
-             \"topics\":null,\
-             \"offset\":null,\
-             \"limit\":null\
+             \"topics\":null\
              }"
         );
 
@@ -255,8 +233,6 @@ mod tests {
                     H256::from_str("d397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5").unwrap(),
                 ]),
             ]),
-            offset: Some(U64::from(1)),
-            limit: Some(U64::from(2)),
         };
 
         let serialized_filter = serde_json::to_string(&filter).unwrap();
@@ -273,9 +249,7 @@ mod tests {
              \"topics\":[\
                 \"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5\",\
                 [\"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5\",\"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5\"]\
-             ],\
-             \"offset\":\"0x1\",\
-             \"limit\":\"0x2\"\
+             ]\
              }"
         );
     }
@@ -292,8 +266,6 @@ mod tests {
             block_hashes: None,
             address: None,
             topics: None,
-            offset: None,
-            limit: None,
         };
 
         let deserialized_filter: CfxRpcLogFilter =
@@ -310,9 +282,7 @@ mod tests {
              \"topics\":[\
                 \"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5\",\
                 [\"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5\",\"0xd397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5\"]\
-             ],\
-             \"offset\":\"0x1\",\
-             \"limit\":\"0x2\"\
+             ]\
         }";
 
         let result_filter = CfxRpcLogFilter {
@@ -335,8 +305,6 @@ mod tests {
                     H256::from_str("d397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5").unwrap(),
                 ]),
             ]),
-            offset: Some(U64::from(1)),
-            limit: Some(U64::from(2)),
         };
 
         let deserialized_filter: CfxRpcLogFilter =
@@ -363,8 +331,6 @@ mod tests {
                     H256::from_str("d397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5").unwrap(),
                 ]),
             ]),
-            offset: Some(U64::from(1)),
-            limit: Some(U64::from(2)),
         };
 
         let primitive_epoch_filter = PrimitiveFilter::EpochLogFilter {
@@ -384,8 +350,6 @@ mod tests {
                     None,
                     None,
                 ],
-                offset: Some(1),
-                limit: Some(2),
                 trusted: false,
                 space: Space::Native,
             },
@@ -412,8 +376,6 @@ mod tests {
                     H256::from_str("d397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5").unwrap(),
                 ]),
             ]),
-            offset: Some(U64::from(1)),
-            limit: Some(U64::from(2)),
         };
 
         let primitive_block_number_filter = PrimitiveFilter::BlockNumberLogFilter {
@@ -433,8 +395,6 @@ mod tests {
                     None,
                     None,
                 ],
-                offset: Some(1),
-                limit: Some(2),
                 trusted: false,
                 space: Space::Native,
             },
@@ -467,8 +427,6 @@ mod tests {
                     H256::from_str("d397b3b043d87fcd6fad1291ff0bfd16401c274896d8c63a923727f077b8e0b5").unwrap(),
                 ]),
             ]),
-            offset: Some(U64::from(1)),
-            limit: Some(U64::from(2)),
         };
 
         let primitive_block_hash_filter = PrimitiveFilter::BlockHashLogFilter {
@@ -490,8 +448,6 @@ mod tests {
                     None,
                     None,
                 ],
-                offset: Some(1),
-                limit: Some(2),
                 trusted: false,
                 space: Space::Native,
             },

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -146,6 +146,8 @@ pub struct ConsensusConfig {
     /// Limits on epoch and block number ranges during log filtering.
     pub get_logs_filter_max_epoch_range: Option<u64>,
     pub get_logs_filter_max_block_number_range: Option<u64>,
+    /// Max limiation for logs
+    pub get_logs_filter_max_limit: Option<usize>,
 
     /// TODO: These parameters are only utilized in catch-up now.
     /// TODO: They should be used in data garbage collection, too.
@@ -1119,6 +1121,8 @@ impl ConsensusGraph {
                 Ok(log) => blocks_to_skip.contains(&log.block_hash),
                 Err(_) => false,
             })
+            // Limit logs can return
+            .take(self.config.get_logs_filter_max_limit.unwrap_or(::std::usize::MAX - 1) + 1)
             // short-circuit on error
             .collect::<Result<Vec<LocalizedLogEntry>, FilterError>>()?;
 
@@ -1227,6 +1231,8 @@ impl ConsensusGraph {
                 Ok(it) => Either::Left(it.into_iter().map(Ok)),
                 Err(e) => Either::Right(std::iter::once(Err(e))),
             })
+            // Limit logs can return
+            .take(self.config.get_logs_filter_max_limit.unwrap_or(::std::usize::MAX - 1) + 1)
             // short-circuit on error
             .collect::<Result<Vec<_>, _>>()?;
 

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -1090,9 +1090,6 @@ impl ConsensusGraph {
     {
         let bloom_possibilities = filter.bloom_possibilities();
 
-        let offset = filter.offset.unwrap_or(0);
-        let limit = filter.limit.unwrap_or(::std::usize::MAX);
-
         // we store the last epoch processed and the corresponding pivot hash so
         // that we can check whether it changed between batches
         let mut consistency_check_data: Option<(u64, H256)> = None;
@@ -1122,8 +1119,6 @@ impl ConsensusGraph {
                 Ok(log) => blocks_to_skip.contains(&log.block_hash),
                 Err(_) => false,
             })
-            .skip(offset)
-            .take(limit)
             // short-circuit on error
             .collect::<Result<Vec<LocalizedLogEntry>, FilterError>>()?;
 
@@ -1232,9 +1227,6 @@ impl ConsensusGraph {
                 Ok(it) => Either::Left(it.into_iter().map(Ok)),
                 Err(e) => Either::Right(std::iter::once(Err(e))),
             })
-            // take as many as we need
-            .skip(filter.offset.unwrap_or(0))
-            .take(filter.limit.unwrap_or(::std::usize::MAX))
             // short-circuit on error
             .collect::<Result<Vec<_>, _>>()?;
 

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -1122,7 +1122,12 @@ impl ConsensusGraph {
                 Err(_) => false,
             })
             // Limit logs can return
-            .take(self.config.get_logs_filter_max_limit.unwrap_or(::std::usize::MAX - 1) + 1)
+            .take(
+                self.config
+                    .get_logs_filter_max_limit
+                    .unwrap_or(::std::usize::MAX - 1)
+                    + 1,
+            )
             // short-circuit on error
             .collect::<Result<Vec<LocalizedLogEntry>, FilterError>>()?;
 
@@ -1232,7 +1237,12 @@ impl ConsensusGraph {
                 Err(e) => Either::Right(std::iter::once(Err(e))),
             })
             // Limit logs can return
-            .take(self.config.get_logs_filter_max_limit.unwrap_or(::std::usize::MAX - 1) + 1)
+            .take(
+                self.config
+                    .get_logs_filter_max_limit
+                    .unwrap_or(::std::usize::MAX - 1)
+                    + 1,
+            )
             // short-circuit on error
             .collect::<Result<Vec<_>, _>>()?;
 

--- a/core/src/light_protocol/query_service.rs
+++ b/core/src/light_protocol/query_service.rs
@@ -962,10 +962,6 @@ impl QueryService {
                 .any(|bloom| block_log_bloom.contains_bloom(bloom))
         };
 
-        // set maximum to number of logs returned
-        let offset = filter.offset.unwrap_or(0);
-        let limit = filter.limit.unwrap_or(::std::usize::MAX);
-
         // construct a stream object for log filtering
         // we first retrieve the epoch blooms and try to match against them. for
         // matching epochs, we retrieve the corresponding receipts and find the
@@ -1056,9 +1052,6 @@ impl QueryService {
             })
             // --> TryStream<LocalizedLogEntry>
 
-            // limit number of entries we need
-            .skip(offset)
-            .take(limit)
             // --> TryStream<LocalizedLogEntry>
 
             .try_collect();

--- a/core/src/light_protocol/query_service.rs
+++ b/core/src/light_protocol/query_service.rs
@@ -1050,10 +1050,8 @@ impl QueryService {
                 log.transaction_hash = txs[log.transaction_index].hash();
                 log
             })
-            // --> TryStream<LocalizedLogEntry>
-
-            // --> TryStream<LocalizedLogEntry>
-
+            // Limit logs can return
+            .take( self.consensus.get_config().get_logs_filter_max_limit.unwrap_or(::std::usize::MAX - 1) + 1)
             .try_collect();
         // --> TryFuture<Vec<LocalizedLogEntry>>
 

--- a/core/src/light_protocol/query_service.rs
+++ b/core/src/light_protocol/query_service.rs
@@ -1051,7 +1051,7 @@ impl QueryService {
                 log
             })
             // Limit logs can return
-            .take( self.consensus.get_config().get_logs_filter_max_limit.unwrap_or(::std::usize::MAX - 1) + 1)
+            .take(self.consensus.get_config().get_logs_filter_max_limit.unwrap_or(::std::usize::MAX - 1) + 1)
             .try_collect();
         // --> TryFuture<Vec<LocalizedLogEntry>>
 

--- a/core/src/sync/utils.rs
+++ b/core/src/sync/utils.rs
@@ -256,6 +256,7 @@ pub fn initialize_synchronization_graph_with_data_manager(
             get_logs_epoch_batch_size: 32,
             get_logs_filter_max_epoch_range: None,
             get_logs_filter_max_block_number_range: None,
+            get_logs_filter_max_limit: None,
             sync_state_starting_epoch: None,
             sync_state_epoch_gap: None,
         },

--- a/primitives/src/filter.rs
+++ b/primitives/src/filter.rs
@@ -213,19 +213,6 @@ pub struct LogFilterParams {
     /// If specified, log must contain one of these topics.
     pub topics: Vec<Option<Vec<H256>>>,
 
-    /// Logs offset
-    ///
-    /// If None, return all logs
-    /// If specified, should skip the *last* `n` logs.
-    pub offset: Option<usize>,
-
-    /// Logs limit
-    ///
-    /// If None, return all logs
-    /// If specified, should only return *last* `n` logs
-    /// after the offset has been applied.
-    pub limit: Option<usize>,
-
     /// Indicate if the log filter can be trusted, so we do not need to check
     /// other fields.
     ///
@@ -244,8 +231,6 @@ impl Default for LogFilterParams {
         LogFilterParams {
             address: None,
             topics: vec![None, None, None, None],
-            offset: None,
-            limit: None,
             trusted: false,
             space: Space::Native,
         }

--- a/tests/conflux/filter.py
+++ b/tests/conflux/filter.py
@@ -4,7 +4,7 @@ from conflux.config import DEFAULT_PY_TEST_CHAIN_ID
 
 class Filter():
     def __init__(self, from_epoch=None, to_epoch=None, from_block = None, to_block = None, block_hashes = None, address = None, topics = [],
-                 offset = None, limit = None, encode_address=True, networkid=DEFAULT_PY_TEST_CHAIN_ID):
+                encode_address=True, networkid=DEFAULT_PY_TEST_CHAIN_ID):
         if encode_address and address is not None:
             if isinstance(address, list):
                 base32_address = []
@@ -20,5 +20,3 @@ class Filter():
         self.blockHashes = block_hashes
         self.address = address
         self.topics = topics
-        self.offset = offset
-        self.limit = limit

--- a/tests/evm_space/log_filtering_test.py
+++ b/tests/evm_space/log_filtering_test.py
@@ -337,19 +337,10 @@ class CrossSpaceLogFilteringTest(Web3Base):
         logs_2 = self.nodes[0].eth_getLogs(filter)
         assert_equal(logs_2, logs)
 
-        # filter limit
-        filter = { "topics": [TEST_EVENT_TOPIC], "blockHash": block_e, "limit": 1 }
-        logs_2 = self.nodes[0].eth_getLogs(filter)
-        assert_equal(logs_2, [logs[-1]])
-
         # "earliest", "latest"
         filter = { "topics": [TEST_EVENT_TOPIC], "fromBlock": "earliest", "toBlock": "latest" }
         logs_2 = self.nodes[0].eth_getLogs(filter)
         assert_equal(len(logs_2), 8)
-
-        filter = { "topics": [TEST_EVENT_TOPIC], "fromBlock": "earliest", "toBlock": "latest", "limit": 4 }
-        logs_2 = self.nodes[0].eth_getLogs(filter)
-        assert_equal(logs_2, logs)
 
         # address
         filter = { "address": confluxContractAddr }
@@ -363,14 +354,6 @@ class CrossSpaceLogFilteringTest(Web3Base):
         # get-logs-filter-max-limit should limit the number of logs returned.
         self.stop_node(0)
         self.start_node(0, ["--get-logs-filter-max-limit", str(7)])
-
-        # limit <= max_limit: should not raise error
-        filter = { "address": evmContractAddr, "limit": 7 }
-        logs = self.nodes[0].eth_getLogs(filter)
-
-        # limit > max_limit but len(res) <= max_limit: should not raise error
-        filter = { "address": confluxContractAddr, "limit": 9 }
-        logs = self.nodes[0].eth_getLogs(filter)
 
         # len(res) > max_limit: raise error
         filter = { "address": evmContractAddr }

--- a/tests/issue2260_test.py
+++ b/tests/issue2260_test.py
@@ -80,17 +80,7 @@ class Issue2260(ConfluxTestFramework):
         block_number_a = int(self.rpc.block_by_hash(block_a)['blockNumber'], 0)
         block_number_d = int(self.rpc.block_by_hash(block_d)['blockNumber'], 0)
 
-        filter = Filter(from_block=hex(block_number_a), to_block=hex(block_number_d), offset=hex(0), limit=hex(1))
-        logs = self.rpc.get_logs(filter)
-        assert_equal(len(logs), 1)
-        assert_equal(logs[0]["topics"][2], number_to_topic(2))
-
-        filter = Filter(from_block=hex(block_number_a), to_block=hex(block_number_d), offset=hex(1), limit=hex(1))
-        logs = self.rpc.get_logs(filter)
-        assert_equal(len(logs), 1)
-        assert_equal(logs[0]["topics"][2], number_to_topic(1))
-
-        filter = Filter(from_block=hex(block_number_a), to_block=hex(block_number_d), offset=hex(0), limit=hex(2))
+        filter = Filter(from_block=hex(block_number_a), to_block=hex(block_number_d))
         logs = self.rpc.get_logs(filter)
         assert_equal(len(logs), 2)
         assert_equal(logs[0]["topics"][2], number_to_topic(1))

--- a/tests/light/log_filtering_test.py
+++ b/tests/light/log_filtering_test.py
@@ -114,14 +114,6 @@ class LogFilteringTest(ConfluxTestFramework):
         self.check_filter(Filter(topics=[None, self.address_to_topic(sender)]))
         self.check_filter(Filter(topics=[FOO_TOPIC, None, [self.number_to_topic(3), self.number_to_topic(4)]]))
 
-        # apply filter with limit
-        self.log.info("testing filter limit...")
-        self.check_filter(Filter(limit=("0x%x" % (NUM_CALLS // 2))))
-
-        # apply filter with offset and limit
-        self.log.info("testing filter offset and limit...")
-        self.check_filter(Filter(offset=("0x%x" % (NUM_CALLS // 4)), limit=("0x%x" % (NUM_CALLS // 2))))
-
         # apply filter for specific contract address
         self.log.info("testing address filtering...")
         self.check_filter(Filter(address=[contractAddr]))

--- a/tests/log_filtering_test.py
+++ b/tests/log_filtering_test.py
@@ -117,20 +117,6 @@ class LogFilteringTest(ConfluxTestFramework):
         self.assert_response_format_correct(logs)
         assert_equal(len(logs), 2)
 
-        # apply filter with limit
-        filter = Filter(limit=hex(NUM_CALLS // 2))
-        logs = self.rpc.get_logs(filter)
-
-        self.assert_response_format_correct(logs)
-        assert_equal(len(logs), NUM_CALLS // 2)
-
-        # apply filter with offset
-        filter = Filter(offset=hex(NUM_CALLS // 4))
-        logs = self.rpc.get_logs(filter)
-
-        self.assert_response_format_correct(logs)
-        assert_equal(len(logs), 3 * NUM_CALLS // 4)
-
         # apply filter for specific contract address
         _, contractAddr2 = self.deploy_contract(sender, priv_key, bytecode)
 
@@ -212,58 +198,10 @@ class LogFilteringTest(ConfluxTestFramework):
         logs2 = self.rpc.get_logs(filter)
         assert_equal(logs, logs2)
 
-        # given a limit, we should receive the _last_ few logs
-        filter = Filter(block_hashes=[block_hash_1, block_hash_2], limit = hex(3 * NUM_CALLS + NUM_CALLS // 2), topics=[BAR_TOPIC])
-        logs = self.rpc.get_logs(filter)
-        assert_equal(len(logs), 3 * NUM_CALLS + NUM_CALLS // 2)
-
-        for ii in range(0, 3 * NUM_CALLS + NUM_CALLS // 2):
-            assert_equal(len(logs[ii]["topics"]), 3)
-            assert_equal(logs[ii]["topics"][0], BAR_TOPIC)
-            assert_equal(logs[ii]["topics"][1], self.address_to_topic(sender))
-            assert_equal(logs[ii]["topics"][2], self.number_to_topic(NUM_CALLS // 2 + ii))
-
-        # given an offset and a limit, we should receive the corresponding logs
-        filter = Filter(block_hashes=[block_hash_1, block_hash_2], offset = hex(NUM_CALLS // 2), limit = hex(NUM_CALLS // 2), topics=[BAR_TOPIC])
-        logs = self.rpc.get_logs(filter)
-        assert_equal(len(logs), NUM_CALLS // 2)
-
-        for ii in range(0, NUM_CALLS // 2):
-            assert_equal(len(logs[ii]["topics"]), 3)
-            assert_equal(logs[ii]["topics"][0], BAR_TOPIC)
-            assert_equal(logs[ii]["topics"][1], self.address_to_topic(sender))
-            assert_equal(logs[ii]["topics"][2], self.number_to_topic(3 * NUM_CALLS + ii))
-
-        filter = Filter(from_epoch = epoch_1, to_epoch = epoch_2, offset = hex(NUM_CALLS // 2), limit = hex(NUM_CALLS // 2), topics=[BAR_TOPIC])
-        logs2 = self.rpc.get_logs(filter)
-        assert_equal(logs, logs2)
-
-        # test paging use case
-        BATCH_SIZE = 7
-
-        filter = Filter(block_hashes=[block_hash_1, block_hash_2], topics=[BAR_TOPIC])
-        all_logs = self.rpc.get_logs(filter)
-
-        collected_logs = []
-        offset = 0
-
-        while True:
-            filter = Filter(block_hashes=[block_hash_1, block_hash_2], offset = hex(offset), limit = hex(BATCH_SIZE), topics=[BAR_TOPIC])
-            logs = self.rpc.get_logs(filter)
-            if len(logs) == 0: break
-            collected_logs = logs + collected_logs
-            offset += BATCH_SIZE
-
-        assert_equal(collected_logs, all_logs)
-
         # get-logs-filter-max-limit should limit the number of logs returned.
         self.stop_node(0)
         self.start_node(0, ["--get-logs-filter-max-limit", str(2 * NUM_CALLS)])
         # should not raise error
-        filter = Filter(from_epoch="earliest", to_epoch="latest_state", topics=[BAR_TOPIC], limit=hex(2 * NUM_CALLS))
-        logs = self.rpc.get_logs(filter)
-        filter = Filter(from_epoch="earliest", to_epoch="latest_state", topics=[BAR_TOPIC], limit=hex(2 * NUM_CALLS + 1))
-        assert_raises_rpc_error(None, None, self.rpc.get_logs, filter)
         filter = Filter(from_epoch="earliest", to_epoch="latest_state", topics=[BAR_TOPIC])
         assert_raises_rpc_error(None, None, self.rpc.get_logs, filter)
 

--- a/tests/rpc/test_get_logs.py
+++ b/tests/rpc/test_get_logs.py
@@ -59,14 +59,6 @@ class TestGetLogs(RpcClient):
         filter = Filter(topics=[NULL_H256] * 5)
         assert_raises_rpc_error(None, None, self.get_logs, filter)
 
-        # invalid `offset` type
-        filter = Filter(offset=1)
-        assert_raises_rpc_error(None, None, self.get_logs, filter)
-
-        # invalid `limit` type
-        filter = Filter(limit=1)
-        assert_raises_rpc_error(None, None, self.get_logs, filter)
-
         # invalid filter fields
         filter = Filter()
         filter.fromBlock = "0x0"
@@ -114,9 +106,7 @@ class TestGetLogs(RpcClient):
             to_epoch="latest_state",
             block_hashes = [self.blocks[0]],
             address=[NULL_H160],
-            topics=[NULL_H256, [NULL_H256, NULL_H256]],
-            offset="0x0",
-            limit="0x1"
+            topics=[NULL_H256, [NULL_H256, NULL_H256]]
         )
 
         assert_raises_rpc_error(None, None, self.get_logs, filter)

--- a/tests/test_framework/test_node.py
+++ b/tests/test_framework/test_node.py
@@ -278,6 +278,13 @@ class TestNode:
         stderr = self.stderr.read().decode('utf-8').strip()
         # TODO: Check how to avoid `pthread lock: Invalid argument`.
         if stderr != expected_stderr and stderr != "pthread lock: Invalid argument":
+            # print process status for debug
+            p = self.process.poll()
+            if p is None:
+                self.log.info("Process is still running")
+            else:
+                self.log.info("Process has terminated with code {}".format(p))
+
             raise AssertionError("Unexpected stderr {} != {} from {}:{} index={}".format(
                 stderr, expected_stderr, self.ip, self.port, self.index))
 


### PR DESCRIPTION
Starting from v2.0.3, cfx_getLogs and eth_getLogs will no longer support the parameters limit and offset. They are not efficient and can be replaced by setting the block/epoch range instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2539)
<!-- Reviewable:end -->
