### PR TITLE
Remove interfaces from StateDb that inappropriately try to distinguish default and non-existing values

### DIFF
--- a/core/src/state/state_object/staking.rs
+++ b/core/src/state/state_object/staking.rs
@@ -168,9 +168,9 @@ pub fn initialize_or_update_dao_voted_params(
     // Only write storage_collateral_refund_ratio if it has been set in the
     // db. This keeps the state unchanged before cip107 is enabled.
     // TODO: better way in check if cip107 encabled.
-    if let Some(old_storage_point_prop) =
-        state.get_system_storage_opt(&storage_point_prop())?
-    {
+    let old_storage_point_prop =
+        state.get_system_storage(&storage_point_prop())?;
+    if !old_storage_point_prop.is_zero() {
         debug!("old_storage_point_prop: {}", old_storage_point_prop);
         state.set_system_storage(
             storage_point_prop().to_vec(),

--- a/core/src/state/state_object/storage_entry.rs
+++ b/core/src/state/state_object/storage_entry.rs
@@ -22,12 +22,6 @@ impl State {
         )
     }
 
-    pub fn get_system_storage_opt(&self, key: &[u8]) -> DbResult<Option<U256>> {
-        let acc =
-            try_loaded!(self.read_native_account_lock(&SYSTEM_STORAGE_ADDRESS));
-        acc.storage_opt_at(&self.db, key)
-    }
-
     pub fn storage_at(
         &self, address: &AddressWithSpace, key: &[u8],
     ) -> DbResult<U256> {

--- a/core/statedb/src/statedb_ext.rs
+++ b/core/statedb/src/statedb_ext.rs
@@ -43,8 +43,6 @@ pub trait StateDbExt {
     ) -> Result<Option<VoteStakeList>>;
 
     fn get_global_param<T: GlobalParamKey>(&self) -> Result<U256>;
-    fn get_global_param_opt<T: GlobalParamKey>(&self) -> Result<Option<U256>>;
-
     fn set_global_param<T: GlobalParamKey>(
         &mut self, value: &U256,
         debug_record: Option<&mut ComputeEpochDebugRecord>,
@@ -198,13 +196,8 @@ impl StateDbExt for StateDbGeneric {
         )
     }
 
-    fn get_global_param_opt<T: GlobalParamKey>(&self) -> Result<Option<U256>> {
-        let value_opt = self.get::<U256>(T::STORAGE_KEY)?;
-        Ok(value_opt)
-    }
-
     fn get_global_param<T: GlobalParamKey>(&self) -> Result<U256> {
-        Ok(self.get_global_param_opt::<T>()?.unwrap_or_default())
+        Ok(self.get::<U256>(T::STORAGE_KEY)?.unwrap_or_default())
     }
 
     fn set_global_param<T: GlobalParamKey>(


### PR DESCRIPTION
This PR addresses a recent issue in the Conflux StateDb interface and its upper-layer applications.

StateDb in Conflux provides a KeyValue interface, allowing storage of any struct that implements the Rlp serialize/deserialize traits. In the current design, if a value to be stored is the default value, its corresponding entry is removed, rather than being stored. This is intended to minimize storage usage and manage the size of the blockchain ledger.

However, recent interfaces introduced can potentially cause confusion as they attempt to differentiate between a variable being non-existent and a variable equating to zero. Since the StateDb does not distinguish between these two scenarios during storage, having interfaces that attempt to make this distinction can lead to inconsistencies.

Changes made in this PR include:

- Removal of interfaces that inappropriately try to confuse between non-existing and zero values.
- Updates to related logic in StateDb and its upper-layer applications previously based on these interfaces.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/2701)
<!-- Reviewable:end -->
