### PR TITLE
[Fix] Retrieve logs from phantom block for eSpace

### DIFF
--- a/client/src/rpc/impls/eth_filter.rs
+++ b/client/src/rpc/impls/eth_filter.rs
@@ -571,13 +571,11 @@ fn retrieve_epoch_logs(
         Some(pivot),
         false, /* include_traces */
     ) {
-        Ok(v) => match v {
-            Some(b) => b,
-            None => {
-                error!("Block not executed yet {:?}", pivot);
-                return None;
-            }
-        },
+        Ok(Some(b)) => b,
+        Ok(None) => {
+            error!("Block not executed yet {:?}", pivot);
+            return None;
+        }
         Err(e) => {
             error!("get_phantom_block_by_number failed with {}", e);
             return None;

--- a/client/src/rpc/impls/eth_pubsub.rs
+++ b/client/src/rpc/impls/eth_pubsub.rs
@@ -388,13 +388,11 @@ impl ChainNotificationHandler {
                 Some(pivot),
                 false, /* include_traces */
             ) {
-                Ok(v) => match v {
-                    Some(b) => return Some(b),
-                    None => {
-                        error!("Block not executed yet {:?}", pivot);
-                        let _ = sleep(POLL_INTERVAL_MS).compat().await;
-                    }
-                },
+                Ok(Some(b)) => return Some(b),
+                Ok(None) => {
+                    error!("Block not executed yet {:?}", pivot);
+                    let _ = sleep(POLL_INTERVAL_MS).compat().await;
+                }
                 Err(e) => {
                     error!("get_phantom_block_by_number failed {}", e);
                     return None;

--- a/client/src/rpc/impls/eth_pubsub.rs
+++ b/client/src/rpc/impls/eth_pubsub.rs
@@ -16,11 +16,12 @@ use cfx_parameters::{
 use cfx_types::{Space, H256};
 use cfxcore::{
     channel::Channel, BlockDataManager, ConsensusGraph, Notifications,
-    SharedConsensusGraph,
+    SharedConsensusGraph, consensus::PhantomBlock,
 };
+use crate::rpc::types::eth::Log;
 use futures::{
     compat::Future01CompatExt,
-    future::{join_all, FutureExt, TryFutureExt},
+    future::{FutureExt, TryFutureExt},
 };
 use itertools::zip;
 use jsonrpc_core::{futures::Future, Result as RpcResult};
@@ -158,7 +159,7 @@ impl PubSubClient {
         // loop asynchronously
         let fut = async move {
             let mut last_epoch = 0;
-            let mut epochs: VecDeque<(u64, Vec<H256>)> = VecDeque::new();
+            let mut epochs: VecDeque<(u64, Vec<H256>, Vec<Log>)> = VecDeque::new();
 
             while let Some(epoch) = receiver.recv().await {
                 trace!("logs_loop({:?}): {:?}", id, epoch);
@@ -192,15 +193,14 @@ impl PubSubClient {
                         }
                     }
 
-                    for e in reverted.into_iter() {
+                    for (_, _, logs) in reverted.into_iter() {
                         handler
-                            .notify_logs(&sub, filter.clone(), e, true)
+                            .notify_removed_logs(&sub, logs)
                             .await;
                     }
                 }
 
                 last_epoch = epoch.0;
-                epochs.push_back(epoch.clone());
 
                 let latest_finalized_epoch_number =
                     consensus.latest_finalized_epoch_number();
@@ -213,7 +213,8 @@ impl PubSubClient {
                 }
 
                 // publish matching logs
-                handler.notify_logs(&sub, filter, epoch, false).await;
+                let logs = handler.notify_logs(&sub, filter, epoch.clone(), false).await;
+                epochs.push_back((epoch.0, epoch.1, logs));
             }
         };
 
@@ -314,10 +315,20 @@ impl ChainNotificationHandler {
         }
     }
 
+    async fn notify_removed_logs(
+        &self, subscriber: &Client, logs: Vec<Log>    ) 
+    {
+        // send logs in order
+        for mut log in logs.into_iter() {
+            log.removed = true;
+            Self::notify_async(subscriber, pubsub::Result::Log(log)).await;
+        }
+    }
+
     async fn notify_logs(
         &self, subscriber: &Client, filter: LogFilter, epoch: (u64, Vec<H256>),
         removed: bool,
-    )
+    ) -> Vec<Log>
     {
         debug!("notify_logs({:?})", epoch);
 
@@ -326,7 +337,7 @@ impl ChainNotificationHandler {
         // subscriber? would it be better to do this once for each epoch?
         let logs = match self.retrieve_epoch_logs(epoch).await {
             Some(logs) => logs,
-            None => return,
+            None => return vec![],
         };
 
         // apply filter to logs
@@ -341,10 +352,12 @@ impl ChainNotificationHandler {
         // send logs in order
         // FIXME(thegaram): Sink::notify flushes after each item.
         // consider sending them in a batch.
+        let mut ret = vec![];
         for log in logs {
             match log {
                 Ok(l) => {
-                    Self::notify_async(subscriber, pubsub::Result::Log(l)).await
+                    Self::notify_async(subscriber, pubsub::Result::Log(l.clone())).await;
+                    ret.push(l);
                 }
                 Err(e) => {
                     error!(
@@ -354,6 +367,56 @@ impl ChainNotificationHandler {
                 }
             }
         }
+
+        ret
+    }
+
+    async fn get_phantom_block(&self, epoch_number: u64, pivot: H256) -> Option<PhantomBlock>{
+        debug!("eth pubsub get_phantom_block");
+        const POLL_INTERVAL_MS: Duration = Duration::from_millis(100);
+
+        for ii in 0.. {
+            let latest = self.consensus.best_epoch_number();
+            match self.consensus_graph().get_phantom_block_by_number(
+                EpochNumber::Number(epoch_number),
+                Some(pivot),
+                false, /* include_traces */
+            ) {
+                Ok(v) => {
+                    match v {
+                        Some(b) => return Some(b),
+                        None => {
+                            error!("Block not executed yet {:?}", pivot);
+                            let _ = sleep(POLL_INTERVAL_MS).compat().await;
+                        }
+                    }
+                },
+                Err(e) => {
+                    error!("get_phantom_block_by_number failed {}", e);
+                    return None;
+                }
+            };
+
+            // we assume that an epoch gets executed within 100 seconds
+            if ii > 1000 {
+                error!("Cannot construct phantom block for {:?}", pivot);
+                return None;
+            } else {
+                if latest
+                    > epoch_number + DEFERRED_STATE_EPOCH_COUNT + REWARD_EPOCH_COUNT
+                {
+                    // Even if the epoch was executed, the phantom block on the fork
+                    // should be unable to constructed.
+                    warn!(
+                        "Cannot onstruct phantom block for {:?}, latest_epoch={}",
+                        pivot, latest
+                    );
+                    return None;
+                }
+            }
+        }
+
+        unreachable!()
     }
 
     // attempt to retrieve block receipts from BlockDataManager
@@ -423,43 +486,22 @@ impl ChainNotificationHandler {
         let (epoch_number, hashes) = epoch;
         let pivot = hashes.last().cloned().expect("epoch should not be empty");
 
-        // retrieve epoch receipts
-        let fut = hashes
-            .iter()
-            .map(|h| self.retrieve_block_receipts(&h, &pivot));
-
-        let receipts = join_all(fut)
-            .await
-            .into_iter()
-            .collect::<Option<Vec<_>>>()?;
+        let pb = self.get_phantom_block(epoch_number, pivot).await?;
 
         let mut logs = vec![];
         let mut log_index = 0;
 
-        for (block_hash, block_receipts) in zip(hashes, receipts) {
-            // retrieve block transactions
-            let block = match self
-                .data_man
-                .block_by_hash(&block_hash, true /* update_cache */)
-            {
-                Some(b) => b,
-                None => {
-                    warn!("Unable to retrieve block {:?}", block_hash);
-                    return None;
-                }
-            };
-
-            let txs = &block.transactions;
-            assert_eq!(block_receipts.receipts.len(), txs.len());
+            let txs = &pb.transactions;
+            assert_eq!(pb.receipts.len(), txs.len());
 
             // construct logs
             for (txid, (receipt, tx)) in
-                zip(&block_receipts.receipts, txs).enumerate()
+                zip(&pb.receipts, txs).enumerate()
             {
                 for (logid, entry) in receipt.logs.iter().cloned().enumerate() {
                     logs.push(LocalizedLogEntry {
                         entry,
-                        block_hash,
+                        block_hash: pivot,
                         epoch_number,
                         transaction_hash: tx.hash,
                         transaction_index: txid,
@@ -470,7 +512,6 @@ impl ChainNotificationHandler {
                     log_index += 1;
                 }
             }
-        }
 
         Some(logs)
     }


### PR DESCRIPTION
For eSpace API, logs need to retrieve from phantom blocks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2605)
<!-- Reviewable:end -->
