### PR TITLE
Format space in RPC

### DIFF
--- a/client/src/rpc/types/log.rs
+++ b/client/src/rpc/types/log.rs
@@ -4,7 +4,7 @@
 
 use crate::rpc::types::{Bytes, RpcAddress};
 use cfx_addr::Network;
-use cfx_types::{Space, H256, U256};
+use cfx_types::{H256, U256};
 use primitives::log_entry::{LocalizedLogEntry, LogEntry};
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
@@ -45,7 +45,7 @@ pub struct Log {
 
     /// Log space
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub space: Option<Space>,
+    pub space: Option<String>,
 }
 
 impl Log {
@@ -79,7 +79,11 @@ impl Log {
             transaction_index: None,
             log_index: None,
             transaction_log_index: None,
-            space: if include_space { Some(e.space) } else { None },
+            space: if include_space {
+                Some(e.space.into())
+            } else {
+                None
+            },
         })
     }
 }
@@ -94,7 +98,7 @@ mod tests {
 
     #[test]
     fn log_serialization() {
-        let s = r#"{"address":"CFXTEST:TYPE.USER:AAK3WAKCPSF3CP0MFHDWHTTUG924VERHBUV9NMM3YC","topics":["0xa6697e974e6a320f454390be03f74955e8978f1a6971ea6730542e37b66179bc","0x4861736852656700000000000000000000000000000000000000000000000000"],"data":"0x","blockHash":"0xed76641c68a1c641aee09a94b3b471f4dc0316efe5ac19cf488e2674cf8d05b5","epochNumber":"0x4510c","transactionHash":"0x0000000000000000000000000000000000000000000000000000000000000000","transactionIndex":"0x0","logIndex":"0x1","transactionLogIndex":"0x1","space":"Native"}"#;
+        let s = r#"{"address":"CFXTEST:TYPE.USER:AAK3WAKCPSF3CP0MFHDWHTTUG924VERHBUV9NMM3YC","topics":["0xa6697e974e6a320f454390be03f74955e8978f1a6971ea6730542e37b66179bc","0x4861736852656700000000000000000000000000000000000000000000000000"],"data":"0x","blockHash":"0xed76641c68a1c641aee09a94b3b471f4dc0316efe5ac19cf488e2674cf8d05b5","epochNumber":"0x4510c","transactionHash":"0x0000000000000000000000000000000000000000000000000000000000000000","transactionIndex":"0x0","logIndex":"0x1","transactionLogIndex":"0x1","space":"native"}"#;
 
         let log = Log {
             address: RpcAddress::try_from_h160(H160::from_str("13990122638b9132ca29c723bdf037f1a891a70c").unwrap(), Network::Test).unwrap(),
@@ -109,7 +113,7 @@ mod tests {
             transaction_index: Some(U256::default()),
             transaction_log_index: Some(1.into()),
             log_index: Some(U256::from(1)),
-            space: Some(Space::Native),
+            space: Some(Space::Native.into()),
         };
 
         let serialized = serde_json::to_string(&log).unwrap();

--- a/client/src/rpc/types/receipt.rs
+++ b/client/src/rpc/types/receipt.rs
@@ -81,7 +81,7 @@ pub struct Receipt {
     pub storage_released: Vec<StorageChange>,
     /// Transaction space.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub space: Option<Space>,
+    pub space: Option<String>,
 }
 
 impl Receipt {
@@ -212,7 +212,7 @@ impl Receipt {
                 .map(|sc| StorageChange::try_from(sc, network))
                 .collect::<Result<_, _>>()?,
             space: if include_eth_receipt {
-                Some(space)
+                Some(space.into())
             } else {
                 None
             },


### PR DESCRIPTION
unified to use string space in RPC

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/2686)
<!-- Reviewable:end -->
