### PR TITLE
return both compressed and uncompressed bls public key in ledger info

### DIFF
--- a/client/src/rpc/types/pos/epoch_state.rs
+++ b/client/src/rpc/types/pos/epoch_state.rs
@@ -64,7 +64,7 @@ pub struct ValidatorConsensusInfo {
     // the voted hash. Thus, if a malicious pubkey is provided here, its
     // LedgerInfo won't get a QC.
     // #[serde(deserialize_with = "deserialize_bls_public_key_unchecked")]
-    /// Uncompressed BLS public key in 96 bytes.
+    /// Compressed BLS public key in 48 bytes for BCS serialization.
     public_key: Bytes,
     /// None if we do not need VRF.
     vrf_public_key: Option<Bytes>,
@@ -79,7 +79,7 @@ impl From<&PrimitiveValidatorConsensusInfo> for ValidatorConsensusInfo {
                 .clone()
                 .raw()
                 .as_affine()
-                .to_uncompressed()
+                .to_compressed()
                 .to_vec()
                 .into(),
             vrf_public_key: value


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/2706)
<!-- Reviewable:end -->
