### PR TITLE
Refine Executive & Remove Tracer from VM Interpreter Input

### DIFF
--- a/core/src/evm/tests.rs
+++ b/core/src/evm/tests.rs
@@ -48,11 +48,10 @@ fn test_add(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_eq!(gas_left, U256::from(94_988));
@@ -74,11 +73,10 @@ fn test_sha3(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_eq!(gas_left, U256::from(94_961));
@@ -100,11 +98,10 @@ fn test_address(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_eq!(gas_left, U256::from(94_995));
@@ -130,11 +127,10 @@ fn test_origin(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut context = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, context.spec(), context.depth());
-        test_finalize(vm.exec(&mut context, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut context).ok().unwrap()).unwrap()
     };
 
     assert_eq!(gas_left, U256::from(94_995));
@@ -159,7 +155,6 @@ fn test_selfbalance(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     ctx.balances = {
         let mut x = HashMap::new();
@@ -168,7 +163,7 @@ fn test_selfbalance(factory: super::Factory) {
     };
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
     assert_eq!(gas_left, U256::from(94_992));
     assert_store(
@@ -192,11 +187,10 @@ fn test_sender(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_eq!(gas_left, U256::from(94_995));
@@ -218,11 +212,10 @@ fn test_chain_id(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new().with_chain_id(9);
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_eq!(gas_left, U256::from(94_995));
@@ -259,13 +252,13 @@ fn test_extcodecopy(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
+
     ctx.codes.insert(sender, Arc::new(sender_code));
 
     //let gas_left = {
     {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     //assert_eq!(gas_left, U256::from(79_935));
@@ -287,11 +280,10 @@ fn test_log_empty(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_eq!(gas_left, U256::from(99_619));
@@ -322,11 +314,10 @@ fn test_log_sender(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_eq!(gas_left, U256::from(98_974));
@@ -362,12 +353,12 @@ fn test_blockhash(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
+
     ctx.blockhashes.insert(U256::zero(), blockhash.clone());
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_eq!(gas_left, U256::from(94_974));
@@ -390,11 +381,10 @@ fn test_calldataload(factory: super::Factory) {
     params.code = Some(Arc::new(code));
     params.data = Some(data);
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_eq!(gas_left, U256::from(94_991));
@@ -415,12 +405,12 @@ fn test_author(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
+
     ctx.env.author = author;
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_eq!(gas_left, U256::from(94_995));
@@ -440,12 +430,12 @@ fn test_timestamp(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
+
     ctx.env.timestamp = timestamp;
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_eq!(gas_left, U256::from(94_995));
@@ -465,12 +455,12 @@ fn test_number(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
+
     ctx.env.number = number;
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_eq!(gas_left, U256::from(94_995));
@@ -490,12 +480,12 @@ fn test_difficulty(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
+
     ctx.env.difficulty = difficulty;
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_eq!(gas_left, U256::from(94_995));
@@ -515,12 +505,12 @@ fn test_gas_limit(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
+
     ctx.env.gas_limit = gas_limit;
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_eq!(gas_left, U256::from(94_995));
@@ -539,11 +529,10 @@ fn test_mul(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_store(
@@ -562,11 +551,10 @@ fn test_sub(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_store(
@@ -585,11 +573,10 @@ fn test_div(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_store(
@@ -608,11 +595,10 @@ fn test_div_zero(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_store(
@@ -633,11 +619,10 @@ fn test_mod(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_store(
@@ -663,11 +648,10 @@ fn test_smod(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_store(
@@ -693,11 +677,10 @@ fn test_sdiv(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_store(
@@ -721,12 +704,11 @@ fn test_exp(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     //let gas_left = {
     {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_store(
@@ -755,11 +737,10 @@ fn test_comparison(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_store(
@@ -796,11 +777,10 @@ fn test_signed_comparison(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_store(
@@ -834,11 +814,10 @@ fn test_bitops(factory: super::Factory) {
     params.gas = U256::from(150_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_store(
@@ -882,11 +861,10 @@ fn test_addmod_mulmod(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_store(
@@ -920,11 +898,10 @@ fn test_byte(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_store(
@@ -948,11 +925,10 @@ fn test_signextend(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_store(
@@ -977,11 +953,10 @@ fn test_badinstruction_int() {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let err = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap_err()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap_err()
     };
 
     match err {
@@ -998,11 +973,10 @@ fn test_pop(factory: super::Factory) {
     params.gas = U256::from(100_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_store(
@@ -1026,12 +1000,11 @@ fn test_extops(factory: super::Factory) {
     params.value = ActionValue::Transfer(U256::from(0x99));
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     //let gas_left = {
     {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_store(
@@ -1075,12 +1048,11 @@ fn test_jumps(factory: super::Factory) {
     params.gas = U256::from(150_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     //let gas_left = {
     {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     // assert_eq!(ctx.sstore_clears, ctx.spec().sstore_refund_gas as i128);
@@ -1106,11 +1078,10 @@ fn test_subs_simple(factory: super::Factory) {
     params.gas = U256::from(18);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_eq!(gas_left, U256::from(0));
@@ -1125,11 +1096,10 @@ fn test_subs_two_levels(factory: super::Factory) {
     params.gas = U256::from(36);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_eq!(gas_left, U256::from(0));
@@ -1144,11 +1114,10 @@ fn test_subs_invalid_jump(factory: super::Factory) {
     params.gas = U256::from(24);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let current = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap())
+        test_finalize(vm.exec(&mut ctx).ok().unwrap())
     };
 
     let expected =
@@ -1165,11 +1134,10 @@ fn test_subs_shallow_return_stack(factory: super::Factory) {
     params.gas = U256::from(24);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let current = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap())
+        test_finalize(vm.exec(&mut ctx).ok().unwrap())
     };
 
     let expected = Result::Err(vm::Error::SubStackUnderflow {
@@ -1204,11 +1172,10 @@ fn test_subs_substack_limit(factory: super::Factory) {
     params.gas = U256::from(1_000_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_eq!(gas_left, U256::from(959_049));
@@ -1226,11 +1193,10 @@ fn test_subs_substack_out(factory: super::Factory) {
     params.gas = U256::from(1_000_000);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let current = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap())
+        test_finalize(vm.exec(&mut ctx).ok().unwrap())
     };
 
     let expected = Result::Err(vm::Error::OutOfSubStack {
@@ -1248,11 +1214,10 @@ fn test_subs_sub_at_end(factory: super::Factory) {
     params.gas = U256::from(30);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let gas_left = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_eq!(gas_left, U256::from(0));
@@ -1266,11 +1231,10 @@ fn test_subs_walk_into_subroutine(factory: super::Factory) {
     params.gas = U256::from(100);
     params.code = Some(Arc::new(code));
     let mut ctx = MockContext::new();
-    let mut tracer = ();
 
     let current = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap())
+        test_finalize(vm.exec(&mut ctx).ok().unwrap())
     };
 
     let expected = Result::Err(vm::Error::InvalidSubEntry);
@@ -1288,7 +1252,7 @@ fn test_calls(factory: super::Factory) {
     params.code = Some(Arc::new(code));
     params.address = address.clone();
     let mut ctx = MockContext::new();
-    let mut tracer = ();
+
     ctx.balances = {
         let mut s = HashMap::new();
         s.insert(params.address.clone(), params.gas);
@@ -1298,7 +1262,7 @@ fn test_calls(factory: super::Factory) {
     //let gas_left = {
     {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap()
     };
 
     assert_set_contains(
@@ -1341,12 +1305,12 @@ fn test_create_in_staticcall(factory: super::Factory) {
     params.code = Some(Arc::new(code));
     params.address = address.clone();
     let mut ctx = MockContext::new_spec();
-    let mut tracer = ();
+
     ctx.is_static = true;
 
     let err = {
         let vm = factory.create(params, ctx.spec(), ctx.depth());
-        test_finalize(vm.exec(&mut ctx, &mut tracer).ok().unwrap()).unwrap_err()
+        test_finalize(vm.exec(&mut ctx).ok().unwrap()).unwrap_err()
     };
 
     assert_eq!(err, vm::Error::MutableCallInStaticContext);

--- a/core/src/executive/internal_contract/components/context.rs
+++ b/core/src/executive/internal_contract/components/context.rs
@@ -1,4 +1,5 @@
 use crate::{
+    observer::VmObserve,
     state::{CallStackInfo, State, Substate},
     vm::{self, ActionParams, Env, Spec},
 };
@@ -17,6 +18,7 @@ pub struct InternalRefContext<'a> {
     pub callstack: &'a mut CallStackInfo,
     pub state: &'a mut State,
     pub substate: &'a mut Substate,
+    pub tracer: &'a mut dyn VmObserve,
     pub static_flag: bool,
     pub depth: usize,
 }

--- a/core/src/executive/internal_contract/components/contract.rs
+++ b/core/src/executive/internal_contract/components/contract.rs
@@ -12,7 +12,6 @@ use crate::{
     bytes::Bytes,
     evm::Spec,
     hash::keccak,
-    observer::VmObserve,
     spec::CommonParams,
     vm::{self, ActionParams, ExecTrapResult, GasLeft, TrapResult},
 };
@@ -39,9 +38,7 @@ pub trait InternalContractTrait: Send + Sync + IsActive {
     /// execute this internal contract on the given parameters.
     fn execute(
         &self, params: &ActionParams, context: &mut InternalRefContext,
-        tracer: &mut dyn VmObserve,
-    ) -> ExecTrapResult<GasLeft>
-    {
+    ) -> ExecTrapResult<GasLeft> {
         let func_table = self.get_func_table();
 
         let (solidity_fn, call_params) =
@@ -52,7 +49,7 @@ pub trait InternalContractTrait: Send + Sync + IsActive {
                 }
             };
 
-        solidity_fn.execute(call_params, params, context, tracer)
+        solidity_fn.execute(call_params, params, context)
     }
 
     fn code(&self) -> Arc<Bytes> { INTERNAL_CONTRACT_CODE.clone() }

--- a/core/src/executive/internal_contract/contracts/admin.rs
+++ b/core/src/executive/internal_contract/contracts/admin.rs
@@ -24,7 +24,7 @@ impl_function_type!(SetAdmin, "non_payable_write", gas: |spec: &Spec| spec.sstor
 impl SimpleExecutionTrait for SetAdmin {
     fn execute_inner(
         &self, inputs: (Address, Address), params: &ActionParams,
-        context: &mut InternalRefContext, _tracer: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<()>
     {
         set_admin(inputs.0, inputs.1, params, context)
@@ -39,7 +39,7 @@ impl_function_type!(Destroy, "non_payable_write", gas: |spec: &Spec| spec.sstore
 impl SimpleExecutionTrait for Destroy {
     fn execute_inner(
         &self, input: Address, params: &ActionParams,
-        context: &mut InternalRefContext, tracer: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<()>
     {
         destroy(
@@ -48,7 +48,7 @@ impl SimpleExecutionTrait for Destroy {
             context.state,
             context.spec,
             context.substate,
-            tracer,
+            context.tracer,
         )
     }
 }
@@ -61,7 +61,7 @@ impl_function_type!(GetAdmin, "query_with_default_gas");
 impl SimpleExecutionTrait for GetAdmin {
     fn execute_inner(
         &self, input: Address, _params: &ActionParams,
-        context: &mut InternalRefContext, _tracer: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<Address>
     {
         Ok(context.state.admin(&input)?)

--- a/core/src/executive/internal_contract/contracts/context.rs
+++ b/core/src/executive/internal_contract/contracts/context.rs
@@ -34,7 +34,7 @@ impl_function_type!(EpochNumber, "query", gas: |spec: &Spec| spec.tier_step_gas[
 impl SimpleExecutionTrait for EpochNumber {
     fn execute_inner(
         &self, _input: (), _params: &ActionParams,
-        context: &mut InternalRefContext, _tracer: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<U256>
     {
         Ok(U256::from(context.env.epoch_height))
@@ -51,7 +51,7 @@ impl_function_type!(PoSHeight, "query", gas: |spec: &Spec| spec.tier_step_gas[(G
 impl SimpleExecutionTrait for PoSHeight {
     fn execute_inner(
         &self, _input: (), _params: &ActionParams,
-        context: &mut InternalRefContext, _tracer: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<U256>
     {
         Ok(context.env.pos_view.unwrap_or(0).into())
@@ -68,7 +68,7 @@ impl_function_type!(FinalizedEpoch, "query", gas: |spec: &Spec| spec.tier_step_g
 impl SimpleExecutionTrait for FinalizedEpoch {
     fn execute_inner(
         &self, _input: (), _params: &ActionParams,
-        context: &mut InternalRefContext, _tracer: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<U256>
     {
         Ok(context.env.finalized_epoch.unwrap_or(0).into())

--- a/core/src/executive/internal_contract/contracts/params_control.rs
+++ b/core/src/executive/internal_contract/contracts/params_control.rs
@@ -57,7 +57,7 @@ impl UpfrontPaymentTrait for CastVote {
 impl SimpleExecutionTrait for CastVote {
     fn execute_inner(
         &self, inputs: (u64, Vec<Vote>), params: &ActionParams,
-        context: &mut InternalRefContext, _tracer: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<()>
     {
         cast_vote(params.sender, inputs.0, inputs.1, params, context)
@@ -73,7 +73,7 @@ impl_function_type!(ReadVote, "query", gas: |spec: &Spec| params_index_max(spec)
 impl SimpleExecutionTrait for ReadVote {
     fn execute_inner(
         &self, input: Address, params: &ActionParams,
-        context: &mut InternalRefContext, _tracer: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<Vec<Vote>>
     {
         read_vote(input, params, context)
@@ -87,7 +87,7 @@ impl_function_type!(CurrentRound, "query", gas: |spec:&Spec| spec.tier_step_gas[
 impl SimpleExecutionTrait for CurrentRound {
     fn execute_inner(
         &self, _input: (), _params: &ActionParams,
-        context: &mut InternalRefContext, _tracer: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<u64>
     {
         Ok(
@@ -106,7 +106,7 @@ impl_function_type!(TotalVotes, "query", gas: |spec: &Spec| params_index_max(spe
 impl SimpleExecutionTrait for TotalVotes {
     fn execute_inner(
         &self, input: u64, _params: &ActionParams,
-        context: &mut InternalRefContext, _tracer: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<Vec<Vote>>
     {
         total_votes(input, context)
@@ -121,7 +121,7 @@ impl_function_type!(PosStakeForVotes, "query", gas: |spec: &Spec| 2 * spec.sload
 impl SimpleExecutionTrait for PosStakeForVotes {
     fn execute_inner(
         &self, input: u64, _params: &ActionParams,
-        context: &mut InternalRefContext, _tracer: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<U256>
     {
         pos_stake_for_votes(input, context)

--- a/core/src/executive/internal_contract/contracts/pos.rs
+++ b/core/src/executive/internal_contract/contracts/pos.rs
@@ -86,7 +86,6 @@ impl SimpleExecutionTrait for Register {
     fn execute_inner(
         &self, inputs: (H256, u64, BlsPubKey, VrfPubKey, BlsProof),
         params: &ActionParams, context: &mut InternalRefContext,
-        _tracer: &mut dyn VmObserve,
     ) -> vm::Result<()>
     {
         if !context.spec.cip43_init && context.env.pos_view.is_none() {
@@ -131,7 +130,7 @@ impl UpfrontPaymentTrait for IncreaseStake {
 impl SimpleExecutionTrait for IncreaseStake {
     fn execute_inner(
         &self, inputs: u64, params: &ActionParams,
-        context: &mut InternalRefContext, _tracer: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<()>
     {
         if !context.spec.cip43_init && context.env.pos_view.is_none() {
@@ -150,7 +149,7 @@ impl_function_type!(Retire, "non_payable_write", gas: |spec: &Spec| spec.retire_
 impl SimpleExecutionTrait for Retire {
     fn execute_inner(
         &self, votes: u64, params: &ActionParams,
-        context: &mut InternalRefContext, _tracer: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<()>
     {
         if context.env.pos_view.is_none() {
@@ -169,7 +168,7 @@ impl_function_type!(GetStatus, "query", gas: |spec: &Spec| spec.sload_gas + spec
 impl SimpleExecutionTrait for GetStatus {
     fn execute_inner(
         &self, inputs: H256, params: &ActionParams,
-        context: &mut InternalRefContext, _tracer: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<(u64, u64)>
     {
         let status = get_status(inputs, params, context)?;
@@ -184,7 +183,7 @@ impl_function_type!(IdentifierToAddress, "query", gas: |spec: &Spec| spec.sload_
 impl SimpleExecutionTrait for IdentifierToAddress {
     fn execute_inner(
         &self, inputs: H256, params: &ActionParams,
-        context: &mut InternalRefContext, _tracer: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<Address>
     {
         Ok(identifier_to_address(inputs, params, context)?)
@@ -198,7 +197,7 @@ impl_function_type!(AddressToIdentifier, "query", gas: |spec: &Spec| spec.sload_
 impl SimpleExecutionTrait for AddressToIdentifier {
     fn execute_inner(
         &self, inputs: Address, params: &ActionParams,
-        context: &mut InternalRefContext, _tracer: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<H256>
     {
         Ok(address_to_identifier(inputs, params, context)?)

--- a/core/src/executive/internal_contract/contracts/sponsor.rs
+++ b/core/src/executive/internal_contract/contracts/sponsor.rs
@@ -57,10 +57,10 @@ impl_function_type!(SetSponsorForGas, "payable_write", gas: |spec: &Spec| 2 * sp
 impl SimpleExecutionTrait for SetSponsorForGas {
     fn execute_inner(
         &self, inputs: (Address, U256), params: &ActionParams,
-        context: &mut InternalRefContext, tracer: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<()>
     {
-        set_sponsor_for_gas(inputs.0, inputs.1, params, context, tracer)
+        set_sponsor_for_gas(inputs.0, inputs.1, params, context)
     }
 }
 
@@ -72,10 +72,10 @@ impl_function_type!(SetSponsorForCollateral, "payable_write", gas: |spec: &Spec|
 impl SimpleExecutionTrait for SetSponsorForCollateral {
     fn execute_inner(
         &self, input: Address, params: &ActionParams,
-        context: &mut InternalRefContext, tracer: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<()>
     {
-        set_sponsor_for_collateral(input, params, context, tracer)
+        set_sponsor_for_collateral(input, params, context)
     }
 }
 
@@ -97,7 +97,7 @@ impl UpfrontPaymentTrait for AddPrivilege {
 impl SimpleExecutionTrait for AddPrivilege {
     fn execute_inner(
         &self, addresses: Vec<Address>, params: &ActionParams,
-        context: &mut InternalRefContext, _: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<()>
     {
         if !context.is_contract_address(&params.sender)? {
@@ -134,7 +134,7 @@ impl UpfrontPaymentTrait for RemovePrivilege {
 impl SimpleExecutionTrait for RemovePrivilege {
     fn execute_inner(
         &self, addresses: Vec<Address>, params: &ActionParams,
-        context: &mut InternalRefContext, _: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<()>
     {
         if !context.is_contract_address(&params.sender)? {
@@ -162,7 +162,7 @@ impl_function_type!(GetSponsorForGas, "query_with_default_gas");
 impl SimpleExecutionTrait for GetSponsorForGas {
     fn execute_inner(
         &self, input: Address, _: &ActionParams,
-        context: &mut InternalRefContext, _: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<Address>
     {
         Ok(context.state.sponsor_for_gas(&input)?.unwrap_or_default())
@@ -177,7 +177,7 @@ impl_function_type!(GetSponsoredBalanceForGas, "query_with_default_gas");
 impl SimpleExecutionTrait for GetSponsoredBalanceForGas {
     fn execute_inner(
         &self, input: Address, _: &ActionParams,
-        context: &mut InternalRefContext, _: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<U256>
     {
         Ok(context.state.sponsor_balance_for_gas(&input)?)
@@ -192,7 +192,7 @@ impl_function_type!(GetSponsoredGasFeeUpperBound, "query_with_default_gas");
 impl SimpleExecutionTrait for GetSponsoredGasFeeUpperBound {
     fn execute_inner(
         &self, input: Address, _: &ActionParams,
-        context: &mut InternalRefContext, _: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<U256>
     {
         Ok(context.state.sponsor_gas_bound(&input)?)
@@ -207,7 +207,7 @@ impl_function_type!(GetSponsorForCollateral, "query_with_default_gas");
 impl SimpleExecutionTrait for GetSponsorForCollateral {
     fn execute_inner(
         &self, input: Address, _: &ActionParams,
-        context: &mut InternalRefContext, _: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<Address>
     {
         Ok(context
@@ -225,7 +225,7 @@ impl_function_type!(GetSponsoredBalanceForCollateral, "query_with_default_gas");
 impl SimpleExecutionTrait for GetSponsoredBalanceForCollateral {
     fn execute_inner(
         &self, input: Address, _: &ActionParams,
-        context: &mut InternalRefContext, _: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<U256>
     {
         Ok(context.state.sponsor_balance_for_collateral(&input)?)
@@ -240,7 +240,7 @@ impl_function_type!(IsWhitelisted, "query", gas: |spec: &Spec| spec.sload_gas);
 impl SimpleExecutionTrait for IsWhitelisted {
     fn execute_inner(
         &self, (contract, user): (Address, Address), _: &ActionParams,
-        context: &mut InternalRefContext, _: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<bool>
     {
         if context.is_contract_address(&contract)? {
@@ -259,7 +259,7 @@ impl_function_type!(IsAllWhitelisted, "query", gas: |spec: &Spec| spec.sload_gas
 impl SimpleExecutionTrait for IsAllWhitelisted {
     fn execute_inner(
         &self, contract: Address, _: &ActionParams,
-        context: &mut InternalRefContext, _: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<bool>
     {
         if context.is_contract_address(&contract)? {
@@ -291,7 +291,6 @@ impl SimpleExecutionTrait for AddPrivilegeByAdmin {
     fn execute_inner(
         &self, (contract, addresses): (Address, Vec<Address>),
         params: &ActionParams, context: &mut InternalRefContext,
-        _: &mut dyn VmObserve,
     ) -> vm::Result<()>
     {
         if context.is_contract_address(&contract)?
@@ -328,7 +327,6 @@ impl SimpleExecutionTrait for RemovePrivilegeByAdmin {
     fn execute_inner(
         &self, (contract, addresses): (Address, Vec<Address>),
         params: &ActionParams, context: &mut InternalRefContext,
-        _: &mut dyn VmObserve,
     ) -> vm::Result<()>
     {
         if context.is_contract_address(&contract)?
@@ -354,7 +352,7 @@ impl_function_type!(AvailableStoragePoints, "query", gas: |spec: &Spec| spec.slo
 impl SimpleExecutionTrait for AvailableStoragePoints {
     fn execute_inner(
         &self, contract: Address, _: &ActionParams,
-        context: &mut InternalRefContext, _: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<U256>
     {
         if context.is_contract_address(&contract)? {

--- a/core/src/executive/internal_contract/contracts/staking.rs
+++ b/core/src/executive/internal_contract/contracts/staking.rs
@@ -51,7 +51,7 @@ impl UpfrontPaymentTrait for Deposit {
 impl SimpleExecutionTrait for Deposit {
     fn execute_inner(
         &self, input: U256, params: &ActionParams,
-        context: &mut InternalRefContext, tracer: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<()>
     {
         deposit(
@@ -60,7 +60,7 @@ impl SimpleExecutionTrait for Deposit {
             context.env,
             context.spec,
             context.state,
-            tracer,
+            context.tracer,
         )
     }
 }
@@ -87,7 +87,7 @@ impl UpfrontPaymentTrait for Withdraw {
 impl SimpleExecutionTrait for Withdraw {
     fn execute_inner(
         &self, input: U256, params: &ActionParams,
-        context: &mut InternalRefContext, tracer: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<()>
     {
         withdraw(
@@ -96,7 +96,7 @@ impl SimpleExecutionTrait for Withdraw {
             context.env,
             context.spec,
             context.state,
-            tracer,
+            context.tracer,
         )
     }
 }
@@ -120,7 +120,7 @@ impl UpfrontPaymentTrait for VoteLock {
 impl SimpleExecutionTrait for VoteLock {
     fn execute_inner(
         &self, inputs: (U256, U256), params: &ActionParams,
-        context: &mut InternalRefContext, _tracer: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<()>
     {
         vote_lock(inputs.0, inputs.1, params, context.env, context.state)
@@ -135,7 +135,7 @@ impl_function_type!(GetStakingBalance, "query_with_default_gas");
 impl SimpleExecutionTrait for GetStakingBalance {
     fn execute_inner(
         &self, input: Address, _: &ActionParams,
-        context: &mut InternalRefContext, _tracer: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<U256>
     {
         Ok(context.state.staking_balance(&input)?)
@@ -161,7 +161,7 @@ impl UpfrontPaymentTrait for GetLockedStakingBalance {
 impl SimpleExecutionTrait for GetLockedStakingBalance {
     fn execute_inner(
         &self, (address, block_number): (Address, U256), _: &ActionParams,
-        context: &mut InternalRefContext, _tracer: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<U256>
     {
         Ok(get_locked_staking(
@@ -192,7 +192,7 @@ impl UpfrontPaymentTrait for GetVotePower {
 impl SimpleExecutionTrait for GetVotePower {
     fn execute_inner(
         &self, (address, block_number): (Address, U256), _: &ActionParams,
-        context: &mut InternalRefContext, _tracer: &mut dyn VmObserve,
+        context: &mut InternalRefContext,
     ) -> vm::Result<U256>
     {
         Ok(get_vote_power(

--- a/core/src/executive/vm_exec.rs
+++ b/core/src/executive/vm_exec.rs
@@ -2,7 +2,6 @@ use crate::{
     builtin::Builtin,
     evm::{CallType, Context, GasLeft, MessageCallResult, ReturnData},
     executive::InternalContractTrait,
-    observer::VmObserve,
     vm::{
         ActionParams, Error as VmError, Exec, ExecTrapResult, ResumeCall,
         TrapResult,
@@ -16,9 +15,7 @@ pub struct NoopExec {
 }
 
 impl Exec for NoopExec {
-    fn exec(
-        self: Box<Self>, _: &mut dyn Context, _: &mut dyn VmObserve,
-    ) -> ExecTrapResult<GasLeft> {
+    fn exec(self: Box<Self>, _: &mut dyn Context) -> ExecTrapResult<GasLeft> {
         TrapResult::Return(Ok(GasLeft::Known(self.gas)))
     }
 }
@@ -29,9 +26,7 @@ pub struct BuiltinExec<'a> {
 
 impl<'a> Exec for BuiltinExec<'a> {
     // Copied from exec function of CallCreateExecutive.
-    fn exec(
-        self: Box<Self>, _: &mut dyn Context, _: &mut dyn VmObserve,
-    ) -> ExecTrapResult<GasLeft> {
+    fn exec(self: Box<Self>, _: &mut dyn Context) -> ExecTrapResult<GasLeft> {
         let default = [];
         let data = if let Some(ref d) = self.params.data {
             d as &[u8]
@@ -72,7 +67,7 @@ pub struct InternalContractExec<'a> {
 
 impl<'a> Exec for InternalContractExec<'a> {
     fn exec(
-        self: Box<Self>, context: &mut dyn Context, tracer: &mut dyn VmObserve,
+        self: Box<Self>, context: &mut dyn Context,
     ) -> ExecTrapResult<GasLeft> {
         let result = if self.params.call_type != CallType::Call
             && self.params.call_type != CallType::StaticCall
@@ -82,7 +77,7 @@ impl<'a> Exec for InternalContractExec<'a> {
             )))
         } else {
             let mut context = context.internal_ref();
-            self.internal.execute(&self.params, &mut context, tracer)
+            self.internal.execute(&self.params, &mut context)
         };
         if let TrapResult::Return(ref vm_result) = result {
             debug!("Internal Call Result: {:?}", vm_result);

--- a/core/src/machine.rs
+++ b/core/src/machine.rs
@@ -75,6 +75,8 @@ impl Machine {
 
     /// Get a VM factory that can execute on this state.
     pub fn vm_factory(&self) -> VmFactory { self.vm.clone() }
+
+    pub fn vm_factory_ref(&self) -> &VmFactory { &self.vm }
 }
 
 pub fn new_machine(params: CommonParams, vm: VmFactory) -> Machine {

--- a/core/src/state/account_entry.rs
+++ b/core/src/state/account_entry.rs
@@ -3,81 +3,62 @@
 // See http://www.gnu.org/licenses/
 
 use super::overlay_account::OverlayAccount;
-use cfx_types::U256;
 
+/// In-memory copy of the account data.
 #[derive(Debug)]
-/// In-memory copy of the account data. Holds the optional account
-/// and the modification status.
-/// Account entry can contain existing (`Some`) or non-existing
-/// account (`None`)
-pub struct AccountEntry {
-    /// Account proxy. `None` if account known to be non-existent.
-    pub account: Option<OverlayAccount>,
-    /// Unmodified account balance.
-    pub old_balance: Option<U256>,
-    // FIXME: remove it.
-    /// Entry state.
-    pub state: AccountState,
+pub enum AccountEntry {
+    /// Represents an account that is confirmed to be absent from the database.
+    DbAbsent,
+    /// An in-memory cached account paired with a dirty bit to indicate
+    /// modifications.
+    Cached(OverlayAccount, bool),
 }
 
-impl AccountEntry {
-    // FIXME: remove it.
-    pub fn is_dirty(&self) -> bool { self.state == AccountState::Dirty }
+use AccountEntry::*;
 
-    pub fn overwrite_with(&mut self, other: AccountEntry) {
-        self.state = other.state;
-        match other.account {
-            Some(acc) => {
-                if let Some(ref mut ours) = self.account {
-                    ours.overwrite_with(acc);
-                } else {
-                    self.account = Some(acc);
-                }
-            }
-            None => self.account = None,
+impl AccountEntry {
+    pub fn is_dirty(&self) -> bool { matches!(self, Cached(_, true)) }
+
+    pub fn is_db_absent(&self) -> bool { matches!(self, DbAbsent) }
+
+    pub fn account(&self) -> Option<&OverlayAccount> {
+        match self {
+            DbAbsent => None,
+            Cached(acc, _) => Some(acc),
+        }
+    }
+
+    pub fn account_mut(&mut self) -> Option<&mut OverlayAccount> {
+        match self {
+            DbAbsent => None,
+            Cached(acc, _) => Some(acc),
+        }
+    }
+
+    pub fn into_account(self) -> Option<OverlayAccount> {
+        match self {
+            DbAbsent => None,
+            Cached(acc, _) => Some(acc),
         }
     }
 
     /// Clone dirty data into new `AccountEntry`. This includes
     /// basic account data and modified storage keys.
-    pub fn clone_dirty(&self) -> AccountEntry {
-        AccountEntry {
-            old_balance: self.old_balance,
-            account: self.account.as_ref().map(OverlayAccount::clone_dirty),
-            state: self.state,
+    pub fn clone_cache(&self) -> AccountEntry {
+        match self {
+            DbAbsent => DbAbsent,
+            Cached(acc, dirty_bit) => Cached(acc.clone_dirty(), *dirty_bit),
         }
     }
 
-    pub fn new_dirty(account: Option<OverlayAccount>) -> AccountEntry {
-        AccountEntry {
-            old_balance: account.as_ref().map(|acc| acc.balance().clone()),
-            account,
-            state: AccountState::Dirty,
-        }
+    pub fn new_dirty(account: OverlayAccount) -> AccountEntry {
+        Cached(account, true)
     }
 
-    pub fn new_clean(account: Option<OverlayAccount>) -> AccountEntry {
-        AccountEntry {
-            old_balance: account.as_ref().map(|acc| acc.balance().clone()),
-            account,
-            state: AccountState::CleanFresh,
+    pub fn new_loaded(account: Option<OverlayAccount>) -> AccountEntry {
+        match account {
+            Some(acc) => Cached(acc, false),
+            None => DbAbsent,
         }
     }
-}
-
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
-/// Account modification state. Used to check if the account was
-/// Modified in between commits and overall.
-#[allow(dead_code)]
-pub enum AccountState {
-    /// Account was loaded from disk and never modified in this state object.
-    CleanFresh,
-    /// Account was loaded from the global cache and never modified.
-    CleanCached,
-    /// Account has been modified and is not committed to the trie yet.
-    /// This is set if any of the account data is changed, including
-    /// storage and code.
-    Dirty,
-    /// Account was modified and committed to the trie.
-    Committed,
 }

--- a/core/src/state/overlay_account/commit.rs
+++ b/core/src/state/overlay_account/commit.rs
@@ -10,7 +10,7 @@ use super::OverlayAccount;
 
 impl OverlayAccount {
     pub fn commit(
-        &mut self, db: &mut StateDb, address: &AddressWithSpace,
+        mut self, db: &mut StateDb, address: &AddressWithSpace,
         mut debug_record: Option<&mut ComputeEpochDebugRecord>,
     ) -> DbResult<()>
     {

--- a/core/src/state/overlay_account/factory.rs
+++ b/core/src/state/overlay_account/factory.rs
@@ -2,7 +2,7 @@ use crate::hash::KECCAK_EMPTY;
 use cfx_types::{Address, AddressSpaceUtil, AddressWithSpace, Space, U256};
 use primitives::{Account, SponsorInfo, StorageLayout};
 
-use super::{AccountEntry, OverlayAccount};
+use super::OverlayAccount;
 
 impl Default for OverlayAccount {
     fn default() -> Self {
@@ -141,25 +141,6 @@ impl OverlayAccount {
         account.storage_layout_change = self.storage_layout_change.clone();
         account
     }
-
-    pub fn overwrite_with(&mut self, other: OverlayAccount) {
-        self.balance = other.balance;
-        self.nonce = other.nonce;
-        self.admin = other.admin;
-        self.sponsor_info = other.sponsor_info;
-        self.code_hash = other.code_hash;
-        self.code = other.code;
-        self.storage_read_cache = other.storage_read_cache;
-        self.storage_write_cache = other.storage_write_cache;
-        self.storage_layout_change = other.storage_layout_change;
-        self.staking_balance = other.staking_balance;
-        self.collateral_for_storage = other.collateral_for_storage;
-        self.accumulated_interest_return = other.accumulated_interest_return;
-        self.deposit_list = other.deposit_list;
-        self.vote_stake_list = other.vote_stake_list;
-        self.is_newly_created_contract = other.is_newly_created_contract;
-        self.invalidated_storage = other.invalidated_storage;
-    }
 }
 
 impl OverlayAccount {
@@ -176,9 +157,5 @@ impl OverlayAccount {
         account.sponsor_info = self.sponsor_info.clone();
         account.set_address(self.address);
         account
-    }
-
-    pub fn into_dirty_entry(self) -> AccountEntry {
-        AccountEntry::new_dirty(Some(self))
     }
 }

--- a/core/src/state/overlay_account/tests.rs
+++ b/core/src/state/overlay_account/tests.rs
@@ -764,7 +764,7 @@ fn test_clone_overwrite() {
 
     overlay_account2.set_storage_simple(vec![0; 32], U256::zero());
     overlay_account2.set_storage_simple(vec![1; 32], U256::zero());
-    overlay_account1.overwrite_with(overlay_account2);
+    overlay_account1 = overlay_account2;
     assert_ne!(account1, overlay_account1.as_account());
     assert_eq!(account2, overlay_account1.as_account());
     assert_eq!(overlay_account1.storage_write_cache.len(), 2);

--- a/core/src/state/state_object/checkpoints.rs
+++ b/core/src/state/state_object/checkpoints.rs
@@ -1,5 +1,42 @@
-use super::State;
-use std::collections::{hash_map::Entry, HashMap};
+use cfx_types::AddressWithSpace;
+
+use crate::state::{
+    account_entry::AccountEntry, overlay_account::OverlayAccount,
+};
+
+use super::{GlobalStat, State};
+use std::collections::{hash_map::Entry::*, HashMap};
+
+/// An account entry in the checkpoint
+pub(super) enum CheckpointEntry {
+    /// The account has not been read or modified from the database.
+    Unchanged,
+    /// The recorded state of the account at this checkpoint. It may be
+    /// modified or unmodified.
+    Recorded(AccountEntry),
+}
+use CheckpointEntry::*;
+
+impl CheckpointEntry {
+    fn from_cache(value: Option<AccountEntry>) -> Self {
+        match value {
+            Some(v) => Recorded(v),
+            None => Unchanged,
+        }
+    }
+}
+
+pub(super) struct CheckpointLayer {
+    global_stat: GlobalStat,
+    entries: HashMap<AddressWithSpace, CheckpointEntry>,
+}
+
+impl CheckpointLayer {
+    #[cfg(test)]
+    pub fn entries(&self) -> &HashMap<AddressWithSpace, CheckpointEntry> {
+        &self.entries
+    }
+}
 
 impl State {
     /// Create a recoverable checkpoint of this state. Return the checkpoint
@@ -7,74 +44,107 @@ impl State {
     /// creation time of the checkpoint and updated after that and before
     /// the creation of the next checkpoint.
     pub fn checkpoint(&mut self) -> usize {
-        self.global_stat_checkpoints
-            .get_mut()
-            .push(self.global_stat.clone());
         let checkpoints = self.checkpoints.get_mut();
         let index = checkpoints.len();
-        checkpoints.push(HashMap::new());
+        checkpoints.push(CheckpointLayer {
+            global_stat: self.global_stat,
+            entries: HashMap::new(),
+        });
         index
     }
 
     /// Merge last checkpoint with previous.
-    /// Caller should make sure the function
-    /// `collect_ownership_changed()` was called before calling
-    /// this function.
     pub fn discard_checkpoint(&mut self) {
         // merge with previous checkpoint
-        let last = self.checkpoints.get_mut().pop();
-        if let Some(mut checkpoint) = last {
-            self.global_stat_checkpoints.get_mut().pop();
-            if let Some(ref mut prev) = self.checkpoints.get_mut().last_mut() {
-                if prev.is_empty() {
-                    **prev = checkpoint;
-                } else {
-                    for (k, v) in checkpoint.drain() {
-                        prev.entry(k).or_insert(v);
-                    }
-                }
+        let mut checkpoint =
+            unwrap_or_return!(self.checkpoints.get_mut().pop()).entries;
+
+        let prev =
+            &mut unwrap_or_return!(self.checkpoints.get_mut().last_mut())
+                .entries;
+
+        if prev.is_empty() {
+            *prev = checkpoint;
+        } else {
+            for (k, v) in checkpoint.drain() {
+                prev.entry(k).or_insert(v);
             }
         }
     }
 
     /// Revert to the last checkpoint and discard it.
     pub fn revert_to_checkpoint(&mut self) {
-        if let Some(mut checkpoint) = self.checkpoints.get_mut().pop() {
-            self.global_stat = self
-                .global_stat_checkpoints
-                .get_mut()
-                .pop()
-                .expect("staking_state_checkpoint should exist");
-            for (k, v) in checkpoint.drain() {
-                match v {
-                    Some(v) => match self.cache.get_mut().entry(k) {
-                        Entry::Occupied(mut e) => {
-                            e.get_mut().overwrite_with(v);
-                        }
-                        Entry::Vacant(e) => {
-                            e.insert(v);
-                        }
-                    },
-                    None => {
-                        if let Entry::Occupied(e) =
-                            self.cache.get_mut().entry(k)
-                        {
-                            if e.get().is_dirty() {
-                                e.remove();
-                            }
-                        }
+        let CheckpointLayer {
+            entries: mut checkpoint,
+            global_stat,
+        } = unwrap_or_return!(self.checkpoints.get_mut().pop());
+
+        self.global_stat = global_stat;
+
+        for (k, v) in checkpoint.drain() {
+            let mut entry_in_cache = if let Occupied(e) =
+                self.cache.get_mut().entry(k)
+            {
+                e
+            } else {
+                // All the entries in checkpoint must be copied from cache by
+                // the following function insert_to_cache and
+                // clone_to_checkpoint.
+                // A cache entries will never be removed, except it is revert to
+                // an Unchanged checkpoint. If this exceptional case happens,
+                // this entry has never be loaded or write during transaction
+                // execution (regardless the reverted operations), and thus
+                // cannot have keys in the checkpoint.
+
+                unreachable!(
+                    "Cache should always have more keys than checkpoint"
+                );
+            };
+            match v {
+                Recorded(entry_in_checkpoint) => {
+                    *entry_in_cache.get_mut() = entry_in_checkpoint;
+                }
+                Unchanged => {
+                    // If the AccountEntry in cache does not have a dirty bit,
+                    // we can keep it in cache to avoid an duplicate db load.
+                    if entry_in_cache.get().is_dirty() {
+                        entry_in_cache.remove();
                     }
                 }
             }
         }
     }
 
+    pub(super) fn insert_to_cache(&mut self, account: OverlayAccount) {
+        let address = *account.address();
+        let old_account_entry = self
+            .cache
+            .get_mut()
+            .insert(address, AccountEntry::new_dirty(account));
+
+        let checkpoint =
+            unwrap_or_return!(self.checkpoints.get_mut().last_mut());
+        checkpoint
+            .entries
+            .entry(address)
+            .or_insert_with(|| CheckpointEntry::from_cache(old_account_entry));
+    }
+
+    pub(super) fn clone_to_checkpoint(
+        &self, address: AddressWithSpace, account_entry: &AccountEntry,
+    ) {
+        let mut checkpoints = self.checkpoints.write();
+        let checkpoint = unwrap_or_return!(checkpoints.last_mut());
+
+        checkpoint
+            .entries
+            .entry(address)
+            .or_insert_with(|| Recorded(account_entry.clone_cache()));
+    }
+
     #[cfg(any(test, feature = "testonly_code"))]
     pub fn clear(&mut self) {
-        use super::GlobalStat;
-
         assert!(self.checkpoints.get_mut().is_empty());
-        assert!(self.global_stat_checkpoints.get_mut().is_empty());
         self.cache.get_mut().clear();
         self.global_stat = GlobalStat::loaded(&self.db).expect("no db error");
     }

--- a/core/src/state/state_object/global_statistics.rs
+++ b/core/src/state/state_object/global_statistics.rs
@@ -8,7 +8,7 @@ use cfx_types::{Address, AddressSpaceUtil, U256};
 impl State {
     /// Calculate the secondary reward for the next block number.
     pub fn bump_block_number_accumulate_interest(&mut self) {
-        assert!(self.global_stat_checkpoints.get_mut().is_empty());
+        assert!(self.checkpoints.get_mut().is_empty());
         let interset_rate_per_block = self.global_stat.get::<InterestRate>();
         let accumulate_interest_rate =
             self.global_stat.val::<AccumulateInterestRate>();
@@ -18,7 +18,7 @@ impl State {
     }
 
     pub fn secondary_reward(&self) -> U256 {
-        assert!(self.global_stat_checkpoints.read().is_empty());
+        assert!(self.checkpoints.read().is_empty());
         let secondary_reward = *self.global_stat.refr::<TotalStorage>()
             * *self.global_stat.refr::<InterestRate>()
             / *INTEREST_RATE_PER_BLOCK_SCALE;

--- a/core/src/state/state_object/pos.rs
+++ b/core/src/state/state_object/pos.rs
@@ -23,7 +23,7 @@ impl State {
     pub fn inc_distributable_pos_interest(
         &mut self, current_block_number: u64,
     ) -> DbResult<()> {
-        assert!(self.global_stat_checkpoints.get_mut().is_empty());
+        assert!(self.checkpoints.get_mut().is_empty());
 
         let next_distribute_block =
             self.global_stat.refr::<LastDistributeBlock>().as_u64()
@@ -87,7 +87,7 @@ pub fn distribute_pos_interest<'a, I>(
     state: &mut State, pos_points: I, current_block_number: u64,
 ) -> DbResult<Vec<(Address, H256, U256)>>
 where I: Iterator<Item = (&'a H256, u64)> + 'a {
-    assert!(state.global_stat_checkpoints.get_mut().is_empty());
+    assert!(state.checkpoints.get_mut().is_empty());
 
     let distributable_pos_interest = state.distributable_pos_interest();
 

--- a/core/src/vm/context.rs
+++ b/core/src/vm/context.rs
@@ -28,9 +28,7 @@ use super::{
     spec::Spec,
     Error,
 };
-use crate::{
-    executive::internal_contract::InternalRefContext, observer::VmObserve,
-};
+use crate::executive::internal_contract::InternalRefContext;
 use cfx_bytes::Bytes;
 use cfx_types::{Address, AddressWithSpace, Space, H256, U256};
 use std::sync::Arc;
@@ -145,9 +143,7 @@ pub trait Context {
 
     /// Should be called when contract commits suicide.
     /// Address to which funds should be refunded.
-    fn suicide(
-        &mut self, refund_address: &Address, tracer: &mut dyn VmObserve,
-    ) -> Result<()>;
+    fn suicide(&mut self, refund_address: &Address) -> Result<()>;
 
     /// Returns specification.
     fn spec(&self) -> &Spec;

--- a/core/src/vm/mod.rs
+++ b/core/src/vm/mod.rs
@@ -27,7 +27,6 @@ pub use self::{
     return_data::{GasLeft, ReturnData},
     spec::{CleanDustMode, Spec, WasmCosts},
 };
-use crate::observer::VmObserve;
 
 /// Virtual Machine interface
 pub trait Exec: Send {
@@ -35,7 +34,7 @@ pub trait Exec: Send {
     /// It returns either an error, a known amount of gas left, or parameters
     /// to be used to compute the final gas left.
     fn exec(
-        self: Box<Self>, context: &mut dyn Context, tracer: &mut dyn VmObserve,
+        self: Box<Self>, context: &mut dyn Context,
     ) -> ExecTrapResult<GasLeft>;
 }
 

--- a/core/src/vm/tests.rs
+++ b/core/src/vm/tests.rs
@@ -23,9 +23,7 @@ use super::{
     CreateContractAddress, Env, Error, GasLeft, MessageCallResult, Result,
     ReturnData, Spec,
 };
-use crate::{
-    executive::internal_contract::InternalRefContext, observer::VmObserve,
-};
+use crate::executive::internal_contract::InternalRefContext;
 use cfx_bytes::Bytes;
 use cfx_types::{address_util::AddressUtil, Address, Space, H256, U256};
 use hash::keccak;
@@ -213,9 +211,7 @@ impl Context for MockContext {
         unimplemented!();
     }
 
-    fn suicide(
-        &mut self, refund_address: &Address, _: &mut dyn VmObserve,
-    ) -> Result<()> {
+    fn suicide(&mut self, refund_address: &Address) -> Result<()> {
         if !refund_address.is_genesis_valid_address() {
             return Err(Error::InvalidAddress(*refund_address));
         }


### PR DESCRIPTION
This PR overhauls the logic associated with `CallCreateExecutive`. The goal is to clean and simplify the structure, eliminating unnecessary fields and enhancing naming conventions for clarity.

## Details

### Naming Clarity
The original code had various references to `executive` which could be confusing. We now refer to each layer of VM contract call as a `frame`, resembling C language function calls where each call layer on the stack is termed a *frame*.

### Context Field
The `CallCreateExecutive` contained a `context` of type `LocalContext`. This is the only field retained in `CallCreateExecutive` and has been renamed to `FrameContext`.

### Redundant Field Removal
The `create_address` field in `CallCreateExecutive` was redundant with existing content in the `context` and has been removed.

### Kind Field
The `kind` field was only used when initializing a frame. It can be efficiently derived from the initialization parameters `ActionParams` and has thus been removed.

### Status Field & Frame Types
The `status` was an enum, consisting of states like `Input(...)`, `ResumeCall(...)`, etc. Its purpose was to differentiate input parameters for a frame's initial run and its resumption after being suspended by a sub-call.

A more appropriate approach is to differentiate between the frames executing for the first time and those resuming. Different functions should handle the distinct executions, each receiving specific parameters. 

As a result, `status` has been discarded. `CallCreateExecutive` is now split into two types: `FreshFrame` and `SuspendedFrame`.

### Unified Parameters as Runtime Resources
Many functions in `CallCreateExecutive` had parameters like `&mut State`, `&mut CallStackInfo`, and `&mut dyn VmObserve` (tracer). These are shared resources that any frame can modify, with changes being observable in subsequent executions. Due to Rust's lifetimes, these mutable references can't be owned by each frame. Instead, the loop managing the frame stack passes them in as mutable references during each frame's execution. We've grouped these logically similar parameters into a new type named `RuntimeRes` (runtime resources).

### Integration of VmObserve
When handling the parameters mentioned above, we realized that `VmObserve` should be integrated into VM Interpreter's "runtime context" like `State` and `CallStackInfo`, instead of being passed as a separate parameter. This change makes many functions free from maintaining and passing the tracer pointer.

### Function Merge
The functions `new_call_raw` and `new_create_raw` in `CallCreateExecutive` had similar logic and have been merged into a single function.

## Additional Changes
A recent goal is to refactor the lengthy `transact` function (380 lines) and the `executive.rs` file (2000 lines) for clearer logic. This PR doesn't reorder the file or functions for easier diff review. It only extracts two logical modules from the `transact` function: the construction of frame input `ActionParams` and the verification of build validity, primarily checking for `create address` conflicts. These modifications are included in this PR as they are relevant to the frame-related logic.

Further file and function reordering will be addressed in subsequent PRs.

<!-- Reviewable:start -->
- - -

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/2731)
<!-- Reviewable:end -->
