### PR TITLE
add start_newPendingTransactions_loop

### DIFF
--- a/client/src/rpc/impls/eth_pubsub.rs
+++ b/client/src/rpc/impls/eth_pubsub.rs
@@ -114,7 +114,7 @@ impl PubSubClient {
 
         let fut = async move {
             while let Some(new_tx) = receiver.recv().await {
-                debug!("new_pending_transactions_loop: {:?}", new_tx);
+                trace!("new_pending_transactions_loop: {:?}", new_tx);
     
                 handler_clone.notify_new_pending_transaction(new_tx);
             }
@@ -290,13 +290,13 @@ impl ChainNotificationHandler {
 
     // notify each subscriber about new pending transaction `hash` concurrently
     fn notify_new_pending_transaction(&self, hash: H256) {
-        info!("notify_new_pending_transaction({:?})", hash);
+        trace!("notify_new_pending_transaction({:?})", hash);
 
         let subscribers = self.pending_transactions_subscribers.read();
 
         // do not retrieve anything unnecessarily
         if subscribers.is_empty() {
-            debug!("No subscribers for pending transactions");
+            trace!("No subscribers for pending transactions");
             return;
         }
 

--- a/core/src/channel.rs
+++ b/core/src/channel.rs
@@ -113,6 +113,7 @@ pub struct Notifications {
     pub new_block_hashes: Arc<Channel<H256>>,
     pub epochs_ordered: Arc<Channel<(u64, Vec<H256>)>>,
     pub blame_verification_results: Arc<Channel<(u64, Option<u64>)>>, /* <height, witness> */
+    pub new_pending_transactions: Arc<Channel<H256>>,
 }
 
 impl Notifications {
@@ -123,6 +124,7 @@ impl Notifications {
             blame_verification_results: Arc::new(Channel::new(
                 "blame-verification-results",
             )),
+            new_pending_transactions: Arc::new(Channel::new("new-pending-transactions")),
         })
     }
 }


### PR DESCRIPTION

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/2690)
<!-- Reviewable:end -->

Support for new pending transactions pubsub #2672

[WIP]
do we have a notification Channel to subscribe for when new pending transaction? so far I'm using the new_block_hashes channel 