### PR TITLE
Fix double-lock in sync_manager.rs

### DIFF
--- a/core/src/light_protocol/handler/sync/common/sync_manager.rs
+++ b/core/src/light_protocol/handler/sync/common/sync_manager.rs
@@ -311,6 +311,7 @@ where
                     missing, peer, e
                 );
 
+                drop(in_flight);
                 self.insert_waiting(missing.into_iter());
             }
         }


### PR DESCRIPTION
There is a double-lock bug in fn `request_now_from_peer`:
The first lock:
https://github.com/Conflux-Chain/conflux-rust/blob/cc2c436a3bd76f62d196cff0d8845efbf1fa149d/core/src/light_protocol/handler/sync/common/sync_manager.rs#L291
Call `insert_waiting`:
https://github.com/Conflux-Chain/conflux-rust/blob/cc2c436a3bd76f62d196cff0d8845efbf1fa149d/core/src/light_protocol/handler/sync/common/sync_manager.rs#L314
The second lock:
https://github.com/Conflux-Chain/conflux-rust/blob/cc2c436a3bd76f62d196cff0d8845efbf1fa149d/core/src/light_protocol/handler/sync/common/sync_manager.rs#L146-L148

The fix is to add `drop` before calling `insert_waiting`.

Found the bug with my static detector lockbud.
