### PR TITLE
Update VM Tracer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -225,7 +225,7 @@ version = "0.1.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 2.0.5",
 ]
@@ -340,7 +340,7 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "regex",
  "rustc-hash",
@@ -872,6 +872,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfx-vm-tracer-derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2 1.0.69",
+ "quote 1.0.26",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "cfxcore"
 version = "2.0.2"
 dependencies = [
@@ -894,6 +903,7 @@ dependencies = [
  "cfx-storage",
  "cfx-types",
  "cfx-utils",
+ "cfx-vm-tracer-derive",
  "cfxkey",
  "channel",
  "clap",
@@ -923,6 +933,8 @@ dependencies = [
  "hashbrown 0.7.2",
  "heap-map",
  "hibitset",
+ "impl-tools",
+ "impl-trait-for-tuples 0.2.2",
  "io",
  "itertools 0.9.0",
  "jsonrpc-core",
@@ -1683,7 +1695,7 @@ dependencies = [
  "cc",
  "codespan-reporting",
  "once_cell",
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "scratch",
  "syn 2.0.5",
@@ -1701,7 +1713,7 @@ version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "631569015d0d8d54e6c241733f944042623ab6df7bc3be7466874b05fcdb1c5f"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 2.0.5",
 ]
@@ -1726,7 +1738,7 @@ dependencies = [
 name = "delegate"
 version = "0.4.2"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -1737,7 +1749,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fd733b5bf0bb5ca3c7cdea2135c91234c80b730e6e8a270851455a63b46c830"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -1757,7 +1769,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -1843,7 +1855,7 @@ name = "diem-crypto-derive"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -1896,7 +1908,7 @@ dependencies = [
 name = "diem-log-derive"
 version = "0.1.0"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -2231,7 +2243,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "355f93763ef7b0ae1c43c4d8eccc9d5848d84ad1a1d8ce61c421d1ac85a19d05"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -2253,7 +2265,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5c450cf304c9e18d45db562025a14fb1ca0f5c769b6f609309f81d4c31de455"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -2265,7 +2277,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11f36e95862220b211a6e2aa5eca09b4fa391b13cd52ceb8035a24bf65a79de2"
 dependencies = [
  "once_cell",
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -2458,7 +2470,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
  "synstructure",
@@ -2695,7 +2707,7 @@ version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -2825,7 +2837,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -3345,12 +3357,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-tools"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82c305b1081f1a99fda262883c788e50ab57d36c00830bdd7e0a82894ad965c"
+dependencies = [
+ "autocfg",
+ "impl-tools-lib",
+ "proc-macro-error",
+ "syn 2.0.5",
+]
+
+[[package]]
+name = "impl-tools-lib"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85d3946d886eaab0702fa0c6585adcced581513223fa9df7ccfabbd9fa331a88"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2 1.0.69",
+ "quote 1.0.26",
+ "syn 2.0.5",
+]
+
+[[package]]
 name = "impl-trait-for-tuples"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef5550a42e3740a0e71f909d4c861056a284060af885ae7aa6242820f920d9d"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
+ "quote 1.0.26",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+dependencies = [
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -3552,7 +3599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99a847f9ec7bb52149b2786a17c9cb260d6effc6b8eeb8c16b343a487a7563a3"
 dependencies = [
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -3946,7 +3993,7 @@ dependencies = [
 name = "malloc_size_of_derive"
 version = "0.1.1"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "syn 1.0.109",
  "synstructure",
 ]
@@ -4301,7 +4348,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -4353,7 +4400,7 @@ dependencies = [
 name = "num-variants"
 version = "0.1.0"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -4432,7 +4479,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -4554,7 +4601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9344bc978467339b9ae688f9dcf279d1aaa0ccfc88e9a780c729b765a82d57d5"
 dependencies = [
  "cfg-if 0.1.10",
- "impl-trait-for-tuples",
+ "impl-trait-for-tuples 0.1.3",
  "parity-util-mem-derive",
  "winapi 0.3.9",
 ]
@@ -4565,7 +4612,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "syn 1.0.109",
  "synstructure",
 ]
@@ -4825,7 +4872,7 @@ version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -5112,7 +5159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
  "version_check",
@@ -5124,7 +5171,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "version_check",
 ]
@@ -5140,9 +5187,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.53"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -5249,7 +5296,7 @@ version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
 ]
 
 [[package]]
@@ -5469,7 +5516,7 @@ version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d2275aab483050ab2a7364c1a46604865ee7d6906684e08db0f090acf74f9e7"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 2.0.5",
 ]
@@ -5934,7 +5981,7 @@ version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 2.0.5",
 ]
@@ -5991,7 +6038,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -6049,7 +6096,7 @@ name = "sha3-macro"
 version = "0.1.0"
 dependencies = [
  "keccak-hash",
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -6133,7 +6180,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -6174,7 +6221,7 @@ name = "solidity-abi-derive"
 version = "0.1.0"
 dependencies = [
  "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -6305,7 +6352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
 dependencies = [
  "heck",
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -6354,7 +6401,7 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "unicode-ident",
 ]
@@ -6365,7 +6412,7 @@ version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89c2d1c76a26822187a1fbb5964e3fff108bc208f02e820ab9dac1234f6b388a"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "unicode-ident",
 ]
@@ -6376,7 +6423,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
  "unicode-xid 0.2.4",
@@ -6473,7 +6520,7 @@ version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 2.0.5",
 ]
@@ -6736,7 +6783,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -6747,7 +6794,7 @@ version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -7292,7 +7339,7 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
  "wasm-bindgen-shared",
@@ -7326,7 +7373,7 @@ version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
  "wasm-bindgen-backend",
@@ -7584,7 +7631,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
- "proc-macro2 1.0.53",
+ "proc-macro2 1.0.69",
  "quote 1.0.26",
  "syn 1.0.109",
  "synstructure",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,6 +19,7 @@ cfx-parameters = { path = "parameters" }
 cfx-statedb = { path = "statedb" }
 cfx-state = { path = "state" }
 cfx-storage = { path = "storage", optional = true }
+cfx-vm-tracer-derive = {path="../util/cfx-vm-tracer-derive"}
 cfx-types = { path = "../cfx_types" }
 cfx-utils = { path = "../cfx_utils" }
 channel = { path = "./src/pos/common/channel"}
@@ -132,6 +133,8 @@ proptest-derive = { version = "0.3.0", optional = true }
 diem-temppath = { path = "./src/pos/common/temppath" }
 crash-handler = { path = "../core/src/pos/common/crash-handler" }
 heap-map = {path = "../util/heap-map" }
+impl-trait-for-tuples = "^0.2"
+impl-tools = "^0.10"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/core/src/executive/context.rs
+++ b/core/src/executive/context.rs
@@ -11,7 +11,7 @@ use super::{
 use crate::{
     bytes::Bytes,
     machine::Machine,
-    observer::VmObserve,
+    observer::TracerTrait,
     state::{CallStackInfo, State, Substate},
     vm::{
         self, ActionParams, ActionValue, CallType, Context as ContextTrait,
@@ -71,7 +71,7 @@ pub struct Context<'a> {
 
     state: &'a mut State,
     callstack: &'a mut CallStackInfo,
-    tracer: &'a mut dyn VmObserve,
+    tracer: &'a mut dyn TracerTrait,
 }
 
 impl<'a> Context<'a> {

--- a/core/src/executive/estimation.rs
+++ b/core/src/executive/estimation.rs
@@ -1,5 +1,5 @@
-use super::{Executed, ExecutionError, Observer};
-use crate::{executive::executed::ExecutionOutcome, vm};
+use super::{Executed, ExecutionError};
+use crate::{executive::executed::ExecutionOutcome, observer::Observer, vm};
 use cfx_parameters::{consensus::ONE_CFX_IN_DRIP, staking::*};
 use cfx_state::CleanupMode;
 use cfx_statedb::Result as DbResult;

--- a/core/src/executive/frame/resources.rs
+++ b/core/src/executive/frame/resources.rs
@@ -1,12 +1,12 @@
 use crate::{
-    observer::VmObserve,
+    observer::TracerTrait,
     state::{CallStackInfo, State},
 };
 
 pub struct RuntimeRes<'a> {
     pub state: &'a mut State,
     pub callstack: &'a mut CallStackInfo,
-    pub tracer: &'a mut dyn VmObserve,
+    pub tracer: &'a mut dyn TracerTrait,
 }
 
 #[cfg(test)]

--- a/core/src/executive/internal_contract/components/context.rs
+++ b/core/src/executive/internal_contract/components/context.rs
@@ -1,5 +1,5 @@
 use crate::{
-    observer::VmObserve,
+    observer::TracerTrait,
     state::{CallStackInfo, State, Substate},
     vm::{self, ActionParams, Env, Spec},
 };
@@ -18,7 +18,7 @@ pub struct InternalRefContext<'a> {
     pub callstack: &'a mut CallStackInfo,
     pub state: &'a mut State,
     pub substate: &'a mut Substate,
-    pub tracer: &'a mut dyn VmObserve,
+    pub tracer: &'a mut dyn TracerTrait,
     pub static_flag: bool,
     pub depth: usize,
 }

--- a/core/src/executive/internal_contract/contracts/mod.rs
+++ b/core/src/executive/internal_contract/contracts/mod.rs
@@ -28,7 +28,7 @@ mod preludes {
         evm::{ActionParams, Spec},
         group_impl_is_active, impl_function_type, make_function_table,
         make_solidity_contract, make_solidity_event, make_solidity_function,
-        observer::VmObserve,
+        observer::TracerTrait,
         spec::CommonParams,
         vm,
     };

--- a/core/src/executive/internal_contract/impls/admin.rs
+++ b/core/src/executive/internal_contract/impls/admin.rs
@@ -3,7 +3,7 @@
 // See http://www.gnu.org/licenses/
 
 use crate::{
-    observer::{AddressPocket, VmObserve},
+    observer::{AddressPocket, TracerTrait},
     state::{cleanup_mode, State, Substate},
     vm::{self, ActionParams, Spec},
 };
@@ -28,7 +28,7 @@ fn available_admin_address(_spec: &Spec, address: &Address) -> bool {
 pub fn suicide(
     contract_address: &AddressWithSpace, refund_address: &AddressWithSpace,
     state: &mut State, spec: &Spec, substate: &mut Substate,
-    tracer: &mut dyn VmObserve,
+    tracer: &mut dyn TracerTrait,
 ) -> vm::Result<()>
 {
     substate.suicides.insert(contract_address.clone());
@@ -114,7 +114,7 @@ pub fn set_admin(
 /// The input should consist of 20 bytes `contract_address`
 pub fn destroy(
     contract_address: Address, params: &ActionParams, state: &mut State,
-    spec: &Spec, substate: &mut Substate, tracer: &mut dyn VmObserve,
+    spec: &Spec, substate: &mut Substate, tracer: &mut dyn TracerTrait,
 ) -> vm::Result<()>
 {
     debug!("contract_address={:?}", contract_address);

--- a/core/src/executive/internal_contract/impls/staking.rs
+++ b/core/src/executive/internal_contract/impls/staking.rs
@@ -6,7 +6,7 @@ use crate::{
     consensus_internal_parameters::MINED_BLOCK_COUNT_PER_QUARTER,
     evm::Spec,
     internal_bail,
-    observer::{AddressPocket, VmObserve},
+    observer::{AddressPocket, TracerTrait},
     state::State,
     vm::{self, ActionParams, Env},
 };
@@ -16,7 +16,7 @@ use cfx_types::{Address, AddressSpaceUtil, U256};
 /// Implementation of `deposit(uint256)`.
 pub fn deposit(
     amount: U256, params: &ActionParams, env: &Env, spec: &Spec,
-    state: &mut State, tracer: &mut dyn VmObserve,
+    state: &mut State, tracer: &mut dyn TracerTrait,
 ) -> vm::Result<()>
 {
     if amount < U256::from(ONE_CFX_IN_DRIP) {
@@ -39,7 +39,7 @@ pub fn deposit(
 /// Implementation of `withdraw(uint256)`.
 pub fn withdraw(
     amount: U256, params: &ActionParams, env: &Env, spec: &Spec,
-    state: &mut State, tracer: &mut dyn VmObserve,
+    state: &mut State, tracer: &mut dyn TracerTrait,
 ) -> vm::Result<()>
 {
     state.remove_expired_vote_stake_info(&params.sender, env.number)?;

--- a/core/src/executive/mod.rs
+++ b/core/src/executive/mod.rs
@@ -17,7 +17,7 @@ pub use self::{
     executed::*,
     executive::{
         contract_address, gas_required_for, CollateralCheckError,
-        CollateralCheckResult, Executive, ExecutiveGeneric, Observer,
+        CollateralCheckResult, Executive, ExecutiveGeneric,
     },
     frame::FrameReturn,
     internal_contract::{InternalContractMap, InternalContractTrait},

--- a/core/src/observer/gasman.rs
+++ b/core/src/observer/gasman.rs
@@ -1,4 +1,4 @@
-use super::VmObserve;
+use super::*;
 use crate::{
     executive::FrameReturn,
     vm::{ActionParams, Result as VmResult},
@@ -7,7 +7,6 @@ use cfx_parameters::{
     block::CROSS_SPACE_GAS_RATIO,
     internal_contract_addresses::CROSS_SPACE_CONTRACT_ADDRESS,
 };
-use cfx_state::tracer::{AddressPocket, StateTracer};
 use cfx_types::U256;
 
 const EVM_RATIO: (u64, u64) = (64, 63);
@@ -85,20 +84,7 @@ impl GasMan {
     }
 }
 
-impl StateTracer for GasMan {
-    fn trace_internal_transfer(
-        &mut self, _: AddressPocket, _: AddressPocket, _: U256,
-    ) {
-    }
-
-    fn checkpoint(&mut self) {}
-
-    fn discard_checkpoint(&mut self) {}
-
-    fn revert_to_checkpoint(&mut self) {}
-}
-
-impl VmObserve for GasMan {
+impl CallTracer for GasMan {
     fn record_call(&mut self, params: &ActionParams) {
         let cross_space_internal =
             params.code_address == CROSS_SPACE_CONTRACT_ADDRESS;
@@ -121,3 +107,6 @@ impl VmObserve for GasMan {
         self.record_return(&gas_left);
     }
 }
+
+impl CheckpointTracer for GasMan {}
+impl InternalTransferTracer for GasMan {}

--- a/core/src/observer/traits.rs
+++ b/core/src/observer/traits.rs
@@ -1,0 +1,37 @@
+pub use super::internal_transfer::AddressPocket;
+use crate::{
+    executive::FrameReturn,
+    vm::{ActionParams, Result as VmResult},
+};
+
+use impl_tools::autoimpl;
+use impl_trait_for_tuples::impl_for_tuples;
+
+#[impl_for_tuples(3)]
+#[autoimpl(for<T: trait + ?Sized> &mut T)]
+pub trait CheckpointTracer {
+    fn trace_checkpoint(&mut self) {}
+
+    /// Discard the top checkpoint for validity mark
+    fn trace_checkpoint_discard(&mut self) {}
+
+    /// Mark the traces to the top checkpoint as "valid = false"
+    fn trace_checkpoint_revert(&mut self) {}
+}
+
+#[impl_for_tuples(3)]
+#[autoimpl(for<T: trait + ?Sized> &mut T)]
+#[allow(unused_variables)]
+pub trait CallTracer {
+    /// Prepares call trace for given params.
+    fn record_call(&mut self, params: &ActionParams) {}
+
+    /// Prepares call result trace
+    fn record_call_result(&mut self, result: &VmResult<FrameReturn>) {}
+
+    /// Prepares create trace for given params.
+    fn record_create(&mut self, params: &ActionParams) {}
+
+    /// Prepares create result trace
+    fn record_create_result(&mut self, result: &VmResult<FrameReturn>) {}
+}

--- a/core/src/state/state_object/collateral.rs
+++ b/core/src/state/state_object/collateral.rs
@@ -4,7 +4,7 @@ use crate::{
         internal_contract::storage_point_prop, CollateralCheckError,
         CollateralCheckResult,
     },
-    observer::VmObserve,
+    observer::TracerTrait,
     state::trace::{
         trace_convert_stroage_points, trace_occupy_collateral,
         trace_refund_collateral,
@@ -96,7 +96,7 @@ impl State {
     #[cfg(test)]
     pub fn settle_collateral_and_check(
         &mut self, storage_owner: &Address, storage_limit: &U256,
-        substate: &mut Substate, tracer: &mut dyn VmObserve, spec: &Spec,
+        substate: &mut Substate, tracer: &mut dyn TracerTrait, spec: &Spec,
         dry_run: bool,
     ) -> DbResult<CollateralCheckResult>
     {
@@ -154,7 +154,7 @@ impl State {
 /// Charges or refund storage collateral and update `total_storage_tokens`.
 fn settle_collateral_for_address(
     state: &mut State, addr: &Address, substate: &Substate,
-    tracer: &mut dyn VmObserve, spec: &Spec, dry_run: bool,
+    tracer: &mut dyn TracerTrait, spec: &Spec, dry_run: bool,
 ) -> DbResult<CollateralCheckResult>
 {
     let addr_with_space = addr.with_native_space();
@@ -213,7 +213,7 @@ fn settle_collateral_for_address(
 /// checked out. This function should only be called in post-processing
 /// of a transaction.
 pub fn settle_collateral_for_all(
-    state: &mut State, substate: &Substate, tracer: &mut dyn VmObserve,
+    state: &mut State, substate: &Substate, tracer: &mut dyn TracerTrait,
     spec: &Spec, dry_run: bool,
 ) -> DbResult<CollateralCheckResult>
 {

--- a/core/src/state/trace.rs
+++ b/core/src/state/trace.rs
@@ -1,10 +1,10 @@
-use cfx_state::tracer::AddressPocket::*;
+use crate::observer::AddressPocket::*;
 use cfx_types::{address_util::AddressUtil, Address, AddressSpaceUtil, U256};
 
-use crate::observer::VmObserve;
+use crate::observer::TracerTrait;
 
 pub fn trace_convert_stroage_points(
-    tracer: &mut dyn VmObserve, addr: Address, from_balance: U256,
+    tracer: &mut dyn TracerTrait, addr: Address, from_balance: U256,
     from_collateral: U256,
 )
 {
@@ -25,7 +25,7 @@ pub fn trace_convert_stroage_points(
 }
 
 pub fn trace_refund_collateral(
-    tracer: &mut dyn VmObserve, addr: Address, by: U256,
+    tracer: &mut dyn TracerTrait, addr: Address, by: U256,
 ) {
     if !by.is_zero() {
         tracer.trace_internal_transfer(
@@ -41,7 +41,7 @@ pub fn trace_refund_collateral(
 }
 
 pub fn trace_occupy_collateral(
-    tracer: &mut dyn VmObserve, addr: Address, by: U256,
+    tracer: &mut dyn TracerTrait, addr: Address, by: U256,
 ) {
     if !by.is_zero() {
         tracer.trace_internal_transfer(

--- a/core/state/src/lib.rs
+++ b/core/state/src/lib.rs
@@ -8,6 +8,7 @@ pub(self) mod cache_object;
 pub mod state;
 #[cfg(feature = "new_state_impl")]
 pub(self) mod state_object_cache;
+#[cfg(feature = "new_state_impl")]
 pub mod tracer;
 
 /// Mode of dealing with null accounts.

--- a/util/cfx-vm-tracer-derive/Cargo.toml
+++ b/util/cfx-vm-tracer-derive/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "cfx-vm-tracer-derive"
+version = "0.1.0"
+authors = ["Your Name <your.email@example.com>"]
+edition = "2018"
+
+# Set the crate type to "proc-macro"
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "1"
+quote = "1.0"
+proc-macro2 = "1.0.69"

--- a/util/cfx-vm-tracer-derive/src/lib.rs
+++ b/util/cfx-vm-tracer-derive/src/lib.rs
@@ -1,0 +1,144 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Data, DataStruct, DeriveInput, Error, Fields, Ident};
+
+type Result<T> = std::result::Result<T, Error>;
+
+macro_rules! unwrap_or_compile_error {
+    ($e:expr) => {
+        match $e {
+            Ok(x) => x,
+            Err(e) => return e.into_compile_error().into(),
+        }
+    };
+}
+
+#[proc_macro_derive(AsTracer, attributes(skip_tracer))]
+pub fn generate_function(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+
+    let data = unwrap_or_compile_error!(get_struct_data(&input));
+    let skipped_fields = unwrap_or_compile_error!(check_all_fields(data));
+    let field_names = unwrap_or_compile_error!(get_field_names(data, name));
+    unwrap_or_compile_error!(check_num_fields(&field_names, name, 10));
+
+    let mut match_arms = Vec::new();
+    let match_more_fields = if skipped_fields {
+        quote!(, ..)
+    } else {
+        quote!()
+    };
+
+    for mask in 0..(1 << field_names.len()) {
+        let mut this_combination = Vec::new();
+        let mut tuple_elements = Vec::new();
+        for (index, field) in field_names.iter().enumerate() {
+            if (mask >> index) & 1 == 1 {
+                this_combination.push(quote! { #field: Some(#field) });
+                tuple_elements.push(quote! { #field });
+            } else {
+                this_combination.push(quote! { #field: None });
+            }
+        }
+        let match_arm = match tuple_elements.len() {
+            0 => quote! {
+                #name {#(#this_combination),* #match_more_fields} => Box::new(()) // as Box<dyn MyTrait>
+            },
+            1 => quote! {
+                #name {#(#this_combination),* #match_more_fields} => Box::new(#(#tuple_elements),*) // as Box<dyn MyTrait>
+            },
+            _ => quote! {
+                #name {#(#this_combination),* #match_more_fields} => Box::new((#(#tuple_elements),*)) // as Box<dyn MyTrait>
+            },
+        };
+        match_arms.push(match_arm);
+    }
+
+    let expanded = quote! {
+        impl AsTracer for #name {
+            fn as_tracer<'a>(&'a mut self) -> Box<dyn 'a + TracerTrait> {
+                match self {
+                    #(#match_arms,)*
+                }
+            }
+        }
+    };
+
+    expanded.into()
+}
+
+fn get_struct_data(input: &DeriveInput) -> Result<&DataStruct> {
+    match &input.data {
+        Data::Struct(data) => Ok(data),
+        _ => Err(Error::new_spanned(&input.ident, "Only struct is supported")),
+    }
+}
+
+fn check_all_fields(data: &DataStruct) -> Result<bool> {
+    let mut type_error = vec![];
+    let mut skipped_field = false;
+    for field in &data.fields {
+        if field
+            .attrs
+            .iter()
+            .any(|attr| attr.path.is_ident("skip_tracer"))
+        {
+            skipped_field = true;
+            continue;
+        }
+
+        if let syn::Type::Path(type_path) = &field.ty {
+            if type_path
+                .path
+                .segments
+                .last()
+                .map_or(false, |seg| seg.ident == "Option")
+            {
+                continue;
+            }
+        }
+        type_error.push(Error::new_spanned(
+            &field.ty,
+            "All fields must be of type Option",
+        ));
+    }
+    if !type_error.is_empty() {
+        let mut type_error_iter = type_error.into_iter();
+        let mut error = type_error_iter.next().unwrap();
+        error.extend(type_error_iter);
+        Err(error)
+    } else {
+        Ok(skipped_field)
+    }
+}
+
+fn get_field_names<'a>(
+    data: &'a DataStruct, name: &Ident,
+) -> Result<Vec<&'a Option<Ident>>> {
+    match &data.fields {
+        Fields::Named(fields) => Ok(fields
+            .named
+            .iter()
+            .filter(|f| {
+                !f.attrs.iter().any(|attr| attr.path.is_ident("skip_tracer"))
+            })
+            .map(|f| &f.ident)
+            .collect::<Vec<_>>()),
+        _ => Err(Error::new_spanned(&name, "Only named struct is supported")),
+    }
+}
+
+fn check_num_fields(
+    field_names: &Vec<&Option<Ident>>, name: &Ident, max_entries: usize,
+) -> Result<()> {
+    if field_names.len() > max_entries {
+        Err(Error::new_spanned(
+            name,
+            "Too many fields in the struct! Limit is 10.",
+        ))
+    } else {
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR refines the tracer-related logic, addressing the dilemma of enhancing the expandability of our current tracer implementation. This enhancement is pivotal for our subsequent plan to make Conflux's trace output compatible with both parity's and geth's distinct trace outputs.

Furthermore, due to the presence of trace-related code within executive.rs, this PR has relocated that portion to a dedicated tracer module, making this PR a part of our ongoing effort to split and refactor `executive.rs`.

## Addressing the Tracer Dilemma

When the VM is in operation, the tracer pointer `&mut dyn VmObserve` may cover anywhere from zero to multiple tracer instances of varying types. Each time a trace function is called, all tracer instances are notified of the corresponding event. Some tracers respond according to their specific design, while others might do nothing.

The variety of instance types is influenced by shifting business needs, and the actual instances employed are decided at runtime. Additionally, the tracer trait interface itself might undergo changes in line with business evolution. This poses a challenge to support extensible tracers while avoiding redundant code.

To address this, we've adopted third-party library attribute macros, enabling automatic implementation of the tracer trait for the tracer tuple. Furthermore, the `AsTracer` procedural macro has been introduced to convert the employed tracer instance list, decided at runtime, into a tracer tuple, subsequently transforming it into a tracer trait pointer.

### Pros and Cons

This approach offers a significant benefit: irrespective of the number of tracer instances present at runtime, dynamic dispatch (via vtable pointer jumping) is executed only once for each trace function. This ensures that if a tuple contains multiple instances but only one reacts to a trace function, the compiler can optimize this scenario efficiently. 

On the flip side, there is a potential drawback. The binary code size could rise exponentially based on the count of tracer instance types. For a scenario with `n` tracer instances, the branching in `AsTracer` would be `2^n`. 

At the moment, `n` stands at 2 and might extend to 3 or 4. However, in the foreseeable future, it's unlikely for `n` to cross the threshold of 10. Should we notice a surge in tracer instance types, we might consider converting some of the tracers to dynamically dispatched pointers using the `AsTracer` function. When `n` exceeds 10, the procedural macro will also raise a compilation error to alert about this issue.

Moreover, in line with these optimizations, superfluous implementations have been discarded.

## Other changes

We've relocated the `AddressPocket` implementation from the `cfx-state` crate to the `tracer` module in `cfxcore`.

## Additional Discussion: Addressing the Legacy Issue

The issue with `cfx-state` can be traced back to a problematic architectural plan in the past. Its original intention was to create a general state structure that could cater to various virtual machine (VM) implementations. However, this effort was destined to fall short. Because the state is intricately coupled with the current VM. Approximately 30 state interfaces were custom-tailored specifically for the existing single VM implementation. 

This issue emerged as a consequence of an earlier developer's personal obsession with interface abstraction and generics, at the expense of neglecting code maintainability and internal logic. This enthusiasm failed to yield code that could be easily extended, resulting instead in code that is arduous to comprehend and upkeep. 

Currently, we have largely relocated the active code from `cfx-state` crate back to `cfxcore`, with the intention of eventually phasing out the `cfx-state` crate altogether. 

There is also the possibility of consolidating the `State` and `VM` components into a standalone crate, given the close-knit relationship between them. Since the consensus and RPC layers exclusively focus on transaction types, execution parameters, and results without delving into the intricacies of the execution layer, we believe this to be a reasonable course of action.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/2733)
<!-- Reviewable:end -->
