### PR TITLE
Retry tests in `test_all.py` on failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ target
 .gitmodules
 .phabricator*
 build/
+build_clippy/
 **/blockchain_db/
 **/sqlite_db/
 **/net_config/

--- a/dev-support/test.sh
+++ b/dev-support/test.sh
@@ -7,10 +7,16 @@ set -o pipefail
 
 ROOT_DIR="$( cd $SCRIPT_DIR/.. && pwd )"
 TEST_MAX_WORKERS="${1-6}"
+TEST_MAX_RETRIES="${2-1}"
 
 export PYTHONUNBUFFERED=1
 export CARGO_TARGET_DIR=$ROOT_DIR/build
 export RUSTFLAGS="-g -D warnings"
+
+CHECK_BUILD=1
+CHECK_CLIPPY=2
+CHECK_UNIT_TEST=3
+CHECK_INT_TEST=4
 
 function check_build {
     local -n inner_result=$1
@@ -20,7 +26,9 @@ function check_build {
 
     local result
 
-    result=`cargo build --release && cargo doc --document-private-items && cargo test --release --all --no-run && cargo bench --all --no-run`
+    result=$(
+        cargo build --release && cargo doc --document-private-items && cargo test --release --all --no-run && cargo bench --all --no-run | tee /dev/stderr
+    )
 
     local exit_code=$?
 
@@ -43,7 +51,9 @@ function check_fmt_and_clippy {
     SAVED_CARGO_DIR=$CARGO_TARGET_DIR
     export RUSTFLAGS="-g"
     export CARGO_TARGET_DIR="$ROOT_DIR/build_clippy"
-    result=`./cargo_fmt.sh -- --check && cargo clippy --release --all -- -A warnings`
+    result=$(
+        ./cargo_fmt.sh -- --check && cargo clippy --release --all -- -A warnings | tee /dev/stderr
+    )
     export RUSTFLAGS=$SAVED_RUSTFLAGS
     export CARGO_TARGET_DIR=$SAVED_CARGO_DIR
     local exit_code=$?
@@ -60,7 +70,9 @@ function check_unit_tests {
 
     pushd $ROOT_DIR > /dev/null
     local result
-    result=`cargo test --release --all`
+    result=$(
+       cargo test --release --all | tee /dev/stderr
+    )
     local exit_code=$?
     popd > /dev/null
 
@@ -78,7 +90,7 @@ function check_integration_tests {
     result=$(
         # Make symbolic link for conflux binary to where integration test assumes its existence.
         rm -f target; ln -s build target
-        ./tests/test_all.py --max-workers $TEST_MAX_WORKERS| tee /dev/stderr
+        ./tests/test_all.py --max-workers $TEST_MAX_WORKERS --max-retries $TEST_MAX_RETRIES | tee /dev/stderr
     )
     local exit_code=$?
     popd > /dev/null
@@ -91,13 +103,16 @@ function check_integration_tests {
 
 function save_test_result {
     local -n inner_result=$1
+    local stage_number=$2
     local exit_code=${inner_result[0]}
     local result=${inner_result[1]}
-
-    printf "%s\n" "$result"
     
     if [[ $exit_code -ne 0 ]]; then
         printf "%s\n" "$result" >> $ROOT_DIR/.phabricator-comment
+        if [[ $exit_code -eq 80 ]] && [[ $stage_number -eq $CHECK_INT_TEST ]]; then
+            ## If the test fails for "test case error in the integration test", return customized exit code
+            exit 80
+        fi
         exit 1
     fi
 }
@@ -106,11 +121,11 @@ echo -n "" > $ROOT_DIR/.phabricator-comment
 mkdir -p $ROOT_DIR/build
 
 # Build
-declare -a test_result; check_build test_result; save_test_result test_result
+declare -a test_result; check_build test_result; save_test_result test_result $CHECK_BUILD
 # fmt and clippy tests
-declare -a test_result; check_fmt_and_clippy test_result; save_test_result test_result
+declare -a test_result; check_fmt_and_clippy test_result; save_test_result test_result $CHECK_CLIPPY
 # Unit tests
-declare -a test_result; check_unit_tests test_result; save_test_result test_result
+declare -a test_result; check_unit_tests test_result; save_test_result test_result $CHECK_UNIT_TEST
 # Integration test
-declare -a test_result; check_integration_tests test_result; save_test_result test_result
+declare -a test_result; check_integration_tests test_result; save_test_result test_result $CHECK_INT_TEST
 


### PR DESCRIPTION
The current integration test may fail on some random error, so we need to close and reopen PR repeatedly. 

This PR supports retrying tests automatically on error. In Jenkins, this feature will only enabled after the first time a commit has completed its integration test. 

This PR also adjusts the output of the test script.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/2746)
<!-- Reviewable:end -->
