### PR TITLE
Remove old-pivot state to save disk space if possible durinng startup

### DIFF
--- a/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
+++ b/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
@@ -1881,7 +1881,9 @@ impl ConsensusNewBlockHandler {
     /// It also recovers receipts_root and logs_bloom_hash in pivot chain.
     /// This function is only invoked from recover_graph_from_db with
     /// header_only being false.
-    pub fn construct_pivot_state(&self, inner: &mut ConsensusGraphInner) {
+    pub fn construct_pivot_state(
+        &self, inner: &mut ConsensusGraphInner, meter: &ConfirmationMeter,
+    ) {
         // FIXME: this line doesn't exactly match its purpose.
         // FIXME: Is it the checkpoint or synced snapshot or could it be
         // anything else?
@@ -2012,6 +2014,7 @@ impl ConsensusNewBlockHandler {
         }
 
         let mut pre_epoch_state_exist = true;
+        let confirmed_epoch_num = meter.get_confirmed_epoch_num();
 
         for pivot_index in start_pivot_index + 1..end_index {
             let pivot_arena_index = inner.pivot_chain[pivot_index];
@@ -2110,6 +2113,34 @@ impl ConsensusNewBlockHandler {
                     None,
                 );
                 pre_epoch_state_exist = true;
+
+                // Remove non-pivot state to save disk
+                {
+                    let mut confirmed_height = min(confirmed_epoch_num, height);
+                    if confirmed_height < DEFERRED_STATE_EPOCH_COUNT {
+                        confirmed_height = 0;
+                    } else {
+                        confirmed_height -= DEFERRED_STATE_EPOCH_COUNT;
+                    }
+
+                    self.data_man
+                        .storage_manager
+                        .get_storage_manager()
+                        .maintain_state_confirmed(
+                            inner,
+                            inner.cur_era_stable_height,
+                            self.conf.inner_conf.era_epoch_count,
+                            confirmed_height,
+                            &self.data_man.state_availability_boundary,
+                        )
+                        .expect(&concat!(
+                            file!(),
+                            ":",
+                            line!(),
+                            ":",
+                            column!()
+                        ));
+                }
             }
         }
     }

--- a/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
+++ b/core/src/consensus/consensus_inner/consensus_new_block_handler.rs
@@ -2114,7 +2114,9 @@ impl ConsensusNewBlockHandler {
                 );
                 pre_epoch_state_exist = true;
 
-                // Remove non-pivot state to save disk
+                // Remove old-pivot state during start up to save disk,
+                // otherwise, all state will be keep till normal phase, this
+                // will occupy too many disk
                 {
                     let mut confirmed_height = min(confirmed_epoch_num, height);
                     if confirmed_height < DEFERRED_STATE_EPOCH_COUNT {

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -2008,7 +2008,8 @@ impl ConsensusGraphTrait for ConsensusGraph {
         // Ensure that `state_valid` of the first valid block after
         // cur_era_stable_genesis is set
         inner.recover_state_valid();
-        self.new_block_handler.construct_pivot_state(inner);
+        self.new_block_handler
+            .construct_pivot_state(inner, &self.confirmation_meter);
         inner.finish_block_recovery();
     }
 


### PR DESCRIPTION
During startup, all states will not be deleted till normal phase, this will consume too many disk space as statedb is large. Remove the old-pivot state when construct_pivot_state will save this disk consuming.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2555)
<!-- Reviewable:end -->
