### PR TITLE
WIP: Migrate EIP-1898 to Core Space

### DIFF
--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -1539,7 +1539,7 @@ impl RpcImpl {
             BlockHashOrEpochNumber::EpochNumber(e) => {
                 self.consensus.get_block_hashes_by_epoch(e.into())?
             }
-            BlockHashOrEpochNumber::BlockHash(h) => {
+            BlockHashOrEpochNumber::BlockHashWithOption { hash: h, .. } => {
                 if self
                     .consensus
                     .get_data_manager()

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -1539,7 +1539,10 @@ impl RpcImpl {
             BlockHashOrEpochNumber::EpochNumber(e) => {
                 self.consensus.get_block_hashes_by_epoch(e.into())?
             }
-            BlockHashOrEpochNumber::BlockHashWithOption { hash: h, .. } => {
+            BlockHashOrEpochNumber::BlockHashWithOption {
+                hash: h,
+                require_pivot,
+            } => {
                 if self
                     .consensus
                     .get_data_manager()
@@ -1558,10 +1561,12 @@ impl RpcImpl {
                     primitives::EpochNumber::Number(e),
                 )?;
 
-                // if the provided hash is not the pivot hash, abort
+                // if the provided hash is not the pivot hash,
+                // and require_pivot is true or None(default to true)
+                // abort
                 let pivot_hash = *hashes.last().ok_or("Inconsistent state")?;
 
-                if h != pivot_hash {
+                if require_pivot.unwrap_or(true) && (h != pivot_hash) {
                     bail!(pivot_assumption_failed(h, pivot_hash));
                 }
 

--- a/client/src/rpc/impls/light.rs
+++ b/client/src/rpc/impls/light.rs
@@ -701,8 +701,11 @@ impl RpcImpl {
             let epoch = match num {
                 None => EpochNumber::LatestState,
                 Some(BlockHashOrEpochNumber::EpochNumber(e)) => e,
-                Some(BlockHashOrEpochNumber::BlockHash(h)) => consensus_graph
-                    .get_block_epoch_number(&h)
+                Some(BlockHashOrEpochNumber::BlockHashWithOption {
+                    hash,
+                    ..
+                }) => consensus_graph
+                    .get_block_epoch_number(&hash)
                     .map(Into::into)
                     .map(EpochNumber::Num)
                     .ok_or(RpcError::invalid_params(

--- a/client/src/rpc/traits/cfx_space/cfx.rs
+++ b/client/src/rpc/traits/cfx_space/cfx.rs
@@ -90,7 +90,8 @@ pub trait Cfx {
     /// Returns the code at given address at given time (epoch number).
     #[rpc(name = "cfx_getCode")]
     fn code(
-        &self, addr: RpcAddress, epoch_number: Option<EpochNumber>,
+        &self, addr: RpcAddress,
+        block_hash_or_epoch_number: Option<BlockHashOrEpochNumber>,
     ) -> BoxFuture<Bytes>;
 
     /// Returns storage entries from a given contract.

--- a/client/src/rpc/types/epoch_number.rs
+++ b/client/src/rpc/types/epoch_number.rs
@@ -8,7 +8,7 @@ use primitives::{
     EpochNumber as PrimitiveEpochNumber,
 };
 use serde::{
-    de::{Error, Visitor},
+    de::{Error, MapAccess, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
 use std::{fmt, str::FromStr};
@@ -145,10 +145,8 @@ impl<'a> Visitor<'a> for EpochNumberVisitor {
 pub enum BlockHashOrEpochNumber {
     BlockHashWithOption {
         hash: H256,
-        /// The Option is used to provide serialization
-        /// compatibility with "hash:0x..." block hash format.
-        /// None means the raw input is "hash:0x..."
-        /// Some means a EIP-1898 block parameter is received
+        /// Refer to BlockHashOrEpochNumberVisitor
+        /// for implementation detail
         require_pivot: Option<bool>,
     },
     EpochNumber(EpochNumber),
@@ -214,6 +212,11 @@ impl Serialize for BlockHashOrEpochNumber {
 
 struct BlockHashOrEpochNumberVisitor;
 
+// In order to keep compatibility with legacy "hash:0x..." format parameter
+// the `require_pivot` field is designed to be Option<bool>
+// if input is "hash:0x..." then `require_pivot` will be None
+// else if input is a object { blockHash: 0x... }
+// the `require_pivot` will be Some and default to true
 impl<'a> Visitor<'a> for BlockHashOrEpochNumberVisitor {
     type Value = BlockHashOrEpochNumber;
 
@@ -225,6 +228,71 @@ impl<'a> Visitor<'a> for BlockHashOrEpochNumberVisitor {
         )
     }
 
+    fn visit_map<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+    where V: MapAccess<'a> {
+        // require_pivot defaults to true if input is a map
+        let (mut require_pivot, mut epoch_number, mut block_hash) =
+            (true, None::<u64>, None::<H256>);
+
+        // following the implementaion in rpc/types/eth/block_number.rs
+        loop {
+            let key_str: Option<String> = visitor.next_key()?;
+
+            match key_str {
+                Some(key) => match key.as_str() {
+                    "epochNumber" => {
+                        let value: String = visitor.next_value()?;
+                        if value.starts_with("0x") {
+                            let number = u64::from_str_radix(&value[2..], 16)
+                                .map_err(|e| {
+                                Error::custom(format!(
+                                    "Invalid epoch number: {}",
+                                    e
+                                ))
+                            })?;
+
+                            epoch_number = Some(number.into());
+                            break;
+                        } else {
+                            return Err(Error::custom(
+                                "Invalid block number: missing 0x prefix"
+                                    .to_string(),
+                            ));
+                        }
+                    }
+                    "blockHash" => {
+                        block_hash = Some(visitor.next_value()?);
+                    }
+                    "requirePivot" => {
+                        require_pivot = visitor.next_value()?;
+                    }
+                    key => {
+                        return Err(Error::custom(format!(
+                            "Unknown key: {}",
+                            key
+                        )))
+                    }
+                },
+                None => break,
+            };
+        }
+
+        if let Some(number) = epoch_number {
+            return Ok(BlockHashOrEpochNumber::EpochNumber(EpochNumber::Num(
+                number.into(),
+            )));
+        }
+
+        if let Some(hash) = block_hash {
+            return Ok(BlockHashOrEpochNumber::BlockHashWithOption {
+                hash,
+                require_pivot: Some(require_pivot),
+            });
+        }
+
+        return Err(Error::custom("Invalid input"));
+    }
+
     fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
     where E: Error {
         if value.starts_with("hash:0x") {
@@ -233,14 +301,85 @@ impl<'a> Visitor<'a> for BlockHashOrEpochNumberVisitor {
                 require_pivot: None,
             })
         } else {
-            value.parse().map_err(Error::custom).map(|epoch_number| {
-                BlockHashOrEpochNumber::EpochNumber(epoch_number)
-            })
+            value.parse().map_err(Error::custom).map(
+                |epoch_number: EpochNumber| {
+                    BlockHashOrEpochNumber::EpochNumber(epoch_number)
+                },
+            )
         }
     }
 
     fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
     where E: Error {
         self.visit_str(value.as_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+    use std::str::FromStr;
+
+    #[test]
+    fn block_hash_or_epoch_number_deserialization() {
+        let s = r#"[
+			"0xa",
+			"latest_state",
+			"earliest",
+            "latest_mined",
+            "latest_checkpoint",
+            "latest_confirmed",
+            "latest_finalized",
+            "hash:0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+            {"epochNumber": "0xa"},
+			{"blockHash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"},
+			{"blockHash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", "requirePivot": false}
+		]"#;
+        let deserialized: Vec<BlockHashOrEpochNumber> =
+            serde_json::from_str(s).unwrap();
+
+        assert_eq!(
+            deserialized,
+            vec![
+                BlockHashOrEpochNumber::EpochNumber(EpochNumber::Num((10).into())),
+                BlockHashOrEpochNumber::EpochNumber(EpochNumber::LatestState),
+                BlockHashOrEpochNumber::EpochNumber(EpochNumber::Earliest),
+                BlockHashOrEpochNumber::EpochNumber(EpochNumber::LatestMined),
+                BlockHashOrEpochNumber::EpochNumber(EpochNumber::LatestCheckpoint),
+                BlockHashOrEpochNumber::EpochNumber(EpochNumber::LatestConfirmed),
+                BlockHashOrEpochNumber::EpochNumber(EpochNumber::LatestFinalized),
+                BlockHashOrEpochNumber::BlockHashWithOption {
+                    hash: H256::from_str(
+                        "1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                    )
+                    .unwrap(),
+                    // the "hash:0x..." will return an object with 
+                    // require_pivot = None
+                    require_pivot: None
+                },
+                BlockHashOrEpochNumber::EpochNumber(EpochNumber::Num((10).into())),
+                BlockHashOrEpochNumber::BlockHashWithOption {
+                    hash: H256::from_str(
+                        "1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                    )
+                    .unwrap(),
+                    require_pivot: Some(true)
+                },
+                BlockHashOrEpochNumber::BlockHashWithOption {
+                    hash: H256::from_str(
+                        "1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                    )
+                    .unwrap(),
+                    require_pivot: Some(false)
+                }
+            ]
+        )
+    }
+
+    #[test]
+    fn should_not_deserialize() {
+        let s = r#"[{}, "10"]"#;
+        assert!(serde_json::from_str::<Vec<BlockHashOrEpochNumber>>(s).is_err());
     }
 }

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -730,12 +730,14 @@ impl ConsensusGraph {
     ) -> RpcResult<U256>
     {
         let epoch_number = match block_hash_or_epoch_number {
-            BlockHashOrEpochNumber::BlockHash(hash) => EpochNumber::Number(
-                self.inner
-                    .read()
-                    .get_block_epoch_number(&hash)
-                    .ok_or("block epoch number is NULL")?,
-            ),
+            BlockHashOrEpochNumber::BlockHashWithOption { hash, .. } => {
+                EpochNumber::Number(
+                    self.inner
+                        .read()
+                        .get_block_epoch_number(&hash)
+                        .ok_or("block epoch number is NULL")?,
+                )
+            }
             BlockHashOrEpochNumber::EpochNumber(epoch_number) => epoch_number,
         };
         let state = State::new(

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -40,7 +40,7 @@ use crate::{
         trace_filter::TraceFilter,
     },
     pow::{PowComputer, ProofOfWorkConfig},
-    rpc_errors::{invalid_params_check, Result as RpcResult},
+    rpc_errors::{invalid_params, invalid_params_check, Result as RpcResult},
     state::State,
     statistics::SharedStatistics,
     transaction_pool::SharedTransactionPool,
@@ -721,6 +721,33 @@ impl ConsensusGraph {
         Some((results_with_epoch, maybe_state_root))
     }
 
+    pub fn get_block_epoch_number_with_pivot_check(
+        &self, hash: &H256, require_pivot: bool,
+    ) -> RpcResult<u64> {
+        let inner = &*self.inner.read();
+        // TODO: block not found error
+        let epoch_number =
+            inner.get_block_epoch_number(&hash).ok_or(invalid_params(
+                "epoch parameter",
+                format!("block's epoch number is not found: {:?}", hash),
+            ))?;
+
+        if require_pivot {
+            if let Err(..) =
+                inner.check_block_pivot_assumption(&hash, epoch_number)
+            {
+                bail!(invalid_params(
+                    "epoch parameter",
+                    format!(
+                        "should receive a pivot block hash, receives: {:?}",
+                        hash
+                    ),
+                ))
+            }
+        }
+        Ok(epoch_number)
+    }
+
     // TODO: maybe return error for reserved address? Not sure where is the best
     //  place to do the check.
     pub fn next_nonce(
@@ -733,20 +760,12 @@ impl ConsensusGraph {
             BlockHashOrEpochNumber::BlockHashWithOption {
                 hash,
                 require_pivot,
-            } => {
-                let inner = &*self.inner.read();
-                let tmp_epoch_number = inner
-                    .get_block_epoch_number(&hash)
-                    .ok_or("block epoch number is NULL")?;
-
-                if require_pivot.unwrap_or(true) {
-                    inner.check_block_pivot_assumption(
-                        &hash,
-                        tmp_epoch_number,
-                    )?;
-                }
-                EpochNumber::Number(tmp_epoch_number)
-            }
+            } => EpochNumber::Number(
+                self.get_block_epoch_number_with_pivot_check(
+                    &hash,
+                    require_pivot.unwrap_or(true),
+                )?,
+            ),
             BlockHashOrEpochNumber::EpochNumber(epoch_number) => epoch_number,
         };
         let state = State::new(

--- a/primitives/src/epoch.rs
+++ b/primitives/src/epoch.rs
@@ -35,6 +35,9 @@ impl Into<EpochNumber> for u64 {
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum BlockHashOrEpochNumber {
-    BlockHash(H256),
+    BlockHashWithOption {
+        hash: H256,
+        require_pivot: Option<bool>,
+    },
     EpochNumber(EpochNumber),
 }

--- a/tests/conflux/rpc.py
+++ b/tests/conflux/rpc.py
@@ -1,6 +1,6 @@
 import os
 import random
-from typing import Optional
+from typing import Optional, Union
 
 import eth_utils
 import rlp
@@ -175,7 +175,7 @@ class RpcClient:
 
         return res
 
-    def get_code(self, address: str, epoch: str = None) -> str:
+    def get_code(self, address: str, epoch: Union[str, dict] = None) -> str:
         address = hex_to_b32_address(address)
         if epoch is None:
             code = self.node.cfx_getCode(address)

--- a/tests/conflux/rpc.py
+++ b/tests/conflux/rpc.py
@@ -266,16 +266,17 @@ class RpcClient:
             r = self.node.cfx_getAdmin(addr, epoch)
         return b32_address_to_hex(r)
 
-    ''' Ignore block_hash if epoch is not None '''
+    ''' Use the first but not None parameter and ignore the others '''
 
-    def get_nonce(self, addr: str, epoch: str = None, block_hash: str = None) -> int:
+    def get_nonce(self, addr: str, epoch: str = None, block_hash: str = None, block_object: dict = None) -> int:
         addr = hex_to_b32_address(addr)
-        if epoch is None and block_hash is None:
-            return int(self.node.cfx_getNextNonce(addr), 0)
-        elif epoch is None:
-            return int(self.node.cfx_getNextNonce(addr, "hash:" + block_hash), 0)
+        if block_hash:
+            block_hash = "hash:" + block_hash
+        block_param = epoch or block_hash or block_object
+        if block_param:
+            return int(self.node.cfx_getNextNonce(addr, block_param), 0)
         else:
-            return int(self.node.cfx_getNextNonce(addr, epoch), 0)
+            return int(self.node.cfx_getNextNonce(addr), 0)
 
     def send_raw_tx(self, raw_tx: str, wait_for_catchup=True) -> str:
         # We wait for the node out of the catch up mode first

--- a/tests/rpc/test_get_code.py
+++ b/tests/rpc/test_get_code.py
@@ -1,0 +1,83 @@
+import eth_utils
+import sys
+import os
+sys.path.append("..")
+
+from conflux.rpc import RpcClient
+from conflux.utils import sha3 as keccak, parse_as_int
+from jsonrpcclient.exceptions import ReceivedErrorResponseError
+from test_framework.blocktools import encode_hex_0x
+from test_framework.util import assert_equal, test_rpc_call_with_block_object, assert_raises_rpc_error
+
+REVERT_MESSAGE_CONTRACT_PATH = "../contracts/revert_message.dat"
+
+class TestGetCode(RpcClient):
+
+    def test_get_code(self):
+        # test simple storage contract with default value (5)
+        data = "0x608060405234801561001057600080fd5b50600560008190555060e6806100276000396000f3fe6080604052600436106043576000357c01000000000000000000000000000000000000000000000000000000009004806360fe47b11460485780636d4ce63c14607f575b600080fd5b348015605357600080fd5b50607d60048036036020811015606857600080fd5b810190808035906020019092919050505060a7565b005b348015608a57600080fd5b50609160b1565b6040518082815260200191505060405180910390f35b8060008190555050565b6000805490509056fea165627a7a72305820b5180d95fdc3813028ed47f62c7cdf708b76c0db094043f533b42a430d313e150029"
+        tx = self.new_contract_tx("", data, storage_limit=200000)
+        client = self
+        parent_hash = client.block_by_epoch("latest_mined")['hash']
+        rpc_call = self.get_code
+        txs = [tx]
+        expected_result_lambda = lambda x: x != "0x"
+    
+        # generate epoch of 2 block with transactions in each block
+        # NOTE: we need `C` to ensure that the top fork is heavier
+
+        #                      ---        ---        ---
+        #                  .- | A | <--- | C | <--- | D | <--- ...
+        #           ---    |   ---        ---        ---
+        # ... <--- | P | <-*                          .
+        #           ---    |   ---                    .
+        #                  .- | B | <..................
+        #                      ---
+
+        # all block except for block D is empty
+
+        block_a = client.generate_custom_block(parent_hash = parent_hash, referee = [], txs = [])
+        block_b = client.generate_custom_block(parent_hash = parent_hash, referee = [], txs = [])
+        block_c = client.generate_custom_block(parent_hash = block_a, referee = [], txs = [])
+        block_d = client.generate_custom_block(parent_hash = block_c, referee = [block_b], txs = txs)
+
+        parent_hash = block_d
+        
+        for _ in range(5):
+            block = client.generate_custom_block(parent_hash = parent_hash, referee = [], txs = [])
+            parent_hash = block
+            
+        contract_addr = self.get_tx(tx.hash_hex())["contractCreated"]
+        params = [contract_addr]
+        
+        assert_raises_rpc_error(-32602, None, rpc_call, *params, {
+            "blockHash": parent_hash
+        }, err_data_="is not executed")
+        
+        # cannot find this block
+        assert_raises_rpc_error(-32602, "Invalid parameters: epoch parameter", rpc_call, *params, {
+            "blockHash": hex(int(block_d, 16) + 1)
+        }, err_data_="block's epoch number is not found")
+
+        assert_raises_rpc_error(-32602, "Invalid parameters: epoch parameter", rpc_call, *params, {
+            "blockHash": block_b
+        })
+        assert_raises_rpc_error(-32602, "Invalid parameters: epoch parameter", rpc_call, *params, {
+            "blockHash": block_b,
+            "requirePivot": True
+        })
+
+        result1 = rpc_call(*params, {
+            "blockHash": block_d
+        })
+        result1 = rpc_call(*params, {
+            "blockHash": block_d
+        })
+
+        result2 = rpc_call(*params, {
+            "blockHash": block_b,
+            "requirePivot": False
+        })
+
+        assert(expected_result_lambda(result1))
+        assert_equal(result2, result1)

--- a/tests/rpc/test_get_nonce.py
+++ b/tests/rpc/test_get_nonce.py
@@ -2,7 +2,7 @@ import sys
 sys.path.append("..")
 
 from conflux.rpc import RpcClient
-from test_framework.util import assert_equal, assert_raises_rpc_error
+from test_framework.util import assert_equal, assert_raises_rpc_error, test_rpc_call_with_block_object
 
 NUM_TXS = 10
 
@@ -72,48 +72,13 @@ class TestGetNonce(RpcClient):
         assert_equal(new_nonce, pre_nonce + 1)
         
     def test_block_object(self):
-        parent_hash = self.block_by_epoch("latest_mined")['hash']
         start_nonce = self.get_nonce(self.GENESIS_ADDR)
 
-        # generate epoch of 2 block with transactions in each block
-        # NOTE: we need `C` to ensure that the top fork is heavier
-
-        #                      ---        ---        ---
-        #                  .- | A | <--- | C | <--- | D | <--- ...
-        #           ---    |   ---        ---        ---
-        # ... <--- | P | <-*                          .
-        #           ---    |   ---                    .
-        #                  .- | B | <..................
-        #                      ---
-
         txs = [self.new_tx(receiver=self.rand_addr(), nonce = start_nonce + ii) for ii in range(NUM_TXS)]
-        txs1 = txs[:NUM_TXS//2]
-        txs2 = txs[NUM_TXS//2:]
-        
-        block_a = self.generate_custom_block(parent_hash = parent_hash, referee = [], txs = [])
-        block_b = self.generate_custom_block(parent_hash = parent_hash, referee = [], txs = txs1)
-        block_c = self.generate_custom_block(parent_hash = block_a, referee = [], txs = [])
-        block_d = self.generate_custom_block(parent_hash = block_c, referee = [block_b], txs = txs2)
-
-        parent_hash = block_d
-
-        for _ in range(5):
-            block = self.generate_custom_block(parent_hash = parent_hash, referee = [], txs = [])
-            parent_hash = block
-
-        # for cfx_getNextNonce, as B is not a pivot block,
-        # we can only get start_nonce or start_nonce + NUM_TXS
-        
-        assert_raises_rpc_error(None, None, self.node.cfx_getNextNonce, {
-            "blockHash": block_b
-        })
-        
-        nonce1 = self.get_nonce(self.GENESIS_ADDR, block_object={
-            "blockHash": block_d
-        })
-        nonce2 = self.get_nonce(self.GENESIS_ADDR, block_object={
-            "blockHash": block_b,
-            "requirePivot": False
-        })
-        assert_equal(nonce1, start_nonce + NUM_TXS)
-        assert_equal(nonce2, start_nonce + NUM_TXS)
+        test_rpc_call_with_block_object(
+            self,
+            txs,
+            self.get_nonce,
+            lambda x: x == (start_nonce + NUM_TXS),
+            [self.GENESIS_ADDR]
+        )

--- a/tests/rpc/test_get_nonce.py
+++ b/tests/rpc/test_get_nonce.py
@@ -68,3 +68,12 @@ class TestGetNonce(RpcClient):
         block_hash = self.get_transaction_receipt(tx_hash)["blockHash"]
         new_nonce = self.get_nonce(addr=addr, block_hash=block_hash)
         assert_equal(new_nonce, pre_nonce + 1)
+        
+    def test_block_object(self):
+        addr = self.GENESIS_ADDR
+        pre_nonce = self.get_nonce(addr)
+        tx = self.new_tx(nonce=pre_nonce)
+        tx_hash = self.send_tx(tx, True)
+        block_hash = self.get_transaction_receipt(tx_hash)["blockHash"]
+        new_nonce = self.get_nonce(addr=addr, block_object={ "blockHash": block_hash })
+        assert_equal(new_nonce, pre_nonce + 1)

--- a/tests/rpc/test_tx_receipt_by_hash.py
+++ b/tests/rpc/test_tx_receipt_by_hash.py
@@ -119,10 +119,28 @@ class TestGetTxReceiptByHash(RpcClient):
 
         # retrieve epoch receipts by pivot hash
         receipts2 = self.node.cfx_getEpochReceipts(f'hash:{block_d}')
+        receipts2_ = self.node.cfx_getEpochReceipts({
+            "blockHash": block_d
+        })
         assert_equal(receipts2, receipts)
+        assert_equal(receipts2, receipts2_)
 
         # request with non-pivot block hash should fail
         assert_raises_rpc_error(None, None, self.node.cfx_getEpochReceipts, f'hash:{block_b}')
+        assert_raises_rpc_error(None, None, self.node.cfx_getEpochReceipts, {
+            "blockHash": block_b
+        })
+        assert_raises_rpc_error(None, None, self.node.cfx_getEpochReceipts, {
+            "blockHash": block_b,
+            "requirePivot": True,
+        })
+        
+        receipts3 = self.node.cfx_getEpochReceipts({
+            "blockHash": block_b,
+            "requirePivot": False,
+        })
+        
+        assert_equal(receipts3, receipts)
 
         # request with nonexistent block hash should fail
         assert_raises_rpc_error(None, None, self.node.cfx_getEpochReceipts, f'hash:0x66e365b5bbd53bc26fd306fd7c65290b2b13c165d7cae816b651e7fcf2646f37')

--- a/tests/test_framework/util.py
+++ b/tests/test_framework/util.py
@@ -10,6 +10,7 @@ import random
 import re
 from subprocess import CalledProcessError, check_output
 import time
+from typing import Optional, Callable, List, TYPE_CHECKING, cast
 import socket
 import threading
 import jsonrpcclient.exceptions
@@ -22,6 +23,8 @@ import shutil
 from test_framework.simple_rpc_proxy import SimpleRpcProxy
 from . import coverage
 from .authproxy import AuthServiceProxy, JSONRPCException
+if TYPE_CHECKING:
+    from conflux.rpc import RpcClient
 
 solcx.set_solc_version('v0.5.17')
 
@@ -113,7 +116,7 @@ def assert_raises_process_error(returncode, output, fun, *args, **kwds):
         raise AssertionError("No exception raised")
 
 
-def assert_raises_rpc_error(code, message, fun, *args, **kwds):
+def assert_raises_rpc_error(code: Optional[int], message: Optional[str], fun: Callable, *args, err_data_: Optional[str]=None, **kwds):
     """Run an RPC and verify that a specific JSONRPC exception code and message is raised.
 
     Calls function `fun` with arguments `args` and `kwds`. Catches a JSONRPCException
@@ -129,10 +132,10 @@ def assert_raises_rpc_error(code, message, fun, *args, **kwds):
         args*: positional arguments for the function.
         kwds**: named arguments for the function.
     """
-    assert try_rpc(code, message, fun, *args, **kwds), "No exception raised"
+    assert try_rpc(code, message, fun, err_data_, *args, **kwds), "No exception raised"
 
 
-def try_rpc(code, message, fun, *args, **kwds):
+def try_rpc(code: Optional[int], message: Optional[str], fun: Callable, err_data_: Optional[str]=None, *args, **kwds):
     """Tries to run an rpc command.
 
     Test against error code and message if the rpc fails.
@@ -145,9 +148,11 @@ def try_rpc(code, message, fun, *args, **kwds):
         if (code is not None) and (code != error.code):
             raise AssertionError(
                 "Unexpected JSONRPC error code %i" % error.code)
-        if (message is not None) and (message not in error.message):
-            raise AssertionError("Expected substring not found:" +
-                                 error.message)
+        if (message is not None) and (message not in cast(str, error.message)):
+            raise AssertionError(f"Expected substring not found: {error.message}")
+        if (err_data_ is not None):
+            if not getattr(error, "data", None) or (err_data_ not in cast(str, error.data)):
+                raise AssertionError(f"Expected substring not found: {error.data}")
         return True
     except Exception as e:
         raise AssertionError("Unexpected exception raised: " +
@@ -732,4 +737,60 @@ def get_contract_instance(contract_dict=None,
                 raise ValueError("The bytecode or the address must be provided")
     return contract
 
+# This is a util function to test rpc with block object
+def test_rpc_call_with_block_object(client: "RpcClient", txs: List, rpc_call: Callable, expected_result_lambda: Callable[..., bool], params: List=[]):
+    parent_hash = client.block_by_epoch("latest_mined")['hash']
+    
+    # generate epoch of 2 block with transactions in each block
+    # NOTE: we need `C` to ensure that the top fork is heavier
 
+    #                      ---        ---        ---
+    #                  .- | A | <--- | C | <--- | D | <--- ...
+    #           ---    |   ---        ---        ---
+    # ... <--- | P | <-*                          .
+    #           ---    |   ---                    .
+    #                  .- | B | <..................
+    #                      ---
+    
+    # all block except for block D is empty
+
+    block_a = client.generate_custom_block(parent_hash = parent_hash, referee = [], txs = [])
+    block_b = client.generate_custom_block(parent_hash = parent_hash, referee = [], txs = [])
+    block_c = client.generate_custom_block(parent_hash = block_a, referee = [], txs = [])
+    block_d = client.generate_custom_block(parent_hash = block_c, referee = [block_b], txs = txs)
+
+    parent_hash = block_d
+    
+    # current block_d is not executed
+    assert_raises_rpc_error(-32602, None, rpc_call, *params, {
+        "blockHash": block_d
+    }, err_data_="is not executed")
+    
+    # cannot find this block
+    assert_raises_rpc_error(-32602, "Invalid parameters: epoch parameter", rpc_call, *params, {
+        "blockHash": hex(int(block_d, 16) + 1)
+    }, err_data_="block's epoch number is not found")
+
+    for _ in range(5):
+        block = client.generate_custom_block(parent_hash = parent_hash, referee = [], txs = [])
+        parent_hash = block
+
+    assert_raises_rpc_error(-32602, "Invalid parameters: epoch parameter", rpc_call, *params, {
+        "blockHash": block_b
+    })
+    assert_raises_rpc_error(-32602, "Invalid parameters: epoch parameter", rpc_call, *params, {
+        "blockHash": block_b,
+        "requirePivot": True
+    })
+    
+    result1 = rpc_call(*params, {
+        "blockHash": block_d
+    })
+    
+    result2 = rpc_call(*params, {
+        "blockHash": block_b,
+        "requirePivot": False
+    })
+    
+    assert(expected_result_lambda(result1))
+    assert_equal(result2, result1)


### PR DESCRIPTION
[EIP-1898](https://eips.ethereum.org/EIPS/eip-1898)

Design:

Like EIP-1898, this update will introduce a new scheme for epoch parameter, which has 3 optional fields

- `epochNumber`. Corresponding to `blockNumber`
- `blockHash`. Same
- `requirePivot`. Corresponding to `requireCanonical`. And according to current implementation in espace `eth_call` behaviour and core space `EpochReceipt` RPC behavior, this value will default to `true`

Generally, this update will refactor current `BlockHashOrEpochNumber` struct and apply it to other RPCs. As legacy code supports epoch parameter in the format of `hash:0x...`, the `require_pivot` field is designed to be `Option<bool>` to provide compatibility with legacy code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2615)
<!-- Reviewable:end -->
