### PR TITLE
Improve performance of copy and merge snapshot

### DIFF
--- a/core/storage/src/impls/storage_db/snapshot_db_sqlite.rs
+++ b/core/storage/src/impls/storage_db/snapshot_db_sqlite.rs
@@ -342,6 +342,7 @@ impl SnapshotDbTrait for SnapshotDbSqlite {
         debug!("copy_and_merge begins.");
         let mut kv_iter = old_snapshot_db.snapshot_kv_iterator()?.take();
         let mut iter = kv_iter.iter_range(&[], None)?.take();
+        self.start_transaction()?;
         while let Ok(kv_item) = iter.next() {
             match kv_item {
                 Some((k, v)) => {
@@ -350,6 +351,7 @@ impl SnapshotDbTrait for SnapshotDbSqlite {
                 None => break,
             }
         }
+        self.commit_transaction()?;
         self.apply_update_to_kvdb()?;
 
         let mut set_keys_iter = self.dumped_delta_kv_set_keys_iterator()?;


### PR DESCRIPTION
Move put kv into transaction to improve performance of copy and merge snapshot