### PR TITLE
fix: cfx_getDepositList and cfx_getVoteList RPC return value format

### DIFF
--- a/changelogs/JSONRPC.md
+++ b/changelogs/JSONRPC.md
@@ -1,5 +1,15 @@
 # JSON-RPC CHANGELOG
 
+## v2.2.1
+
+- Fix `pending` tag behaviour in espace. Now `pending` tag will be considered as `latest` tag except for `eth_getTransactionCount`.
+- Fix `cfx_getDepositList` and `cfx_getVoteList` return value format.
+
+## v2.2.0
+
+- Support `safe` and `finalized` block tag in espace.
+  - `safe` block number corresponds to `latest_confirmed` and `finalized` corresponds to `latest_finalized`
+
 ## v2.1.1
 
 - Add filter RPCs in eSpace including `eth_newFilter`, `eth_newBlockFilter`, `eth_newPendingTransactionFilter`, `eth_getFilterLogs`, `eth_getFilterChanges`, `eth_uninstallFilter`

--- a/core/src/state/account_entry.rs
+++ b/core/src/state/account_entry.rs
@@ -481,7 +481,7 @@ impl OverlayAccount {
         if !not_maintain_deposit_list {
             self.deposit_list.as_mut().unwrap().push(DepositInfo {
                 amount,
-                deposit_time,
+                deposit_time: deposit_time.into(),
                 accumulated_interest_rate,
             });
         }

--- a/core/src/state/account_entry_tests.rs
+++ b/core/src/state/account_entry_tests.rs
@@ -591,7 +591,7 @@ fn test_vote_lock() {
     assert_eq!(overlay_account.vote_stake_list().unwrap().len(), 4);
     assert_eq!(
         overlay_account.vote_stake_list().unwrap()[0].unlock_block_number,
-        11
+        U256::from(11)
     );
     overlay_account
         .vote_lock(U256::from(1000000), 13 /* unlock_block_number */);
@@ -604,7 +604,7 @@ fn test_vote_lock() {
     assert_eq!(overlay_account.vote_stake_list().unwrap().len(), 4);
     assert_eq!(
         overlay_account.vote_stake_list().unwrap()[0].unlock_block_number,
-        13
+        U256::from(13)
     );
     overlay_account
         .vote_lock(U256::from(2000000), 40 /* unlock_block_number */);
@@ -617,7 +617,7 @@ fn test_vote_lock() {
     assert_eq!(overlay_account.vote_stake_list().unwrap().len(), 3);
     assert_eq!(
         overlay_account.vote_stake_list().unwrap()[0].unlock_block_number,
-        40
+        U256::from(40)
     );
     overlay_account
         .vote_lock(U256::from(10), 600 /* unlock_block_number */);
@@ -630,7 +630,7 @@ fn test_vote_lock() {
     assert_eq!(overlay_account.vote_stake_list().unwrap().len(), 4);
     assert_eq!(
         overlay_account.vote_stake_list().unwrap()[3].unlock_block_number,
-        600
+        U256::from(600)
     );
     overlay_account
         .vote_lock(U256::from(1000), 502 /* unlock_block_number */);
@@ -643,11 +643,11 @@ fn test_vote_lock() {
     assert_eq!(overlay_account.vote_stake_list().unwrap().len(), 3);
     assert_eq!(
         overlay_account.vote_stake_list().unwrap()[0].unlock_block_number,
-        40
+        U256::from(40)
     );
     assert_eq!(
         overlay_account.vote_stake_list().unwrap()[1].unlock_block_number,
-        502
+        U256::from(502)
     );
     overlay_account
         .vote_lock(U256::from(3000000), 550 /* unlock_block_number */);
@@ -660,11 +660,11 @@ fn test_vote_lock() {
     assert_eq!(overlay_account.vote_stake_list().unwrap().len(), 2);
     assert_eq!(
         overlay_account.vote_stake_list().unwrap()[0].unlock_block_number,
-        550
+        U256::from(550)
     );
     assert_eq!(
         overlay_account.vote_stake_list().unwrap()[1].unlock_block_number,
-        600
+        U256::from(600)
     );
 }
 

--- a/primitives/src/account.rs
+++ b/primitives/src/account.rs
@@ -50,7 +50,7 @@ pub struct DepositInfo {
     /// This is the timestamp when this deposit happened, measured in the
     /// number of past blocks. It will be used to calculate
     /// the service charge.
-    pub deposit_time: u64,
+    pub deposit_time: U256,
     /// This is the accumulated interest rate when this deposit happened.
     pub accumulated_interest_rate: U256,
 }
@@ -74,7 +74,7 @@ pub struct VoteStakeInfo {
     pub amount: U256,
     /// This is the timestamp when the vote right will be invalid, measured in
     /// the number of past blocks.
-    pub unlock_block_number: u64,
+    pub unlock_block_number: U256,
 }
 
 #[derive(Clone, Debug, Default, Ord, PartialOrd, Eq, PartialEq)]
@@ -129,6 +129,7 @@ impl VoteStakeList {
     pub fn withdrawable_staking_balance(
         &self, staking_balance: U256, block_number: u64,
     ) -> U256 {
+        let block_number: U256 = block_number.into();
         if !self.is_empty() {
             // Find first index whose `unlock_block_number` is greater than
             // timestamp and all entries before the index could be
@@ -149,6 +150,7 @@ impl VoteStakeList {
     }
 
     pub fn remove_expired_vote_stake_info(&mut self, block_number: u64) {
+        let block_number: U256 = block_number.into();
         if !self.is_empty() && self[0].unlock_block_number <= block_number {
             // Find first index whose `unlock_block_number` is greater than
             // timestamp and all entries before the index could be
@@ -163,6 +165,7 @@ impl VoteStakeList {
     }
 
     pub fn vote_lock(&mut self, amount: U256, unlock_block_number: u64) {
+        let unlock_block_number: U256 = unlock_block_number.into();
         let mut updated = false;
         let mut updated_index = 0;
         match self.binary_search_by(|vote_info| {

--- a/tests/light/rpc_test.py
+++ b/tests/light/rpc_test.py
@@ -385,10 +385,12 @@ class LightRPCTest(ConfluxTestFramework):
         self.log.info(f"Checking cfx_getDepositList & cfx_getVoteList")
         full = self.rpc[FULLNODE0].get_deposit_list(self.stake_addr, latest_state)
         light = self.rpc[LIGHTNODE].get_deposit_list(self.stake_addr, latest_state)
+        assert full[0]["depositTime"].startswith("0x")
         assert_equal(light, full)
 
         full = self.rpc[FULLNODE0].get_vote_list(self.stake_addr, latest_state)
         light = self.rpc[LIGHTNODE].get_vote_list(self.stake_addr, latest_state)
+        assert full[0]["unlockBlockNumber"].startswith("0x")
         assert_equal(light, full)
 
         self.log.info(f"Pass -- cfx_getDepositList & cfx_getVoteList")


### PR DESCRIPTION
Currently, `cfx_getDepositList` and `cfx_getVoteList` RPC return values are not formatted correctly, e.g.

```bash
// Request
curl --data '{"jsonrpc":"2.0","method":"cfx_getVoteList","params":["cfx:aan02vpwvz8crpa1n10j17ufceefptdc2yzkagxk5u", "latest_state"],"id":1}' -H "Content-Type: application/json" localhost:12539

// Result
{
  "jsonrpc": "2.0",
  "result": [{
    "amount": "0x8ac7230489e80000",
    "unlockBlockNumber": 1000000000000 // should be hex string here
  }],
  "id": 1
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2592)
<!-- Reviewable:end -->
