### PR TITLE
espace feature: Support 'finalized' block tag and compatibility support for 'safe' tag

### DIFF
--- a/client/src/rpc/types/eth/block_number.rs
+++ b/client/src/rpc/types/eth/block_number.rs
@@ -46,7 +46,8 @@ pub enum BlockNumber {
     Earliest,
     /// Pending block (being mined)
     Pending,
-    /// Compatibility tag support for ethereum "safe" tag. Will reflect to "latest_confirmed"
+    /// Compatibility tag support for ethereum "safe" tag. Will reflect to
+    /// "latest_confirmed"
     Safe,
     /// Finalized block
     Finalized,
@@ -228,6 +229,8 @@ mod tests {
 			"latest",
 			"earliest",
 			"pending",
+            "safe",
+            "finalized",
 			{"blockNumber": "0xa"},
 			{"blockHash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"},
 			{"blockHash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", "requireCanonical": true}
@@ -241,6 +244,8 @@ mod tests {
                 BlockNumber::Latest,
                 BlockNumber::Earliest,
                 BlockNumber::Pending,
+                BlockNumber::Safe,
+                BlockNumber::Finalized,
                 BlockNumber::Num(10),
                 BlockNumber::Hash {
                     hash: H256::from_str(

--- a/client/src/rpc/types/eth/block_number.rs
+++ b/client/src/rpc/types/eth/block_number.rs
@@ -46,6 +46,10 @@ pub enum BlockNumber {
     Earliest,
     /// Pending block (being mined)
     Pending,
+    /// Compatibility tag support for ethereum "safe" tag. Will reflect to "latest_confirmed"
+    Safe,
+    /// Finalized block
+    Finalized,
 }
 
 impl Default for BlockNumber {
@@ -86,6 +90,8 @@ impl Serialize for BlockNumber {
             BlockNumber::Latest => serializer.serialize_str("latest"),
             BlockNumber::Earliest => serializer.serialize_str("earliest"),
             BlockNumber::Pending => serializer.serialize_str("pending"),
+            BlockNumber::Safe => serializer.serialize_str("safe"),
+            BlockNumber::Finalized => serializer.serialize_str("finalized"),
         }
     }
 }
@@ -169,6 +175,8 @@ impl<'a> Visitor<'a> for BlockNumberVisitor {
             "latest" => Ok(BlockNumber::Latest),
             "earliest" => Ok(BlockNumber::Earliest),
             "pending" => Ok(BlockNumber::Pending),
+            "safe" => Ok(BlockNumber::Safe),
+            "finalized" => Ok(BlockNumber::Finalized),
             _ if value.starts_with("0x") => {
                 u64::from_str_radix(&value[2..], 16)
                     .map(BlockNumber::Num)
@@ -197,6 +205,8 @@ impl TryFrom<BlockNumber> for EpochNumber {
             BlockNumber::Latest => Ok(EpochNumber::LatestState),
             BlockNumber::Earliest => Ok(EpochNumber::Earliest),
             BlockNumber::Pending => Ok(EpochNumber::LatestMined),
+            BlockNumber::Safe => Ok(EpochNumber::LatestConfirmed),
+            BlockNumber::Finalized => Ok(EpochNumber::LatestFinalized),
             BlockNumber::Hash { .. } => Err(invalid_params(
                 "block_num",
                 "Expected block number, found block hash",

--- a/dev-support/dep_pip3.sh
+++ b/dev-support/dep_pip3.sh
@@ -14,7 +14,7 @@ install py-ecc==5.2.0
 install coincurve==15.0.1
 install pysha3
 install trie==1.4.0
-install web3==5.17.0
+install web3==5.31.1
 install py-solc-x
 install jsonrpcclient==3.3.6
 install asyncio

--- a/tests/evm_space/block_tag_test.py
+++ b/tests/evm_space/block_tag_test.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+# allow imports from parent directory
+# source: https://stackoverflow.com/a/11158224
+import os, sys
+sys.path.insert(1, os.path.join(sys.path[0], '..'))
+
+from base import Web3Base
+from test_framework.util import assert_greater_than
+
+class BlockTagTest(Web3Base):
+
+    def run_test(self):
+        # super().run_test()
+        self.nodes[0].generate_empty_blocks(2000)
+        blocks = [
+            self.w3.eth.get_block("finalized"),
+            self.w3.eth.get_block("safe"),
+            self.w3.eth.get_block("latest"),
+        ]
+        assert_greater_than(blocks[1]["number"], blocks[0]["number"]) # type: ignore
+        assert_greater_than(blocks[2]["number"], blocks[1]["number"]) # type: ignore
+
+if __name__ == "__main__":
+    BlockTagTest().main()


### PR DESCRIPTION
Ethereum supports `safe` and `finalized` block tag after the merge
(https://blog.ethereum.org/2021/11/29/how-the-merge-impacts-app-layer)
(https://github.com/ethereum/execution-apis/blob/830fcd8768ef46353c8a0e3b8df85af421026a98/src/schemas/block.yaml#L97-L98) 

This commit adds corresponding support in espace. The `finalized` block tag will be viewed as `latest_finalized` and the `safe` block tag will be viewed as `latest_confirmed`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2586)
<!-- Reviewable:end -->
