### PR TITLE
Remove unsafe code from `heap-map`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2961,8 +2961,10 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 name = "heap-map"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "malloc_size_of",
  "malloc_size_of_derive",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -3703,9 +3705,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "libflate"

--- a/util/heap-map/Cargo.toml
+++ b/util/heap-map/Cargo.toml
@@ -8,3 +8,11 @@ edition = "2018"
 [dependencies]
 malloc_size_of_derive = {path = "../malloc_size_of_derive"}
 malloc_size_of = {path = "../malloc_size_of"}
+
+[dev-dependencies]
+rand = "0.8.0"
+criterion = "0.3.0"
+
+[[bench]]
+name = "bench"
+harness = false

--- a/util/heap-map/benches/bench.rs
+++ b/util/heap-map/benches/bench.rs
@@ -1,0 +1,37 @@
+// Copyright 2019 Conflux Foundation. All rights reserved.
+// Conflux is free software and distributed under GNU General Public License.
+// See http://www.gnu.org/licenses/
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use heap_map::HeapMap;
+
+fn bench_heapmap_insert(c: &mut Criterion) {
+    let mut heapmap = HeapMap::<usize, u64>::new();
+    const SIZE: usize = 1000000usize;
+    let key = || rand::random::<usize>() % (SIZE * 2);
+    for _ in 0..SIZE {
+        heapmap.insert(&key(), rand::random());
+    }
+    c.bench_function("Heapmap insert/remove", move |b| {
+        b.iter(|| {
+            let value = if heapmap.len() > SIZE {
+                black_box(rand::random::<u64>());
+                heapmap.remove(&key())
+            } else {
+                heapmap.insert(&key(), rand::random())
+            };
+            black_box(value)
+        });
+    });
+}
+
+fn bench_overhead(c: &mut Criterion) {
+    const SIZE: usize = 1000000usize;
+    let key = || rand::random::<usize>() % (SIZE * 2);
+    c.bench_function("Pick random input cost", move |b| {
+        b.iter(|| black_box((key(), rand::random::<u64>())))
+    });
+}
+
+criterion_group!(benches, bench_heapmap_insert, bench_overhead);
+criterion_main!(benches);

--- a/util/heap-map/src/tests.rs
+++ b/util/heap-map/src/tests.rs
@@ -1,0 +1,62 @@
+use super::*;
+
+impl<K: hash::Hash + Eq + Copy + Debug, V: Eq + Ord + Clone> Clone
+    for HeapMap<K, V>
+{
+    fn clone(&self) -> Self {
+        Self {
+            data: self.data.clone(),
+            mapping: self.mapping.clone(),
+        }
+    }
+}
+
+impl<K: hash::Hash + Eq + Copy + Debug, V: Eq + Ord + Clone> HeapMap<K, V> {
+    fn check_mono(&self) -> bool {
+        let mut me = self.clone();
+        let mut last_value = if let Some((_k, v)) = me.pop() {
+            v
+        } else {
+            return true;
+        };
+
+        while let Some((_k, v)) = me.pop() {
+            if v > last_value {
+                return false;
+            }
+            last_value = v;
+        }
+
+        true
+    }
+}
+
+#[test]
+fn test_simple() {
+    let mut map = HeapMap::<usize, usize>::new();
+    map.insert(&1, 1);
+    map.insert(&2, 2);
+    assert_eq!(Some((2, 2)), map.pop());
+    assert_eq!(Some((1, 1)), map.pop());
+    assert_eq!(None, map.pop());
+}
+
+#[test]
+fn test_random() {
+    const SIZE: usize = 10000usize;
+    let key = || rand::random::<usize>() % (SIZE * 2);
+    let mut map = HeapMap::<usize, usize>::new();
+
+    for _round in 0..10 {
+        for _ in 0..SIZE {
+            map.insert(&key(), rand::random());
+        }
+        for _iter in 0..1000 {
+            map.remove(&key());
+            map.insert(&key(), rand::random());
+            if _iter % 10 == 9 {
+                assert!(map.check_mono());
+            }
+        }
+    }
+}


### PR DESCRIPTION
The benchmark demonstrates the unsafe core brings < 2% performance gain on a 1-million entry `heap-map`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/2763)
<!-- Reviewable:end -->
