### PR TITLE
 limit per chunk size in syncing snapshot db to avoid OOM

### DIFF
--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -212,6 +212,8 @@ build_config! {
         (max_allowed_timeout_in_observing_period, (u64), 10)
         (max_chunk_number_in_manifest, (usize), 500)
         (max_downloading_chunks, (usize), 8)
+        (max_downloading_chunk_attempts, (usize), 5)
+        (max_downloading_manifest_attempts, (usize), 5)
         (max_handshakes, (usize), 64)
         (max_incoming_peers, (usize), 64)
         (max_inflight_request_count, (u64), 64)
@@ -787,6 +789,9 @@ impl Configuration {
             min_peers_tx_propagation: self.raw_conf.min_peers_tx_propagation,
             max_peers_tx_propagation: self.raw_conf.max_peers_tx_propagation,
             max_downloading_chunks: self.raw_conf.max_downloading_chunks,
+            max_downloading_chunk_attempts: self
+                .raw_conf
+                .max_downloading_chunk_attempts,
             test_mode: self.is_test_mode(),
             dev_mode: self.is_dev_mode(),
             throttling_config_file: self.raw_conf.throttling_conf.clone(),
@@ -849,6 +854,9 @@ impl Configuration {
             manifest_request_timeout: Duration::from_millis(
                 self.raw_conf.snapshot_manifest_request_timeout_ms,
             ),
+            max_downloading_manifest_attempts: self
+                .raw_conf
+                .max_downloading_manifest_attempts,
         }
     }
 

--- a/core/src/sync/message/snapshot_chunk_request.rs
+++ b/core/src/sync/message/snapshot_chunk_request.rs
@@ -63,8 +63,10 @@ impl Handleable for SnapshotChunkRequest {
             snapshot_epoch_id,
             &self.chunk_key,
             &ctx.manager.graph.data_man.storage_manager,
+            ctx.manager.protocol_config.chunk_size_byte * 2,
         ) {
             Ok(Some(chunk)) => chunk,
+            Err(r) => return Err(r),
             _ => Chunk::default(),
         };
 

--- a/core/src/sync/state/snapshot_chunk_sync.rs
+++ b/core/src/sync/state/snapshot_chunk_sync.rs
@@ -367,11 +367,10 @@ impl SnapshotChunkSync {
         if inner.manifest_attempts
             >= self.config.max_downloading_manifest_attempts
         {
-            error!(
+            panic!(
                 "Exceed max manifest attempts {}",
                 self.config.max_downloading_manifest_attempts
             );
-            return;
         }
 
         debug!("sync state status before updating: {:?}", *inner);

--- a/core/src/sync/synchronization_protocol_handler.rs
+++ b/core/src/sync/synchronization_protocol_handler.rs
@@ -411,6 +411,7 @@ pub struct ProtocolConfiguration {
     pub min_peers_tx_propagation: usize,
     pub max_peers_tx_propagation: usize,
     pub max_downloading_chunks: usize,
+    pub max_downloading_chunk_attempts: usize,
     pub test_mode: bool,
     pub dev_mode: bool,
     pub throttling_config_file: Option<String>,

--- a/core/storage/src/lib.rs
+++ b/core/storage/src/lib.rs
@@ -183,7 +183,8 @@ pub use self::{
         delta_mpt::*,
         errors::{Error, ErrorKind, Result},
         merkle_patricia_trie::{
-            simple_mpt::*, KVInserter, MptKeyValue, TrieProof,
+            mpt_cursor::rlp_key_value_len, simple_mpt::*, KVInserter,
+            MptKeyValue, TrieProof,
         },
         node_merkle_proof::{NodeMerkleProof, StorageRootProof},
         proof_merger::StateProofMerger,


### PR DESCRIPTION
-  limit per chunk size to avoid OOM
- retry to download manifest when download chunk failed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-rust/2616)
<!-- Reviewable:end -->
