### PR TITLE
Update the default parameters for SingleMpt storage.

### DIFF
--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -293,6 +293,9 @@ build_config! {
         (storage_delta_mpts_cache_start_size, (u32), cfx_storage::defaults::DEFAULT_DELTA_MPTS_CACHE_START_SIZE)
         (storage_delta_mpts_node_map_vec_size, (u32), cfx_storage::defaults::MAX_CACHED_TRIE_NODES_R_LFU_COUNTER)
         (storage_delta_mpts_slab_idle_size, (u32), cfx_storage::defaults::DEFAULT_DELTA_MPTS_SLAB_IDLE_SIZE)
+        (storage_single_mpt_cache_size, (u32), cfx_storage::defaults::DEFAULT_DELTA_MPTS_CACHE_SIZE * 2)
+        (storage_single_mpt_cache_start_size, (u32), cfx_storage::defaults::DEFAULT_DELTA_MPTS_CACHE_START_SIZE * 2)
+        (storage_single_mpt_slab_idle_size, (u32), cfx_storage::defaults::DEFAULT_DELTA_MPTS_SLAB_IDLE_SIZE * 2)
         (storage_max_open_snapshots, (u16), cfx_storage::defaults::DEFAULT_MAX_OPEN_SNAPSHOTS)
         (storage_max_open_mpt_count, (u32), cfx_storage::defaults::DEFAULT_MAX_OPEN_MPT)
         (strict_tx_index_gc, (bool), true)
@@ -726,6 +729,13 @@ impl Configuration {
             delta_mpts_slab_idle_size: self
                 .raw_conf
                 .storage_delta_mpts_slab_idle_size,
+            single_mpt_cache_start_size: self
+                .raw_conf
+                .storage_single_mpt_cache_start_size,
+            single_mpt_cache_size: self.raw_conf.storage_single_mpt_cache_size,
+            single_mpt_slab_idle_size: self
+                .raw_conf
+                .storage_single_mpt_slab_idle_size,
             max_open_snapshots: self.raw_conf.storage_max_open_snapshots,
             path_delta_mpts_dir: conflux_data_path
                 .join(&*storage_dir::DELTA_MPTS_DIR),

--- a/core/storage/src/impls/state_manager.rs
+++ b/core/storage/src/impls/state_manager.rs
@@ -53,6 +53,9 @@ impl StateManager {
                 conf.path_storage_dir.join("single_mpt"),
                 conf.single_mpt_space,
                 conf.full_state_start_height().expect("enabled"),
+                conf.single_mpt_cache_start_size,
+                conf.single_mpt_cache_size,
+                conf.single_mpt_slab_idle_size,
             ))
         } else {
             None

--- a/core/storage/src/impls/storage_manager/single_mpt_storage_manager.rs
+++ b/core/storage/src/impls/storage_manager/single_mpt_storage_manager.rs
@@ -34,7 +34,9 @@ pub struct SingleMptStorageManager {
 impl SingleMptStorageManager {
     pub fn new_arc(
         db_path: PathBuf, space: Option<Space>, available_height: u64,
-    ) -> Arc<Self> {
+        cache_start_size: u32, cache_size: u32, idle_size: u32,
+    ) -> Arc<Self>
+    {
         if !db_path.exists() {
             fs::create_dir_all(&db_path).expect("db path create error");
         }
@@ -44,11 +46,11 @@ impl SingleMptStorageManager {
             opened_mpt: Mutex::new(None),
         });
         let node_memory_manager = Arc::new(DeltaMptsNodeMemoryManager::new(
-            1_000_000,
-            10_000_000,
-            1_000_000,
-            1_000_000,
-            DeltaMptsCacheAlgorithm::new(10_000_000),
+            cache_start_size,
+            cache_size,
+            idle_size,
+            1_000_000, // unused
+            DeltaMptsCacheAlgorithm::new(cache_size),
         ));
         let mpt = Arc::new(
             DeltaMpt::new_single_mpt(

--- a/core/storage/src/lib.rs
+++ b/core/storage/src/lib.rs
@@ -110,6 +110,9 @@ pub struct StorageConfiguration {
     pub delta_mpts_cache_size: u32,
     pub delta_mpts_node_map_vec_size: u32,
     pub delta_mpts_slab_idle_size: u32,
+    pub single_mpt_cache_start_size: u32,
+    pub single_mpt_cache_size: u32,
+    pub single_mpt_slab_idle_size: u32,
     pub max_open_snapshots: u16,
     pub path_delta_mpts_dir: PathBuf,
     pub path_storage_dir: PathBuf,
@@ -143,6 +146,11 @@ impl StorageConfiguration {
             delta_mpts_node_map_vec_size: defaults::DEFAULT_NODE_MAP_SIZE,
             delta_mpts_slab_idle_size:
                 defaults::DEFAULT_DELTA_MPTS_SLAB_IDLE_SIZE,
+            single_mpt_cache_start_size:
+                defaults::DEFAULT_DELTA_MPTS_CACHE_START_SIZE * 2,
+            single_mpt_cache_size: defaults::DEFAULT_DELTA_MPTS_CACHE_SIZE * 2,
+            single_mpt_slab_idle_size:
+                defaults::DEFAULT_DELTA_MPTS_SLAB_IDLE_SIZE * 2,
             max_open_snapshots: defaults::DEFAULT_MAX_OPEN_SNAPSHOTS,
             path_delta_mpts_dir: conflux_data_path
                 .join(&*storage_dir::DELTA_MPTS_DIR),


### PR DESCRIPTION
This is to avoid the `OutOfMem` error during the SingleMpt state execution.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/2725)
<!-- Reviewable:end -->
