### PR TITLE
Fix a possible panic in Bytes deserialization with Unicode.

### DIFF
--- a/client/src/rpc/types/bytes.rs
+++ b/client/src/rpc/types/bytes.rs
@@ -76,8 +76,10 @@ impl<'a> Visitor<'a> for BytesVisitor {
 
     fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
     where E: Error {
-        if value.len() >= 2 && &value[0..2] == "0x" && value.len() & 1 == 0 {
-            Ok(Bytes::new(FromHex::from_hex(&value[2..]).map_err(|e| {
+        if let (Some(s), true) =
+            (value.strip_prefix("0x"), value.len() & 1 == 0)
+        {
+            Ok(Bytes::new(FromHex::from_hex(s).map_err(|e| {
                 Error::custom(format!("Invalid hex: {}", e))
             })?))
         } else {


### PR DESCRIPTION
If the user uses Unicode characters which spans across multiple bytes, the deserilization may panic with something like
``byte index 2 is not a char boundary; it is inside '�' (bytes 1..4) of``