### PR TITLE
Refine Checkpoints and Cache for Execution State

### DIFF
--- a/core/src/state/account_entry.rs
+++ b/core/src/state/account_entry.rs
@@ -3,81 +3,62 @@
 // See http://www.gnu.org/licenses/
 
 use super::overlay_account::OverlayAccount;
-use cfx_types::U256;
 
+/// In-memory copy of the account data.
 #[derive(Debug)]
-/// In-memory copy of the account data. Holds the optional account
-/// and the modification status.
-/// Account entry can contain existing (`Some`) or non-existing
-/// account (`None`)
-pub struct AccountEntry {
-    /// Account proxy. `None` if account known to be non-existent.
-    pub account: Option<OverlayAccount>,
-    /// Unmodified account balance.
-    pub old_balance: Option<U256>,
-    // FIXME: remove it.
-    /// Entry state.
-    pub state: AccountState,
+pub enum AccountEntry {
+    /// Represents an account that is confirmed to be absent from the database.
+    DbAbsent,
+    /// An in-memory cached account paired with a dirty bit to indicate
+    /// modifications.
+    Cached(OverlayAccount, bool),
 }
 
-impl AccountEntry {
-    // FIXME: remove it.
-    pub fn is_dirty(&self) -> bool { self.state == AccountState::Dirty }
+use AccountEntry::*;
 
-    pub fn overwrite_with(&mut self, other: AccountEntry) {
-        self.state = other.state;
-        match other.account {
-            Some(acc) => {
-                if let Some(ref mut ours) = self.account {
-                    ours.overwrite_with(acc);
-                } else {
-                    self.account = Some(acc);
-                }
-            }
-            None => self.account = None,
+impl AccountEntry {
+    pub fn is_dirty(&self) -> bool { matches!(self, Cached(_, true)) }
+
+    pub fn is_db_absent(&self) -> bool { matches!(self, DbAbsent) }
+
+    pub fn account(&self) -> Option<&OverlayAccount> {
+        match self {
+            DbAbsent => None,
+            Cached(acc, _) => Some(acc),
+        }
+    }
+
+    pub fn account_mut(&mut self) -> Option<&mut OverlayAccount> {
+        match self {
+            DbAbsent => None,
+            Cached(acc, _) => Some(acc),
+        }
+    }
+
+    pub fn into_account(self) -> Option<OverlayAccount> {
+        match self {
+            DbAbsent => None,
+            Cached(acc, _) => Some(acc),
         }
     }
 
     /// Clone dirty data into new `AccountEntry`. This includes
     /// basic account data and modified storage keys.
-    pub fn clone_dirty(&self) -> AccountEntry {
-        AccountEntry {
-            old_balance: self.old_balance,
-            account: self.account.as_ref().map(OverlayAccount::clone_dirty),
-            state: self.state,
+    pub fn clone_cache(&self) -> AccountEntry {
+        match self {
+            DbAbsent => DbAbsent,
+            Cached(acc, dirty_bit) => Cached(acc.clone_dirty(), *dirty_bit),
         }
     }
 
-    pub fn new_dirty(account: Option<OverlayAccount>) -> AccountEntry {
-        AccountEntry {
-            old_balance: account.as_ref().map(|acc| acc.balance().clone()),
-            account,
-            state: AccountState::Dirty,
-        }
+    pub fn new_dirty(account: OverlayAccount) -> AccountEntry {
+        Cached(account, true)
     }
 
-    pub fn new_clean(account: Option<OverlayAccount>) -> AccountEntry {
-        AccountEntry {
-            old_balance: account.as_ref().map(|acc| acc.balance().clone()),
-            account,
-            state: AccountState::CleanFresh,
+    pub fn new_loaded(account: Option<OverlayAccount>) -> AccountEntry {
+        match account {
+            Some(acc) => Cached(acc, false),
+            None => DbAbsent,
         }
     }
-}
-
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
-/// Account modification state. Used to check if the account was
-/// Modified in between commits and overall.
-#[allow(dead_code)]
-pub enum AccountState {
-    /// Account was loaded from disk and never modified in this state object.
-    CleanFresh,
-    /// Account was loaded from the global cache and never modified.
-    CleanCached,
-    /// Account has been modified and is not committed to the trie yet.
-    /// This is set if any of the account data is changed, including
-    /// storage and code.
-    Dirty,
-    /// Account was modified and committed to the trie.
-    Committed,
 }

--- a/core/src/state/overlay_account/commit.rs
+++ b/core/src/state/overlay_account/commit.rs
@@ -10,7 +10,7 @@ use super::OverlayAccount;
 
 impl OverlayAccount {
     pub fn commit(
-        &mut self, db: &mut StateDb, address: &AddressWithSpace,
+        mut self, db: &mut StateDb, address: &AddressWithSpace,
         mut debug_record: Option<&mut ComputeEpochDebugRecord>,
     ) -> DbResult<()>
     {

--- a/core/src/state/overlay_account/factory.rs
+++ b/core/src/state/overlay_account/factory.rs
@@ -2,7 +2,7 @@ use crate::hash::KECCAK_EMPTY;
 use cfx_types::{Address, AddressSpaceUtil, AddressWithSpace, Space, U256};
 use primitives::{Account, SponsorInfo, StorageLayout};
 
-use super::{AccountEntry, OverlayAccount};
+use super::OverlayAccount;
 
 impl Default for OverlayAccount {
     fn default() -> Self {
@@ -141,25 +141,6 @@ impl OverlayAccount {
         account.storage_layout_change = self.storage_layout_change.clone();
         account
     }
-
-    pub fn overwrite_with(&mut self, other: OverlayAccount) {
-        self.balance = other.balance;
-        self.nonce = other.nonce;
-        self.admin = other.admin;
-        self.sponsor_info = other.sponsor_info;
-        self.code_hash = other.code_hash;
-        self.code = other.code;
-        self.storage_read_cache = other.storage_read_cache;
-        self.storage_write_cache = other.storage_write_cache;
-        self.storage_layout_change = other.storage_layout_change;
-        self.staking_balance = other.staking_balance;
-        self.collateral_for_storage = other.collateral_for_storage;
-        self.accumulated_interest_return = other.accumulated_interest_return;
-        self.deposit_list = other.deposit_list;
-        self.vote_stake_list = other.vote_stake_list;
-        self.is_newly_created_contract = other.is_newly_created_contract;
-        self.invalidated_storage = other.invalidated_storage;
-    }
 }
 
 impl OverlayAccount {
@@ -176,9 +157,5 @@ impl OverlayAccount {
         account.sponsor_info = self.sponsor_info.clone();
         account.set_address(self.address);
         account
-    }
-
-    pub fn into_dirty_entry(self) -> AccountEntry {
-        AccountEntry::new_dirty(Some(self))
     }
 }

--- a/core/src/state/overlay_account/tests.rs
+++ b/core/src/state/overlay_account/tests.rs
@@ -764,7 +764,7 @@ fn test_clone_overwrite() {
 
     overlay_account2.set_storage_simple(vec![0; 32], U256::zero());
     overlay_account2.set_storage_simple(vec![1; 32], U256::zero());
-    overlay_account1.overwrite_with(overlay_account2);
+    overlay_account1 = overlay_account2;
     assert_ne!(account1, overlay_account1.as_account());
     assert_eq!(account2, overlay_account1.as_account());
     assert_eq!(overlay_account1.storage_write_cache.len(), 2);

--- a/core/src/state/state_object/checkpoints.rs
+++ b/core/src/state/state_object/checkpoints.rs
@@ -1,5 +1,42 @@
-use super::State;
-use std::collections::{hash_map::Entry, HashMap};
+use cfx_types::AddressWithSpace;
+
+use crate::state::{
+    account_entry::AccountEntry, overlay_account::OverlayAccount,
+};
+
+use super::{GlobalStat, State};
+use std::collections::{hash_map::Entry::*, HashMap};
+
+/// An account entry in the checkpoint
+pub(super) enum CheckpointEntry {
+    /// The account has not been read or modified from the database.
+    Unchanged,
+    /// The recorded state of the account at this checkpoint. It may be
+    /// modified or unmodified.
+    Recorded(AccountEntry),
+}
+use CheckpointEntry::*;
+
+impl CheckpointEntry {
+    fn from_cache(value: Option<AccountEntry>) -> Self {
+        match value {
+            Some(v) => Recorded(v),
+            None => Unchanged,
+        }
+    }
+}
+
+pub(super) struct CheckpointLayer {
+    global_stat: GlobalStat,
+    entries: HashMap<AddressWithSpace, CheckpointEntry>,
+}
+
+impl CheckpointLayer {
+    #[cfg(test)]
+    pub fn entries(&self) -> &HashMap<AddressWithSpace, CheckpointEntry> {
+        &self.entries
+    }
+}
 
 impl State {
     /// Create a recoverable checkpoint of this state. Return the checkpoint
@@ -7,74 +44,107 @@ impl State {
     /// creation time of the checkpoint and updated after that and before
     /// the creation of the next checkpoint.
     pub fn checkpoint(&mut self) -> usize {
-        self.global_stat_checkpoints
-            .get_mut()
-            .push(self.global_stat.clone());
         let checkpoints = self.checkpoints.get_mut();
         let index = checkpoints.len();
-        checkpoints.push(HashMap::new());
+        checkpoints.push(CheckpointLayer {
+            global_stat: self.global_stat,
+            entries: HashMap::new(),
+        });
         index
     }
 
     /// Merge last checkpoint with previous.
-    /// Caller should make sure the function
-    /// `collect_ownership_changed()` was called before calling
-    /// this function.
     pub fn discard_checkpoint(&mut self) {
         // merge with previous checkpoint
-        let last = self.checkpoints.get_mut().pop();
-        if let Some(mut checkpoint) = last {
-            self.global_stat_checkpoints.get_mut().pop();
-            if let Some(ref mut prev) = self.checkpoints.get_mut().last_mut() {
-                if prev.is_empty() {
-                    **prev = checkpoint;
-                } else {
-                    for (k, v) in checkpoint.drain() {
-                        prev.entry(k).or_insert(v);
-                    }
-                }
+        let mut checkpoint =
+            unwrap_or_return!(self.checkpoints.get_mut().pop()).entries;
+
+        let prev =
+            &mut unwrap_or_return!(self.checkpoints.get_mut().last_mut())
+                .entries;
+
+        if prev.is_empty() {
+            *prev = checkpoint;
+        } else {
+            for (k, v) in checkpoint.drain() {
+                prev.entry(k).or_insert(v);
             }
         }
     }
 
     /// Revert to the last checkpoint and discard it.
     pub fn revert_to_checkpoint(&mut self) {
-        if let Some(mut checkpoint) = self.checkpoints.get_mut().pop() {
-            self.global_stat = self
-                .global_stat_checkpoints
-                .get_mut()
-                .pop()
-                .expect("staking_state_checkpoint should exist");
-            for (k, v) in checkpoint.drain() {
-                match v {
-                    Some(v) => match self.cache.get_mut().entry(k) {
-                        Entry::Occupied(mut e) => {
-                            e.get_mut().overwrite_with(v);
-                        }
-                        Entry::Vacant(e) => {
-                            e.insert(v);
-                        }
-                    },
-                    None => {
-                        if let Entry::Occupied(e) =
-                            self.cache.get_mut().entry(k)
-                        {
-                            if e.get().is_dirty() {
-                                e.remove();
-                            }
-                        }
+        let CheckpointLayer {
+            entries: mut checkpoint,
+            global_stat,
+        } = unwrap_or_return!(self.checkpoints.get_mut().pop());
+
+        self.global_stat = global_stat;
+
+        for (k, v) in checkpoint.drain() {
+            let mut entry_in_cache = if let Occupied(e) =
+                self.cache.get_mut().entry(k)
+            {
+                e
+            } else {
+                // All the entries in checkpoint must be copied from cache by
+                // the following function insert_to_cache and
+                // clone_to_checkpoint.
+                // A cache entries will never be removed, except it is revert to
+                // an Unchanged checkpoint. If this exceptional case happens,
+                // this entry has never be loaded or write during transaction
+                // execution (regardless the reverted operations), and thus
+                // cannot have keys in the checkpoint.
+
+                unreachable!(
+                    "Cache should always have more keys than checkpoint"
+                );
+            };
+            match v {
+                Recorded(entry_in_checkpoint) => {
+                    *entry_in_cache.get_mut() = entry_in_checkpoint;
+                }
+                Unchanged => {
+                    // If the AccountEntry in cache does not have a dirty bit,
+                    // we can keep it in cache to avoid an duplicate db load.
+                    if entry_in_cache.get().is_dirty() {
+                        entry_in_cache.remove();
                     }
                 }
             }
         }
     }
 
+    pub(super) fn insert_to_cache(&mut self, account: OverlayAccount) {
+        let address = *account.address();
+        let old_account_entry = self
+            .cache
+            .get_mut()
+            .insert(address, AccountEntry::new_dirty(account));
+
+        let checkpoint =
+            unwrap_or_return!(self.checkpoints.get_mut().last_mut());
+        checkpoint
+            .entries
+            .entry(address)
+            .or_insert_with(|| CheckpointEntry::from_cache(old_account_entry));
+    }
+
+    pub(super) fn clone_to_checkpoint(
+        &self, address: AddressWithSpace, account_entry: &AccountEntry,
+    ) {
+        let mut checkpoints = self.checkpoints.write();
+        let checkpoint = unwrap_or_return!(checkpoints.last_mut());
+
+        checkpoint
+            .entries
+            .entry(address)
+            .or_insert_with(|| Recorded(account_entry.clone_cache()));
+    }
+
     #[cfg(any(test, feature = "testonly_code"))]
     pub fn clear(&mut self) {
-        use super::GlobalStat;
-
         assert!(self.checkpoints.get_mut().is_empty());
-        assert!(self.global_stat_checkpoints.get_mut().is_empty());
         self.cache.get_mut().clear();
         self.global_stat = GlobalStat::loaded(&self.db).expect("no db error");
     }

--- a/core/src/state/state_object/global_statistics.rs
+++ b/core/src/state/state_object/global_statistics.rs
@@ -8,7 +8,7 @@ use cfx_types::{Address, AddressSpaceUtil, U256};
 impl State {
     /// Calculate the secondary reward for the next block number.
     pub fn bump_block_number_accumulate_interest(&mut self) {
-        assert!(self.global_stat_checkpoints.get_mut().is_empty());
+        assert!(self.checkpoints.get_mut().is_empty());
         let interset_rate_per_block = self.global_stat.get::<InterestRate>();
         let accumulate_interest_rate =
             self.global_stat.val::<AccumulateInterestRate>();
@@ -18,7 +18,7 @@ impl State {
     }
 
     pub fn secondary_reward(&self) -> U256 {
-        assert!(self.global_stat_checkpoints.read().is_empty());
+        assert!(self.checkpoints.read().is_empty());
         let secondary_reward = *self.global_stat.refr::<TotalStorage>()
             * *self.global_stat.refr::<InterestRate>()
             / *INTEREST_RATE_PER_BLOCK_SCALE;

--- a/core/src/state/state_object/pos.rs
+++ b/core/src/state/state_object/pos.rs
@@ -23,7 +23,7 @@ impl State {
     pub fn inc_distributable_pos_interest(
         &mut self, current_block_number: u64,
     ) -> DbResult<()> {
-        assert!(self.global_stat_checkpoints.get_mut().is_empty());
+        assert!(self.checkpoints.get_mut().is_empty());
 
         let next_distribute_block =
             self.global_stat.refr::<LastDistributeBlock>().as_u64()
@@ -87,7 +87,7 @@ pub fn distribute_pos_interest<'a, I>(
     state: &mut State, pos_points: I, current_block_number: u64,
 ) -> DbResult<Vec<(Address, H256, U256)>>
 where I: Iterator<Item = (&'a H256, u64)> + 'a {
-    assert!(state.global_stat_checkpoints.get_mut().is_empty());
+    assert!(state.checkpoints.get_mut().is_empty());
 
     let distributable_pos_interest = state.distributable_pos_interest();
 


### PR DESCRIPTION
This PR predominantly addresses updates related to the runtime cache and checkpoint mechanics.

### Optimizing Read-Write Lock Logic on Data Reading

The current codebase has numerous early design choices tailored for parallel execution. However, subsequent technological development diverged from our original designs, rendering these designs unnecessary and ill-suited under the new technical paradigms. Notably, the cache in the State captures the transitional states during a transaction's execution. These states should be insulated and kept hidden from other transactions. Even if we achieve transaction-level parallel execution, these caches should be isolated among different processes.

The need for `RwLock` on the `cache` in `State` persists. Read operations might alter the cache, requiring interior mutability. Additionally, the current codebase requires `State` to implement the `Sync` trait, leading us to choose `RwLock` over `RefCell`.

In light of this understanding, there's room to refine numerous procedures associated with database loading and cache updates, mainly the function `State::read_account_ext`. This function was laden with complex mechanisms to sidestep holding a write lock of the cache during database loads, and aiming to lessen unnecessary write lock requests. With the clarified understanding that the cache remains unshared among processes, the focus on write lock provisions is superfluous. This PR simplified the related logic.

### Refinements in Checkpoint Entry Naming

This PR enhances the naming conventions within **State checkpoints**. Every `checkpoint` is represented as a `HashMap` with items typed as `Option<AccountEntry>`. Within this, AccountEntry further contains an `Option<OverlayAccount>`. Such a layered `Option` structure increases the cost of understanding and maintaining code, especially when discerning a checkpoint entry among scenarios like `None`, `Some(None)`, `Some(<AccountEntry without OverlayAccount>)`, and absent. To streamline this complexity, the PR has transitioned `Option<AccountEntry>` into an enumeration type named `CheckpointEntry`. Similarly, `AccountEntry` has been restructured into an enumeration, clearly clarifying the implications of whether `OverlayAccount` is present or absent. These alterations have retained the original logic.

### Refinement of `AccountState`
For `AccountState`, only `CleanFresh` and `Dirty` states are actively used. The `CleanCached` state, seemingly a relic of an early design for parallel execution, has not been utilized currently, and its original rationale has grown elusive. The `Committed` state was exclusively activated while committing the `OverlayAccount`, after which the OverlayAccount gets dropped without any subsequent tasks. 

In this PR, the commit function is adjusted to take ownership via `mut self` instead of using a mutable reference `&mut self`. Concurrently, the `AccountState` has been transitioned to a dirty bit.


### Enhanced Clarity in `should_update_account_cache` Returns

The `should_update_account_cache` method yields a `DbResult<bool>`, where the boolean indicates the operation's success. Observing that all instances returning `Ok(false)` consistently result in a subsequent db error, this PR converts these cases to `Err(DbError)`. This change ensures the method's outcome is more straightforward: it either meets a `DbError` or completes successfully.

### Additional Code Clean-up
Apart from the main areas of concern described above, this PR has removed several redundant pieces of code:

1. The `overwrite_with` method in `OverlayAccount` is notably ambiguous. Its operation mirrors that of `*self=other`.
2. The maintenance for `global_stat_checkpoints` has been integrated into `checkpoints`.
3. Some code's deep indentation has been streamlined without changing the logic. 
4. `old_balance` in `AccountEntry` is never read, it is removed in this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/2729)
<!-- Reviewable:end -->
