### PR TITLE
 Refinement of Ownership Management and Range Deletion Mechanisms

### DIFF
--- a/core/src/executive/context.rs
+++ b/core/src/executive/context.rs
@@ -123,10 +123,7 @@ impl<'a, 'b> ContextTrait for Context<'a, 'b> {
             address: self.local_part.origin.address,
             space: self.local_part.space,
         };
-        self.local_part
-            .substate
-            .storage_at(self.state, &caller, key)
-            .map_err(Into::into)
+        self.state.storage_at(&caller, key).map_err(Into::into)
     }
 
     fn set_storage(&mut self, key: Vec<u8>, value: U256) -> vm::Result<()> {
@@ -137,14 +134,13 @@ impl<'a, 'b> ContextTrait for Context<'a, 'b> {
         if self.is_static_or_reentrancy() {
             Err(vm::Error::MutableCallInStaticContext)
         } else {
-            self.local_part
-                .substate
+            self.state
                 .set_storage(
-                    self.state,
                     &caller,
                     key,
                     value,
                     self.local_part.origin.storage_owner,
+                    &mut self.local_part.substate,
                 )
                 .map_err(Into::into)
         }

--- a/core/src/executive/executive.rs
+++ b/core/src/executive/executive.rs
@@ -581,7 +581,6 @@ impl<'a> CallCreateExecutive<'a> {
         let maybe_substate;
         if apply_state {
             let mut substate = self.context.substate;
-            state.collect_ownership_changed(&mut substate)?; /* only fail for db error. */
             if let Some(create_address) = self.create_address {
                 substate
                     .contracts_created

--- a/core/src/executive/executive.rs
+++ b/core/src/executive/executive.rs
@@ -1772,6 +1772,8 @@ impl<'a> ExecutiveGeneric<'a> {
                     &mut substate,
                 )?;
             }
+
+            assert!(self.state.is_fresh_storage(address)?);
         }
 
         let res = settle_collateral_for_all(

--- a/core/src/executive/internal_contract/components/context.rs
+++ b/core/src/executive/internal_contract/components/context.rs
@@ -51,13 +51,13 @@ impl<'a> InternalRefContext<'a> {
         &mut self, params: &ActionParams, key: Vec<u8>, value: U256,
     ) -> vm::Result<()> {
         let receiver = params.address.with_space(params.space);
-        self.substate
+        self.state
             .set_storage(
-                self.state,
                 &receiver,
                 key,
                 value,
                 params.storage_owner,
+                self.substate,
             )
             .map_err(|e| e.into())
     }
@@ -66,9 +66,7 @@ impl<'a> InternalRefContext<'a> {
         &mut self, params: &ActionParams, key: &[u8],
     ) -> DbResult<U256> {
         let receiver = params.address.with_space(params.space);
-        self.substate
-            .storage_at(self.state, &receiver, key)
-            .map_err(|e| e.into())
+        self.state.storage_at(&receiver, key).map_err(|e| e.into())
     }
 
     pub fn is_contract_address(&self, address: &Address) -> vm::Result<bool> {

--- a/core/src/executive/internal_contract/contracts/sponsor.rs
+++ b/core/src/executive/internal_contract/contracts/sponsor.rs
@@ -106,7 +106,13 @@ impl SimpleExecutionTrait for AddPrivilege {
                     .into(),
             ));
         }
-        add_privilege(params.sender, addresses, params, context.state)
+        add_privilege(
+            params.sender,
+            addresses,
+            params,
+            context.state,
+            context.substate,
+        )
     }
 }
 
@@ -138,7 +144,13 @@ impl SimpleExecutionTrait for RemovePrivilege {
             ));
         }
 
-        remove_privilege(params.sender, addresses, params, context.state)
+        remove_privilege(
+            params.sender,
+            addresses,
+            params,
+            context.state,
+            context.substate,
+        )
     }
 }
 
@@ -285,7 +297,13 @@ impl SimpleExecutionTrait for AddPrivilegeByAdmin {
         if context.is_contract_address(&contract)?
             && &params.sender == &context.state.admin(&contract)?
         {
-            add_privilege(contract, addresses, params, context.state)?
+            add_privilege(
+                contract,
+                addresses,
+                params,
+                context.state,
+                context.substate,
+            )?
         }
         Ok(())
     }
@@ -316,7 +334,13 @@ impl SimpleExecutionTrait for RemovePrivilegeByAdmin {
         if context.is_contract_address(&contract)?
             && &params.sender == &context.state.admin(&contract)?
         {
-            remove_privilege(contract, addresses, params, context.state)?
+            remove_privilege(
+                contract,
+                addresses,
+                params,
+                context.state,
+                context.substate,
+            )?
         }
         Ok(())
     }

--- a/core/src/executive/internal_contract/impls/sponsor.rs
+++ b/core/src/executive/internal_contract/impls/sponsor.rs
@@ -239,7 +239,7 @@ pub fn set_sponsor_for_collateral(
 /// `addPrivilegeByAdmin(address,address[])`.
 pub fn add_privilege(
     contract: Address, addresses: Vec<Address>, params: &ActionParams,
-    state: &mut State,
+    state: &mut State, substate: &mut Substate,
 ) -> vm::Result<()>
 {
     for user_addr in addresses {
@@ -247,6 +247,7 @@ pub fn add_privilege(
             contract,
             params.storage_owner,
             user_addr,
+            substate,
         )?;
     }
 
@@ -257,7 +258,7 @@ pub fn add_privilege(
 /// `removePrivilegeByAdmin(address,address[])`.
 pub fn remove_privilege(
     contract: Address, addresses: Vec<Address>, params: &ActionParams,
-    state: &mut State,
+    state: &mut State, substate: &mut Substate,
 ) -> vm::Result<()>
 {
     for user_addr in addresses {
@@ -265,6 +266,7 @@ pub fn remove_privilege(
             contract,
             params.storage_owner,
             user_addr,
+            substate,
         )?;
     }
     Ok(())

--- a/core/src/state/overlay_account/factory.rs
+++ b/core/src/state/overlay_account/factory.rs
@@ -1,6 +1,5 @@
 use crate::hash::KECCAK_EMPTY;
 use cfx_types::{Address, AddressSpaceUtil, AddressWithSpace, Space, U256};
-use parking_lot::RwLock;
 use primitives::{Account, SponsorInfo, StorageLayout};
 
 use super::{AccountEntry, OverlayAccount};
@@ -13,10 +12,8 @@ impl Default for OverlayAccount {
             nonce: U256::zero(),
             admin: Address::zero(),
             sponsor_info: Default::default(),
-            storage_value_read_cache: Default::default(),
-            storage_value_write_cache: Default::default(),
-            storage_owner_lv2_write_cache: Default::default(),
-            storage_owner_lv1_write_cache: Default::default(),
+            storage_read_cache: Default::default(),
+            storage_write_cache: Default::default(),
             storage_layout_change: None,
             staking_balance: 0.into(),
             collateral_for_storage: 0.into(),
@@ -139,14 +136,8 @@ impl OverlayAccount {
 
     pub fn clone_dirty(&self) -> Self {
         let mut account = self.clone_basic();
-        account.storage_value_write_cache =
-            self.storage_value_write_cache.clone();
-        account.storage_value_read_cache =
-            self.storage_value_read_cache.clone();
-        account.storage_owner_lv2_write_cache =
-            RwLock::new(self.storage_owner_lv2_write_cache.read().clone());
-        account.storage_owner_lv1_write_cache =
-            self.storage_owner_lv1_write_cache.clone();
+        account.storage_write_cache = self.storage_write_cache.clone();
+        account.storage_read_cache = self.storage_read_cache.clone();
         account.storage_layout_change = self.storage_layout_change.clone();
         account
     }
@@ -158,12 +149,8 @@ impl OverlayAccount {
         self.sponsor_info = other.sponsor_info;
         self.code_hash = other.code_hash;
         self.code = other.code;
-        self.storage_value_read_cache = other.storage_value_read_cache;
-        self.storage_value_write_cache = other.storage_value_write_cache;
-        self.storage_owner_lv2_write_cache =
-            other.storage_owner_lv2_write_cache;
-        self.storage_owner_lv1_write_cache =
-            other.storage_owner_lv1_write_cache;
+        self.storage_read_cache = other.storage_read_cache;
+        self.storage_write_cache = other.storage_write_cache;
         self.storage_layout_change = other.storage_layout_change;
         self.staking_balance = other.staking_balance;
         self.collateral_for_storage = other.collateral_for_storage;

--- a/core/src/state/overlay_account/mod.rs
+++ b/core/src/state/overlay_account/mod.rs
@@ -133,7 +133,7 @@ impl OverlayAccount {
         }
     }
 
-    fn fresh_storage(&self) -> bool {
+    pub fn fresh_storage(&self) -> bool {
         let builtin_address = self.address.space == Space::Native
             && self.address.address.is_builtin_address();
         (self.is_newly_created_contract && !builtin_address)

--- a/core/src/state/overlay_account/tests.rs
+++ b/core/src/state/overlay_account/tests.rs
@@ -752,24 +752,20 @@ fn test_clone_overwrite() {
     assert_eq!(account1, overlay_account1.as_account());
     assert_eq!(account2, overlay_account2.as_account());
 
-    overlay_account1.set_storage(vec![0; 32], U256::zero(), address);
+    overlay_account1.set_storage_simple(vec![0; 32], U256::zero());
     assert_eq!(account1, overlay_account1.as_account());
-    assert_eq!(overlay_account1.storage_value_write_cache.len(), 1);
-    assert_eq!(overlay_account1.storage_owner_lv1_write_cache.len(), 1);
+    assert_eq!(overlay_account1.storage_write_cache.len(), 1);
     let overlay_account = overlay_account1.clone_basic();
     assert_eq!(account1, overlay_account.as_account());
-    assert_eq!(overlay_account.storage_value_write_cache.len(), 0);
-    assert_eq!(overlay_account.storage_owner_lv1_write_cache.len(), 0);
+    assert_eq!(overlay_account.storage_write_cache.len(), 0);
     let overlay_account = overlay_account1.clone_dirty();
     assert_eq!(account1, overlay_account.as_account());
-    assert_eq!(overlay_account.storage_value_write_cache.len(), 1);
-    assert_eq!(overlay_account.storage_owner_lv1_write_cache.len(), 1);
+    assert_eq!(overlay_account.storage_write_cache.len(), 1);
 
-    overlay_account2.set_storage(vec![0; 32], U256::zero(), address);
-    overlay_account2.set_storage(vec![1; 32], U256::zero(), address);
+    overlay_account2.set_storage_simple(vec![0; 32], U256::zero());
+    overlay_account2.set_storage_simple(vec![1; 32], U256::zero());
     overlay_account1.overwrite_with(overlay_account2);
     assert_ne!(account1, overlay_account1.as_account());
     assert_eq!(account2, overlay_account1.as_account());
-    assert_eq!(overlay_account1.storage_value_write_cache.len(), 2);
-    assert_eq!(overlay_account1.storage_owner_lv1_write_cache.len(), 2);
+    assert_eq!(overlay_account1.storage_write_cache.len(), 2);
 }

--- a/core/src/state/state_object/account_controller.rs
+++ b/core/src/state/state_object/account_controller.rs
@@ -1,6 +1,5 @@
 use super::{AccountEntry, OverlayAccount, State};
 use cfx_statedb::Result as DbResult;
-use cfx_storage::utils::access_mode;
 use cfx_types::{
     Address, AddressSpaceUtil, AddressWithSpace, Space, H256, U256,
 };
@@ -36,19 +35,6 @@ impl State {
     pub fn remove_contract(
         &mut self, address: &AddressWithSpace,
     ) -> DbResult<()> {
-        if address.space == Space::Native {
-            let removed_whitelist = self
-                .clear_contract_whitelist::<access_mode::Write>(
-                    &address.address,
-                )?;
-
-            if !removed_whitelist.is_empty() {
-                error!(
-                "removed_whitelist here should be empty unless in unit tests."
-            );
-            }
-        }
-
         self.update_cache(
             address,
             OverlayAccount::new_removed(address).into_dirty_entry(),

--- a/core/src/state/state_object/sponsor.rs
+++ b/core/src/state/state_object/sponsor.rs
@@ -236,12 +236,12 @@ fn storage_range_deletion_for_account(
         StorageKey::new_storage_key(&address, key_prefix)
     }
     .with_native_space();
-    let deletion_log = state
+    let db_deletion_log = state
         .db
-        .delete_all::<access_mode::Write>(storage_key_prefix, None)?
+        .delete_all::<access_mode::Read>(storage_key_prefix, None)?
         .into_iter();
     state
         .write_native_account_lock(address)?
-        .delete_storage_range(deletion_log, address.as_ref(), substate)?;
+        .delete_storage_range(db_deletion_log, key_prefix, substate)?;
     Ok(())
 }

--- a/core/src/state/state_object/storage_entry.rs
+++ b/core/src/state/state_object/storage_entry.rs
@@ -42,6 +42,13 @@ impl State {
             .set_storage(&self.db, key, value, owner, substate)?;
         Ok(())
     }
+
+    pub fn is_fresh_storage(
+        &self, address: &AddressWithSpace,
+    ) -> DbResult<bool> {
+        let acc = try_loaded!(self.read_account_lock(address));
+        Ok(acc.fresh_storage())
+    }
 }
 
 impl State {

--- a/core/src/state/substate.rs
+++ b/core/src/state/substate.rs
@@ -3,13 +3,9 @@
 // See http://www.gnu.org/licenses/
 
 use super::CleanupMode;
-use crate::{
-    evm::{CleanDustMode, Spec},
-    state::State,
-};
+use crate::evm::{CleanDustMode, Spec};
 use cfx_parameters::internal_contract_addresses::ADMIN_CONTROL_CONTRACT_ADDRESS;
-use cfx_statedb::Result as DbResult;
-use cfx_types::{Address, AddressSpaceUtil, AddressWithSpace, U256};
+use cfx_types::{Address, AddressSpaceUtil, AddressWithSpace};
 use primitives::LogEntry;
 use std::collections::{HashMap, HashSet};
 
@@ -155,24 +151,6 @@ impl Substate {
         } else {
             (0, sub - inc)
         }
-    }
-
-    // Let VM access storage from substate so that storage ownership can be
-    // maintained without help from state.
-    pub fn storage_at(
-        &self, state: &State, address: &AddressWithSpace, key: &[u8],
-    ) -> DbResult<U256> {
-        state.storage_at(address, key)
-    }
-
-    // Let VM access storage from substate so that storage ownership can be
-    // maintained without help from state.
-    pub fn set_storage(
-        &mut self, state: &mut State, address: &AddressWithSpace, key: Vec<u8>,
-        value: U256, owner: Address,
-    ) -> DbResult<()>
-    {
-        state.set_storage(address, key, value, owner)
     }
 
     pub fn record_storage_occupy(

--- a/primitives/src/storage.rs
+++ b/primitives/src/storage.rs
@@ -177,7 +177,7 @@ impl StorageLayout {
     }
 }
 
-#[derive(Default, Clone, Debug)]
+#[derive(Default, Clone, Copy, Debug)]
 pub struct StorageValue {
     pub value: U256,
     pub owner: Option<Address>,

--- a/tests/admin_at_creation_test.py
+++ b/tests/admin_at_creation_test.py
@@ -7,8 +7,8 @@ from web3 import Web3
 
 class ClearAdminTest(ConfluxTestFrameworkForContract):
     def set_test_params(self):
+        super().set_test_params()
         self.num_nodes = 8
-        self.conf_parameters["executive_trace"] = "true"
 
     def setup_network(self):
         self.setup_nodes()
@@ -27,7 +27,7 @@ class ClearAdminTest(ConfluxTestFrameworkForContract):
         # Clear admin by non-admin (fail)
         self.log.info("Test unable to clear admin by non-admin.")
         self.adminControl.functions.setAdmin(create2factory_addr, ZERO_ADDRESS).cfx_transact(priv_key=test_account_key)
-        assert_equal(self.client.get_admin(create2factory_addr), genesis_addr)
+        assert_equal(self.client.get_admin(create2factory_addr), genesis_addr.lower())
 
 
         self.log.info("Test contract creation by itself")
@@ -40,7 +40,7 @@ class ClearAdminTest(ConfluxTestFrameworkForContract):
         assert_equal(self.client.get_admin(clear_admin_test_contract2.address), ZERO_ADDRESS)
         # The owner of create2factory_addr isn't hijacked.
         self.log.info("Test unable to hijack set admin.")
-        assert_equal(self.client.get_admin(create2factory_addr), genesis_addr)
+        assert_equal(self.client.get_admin(create2factory_addr), genesis_addr.lower())
 
         self.log.info("Test unable to hijack owner through deployAndHijackAdmin")
         # Create a new contract through deployAndHijackAdmin.
@@ -49,7 +49,7 @@ class ClearAdminTest(ConfluxTestFrameworkForContract):
         fn_call = clear_admin_test_contract.functions.deployAndHijackAdmin(create_data)
         created_address = fn_call.cfx_call(sender = test_account_addr)
         fn_call.cfx_transact(priv_key = test_account_key, value = 123, decimals = 1)
-        assert_equal(self.client.get_admin(created_address), test_account_addr)
+        assert_equal(self.client.get_admin(created_address), test_account_addr.lower())
 
         self.log.info("Pass")
 

--- a/tests/admin_control_test.py
+++ b/tests/admin_control_test.py
@@ -7,6 +7,7 @@ from web3.contract import Contract
 
 class AdminControlTest(ConfluxTestFrameworkForContract):
     def set_test_params(self):
+        super().set_test_params()
         self.num_nodes = 1
 
     def run_test(self):

--- a/tests/cip97_test.py
+++ b/tests/cip97_test.py
@@ -10,6 +10,7 @@ CFX = 10 ** 18
 
 class CIP97Test(ConfluxTestFrameworkForContract):
     def set_test_params(self):
+        super().set_test_params()
         self.num_nodes = 1
         self.conf_parameters["dao_vote_transition_number"] = 100
         self.conf_parameters["hydra_transition_number"] = 90

--- a/tests/commission_privilege_test.py
+++ b/tests/commission_privilege_test.py
@@ -8,6 +8,7 @@ from test_framework.util import *
 
 class CommissionPrivilegeTest(ConfluxTestFrameworkForContract):
     def set_test_params(self):
+        super().set_test_params()
         self.num_nodes = 1
 
     def run_test(self):
@@ -60,7 +61,7 @@ class CommissionPrivilegeTest(ConfluxTestFrameworkForContract):
         b0 = client.get_balance(genesis_addr)
         self.sponsorControl.functions.setSponsorForGas(contract_addr, tx_gas_upper_bound).cfx_transact(value = 1, gas = gas)
         assert_equal(client.get_sponsor_balance_for_gas(contract_addr), 10 ** 18)
-        assert_equal(client.get_sponsor_for_gas(contract_addr), genesis_addr)
+        assert_equal(client.get_sponsor_for_gas(contract_addr), genesis_addr.lower())
         assert_equal(client.get_sponsor_gas_bound(contract_addr), tx_gas_upper_bound)
         assert_equal(client.get_balance(genesis_addr), b0 - 10 ** 18 - charged_of_huge_gas(gas))
 
@@ -155,7 +156,7 @@ class CommissionPrivilegeTest(ConfluxTestFrameworkForContract):
         self.sponsorControl.functions.setSponsorForGas(contract_addr, tx_gas_upper_bound).cfx_transact(
             value = 0.5, storage_limit = 0, priv_key = priv_key3, err_msg = 'VmError(InternalContract("sponsor_balance is not exceed previous sponsor"))')
         assert_equal(client.get_sponsor_balance_for_gas(contract_addr), sb)
-        assert_equal(client.get_sponsor_for_gas(contract_addr), genesis_addr)
+        assert_equal(client.get_sponsor_for_gas(contract_addr), genesis_addr.lower())
         assert_equal(client.get_balance(addr3), b3 - gas)
 
         # new sponsor failed due to small upper bound
@@ -164,7 +165,7 @@ class CommissionPrivilegeTest(ConfluxTestFrameworkForContract):
         self.sponsorControl.functions.setSponsorForGas(contract_addr, tx_gas_upper_bound - 1).cfx_transact(
             value = 1, storage_limit = 0, priv_key = priv_key3, err_msg = 'VmError(InternalContract("upper_bound is not exceed previous sponsor"))')
         assert_equal(client.get_sponsor_balance_for_gas(contract_addr), sb)
-        assert_equal(client.get_sponsor_for_gas(contract_addr), genesis_addr)
+        assert_equal(client.get_sponsor_for_gas(contract_addr), genesis_addr.lower())
         assert_equal(client.get_balance(addr3), b3 - gas)
 
         # new sponsor succeed
@@ -318,7 +319,7 @@ class CommissionPrivilegeTest(ConfluxTestFrameworkForContract):
         self.sponsorControl.functions.setSponsorForCollateral(contract_addr).cfx_transact(value = sb + cfs + 1, decimals = 0)
         assert_equal(client.get_collateral_for_storage(contract_addr), cfs)
         assert_equal(client.get_sponsor_balance_for_collateral(contract_addr), sb + 1)
-        assert_equal(client.get_sponsor_for_collateral(contract_addr), genesis_addr)
+        assert_equal(client.get_sponsor_for_collateral(contract_addr), genesis_addr.lower())
         assert_equal(client.get_balance(genesis_addr), b0 - charged_of_huge_gas(gas) - sb - cfs - 1)
         assert_equal(client.get_balance(addr3), b3 + sb + cfs)
         

--- a/tests/conflux/rpc.py
+++ b/tests/conflux/rpc.py
@@ -447,9 +447,19 @@ class RpcClient:
     def get_transaction_receipt(self, tx_hash: str) -> dict:
         assert_is_hash_string(tx_hash)
         r = self.node.cfx_getTransactionReceipt(tx_hash)
+        if r is None:
+            return None
+        
         convert_b32_address_field_to_hex(r, "contractCreated")
         convert_b32_address_field_to_hex(r, "from")
         convert_b32_address_field_to_hex(r, "to")
+
+        if "storageCollateralized" in r:
+            r["storageCollateralized"] = int(r["storageCollateralized"], 0)
+
+        if "storageReleased" in r:
+            storage_released = { b32_address_to_hex(item["address"]): int(item["collaterals"], 0) for item in r["storageReleased"] }
+            r["storageReleased"] = storage_released
         return r
 
     def txpool_status(self) -> (int, int):

--- a/tests/contract_remove_test.py
+++ b/tests/contract_remove_test.py
@@ -1,0 +1,314 @@
+from web3 import Web3
+from web3.contract import Contract
+
+import itertools
+from conflux.utils import *
+from test_framework.util import *
+from test_framework.mininode import *
+from test_framework.contracts import ConfluxTestFrameworkForContract, Account
+
+SNAPSHOT_EPOCH = 60
+
+def temp_address(number: int):
+    return Web3.toChecksumAddress("{:#042x}".format(number + 100))
+
+
+class ContractRemoveTest(ConfluxTestFrameworkForContract):
+    def __init__(self):
+        super().__init__()
+        self.has_range_delete_bug = False
+        self.has_collateral_bug = True
+
+    @property
+    def correct_wl_value(self):
+        return not self.has_range_delete_bug
+    
+    @property
+    def correct_wl_collateral(self):
+        return not (self.has_collateral_bug or self.has_range_delete_bug)
+
+    def set_test_params(self):
+        super().set_test_params()
+        
+        self.conf_parameters["adaptive_weight_beta"] = "1"
+        self.conf_parameters["timer_chain_block_difficulty_ratio"] = "3"
+        self.conf_parameters["timer_chain_beta"] = "15"
+        self.conf_parameters["dev_snapshot_epoch_count"] = str(SNAPSHOT_EPOCH)
+        self.conf_parameters["anticone_penalty_ratio"] = "10"
+
+    def run_test(self):
+        accounts: List[Account] = self.initialize_accounts(2, value = 1000)
+        self.genesis_addr3 = accounts[0].address
+        self.genesis_key3 = accounts[0].key
+        self.genesis_addr4 = accounts[1].address
+        self.genesis_key4 = accounts[1].key
+
+
+        self.test_range_deletion_on_contract_remove(False)
+        self.test_range_deletion_on_contract_remove(True)
+
+        for (is_sponsored, has_range_delete_bug) in itertools.product([True, False], [True, False]):
+            self.test_sponsor_whitelist_clear_on_contract_remove(is_sponsored, has_range_delete_bug)
+
+        self.log.info("Done")
+
+    def test_range_deletion_on_contract_remove(self, is_sponsored):
+        self.log.info(f"Test storage clear, Sponsored {is_sponsored}")
+        self.is_sponsored = is_sponsored
+        self.storage_owner = self.genesis_addr
+
+        self.test_change_storage_and_kill()
+        self.test_reset_storage_and_kill()
+        self.test_unchange_storage_and_kill()
+        self.test_set_new_storage_and_kill()
+        self.test_set_new_storage_and_later_kill()
+
+    
+    def test_sponsor_whitelist_clear_on_contract_remove(self, is_sponsored, has_range_delete_bug):
+        self.log.info(f"Test whitelist clear, sponsored {is_sponsored}, has range deletion bug {has_range_delete_bug}")
+        self.is_sponsored = is_sponsored
+        self.has_range_delete_bug = has_range_delete_bug
+        self.storage_owner = self.genesis_addr
+
+        self.test_touch_whitelist_and_kill()
+        self.test_set_again_whitelist_and_kill()
+        self.test_reset_whitelist_and_kill()
+        self.test_set_new_whitelist_and_kill()
+        self.test_set_new_storage_and_later_kill()
+
+
+    def test_change_storage_and_kill(self):
+        storage_contract = self.deploy_contract_and_init(5)
+        multi_calldata = [
+            storage_contract.functions.change(3).data(),
+            storage_contract.functions.change(4).data(),
+            storage_contract.functions.selfDestruct(self.genesis_addr3).data()
+        ]
+
+        if not self.is_sponsored:
+            # The check of storage limit is earlier than kill contract. So even if the occupied entry is released in kill process, we still need enough storage_limit. 
+            storage_contract.functions.multiCall(multi_calldata).cfx_transact(storage_limit = 0, err_msg = "VmError(ExceedStorageLimit)")
+        receipt = storage_contract.functions.multiCall(multi_calldata).cfx_transact(storage_limit = 64 * 2)
+        assert_storage_released(receipt, self.genesis_addr4, 64 * 5)
+        assert_storage_released(receipt, self.storage_owner, 0)
+        assert_storage_occupied(receipt, self.storage_owner, 0)
+        assert_equal(self.exist_storage_at(2), False)
+        assert_equal(self.exist_storage_at(4), False)
+
+
+    def test_reset_storage_and_kill(self):
+        storage_contract = self.deploy_contract_and_init(5)
+        multi_calldata = [
+            storage_contract.functions.reset(3).data(),
+            storage_contract.functions.reset(4).data(),
+            storage_contract.functions.selfDestruct(self.genesis_addr3).data()
+        ]
+        receipt = storage_contract.functions.multiCall(multi_calldata).cfx_transact(storage_limit = 0)
+        assert_storage_released(receipt, self.genesis_addr4, 64 * 5)
+        assert_storage_released(receipt, self.storage_owner, 0)
+        assert_storage_occupied(receipt, self.storage_owner, 0)
+        assert_equal(self.exist_storage_at(2), False)
+        assert_equal(self.exist_storage_at(4), False)
+
+
+    def test_unchange_storage_and_kill(self):
+        storage_contract = self.deploy_contract_and_init(5)
+        multi_calldata = [
+            storage_contract.functions.set(3).data(),
+            storage_contract.functions.set(4).data(),
+            storage_contract.functions.selfDestruct(self.genesis_addr3).data()
+        ]
+        receipt = storage_contract.functions.multiCall(multi_calldata).cfx_transact(storage_limit = 0)
+        assert_storage_released(receipt, self.genesis_addr4, 64 * 5)
+        assert_storage_released(receipt, self.storage_owner, 0)
+        assert_storage_occupied(receipt, self.storage_owner, 0)
+        assert_equal(self.exist_storage_at(2), False)
+        assert_equal(self.exist_storage_at(4), False)
+
+
+    def test_set_new_storage_and_kill(self):
+        storage_contract = self.deploy_contract_and_init(5)
+        multi_calldata = [
+            storage_contract.functions.set(5).data(),
+            storage_contract.functions.set(6).data(),
+            storage_contract.functions.selfDestruct(self.genesis_addr3).data()
+        ]
+        if not self.is_sponsored:
+            # The check of storage limit is earlier than kill contract. So even if the occupied entry is released in kill process, we still need enough storage_limit. 
+            storage_contract.functions.multiCall(multi_calldata).cfx_transact(storage_limit = 0, err_msg = "VmError(ExceedStorageLimit)")
+        receipt = storage_contract.functions.multiCall(multi_calldata).cfx_transact(storage_limit = 64 * 2)
+        assert_storage_released(receipt, self.genesis_addr4, 64 * 5)
+        assert_storage_released(receipt, self.storage_owner, 0)
+        assert_storage_occupied(receipt, self.storage_owner, 0)
+        assert_equal(self.exist_storage_at(2), False)
+        assert_equal(self.exist_storage_at(6), False)
+
+
+    def test_set_new_storage_and_later_kill(self):
+        storage_contract = self.deploy_contract_and_init(5)
+        multi_calldata = [
+            storage_contract.functions.change(4).data(),
+            storage_contract.functions.set(5).data(),
+            storage_contract.functions.set(6).data(),
+        ]
+        receipt = storage_contract.functions.multiCall(multi_calldata).cfx_transact(storage_limit = 64 * 3)
+        assert_storage_released(receipt, self.genesis_addr4, 64)
+        assert_storage_released(receipt, self.storage_owner, 0)
+        assert_storage_occupied(receipt, self.storage_owner, 3 * 64)
+        assert_equal(self.exist_storage_at(2), True)
+        assert_equal(self.exist_storage_at(4), True)
+        assert_equal(self.exist_storage_at(6), True)
+
+        receipt = storage_contract.functions.selfDestruct(self.genesis_addr3).cfx_transact(storage_limit = 0)
+        assert_storage_released(receipt, self.genesis_addr4, 4 * 64)
+        assert_storage_released(receipt, self.storage_owner, 3 * 64)
+        assert_storage_occupied(receipt, self.storage_owner, 0)
+        assert_equal(self.exist_storage_at(2), False)
+        assert_equal(self.exist_storage_at(4), False)
+        assert_equal(self.exist_storage_at(6), False)
+
+
+    def test_touch_whitelist_and_kill(self):
+        storage_contract = self.deploy_contract_and_set_whitelist(5)
+        multi_calldata = [
+            storage_contract.functions.getSponsored(temp_address(3)).data(),
+            storage_contract.functions.getSponsored(temp_address(4)).data(),
+            storage_contract.functions.selfDestruct(self.genesis_addr3).data()
+        ]
+        receipt = storage_contract.functions.multiCall(multi_calldata).cfx_transact(storage_limit = 0)
+        # print(receipt)
+        assert_storage_released(receipt, self.genesis_addr4, 64 * 5 if self.correct_wl_collateral else 64 * 2)
+        assert_storage_released(receipt, self.storage_owner, 0)
+        assert_storage_occupied(receipt, self.storage_owner, 0)
+        self.assert_address_sponsored(storage_contract.address, 2, False if self.correct_wl_value else True)
+        # Touch can also eliminate the influence from range deletion bug
+        self.assert_address_sponsored(storage_contract.address, 4, False)
+
+
+    def test_set_again_whitelist_and_kill(self):
+        storage_contract = self.deploy_contract_and_set_whitelist(5)
+        multi_calldata = [
+            storage_contract.functions.setSponsored(temp_address(3)).data(),
+            storage_contract.functions.setSponsored(temp_address(4)).data(),
+            storage_contract.functions.selfDestruct(self.genesis_addr3).data()
+        ]
+        if not self.is_sponsored:
+            # The check of storage limit is earlier than kill contract. So even if the occupied entry is released in kill process, we still need enough storage_limit. 
+            # For sponsor whitelist, the storage owner is changed even if the value does not change. This is a special case of storage owner behaviour
+            storage_contract.functions.multiCall(multi_calldata).cfx_transact(storage_limit = 0, err_msg = "VmError(ExceedStorageLimit)")
+        receipt = storage_contract.functions.multiCall(multi_calldata).cfx_transact(storage_limit = 64 * 2)
+        assert_storage_released(receipt, self.genesis_addr4, 64 * 5 if self.correct_wl_collateral else 64 * 2)
+        assert_storage_released(receipt, self.storage_owner, 0)
+        assert_storage_occupied(receipt, self.storage_owner, 0)
+        self.assert_address_sponsored(storage_contract.address, 2, False if self.correct_wl_value else True)
+        self.assert_address_sponsored(storage_contract.address, 4, False)
+
+
+    def test_reset_whitelist_and_kill(self):
+        storage_contract = self.deploy_contract_and_set_whitelist(5)
+        multi_calldata = [
+            storage_contract.functions.resetSponsored(temp_address(3)).data(),
+            storage_contract.functions.resetSponsored(temp_address(4)).data(),
+            storage_contract.functions.selfDestruct(self.genesis_addr3).data()
+        ]
+        receipt = storage_contract.functions.multiCall(multi_calldata).cfx_transact(storage_limit = 0)
+        assert_storage_released(receipt, self.genesis_addr4, 64 * 5 if self.correct_wl_collateral else 64 * 2)
+        assert_storage_released(receipt, self.storage_owner, 0)
+        assert_storage_occupied(receipt, self.storage_owner, 0)
+        self.assert_address_sponsored(storage_contract.address, 2, False if self.correct_wl_value else True)
+        self.assert_address_sponsored(storage_contract.address, 4, False)
+
+
+    def test_set_new_whitelist_and_kill(self):
+        storage_contract = self.deploy_contract_and_set_whitelist(5)
+        multi_calldata = [
+            storage_contract.functions.setSponsored(temp_address(5)).data(),
+            storage_contract.functions.setSponsored(temp_address(6)).data(),
+            storage_contract.functions.selfDestruct(self.genesis_addr3).data()
+        ]
+        if not self.is_sponsored:
+            # The check of storage limit is earlier than kill contract. So even if the occupied entry is released in kill process, we still need enough storage_limit. 
+            storage_contract.functions.multiCall(multi_calldata).cfx_transact(storage_limit = 0, err_msg = "VmError(ExceedStorageLimit)")
+        receipt = storage_contract.functions.multiCall(multi_calldata).cfx_transact(storage_limit = 64 * 2)
+        assert_storage_released(receipt, self.genesis_addr4, 64 * 5 if self.correct_wl_collateral else 0)
+        assert_storage_released(receipt, self.storage_owner, 0)
+        assert_storage_occupied(receipt, self.storage_owner, 0)
+        self.assert_address_sponsored(storage_contract.address, 2, False if self.correct_wl_value else True)
+        self.assert_address_sponsored(storage_contract.address, 6, False)
+
+
+    def test_set_new_whitelist_and_later_kill(self):
+        start_epoch = self.client.epoch_number() // SNAPSHOT_EPOCH
+
+        storage_contract = self.deploy_contract_and_set_whitelist(5)
+        multi_calldata = [
+            storage_contract.functions.setSponsored(temp_address(4)).data(),
+            storage_contract.functions.setSponsored(temp_address(5)).data(),
+            storage_contract.functions.setSponsored(temp_address(6)).data(),
+        ]
+        receipt = storage_contract.functions.multiCall(multi_calldata).cfx_transact(storage_limit = 64 * 3)
+        assert_storage_released(receipt, self.genesis_addr4, 64)
+        assert_storage_released(receipt, self.storage_owner, 0)
+        assert_storage_occupied(receipt, self.storage_owner, 3 * 64)
+        self.assert_address_sponsored(storage_contract.address, 2, True)
+        self.assert_address_sponsored(storage_contract.address, 4, True)
+        self.assert_address_sponsored(storage_contract.address, 6, True)
+
+        if not self.has_range_delete_bug:
+            self.client.generate_blocks(SNAPSHOT_EPOCH * 2 + 1)
+
+        
+        receipt = storage_contract.functions.selfDestruct(self.genesis_addr3).cfx_transact(storage_limit = 0)
+        assert_storage_released(receipt, self.genesis_addr4, 4 * 64 if self.correct_wl_collateral else 0)
+        assert_storage_released(receipt, self.storage_owner, 3 * 64 if self.correct_wl_collateral else 0)
+        assert_storage_occupied(receipt, self.storage_owner, 0)
+        if self.has_range_delete_bug:
+            end_epoch = int(receipt["epochNumber"],0) // SNAPSHOT_EPOCH
+            # If the test fails here, consider increase SNAPSHOT_EPOCH
+            assert_greater_than(2, end_epoch - start_epoch)
+        self.assert_address_sponsored(storage_contract.address, 2, False if self.correct_wl_value else True)
+        self.assert_address_sponsored(storage_contract.address, 4, False if self.correct_wl_value else True)
+        self.assert_address_sponsored(storage_contract.address, 6, False if self.correct_wl_value else True)
+        
+
+    def deploy_contract_and_init(self, num_entries):
+        storage_contract: Contract = self.cfx_contract("StorageExt").deploy(transact_args=dict(priv_key = self.genesis_key3))
+
+        multi_calldata = [storage_contract.functions.set(i).data() for i in range(num_entries)]
+        storage_contract.functions.multiCall(multi_calldata).cfx_transact(priv_key = self.genesis_key4, storage_limit = 64 * num_entries)
+        self.exist_storage_at = lambda x: self.client.get_storage_at(storage_contract.address.lower(), "{:#066x}".format(x)) is not None
+        assert_equal(self.exist_storage_at(num_entries - 1), True)
+        assert_equal(self.exist_storage_at(num_entries), False)
+        
+        if self.is_sponsored:
+            storage_contract.functions.setSponsored(self.genesis_addr).cfx_transact(priv_key = self.genesis_key3, storage_limit = 64)
+            self.internal_contract("SponsorWhitelistControl").functions.setSponsorForCollateral(storage_contract.address).cfx_transact(priv_key = self.genesis_key3, value = 100)
+            self.storage_owner = storage_contract.address
+        return storage_contract
+    
+    def deploy_contract_and_set_whitelist(self, num_entries):
+        storage_contract: Contract = self.cfx_contract("StorageExt").deploy(transact_args=dict(priv_key = self.genesis_key3))
+
+        multi_calldata = [storage_contract.functions.setSponsored(temp_address(i)).data() for i in range(num_entries)]
+        storage_contract.functions.multiCall(multi_calldata).cfx_transact(priv_key = self.genesis_key4, storage_limit = 64 * num_entries)
+        self.assert_address_sponsored(storage_contract.address, num_entries - 1, True)
+        self.assert_address_sponsored(storage_contract.address, num_entries, False)
+
+        if self.is_sponsored:
+            storage_contract.functions.setSponsored(self.genesis_addr).cfx_transact(priv_key = self.genesis_key3, storage_limit = 64)
+            self.internal_contract("SponsorWhitelistControl").functions.setSponsorForCollateral(storage_contract.address).cfx_transact(priv_key = self.genesis_key3, value = 100)
+            self.storage_owner = storage_contract.address
+        
+        if not self.has_range_delete_bug:
+            # We can not fix the range deletion bug now. We can only generate enough blocks to eliminate the influence of this bug.
+            self.client.generate_blocks(SNAPSHOT_EPOCH * 2 + 1)
+        return storage_contract
+    
+    def assert_address_sponsored(self, contract_address, sponsored_index: int, expected: bool):
+        actual = self.internal_contract("SponsorWhitelistControl").functions.isWhitelisted(contract_address, temp_address(sponsored_index)).cfx_call()
+        assert_equal(expected, actual)
+        
+
+
+if __name__ == "__main__":
+    ContractRemoveTest().main()

--- a/tests/overlay_account_storage_test.py
+++ b/tests/overlay_account_storage_test.py
@@ -1,0 +1,177 @@
+from web3 import Web3
+from web3.contract import ContractFunction, Contract
+
+from conflux.rpc import RpcClient
+from conflux.utils import *
+from test_framework.util import *
+from test_framework.mininode import *
+from test_framework.contracts import ConfluxTestFrameworkForContract, Account
+
+class OverlayAccountStorageTest(ConfluxTestFrameworkForContract):
+    def run_test(self):
+        accounts: List[Account] = self.initialize_accounts(2, value = 1000)
+        self.genesis_key3 = accounts[0].key
+        self.genesis_addr3 = accounts[0].address
+        self.genesis_key4 = accounts[1].key
+        self.genesis_addr4 = accounts[1].address
+
+        
+        def direct_call(call_fn, storage_contract, priv_key, before_value, after_value):
+            return call_fn.cfx_transact(priv_key=priv_key)
+        
+        self.run_task_group(direct_call)
+
+        def read_then_call(call_fn: ContractFunction, storage_contract: Contract, priv_key, before_value, after_value):
+            call_contract: Contract = self.cfx_contract("StorageExt").at(call_fn.address)
+            return call_contract.functions.multiCallExternal([
+                storage_contract.functions.assertValue(0, before_value).data(),
+                call_fn.data(),
+            ], [
+                storage_contract.address,
+                call_fn.address,
+            ]).cfx_transact(priv_key=priv_key)
+        
+        
+        self.run_task_group(read_then_call)
+
+        def read_revert_then_call(call_fn: ContractFunction, storage_contract: Contract, priv_key, before_value, after_value):
+            call_contract: Contract = self.cfx_contract("StorageExt").at(call_fn.address)
+            return call_contract.functions.multiCallExternalWithFlag([
+                storage_contract.functions.assertValue(0, 999).data(),
+                call_fn.data(),
+            ], [
+                storage_contract.address,
+                call_fn.address,
+            ], [2, 0]).cfx_transact(priv_key=priv_key)
+        
+        self.run_task_group(read_revert_then_call)
+
+        def revert_on_first_call(call_fn: ContractFunction, storage_contract: Contract, priv_key, before_value, after_value):
+            call_contract: Contract = self.cfx_contract("StorageExt").at(call_fn.address)
+            call_data = call_fn.data()
+            reverted_call = call_contract.functions.callAnother(call_fn.address, call_data, 4).data()
+            return call_contract.functions.multiCallExternalWithFlag([
+                storage_contract.functions.assertValue(0, before_value).data(),
+                reverted_call,
+                storage_contract.functions.assertValue(0, before_value).data(),
+                call_data,
+                storage_contract.functions.assertValue(0, after_value).data(),
+            ], [
+                storage_contract.address,
+                call_fn.address,
+                storage_contract.address,
+                call_fn.address,
+                storage_contract.address,
+            ], [0, 2, 0, 0, 0]).cfx_transact(priv_key=priv_key)
+        
+        self.run_task_group(revert_on_first_call)
+
+        def revert_on_second_call(call_fn: ContractFunction, storage_contract: Contract, priv_key, before_value, after_value):
+            call_contract: Contract = self.cfx_contract("StorageExt").at(call_fn.address)
+            call_data = call_fn.data()
+            reverted_call = call_contract.functions.callAnother(call_fn.address, call_data, 4).data()
+            return call_contract.functions.multiCallExternalWithFlag([
+                storage_contract.functions.assertValue(0, before_value).data(),
+                call_data,
+                storage_contract.functions.assertValue(0, after_value).data(),
+                reverted_call,
+                storage_contract.functions.assertValue(0, after_value).data(),
+            ], [
+                storage_contract.address,
+                call_fn.address,
+                storage_contract.address,
+                call_fn.address,
+                storage_contract.address,
+            ], [0, 0, 0, 2, 0]).cfx_transact(priv_key=priv_key)
+        
+        self.run_task_group(revert_on_second_call)
+
+        
+    def run_task_group(self, customized_enactor):
+
+        self.storage_contract: Contract = self.cfx_contract("StorageExt").deploy()
+        self.another_contract: Contract = self.cfx_contract("StorageExt").deploy()
+
+        storage_contract = self.storage_contract
+        another_contract = self.another_contract
+        
+        self.customized_enactor = customized_enactor
+
+        fn = storage_contract.functions.set(0)
+        receipt = self.customized_call(fn, priv_key = self.genesis_key2, task_index = 0)
+        assert_storage_occupied(receipt, self.genesis_addr2, 64)
+        assert_equal(len(receipt["storageReleased"]), 0)
+
+        fn = storage_contract.functions.change(0)
+        receipt = self.customized_call(fn, priv_key = self.genesis_key2, task_index = 1)
+        assert_storage_occupied(receipt, self.genesis_addr2, 0)
+        assert_equal(len(receipt["storageReleased"]), 0)
+
+        fn = storage_contract.functions.change(0)
+        receipt = self.customized_call(fn, priv_key = self.genesis_key3, task_index = 2)
+        assert_storage_occupied(receipt, self.genesis_addr3, 64)
+        assert_storage_released(receipt, self.genesis_addr2, 64)
+        assert_equal(len(receipt["storageReleased"]), 1)
+
+        self.internal_contract("SponsorWhitelistControl").functions.setSponsorForCollateral(storage_contract.address).cfx_transact(value = 1000)
+        storage_contract.functions.setSponsored(self.genesis_addr3).cfx_transact()
+
+        fn = storage_contract.functions.change(0)
+        receipt = self.customized_call(fn, priv_key = self.genesis_key3, task_index = 3)
+        assert_storage_occupied(receipt, storage_contract.address, 64)
+        assert_storage_released(receipt, self.genesis_addr3, 64)
+        assert_equal(len(receipt["storageReleased"]), 1)
+
+        fn = storage_contract.functions.change(0)
+        receipt = self.customized_call(fn, priv_key = self.genesis_key4, task_index = 4)
+        assert_storage_occupied(receipt, self.genesis_addr4, 64)
+        assert_storage_released(receipt, storage_contract.address, 64)
+        assert_equal(len(receipt["storageReleased"]), 1)
+
+
+        fn = another_contract.functions.callAnother(storage_contract.address, storage_contract.functions.change(0).data(), 0)
+        receipt = self.customized_call(fn, priv_key = self.genesis_key4, task_index = 5)
+        assert_storage_occupied(receipt, self.genesis_addr4, 0)
+        assert_equal(len(receipt["storageReleased"]), 0)
+
+        self.internal_contract("SponsorWhitelistControl").functions.setSponsorForCollateral(another_contract.address).cfx_transact(value = 1000)
+        another_contract.functions.setSponsored(self.genesis_addr4).cfx_transact()
+
+        fn = another_contract.functions.callAnother(storage_contract.address, storage_contract.functions.change(0).data(), 0)
+        receipt = self.customized_call(fn, priv_key = self.genesis_key4, task_index = 6)
+        assert_storage_occupied(receipt, another_contract.address, 64)
+        assert_storage_released(receipt, self.genesis_addr4, 64)
+        assert_equal(len(receipt["storageReleased"]), 1)
+
+        fn = storage_contract.functions.change(0)
+        receipt = self.customized_call(fn, priv_key = self.genesis_key3, task_index = 7)
+        assert_storage_occupied(receipt, storage_contract.address, 64)
+        assert_storage_released(receipt, another_contract.address, 64)
+        assert_equal(len(receipt["storageReleased"]), 1)
+
+        fn = another_contract.functions.callAnother(storage_contract.address, storage_contract.functions.reset(0).data(), 0)
+        receipt = self.customized_call(fn, priv_key = self.genesis_key2, task_index = 8)
+        assert_storage_occupied(receipt, self.genesis_addr2, 0)
+        assert_storage_released(receipt, storage_contract.address, 64)
+        assert_equal(len(receipt["storageReleased"]), 1)
+
+    def customized_call(self, call_fn: ContractFunction, priv_key, task_index):
+        before_value = task_index
+        after_value = (task_index + 1) % 9
+        assert_equal(self.storage_at(self.storage_contract.address, 0), before_value)
+        receipt = self.customized_enactor(call_fn, self.storage_contract, priv_key, before_value, after_value)
+        assert_equal(self.storage_at(self.storage_contract.address, 0), after_value)
+        return receipt
+
+
+    def storage_at(self, addr, key):
+        result = self.client.get_storage_at(addr.lower(), "{:#066x}".format(key)) 
+        if result is None:
+            return 0
+        else:
+            return int(result, 0)
+        
+
+        
+if __name__ == "__main__":
+    OverlayAccountStorageTest().main()

--- a/tests/rpc/test_tx_receipt_by_hash.py
+++ b/tests/rpc/test_tx_receipt_by_hash.py
@@ -32,9 +32,9 @@ class TestGetTxReceiptByHash(RpcClient):
         assert_equal(receipt['gasCoveredBySponsor'], False)
         assert_equal(receipt['logs'], [])
         assert_equal(receipt['outcomeStatus'], '0x0')
-        assert_equal(receipt['storageCollateralized'], '0x0')
+        assert_equal(receipt['storageCollateralized'], 0)
         assert_equal(receipt['storageCoveredBySponsor'], False)
-        assert_equal(receipt['storageReleased'], [])
+        assert_equal(len(receipt['storageReleased']), 0)
         assert_equal(receipt['txExecErrorMsg'], None)
 
     def test_receipt_with_storage_changes(self):
@@ -49,8 +49,8 @@ class TestGetTxReceiptByHash(RpcClient):
         assert_equal(receipt['outcomeStatus'], '0x0')
         contract = receipt['contractCreated']
 
-        assert_equal(receipt['storageCollateralized'], '0x280')
-        assert_equal(receipt['storageReleased'], [])
+        assert_equal(receipt['storageCollateralized'], 640)
+        assert_equal(len(receipt['storageReleased']), 0)
 
         # call increment()
         data_hex = encode_hex_0x(keccak(b"increment()"))
@@ -58,8 +58,8 @@ class TestGetTxReceiptByHash(RpcClient):
         assert_equal(self.send_tx(tx, True), tx.hash_hex())
         receipt = self.get_transaction_receipt(tx.hash_hex())
 
-        assert_equal(receipt['storageCollateralized'], '0x0')
-        assert_equal(receipt['storageReleased'], [])
+        assert_equal(receipt['storageCollateralized'], 0)
+        assert_equal(len(receipt['storageReleased']), 0)
 
         # call destroy()
         data_hex = encode_hex_0x(keccak(b"destroy()"))
@@ -67,11 +67,10 @@ class TestGetTxReceiptByHash(RpcClient):
         assert_equal(self.send_tx(tx, True), tx.hash_hex())
         receipt = self.get_transaction_receipt(tx.hash_hex())
 
-        assert_equal(receipt['storageCollateralized'], '0x0')
+        assert_equal(receipt['storageCollateralized'], 0)
 
         assert_equal(len(receipt['storageReleased']), 1)
-        assert_equal(receipt['storageReleased'][0]['collaterals'], '0x280')
-        assert_equal(b32_address_to_hex(receipt['storageReleased'][0]['address']), self.GENESIS_ADDR)
+        assert_equal(receipt['storageReleased'][self.GENESIS_ADDR.lower()], 640)
 
     def test_get_epoch_receipts(self):
         parent_hash = self.block_by_epoch("latest_mined")['hash']

--- a/tests/storage_value_unchange_test.py
+++ b/tests/storage_value_unchange_test.py
@@ -1,0 +1,39 @@
+from web3 import Web3
+from web3.contract import ContractFunction, Contract
+
+from conflux.rpc import RpcClient
+from conflux.utils import *
+from test_framework.util import *
+from test_framework.mininode import *
+from test_framework.contracts import ConfluxTestFrameworkForContract
+
+class StorageValueUnchangeTest(ConfluxTestFrameworkForContract):
+    def run_test(self):
+        storage_contract: Contract = self.cfx_contract("StorageExt").deploy()
+
+        # If the storage value does not change, the storage owner remains unchanged
+        receipt = storage_contract.functions.set(0).cfx_transact(storage_limit = 64)
+        assert_storage_occupied(receipt, self.genesis_addr, 64)
+
+        receipt = storage_contract.functions.set(0).cfx_transact(priv_key = self.genesis_key2, storage_limit = 0)
+        assert_equal(receipt["storageCollateralized"], 0)
+        assert_equal(len(receipt["storageReleased"]), 0)
+
+        receipt = storage_contract.functions.reset(0).cfx_transact(storage_limit = 0)
+        assert_storage_released(receipt, self.genesis_addr, 64)
+
+        # However, the sponsor whitelist does not follow this rule
+        receipt = storage_contract.functions.setSponsored(self.genesis_addr).cfx_transact(storage_limit = 64)
+        assert_storage_occupied(receipt, self.genesis_addr, 64)
+
+        receipt = storage_contract.functions.setSponsored(self.genesis_addr).cfx_transact(priv_key = self.genesis_key2, storage_limit = 64)
+        assert_storage_occupied(receipt, self.genesis_addr2, 64)
+        assert_storage_released(receipt, self.genesis_addr, 64)
+
+        receipt = storage_contract.functions.resetSponsored(self.genesis_addr).cfx_transact(storage_limit = 0)
+        assert_storage_released(receipt, self.genesis_addr2, 64)
+        
+
+
+if __name__ == "__main__":
+    StorageValueUnchangeTest().main()

--- a/tests/test_framework/util.py
+++ b/tests/test_framework/util.py
@@ -47,6 +47,18 @@ def assert_fee_amount(fee, tx_size, fee_per_kB):
     if fee > (tx_size + 2) * fee_per_kB / 1000:
         raise AssertionError("Fee of %s BTC too high! (Should be %s BTC)" %
                              (str(fee), str(target_fee)))
+    
+    
+def assert_storage_occupied(receipt, addr, expected):
+    if receipt["storageCoveredBySponsor"]:
+        assert_equal(receipt["to"], addr.lower())
+    else:
+        assert_equal(receipt["from"], addr.lower())
+    assert_equal(receipt["storageCollateralized"], expected)
+
+
+def assert_storage_released(receipt, addr, expected):
+    assert_equal(receipt["storageReleased"].get(addr.lower(), 0), expected)
 
 
 def assert_equal(thing1, thing2, *args):

--- a/tests/vote_token_test.py
+++ b/tests/vote_token_test.py
@@ -5,7 +5,7 @@ from eth_utils import decode_hex
 from conflux.rpc import RpcClient
 from conflux.transactions import CONTRACT_DEFAULT_GAS
 from test_framework.blocktools import create_transaction, encode_hex_0x
-from test_framework.contracts import ConfluxTestFrameworkForContract
+from test_framework.contracts import ConfluxTestFrameworkForContract, Account
 from test_framework.block_gen_thread import BlockGenThread
 from test_framework.mininode import *
 from test_framework.util import *
@@ -29,22 +29,22 @@ class VoteTokenTest(ConfluxTestFrameworkForContract):
         self.tx_conf = {"gas":int_to_hex(self.gas), "gasPrice":int_to_hex(self.gas_price)}
 
     def set_test_params(self):
+        super().set_test_params()
         self.num_nodes = 1
 
     def setup_contract(self):
         self.token_contract = self.cfx_contract("DummyErc20").deploy()
         self.vote_contract = self.cfx_contract("AdvancedTokenVote1202").deploy()
         self.log.info("Initializing contract")
-        self.accounts = [a[0] for a in self.new_address_and_transfer(5)]
 
     def run_test(self):
         self.token_contract = self.cfx_contract("DummyErc20").deploy()
         self.vote_contract = self.cfx_contract("AdvancedTokenVote1202").deploy()
         self.log.info("Initializing contract")
-        self.accounts = self.initialize_accounts(5)
+        self.accounts: List[Account] = self.initialize_accounts(5)
 
         for i in range(1):
-            self.vote_contract.functions.createIssue(i, self.token_contract.address, list(range(self.num_of_options)), [acc[0] for acc in self.accounts], "v").cfx_transact(storage_limit = 5120)
+            self.vote_contract.functions.createIssue(i, self.token_contract.address, list(range(self.num_of_options)), [acc.address for acc in self.accounts], "v").cfx_transact(storage_limit = 5120)
             for _ in range(self.num_of_options):
                 vote_choice = random.randint(0, self.num_of_options - 1)
                 self.vote_contract.functions.vote(i, vote_choice).cfx_transact(storage_limit = 5120)


### PR DESCRIPTION
This PR introduces significant improvements to the storage owner and range deletion logic within the Ethereum Virtual Machine (EVM).

## Enhanced Storage Owner Management

Conflux utilizes a storage collateral system, with each non-zero storage entry associated with an owner responsible for the storage collateral. Changes introduced by a transaction lead to ownership transfers of affected entries, along with associated collateral adjustments.

### Previous Implementation

Previously, storage values were maintained with a straightforward approach: each account maintained a read cache (holding key-value pairs from the db) and a write cache (for modifications not yet committed to the db).

However, the maintenance of ownership followed a more complex process. Even though the value and owner were co-stored in the db, they were handled separately during transaction execution. The buffer and write cache were used to maintain the owner information. As an entry's ownership changed, the new owner would be recorded in the buffer, which would be merged into the write cache upon any contract call return, simultaneously registering the collateral settlement or refund in the substate. These distributed pieces of logic added complexity and increased the potential for errors and maintenance costs,especially when both the owner and value need modification. 

Notably, this buffer design was ultimately unnecessary. While it may seem beneficial in preventing superfluous fetches of old owner information from the db for reverted executions, the reality is that the value and owner are stored together in the db. Fetching the old value to determine whether a write operation changes the value inherently retrieves the old owner. Thus, the buffer and the lazy recording of collateral changes fail to provide performance improvements.

### Updated Implementation

In the revised implementation, the four previously separate maps (value read cache, value write cache, owner buffer, and owner write cache) within an account are consolidated into two: a storage entry read cache and write cache that each includes both the value and owner. This update allows for more streamlined cache operations and uniform handling of owners and cache. Moreover, collateral changes are recorded promptly in the substate.

## Range Deletion Mechanism Enhancement

In Conflux, the killing of a contract demands a range deletion to erase the corresponding state subtree and contract's whitelist.

Currently, the range deletion involves removal of a range in the db and acquisition of key-value pairs for deleted elements. Subsequently, data within the write cache falling within the range is deleted, followed by ownership and collateral update.

This PR introduces a generalized range deletion operation applicable to both contract state and whitelist deletion. The logic for ownership maintenance has been rewritten to align with the updated ownership maintenance scheme.

## Bugs from Testing

During adding test cases for this PR, we identified 3 existing bugs related to the whitelist:

1. If a storage value is written but remains unchanged during transaction execution, its owner stays the same. However, the maintenance of the whitelist does not adhere to this principle.
2. There's an issue at the db level when handling range deletions; it fails to identify all keys in the intermediate set and delta set. This results in an inability to locate the entire whitelist when deleting a contract. More details can be found [here](https://github.com/Conflux-Chain/CIPs/issues/124).
3. When removing a contract, the deletion of a whitelist entry from the db precedes the query for that entry's owner from the db. This implies that if the entry isn't loaded into the cache, the correct refund of storage collateral cannot be processed. In other words, the refunding of storage collateral is dependent on specific cache logic.

This Pull Request retains behaviors consistent with these bugs to ensure forward compatibility. However, we cannot guarantee that all corner cases have been considered in this PR. Therefore, it's imperative to address these bugs promptly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/2703)
<!-- Reviewable:end -->
