### PR TITLE
Improve eSpace EIP-1559/... transaction reminder

### DIFF
--- a/client/src/rpc/impls/eth.rs
+++ b/client/src/rpc/impls/eth.rs
@@ -671,7 +671,7 @@ impl Eth for EthHandler {
         if tx.recover_public().is_err() {
             bail!(invalid_params(
                 "tx",
-                "Can not recover pubkey for Ethereum like tx"
+                "Can not recover pubkey for Ethereum like tx. Conflux eSpace only supports EIP-155 rather than EIP-1559 or other format transactions."
             ));
         }
 


### PR DESCRIPTION
Currently, eSpace will return the error

```
    "error": {
        "code": -32602,
        "message": "Invalid parameters: tx",
        "data": "Can not recover pubkey for Ethereum like tx"
    }
```

if a `EIP-1559` transaction is received.

This error is quite common as for various ethereum sdks, eip-1559 is the default encoding approach and it requires extra settings to send a legacy transaction.
This change would directly notice the developers what is wrong