### PR TITLE
Include more information in cfx_clientVersion like web3_clientVersion

### DIFF
--- a/client/src/rpc/impls/common.rs
+++ b/client/src/rpc/impls/common.rs
@@ -1244,7 +1244,7 @@ impl RpcImpl {
     }
 
     pub fn get_client_version(&self) -> JsonRpcResult<String> {
-        Ok(format!("conflux-rust-{}", crate_version!()).into())
+        Ok(parity_version::version(crate_version!()))
     }
 
     pub fn txpool_pending_nonce_range(


### PR DESCRIPTION
Starting from v2.0.3, cfx_clientVersion will have include more information like web3_clientVersion in eSpace.
