### PR TITLE
Add RPC interface `debug_statOnGasLoad`

### DIFF
--- a/cfx_types/src/lib.rs
+++ b/cfx_types/src/lib.rs
@@ -14,6 +14,7 @@ pub use ethereum_types::{
 };
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 use rlp_derive::{RlpDecodable, RlpEncodable};
+use serde::ser::SerializeMap;
 use serde_derive::{Deserialize, Serialize};
 
 pub use self::space_util::AddressSpaceUtil;
@@ -158,6 +159,16 @@ impl<T> SpaceMap<T> {
             native: f(&mut self.native),
             evm: f(&mut self.evm),
         }
+    }
+}
+
+impl<T: serde::Serialize> serde::Serialize for SpaceMap<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where S: serde::Serializer {
+        let mut map = serializer.serialize_map(Some(self.size()))?;
+        map.serialize_entry("core", &self.native)?;
+        map.serialize_entry("espace", &self.evm)?;
+        map.end()
     }
 }
 

--- a/client/src/rpc/error_codes.rs
+++ b/client/src/rpc/error_codes.rs
@@ -161,6 +161,22 @@ pub fn invalid_params<T: fmt::Debug>(param: &str, details: T) -> Error {
     }
 }
 
+pub fn invalid_params_msg(param: &str) -> Error {
+    Error {
+        code: ErrorCode::InvalidParams,
+        message: format!("Invalid parameters: {}", param),
+        data: None,
+    }
+}
+
+pub fn internal_error_msg(param: &str) -> Error {
+    Error {
+        code: ErrorCode::InternalError,
+        message: format!("Internal error: {}", param),
+        data: None,
+    }
+}
+
 pub fn unknown_block() -> Error {
     Error {
         code: ErrorCode::InvalidParams,

--- a/client/src/rpc/impls/cfx.rs
+++ b/client/src/rpc/impls/cfx.rs
@@ -2,10 +2,14 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use crate::rpc::types::{
-    call_request::rpc_call_request_network, errors::check_rpc_address_network,
-    pos::PoSEpochReward, PoSEconomics, RpcAddress, SponsorInfo,
-    TokenSupplyInfo, VoteParamsInfo, WrapTransaction,
+use crate::rpc::{
+    error_codes::{internal_error_msg, invalid_params_msg},
+    types::{
+        call_request::rpc_call_request_network,
+        errors::check_rpc_address_network, pos::PoSEpochReward, PoSEconomics,
+        RpcAddress, SponsorInfo, StatOnGasLoad, TokenSupplyInfo,
+        VoteParamsInfo, WrapTransaction,
+    },
 };
 use blockgen::BlockGenerator;
 use cfx_statedb::{
@@ -1789,6 +1793,140 @@ impl RpcImpl {
         Ok(Some(epoch_receipt_proof))
     }
 
+    fn stat_on_gas_load(
+        &self, last_epoch: EpochNumber, time_window: U64,
+    ) -> RpcResult<Option<StatOnGasLoad>> {
+        let mut stat = StatOnGasLoad::default();
+        stat.time_elapsed = time_window;
+
+        let block_not_found_error = || {
+            internal_error_msg(
+                "Cannot find the block by a ConsensusGraph provided hash",
+            )
+        };
+
+        let machine = self.tx_pool.machine();
+        let consensus = self.consensus_graph();
+
+        let mut epoch_number = match last_epoch {
+            EpochNumber::Earliest => {
+                bail!(invalid_params_msg("Cannot stat genesis"))
+            }
+            EpochNumber::Num(num) if num.is_zero() => {
+                bail!(invalid_params_msg("Cannot stat genesis"))
+            }
+            EpochNumber::LatestMined => bail!(invalid_params_msg(
+                "Epoch number is earilier than 'latest_state'"
+            )),
+            EpochNumber::Num(num) => {
+                let pivot_hash = consensus.get_hash_from_epoch_number(
+                    primitives::EpochNumber::LatestState,
+                )?;
+                let epoch_number = consensus
+                    .get_block_epoch_number(&pivot_hash)
+                    .ok_or_else(block_not_found_error)?;
+                if epoch_number < num.as_u64() {
+                    bail!(invalid_params_msg(
+                        "Epoch number is earilier than 'latest_state'"
+                    ))
+                }
+                num.as_u64()
+            }
+            EpochNumber::LatestCheckpoint
+            | EpochNumber::LatestFinalized
+            | EpochNumber::LatestConfirmed
+            | EpochNumber::LatestState => {
+                let pivot_hash =
+                    consensus.get_hash_from_epoch_number(last_epoch.into())?;
+                consensus
+                    .get_block_epoch_number(&pivot_hash)
+                    .ok_or_else(block_not_found_error)?
+            }
+        };
+
+        let mut last_timestamp: Option<u64> = None;
+
+        loop {
+            // Step 1: fetch block data
+            let block_hashes = consensus.get_block_hashes_by_epoch(
+                primitives::EpochNumber::Number(epoch_number),
+            )?;
+            let blocks = consensus
+                .get_data_manager()
+                .blocks_by_hash_list(&block_hashes, false)
+                .ok_or_else(block_not_found_error)?;
+            let pivot_block = blocks
+                .last()
+                .ok_or(internal_error_msg("Epoch without block"))?;
+
+            // Step 2: update timestamp
+            let timestamp = pivot_block.block_header.timestamp();
+            if last_timestamp.is_none() {
+                last_timestamp = Some(timestamp)
+            }
+            // Stop if the epoch does not in the query window.
+            if last_timestamp.unwrap().saturating_sub(time_window.as_u64())
+                > timestamp
+            {
+                break;
+            }
+
+            // Step 3: Stat blocks
+            let params = machine.params();
+            stat.epoch_num += 1.into();
+            for b in &blocks {
+                stat.total_block_num += 1.into();
+                stat.total_gas_limit += *b.block_header.gas_limit();
+                if params.can_pack_evm_transaction(b.block_header.height()) {
+                    stat.espace_block_num += 1.into();
+                    stat.espace_gas_limit += *b.block_header.gas_limit()
+                        / params.evm_transaction_gas_ratio;
+                }
+            }
+
+            // Step 4: Stat transactions
+            for b in &blocks {
+                // Fetch execution info or return not found.
+                let exec_info =
+                    match consensus.get_block_execution_info(&b.hash()) {
+                        None => bail!(internal_error_msg(
+                        "Cannot fetch block receipt with checked input params"
+                    )),
+                        Some((res, _)) => res.1,
+                    };
+
+                for (receipt, tx) in exec_info
+                    .block_receipts
+                    .receipts
+                    .iter()
+                    .zip(&b.transactions)
+                {
+                    let space = tx.space();
+                    if receipt.outcome_status == TransactionOutcome::Skipped {
+                        *stat.skipped_tx_count.in_space_mut(space) += 1.into();
+                        *stat.skipped_tx_gas_limit.in_space_mut(space) +=
+                            *tx.gas_limit();
+                    } else {
+                        *stat.confirmed_tx_count.in_space_mut(space) +=
+                            1.into();
+                        *stat.confirmed_tx_gas_limit.in_space_mut(space) +=
+                            *tx.gas_limit();
+                        *stat.tx_gas_charged.in_space_mut(space) +=
+                            receipt.gas_fee / tx.gas_price();
+                    }
+                }
+            }
+
+            // Goto Next Epoch
+            if epoch_number > 0 {
+                epoch_number -= 1;
+            } else {
+                break;
+            }
+        }
+        Ok(Some(stat))
+    }
+
     fn transactions_by_epoch(
         &self, epoch_number: U64,
     ) -> JsonRpcResult<Vec<WrapTransaction>> {
@@ -2265,6 +2403,7 @@ impl LocalRpc for LocalRpcImpl {
             fn consensus_graph_state(&self) -> JsonRpcResult<ConsensusGraphStates>;
             fn epoch_receipts(&self, epoch: BlockHashOrEpochNumber, include_eth_recepits: Option<bool>,) -> JsonRpcResult<Option<Vec<Vec<RpcReceipt>>>>;
             fn epoch_receipt_proof_by_transaction(&self, tx_hash: H256) -> JsonRpcResult<Option<EpochReceiptProof>>;
+            fn stat_on_gas_load(&self, last_epoch: EpochNumber, time_window: U64) -> JsonRpcResult<Option<StatOnGasLoad>>;
             fn sync_graph_state(&self) -> JsonRpcResult<SyncGraphStates>;
             fn send_transaction(
                 &self, tx: SendTxRequest, password: Option<String>) -> BoxFuture<H256>;

--- a/client/src/rpc/impls/light.rs
+++ b/client/src/rpc/impls/light.rs
@@ -44,9 +44,10 @@ use crate::{
             CheckBalanceAgainstTransactionResponse, ConsensusGraphStates,
             EpochNumber, EstimateGasAndCollateralResponse, Log as RpcLog,
             PoSEconomics, Receipt as RpcReceipt, RewardInfo as RpcRewardInfo,
-            RpcAddress, SendTxRequest, SponsorInfo, Status as RpcStatus,
-            StorageCollateralInfo, SyncGraphStates, TokenSupplyInfo,
-            Transaction as RpcTransaction, VoteParamsInfo, WrapTransaction,
+            RpcAddress, SendTxRequest, SponsorInfo, StatOnGasLoad,
+            Status as RpcStatus, StorageCollateralInfo, SyncGraphStates,
+            TokenSupplyInfo, Transaction as RpcTransaction, VoteParamsInfo,
+            WrapTransaction,
         },
         RpcBoxFuture, RpcResult,
     },
@@ -1256,6 +1257,7 @@ impl LocalRpc for DebugRpcImpl {
         fn current_sync_phase(&self) -> JsonRpcResult<String>;
         fn epoch_receipts(&self, epoch: BlockHashOrEpochNumber, include_eth_recepits: Option<bool>) -> JsonRpcResult<Option<Vec<Vec<RpcReceipt>>>>;
         fn epoch_receipt_proof_by_transaction(&self, tx_hash: H256) -> JsonRpcResult<Option<EpochReceiptProof>>;
+        fn stat_on_gas_load(&self, epoch: EpochNumber, time_window: U64) -> JsonRpcResult<Option<StatOnGasLoad>>;
         fn sign_transaction(&self, tx: SendTxRequest, password: Option<String>) -> JsonRpcResult<String>;
         fn sync_graph_state(&self) -> JsonRpcResult<SyncGraphStates>;
         fn transactions_by_epoch(&self, epoch_number: U64) -> JsonRpcResult<Vec<WrapTransaction>>;

--- a/client/src/rpc/traits/cfx_space/debug.rs
+++ b/client/src/rpc/traits/cfx_space/debug.rs
@@ -4,8 +4,9 @@
 
 use crate::rpc::types::{
     BlockHashOrEpochNumber, Bytes as RpcBytes, ConsensusGraphStates,
-    Receipt as RpcReceipt, RpcAddress, SendTxRequest, SyncGraphStates,
-    Transaction as RpcTransaction, WrapTransaction,
+    EpochNumber, Receipt as RpcReceipt, RpcAddress, SendTxRequest,
+    StatOnGasLoad, SyncGraphStates, Transaction as RpcTransaction,
+    WrapTransaction,
 };
 use cfx_types::{H256, H520, U128, U64};
 use cfxcore::verification::EpochReceiptProof;
@@ -111,6 +112,11 @@ pub trait LocalRpc {
         &self, epoch: BlockHashOrEpochNumber,
         include_eth_recepits: Option<bool>,
     ) -> JsonRpcResult<Option<Vec<Vec<RpcReceipt>>>>;
+
+    #[rpc(name = "debug_statOnGasLoad")]
+    fn stat_on_gas_load(
+        &self, last_epoch: EpochNumber, time_window: U64,
+    ) -> JsonRpcResult<Option<StatOnGasLoad>>;
 
     #[rpc(name = "debug_getEpochReceiptProofByTransaction")]
     fn epoch_receipt_proof_by_transaction(

--- a/client/src/rpc/types.rs
+++ b/client/src/rpc/types.rs
@@ -22,6 +22,7 @@ pub mod pubsub;
 mod receipt;
 mod reward_info;
 mod sponsor_info;
+mod stat_on_gas_load;
 mod status;
 mod storage_collateral_info;
 mod sync_graph_states;
@@ -52,6 +53,7 @@ pub use self::{
     receipt::Receipt,
     reward_info::RewardInfo,
     sponsor_info::SponsorInfo,
+    stat_on_gas_load::StatOnGasLoad,
     status::Status,
     storage_collateral_info::StorageCollateralInfo,
     sync_graph_states::SyncGraphStates,

--- a/client/src/rpc/types/stat_on_gas_load.rs
+++ b/client/src/rpc/types/stat_on_gas_load.rs
@@ -1,0 +1,20 @@
+use cfx_types::{SpaceMap, U256, U64};
+use serde_derive::Serialize;
+
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StatOnGasLoad {
+    pub time_elapsed: U64,
+
+    pub epoch_num: U64,
+    pub total_block_num: U64,
+    pub espace_block_num: U64,
+    pub total_gas_limit: U256,
+    pub espace_gas_limit: U256,
+
+    pub skipped_tx_count: SpaceMap<U64>,
+    pub confirmed_tx_count: SpaceMap<U64>,
+    pub skipped_tx_gas_limit: SpaceMap<U256>,
+    pub confirmed_tx_gas_limit: SpaceMap<U256>,
+    pub tx_gas_charged: SpaceMap<U256>,
+}


### PR DESCRIPTION
## Method: `debug_statOnGasLoad`

### Description

The `debug_statOnGasLoad` method provides statistical analysis of gas usage and total gas limit in specified time window ended at specific epoch.

### Parameters

- **epoch_number**: *epoch number literal* | *hex number*
    - The epoch number for which the statistics are to be gathered.
    - *epoch number literal* includes `latest_mined`, `latest_finalized`, `latest_state`, `earliest`, `latest_checkpoint`, `latest_confirmed`.
    - If the `epoch_number` is later than the `latest_state`, it is considered an invalid argument.
- **time_window**: *integer*
    - Time window in seconds.
    - The function iterates over blocks starting from the `epoch_number` and collects statistics until it reaches an epoch with a timestamp earlier than `<block timestamp at epoch_number> - time_window`.

### Return Object

If successful, the method returns an object containing the following properties:

- **timeElapsed**: *hex number*
    - The time window (in second) from the input parameter.
- **epochNum**: *hex number*
    - The number of epochs.
- **totalBlockNum**: *hex number*
    - The number of blocks.
- **espaceBlockNum**: *hex number*
    - The number of blocks that can pack espace transactions.
- **totalGasLimit**: *hex number*
    - The maximum gas limit.
- **espaceGasLimit**: *hex number*
    - The maximum gas limit for espace transactions.
- **confirmedTxCount**: *per space object*
    - The number of executed transactions in each space.
- **skippedTxCount**: *per space object*
    - The number of skipped transactions (due to duplicated packing) in each space.
- **confirmedTxGasLimit**: *per space object*
    - The total gas limit of executed transactions in each space.
- **skippedTxGasLimit**: *per space object*
    - The total gas limit of skipped transactions (due to duplicated packing) in each space.
- **txGasCharged**: *per space object*
    - The total gas charged in each space.

The *per space object* always includes the following properties: 

- **core**: *hex number* - The statistic number in core space.
- **espace**: *hex number* - The statistic number in espace.

### Example

Request:

```json
{
  "jsonrpc": "2.0",
  "method": "debug_statOnGasLoad",
  "params": ["latest_state", "0x12c"],
  "id": 1
}
```

Response:

```json
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
        "confirmedTxCount": {
            "core": "0x31",
            "espace": "0x0"
        },
        "confirmedTxGasLimit": {
            "core": "0x92dda80",
            "espace": "0x0"
        },
        "epochNum": "0x490",
        "espaceBlockNum": "0xe9",
        "espaceGasLimit": "0xd05177c0",
        "skippedTxCount": {
            "core": "0x0",
            "espace": "0x0"
        },
        "skippedTxGasLimit": {
            "core": "0x0",
            "espace": "0x0"
        },
        "timeElapsed": "0x12c",
        "totalBlockNum": "0x490",
        "totalGasLimit": "0x8288bf800",
        "txGasCharged": {
            "core": "0x6e263e0",
            "espace": "0x0"
        }
    }
}
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/2757)
<!-- Reviewable:end -->
