### PR TITLE
Do not reset msg delay when disconnecting peers.

### DIFF
--- a/core/src/sync/request_manager/mod.rs
+++ b/core/src/sync/request_manager/mod.rs
@@ -990,8 +990,7 @@ impl RequestManager {
         if let Some(unfinished_requests) =
             self.request_handler.remove_peer(peer)
         {
-            for mut msg in unfinished_requests {
-                msg.delay = None;
+            for msg in unfinished_requests {
                 self.resend_request_to_another_peer(io, &msg);
             }
         } else {


### PR DESCRIPTION
This resolve the issue that some requests never expire.

Since we always send failed requests to random peers, this should not expose a denial-of-service attack vector.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/2711)
<!-- Reviewable:end -->
