### PR TITLE
refine cfx filter logs

### DIFF
--- a/client/src/rpc/impls/cfx_filter.rs
+++ b/client/src/rpc/impls/cfx_filter.rs
@@ -14,7 +14,7 @@ use crate::rpc::{
         MAX_BLOCK_HISTORY_SIZE,
     },
     traits::cfx::CfxFilter,
-    types::{CfxFilterChanges, CfxFilterLog, CfxRpcLogFilter, Log},
+    types::{CfxFilterChanges, CfxFilterLog, CfxRpcLogFilter, Log, RevertTo},
 };
 use cfx_addr::Network;
 use cfx_types::{Space, H128, H256};
@@ -514,9 +514,9 @@ impl<T: Filterable + Send + Sync + 'static> CfxFilter for T {
                 }
 
                 if reorg_len > 0 {
-                    logs.push(CfxFilterLog::ChainReorg {
+                    logs.push(CfxFilterLog::ChainReorg(RevertTo {
                         revert_to: epochs.first().unwrap().0.into(),
-                    });
+                    }));
                 }
                 let data_man =
                     self.consensus_graph().get_data_manager().clone();

--- a/client/src/rpc/types.rs
+++ b/client/src/rpc/types.rs
@@ -43,7 +43,7 @@ pub use self::{
     },
     consensus_graph_states::ConsensusGraphStates,
     epoch_number::{BlockHashOrEpochNumber, EpochNumber},
-    filter::{CfxFilterChanges, CfxFilterLog, CfxRpcLogFilter},
+    filter::{CfxFilterChanges, CfxFilterLog, CfxRpcLogFilter, RevertTo},
     index::Index,
     log::Log,
     pos_economics::PoSEconomics,

--- a/tests/rpc/filter_log_test.py
+++ b/tests/rpc/filter_log_test.py
@@ -142,7 +142,7 @@ class FilterLogTest(ConfluxTestFramework):
         logs1 = self.nodes[0].cfx_getFilterChanges(filter1)
         logs2 = self.nodes[0].cfx_getFilterChanges(filter2)
         assert_equal(len(logs2), num_to_reexecute + 1)
-        assert logs2[0]["ChainReorg"]
+        assert logs2[0]["revertTo"]
 
         # call cfx_getFilterLogs API
         logs1 = self.nodes[0].cfx_getFilterLogs(filter1)


### PR DESCRIPTION
- Use revertTo instead of revert_to
- Improve serialize CfxFilterLog