### PR TITLE
Add log in test_disconnect_with_demote to investigate flaky error

### DIFF
--- a/tests/network_tests/node_reputation_test.py
+++ b/tests/network_tests/node_reputation_test.py
@@ -92,9 +92,14 @@ class NodeReputationTests(ConfluxTestFramework):
         # demote to untrusted node table
         node = client0.get_node(self.nodes[2].key)
         assert node[0] == "untrusted"
-        assert node[1]["lastConnected"].get("failure")
         assert node[1]["lastContact"].get("demoted")
         assert node[1]["streamToken"] == n[1]["streamToken"]
+
+        # log to dubug flaky error, suspect lastConnected not updated timely, so assert it at last
+        if not node[1]["lastConnected"].get("failure"):
+            self.log.info("Last connected: {}".format(node[1]["lastConnected"]))
+
+        assert node[1]["lastConnected"].get("failure")
 
         # Node 0 will not create outgoing connection to Node 2
         time.sleep((self.test_house_keeping_ms + 100) / 1000)


### PR DESCRIPTION
test_disconnect_with_demote failed with following error:

> 15:33:55 2022-06-21T07:33:53.730000Z TestFramework (ERROR): Assertion failed
> 15:33:55 Traceback (most recent call last):
> 15:33:55   File "/var/lib/jenkins/workspace/conflux-rust-github/tests/test_framework/test_framework.py", line 214, in main
> 15:33:55     self.run_test()
> 15:33:55   File "network_tests/node_reputation_test.py", line 33, in run_test
> 15:33:55     self.test_disconnect_with_demote(client0)
> 15:33:55   File "network_tests/node_reputation_test.py", line 95, in test_disconnect_with_demote
> 15:33:55     assert node[1]["lastConnected"].get("failure")
> 15:33:55 AssertionError

Add log to help investigate the issue if happened again in future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2542)
<!-- Reviewable:end -->
