### PR TITLE
Improve reorg_test reliability

### DIFF
--- a/tests/reorg_test.py
+++ b/tests/reorg_test.py
@@ -58,6 +58,8 @@ class ReorgTest(ConfluxTestFramework):
             for key in new_keys:
                 nonce_map[key] = wait_for_initial_nonce_for_privkey(shard_nodes[0], key)
 
+            # make sure all nodes have sync all accounts and latest state
+            sync_blocks(shard_nodes)
             for i in range(tx_n):
                 sender_key = random.choice(list(balance_map))
                 nonce = nonce_map[sender_key]


### PR DESCRIPTION
Reorg_test sometimes failed with following error:

> 17:46:48 2022-06-27T09:46:44.508000Z TestFramework (INFO): New tx a44415c7f3a8bb0c48951184a9cb662bcd8bec24bfd7363f1a33000258335532: 7d2c send value 0 to 213e, sender balance:848815127685542043682984689664, receiver balance:2729157772860651267088577231272
> 17:46:48 rpc exception code -32602, message: Invalid parameters: tx, data: "Transaction 0xa44415c7f3a8bb0c48951184a9cb662bcd8bec24bfd7363f1a33000258335532 is discarded due to out of balance, needs 21000 but account balance is 0"
> 17:46:48 2022-06-27T09:46:44.518000Z TestFramework (ERROR): Unexpected exception caught during testing

It is unable to repo local. From code, I suspect some node doesn't have latest state. Before sending out tx, make sure each node has same state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2545)
<!-- Reviewable:end -->
