### PR TITLE
Fix for Panic Issue in Historical Replay Tests Due to DAO Parameter Initialization

### DIFF
--- a/core/executor/src/context.rs
+++ b/core/executor/src/context.rs
@@ -111,15 +111,15 @@ impl<'a> Context<'a> {
 
 impl<'a> ContextTrait for Context<'a> {
     fn storage_at(&self, key: &Vec<u8>) -> vm::Result<U256> {
-        let caller = AddressWithSpace {
+        let receiver = AddressWithSpace {
             address: self.origin.address,
             space: self.space,
         };
-        self.state.storage_at(&caller, key).map_err(Into::into)
+        self.state.storage_at(&receiver, key).map_err(Into::into)
     }
 
     fn set_storage(&mut self, key: Vec<u8>, value: U256) -> vm::Result<()> {
-        let caller = AddressWithSpace {
+        let receiver = AddressWithSpace {
             address: self.origin.address,
             space: self.space,
         };
@@ -128,7 +128,7 @@ impl<'a> ContextTrait for Context<'a> {
         } else {
             self.state
                 .set_storage(
-                    &caller,
+                    &receiver,
                     key,
                     value,
                     self.origin.storage_owner,

--- a/core/executor/src/state/mod.rs
+++ b/core/executor/src/state/mod.rs
@@ -18,13 +18,12 @@ mod overlay_account;
 /// State Object: Represents the core object of the state module.
 mod state_object;
 
-pub use overlay_account::COMMISSION_PRIVILEGE_SPECIAL_KEY;
 #[cfg(test)]
 pub use state_object::get_state_for_genesis_write;
 pub use state_object::{
     distribute_pos_interest, initialize_cip107,
     initialize_or_update_dao_voted_params, settle_collateral_for_all,
-    update_pos_status, State,
+    update_pos_status, State, COMMISSION_PRIVILEGE_SPECIAL_KEY,
 };
 
 use cfx_types::AddressWithSpace;

--- a/core/executor/src/state/overlay_account/mod.rs
+++ b/core/executor/src/state/overlay_account/mod.rs
@@ -48,7 +48,6 @@ mod tests;
 
 pub use account_entry::AccountEntry;
 pub use ext_fields::RequireFields;
-pub use sponsor::COMMISSION_PRIVILEGE_SPECIAL_KEY;
 
 use crate::substate::Substate;
 use cfx_types::{

--- a/core/executor/src/state/overlay_account/sponsor.rs
+++ b/core/executor/src/state/overlay_account/sponsor.rs
@@ -1,15 +1,8 @@
 use cfx_parameters::consensus::ONE_CFX_IN_DRIP;
-use cfx_statedb::{Result as DbResult, StateDbGeneric};
 use cfx_types::{Address, U256};
 use primitives::SponsorInfo;
 
-use super::{OverlayAccount, Substate};
-
-lazy_static! {
-    static ref COMMISSION_PRIVILEGE_STORAGE_VALUE: U256 = U256::one();
-    /// If we set this key, it means every account has commission privilege.
-    pub static ref COMMISSION_PRIVILEGE_SPECIAL_KEY: Address = Address::zero();
-}
+use super::OverlayAccount;
 
 impl OverlayAccount {
     pub fn sponsor_info(&self) -> &SponsorInfo { &self.sponsor_info }
@@ -67,56 +60,5 @@ impl OverlayAccount {
         self.address.assert_native();
         assert!(self.sponsor_info.sponsor_balance_for_collateral >= *by);
         self.sponsor_info.sponsor_balance_for_collateral -= *by;
-    }
-
-    pub fn check_contract_whitelist(
-        &self, db: &StateDbGeneric, contract_address: &Address, user: &Address,
-    ) -> DbResult<bool> {
-        let mut special_key = Vec::with_capacity(Address::len_bytes() * 2);
-        special_key.extend_from_slice(contract_address.as_bytes());
-        special_key
-            .extend_from_slice(COMMISSION_PRIVILEGE_SPECIAL_KEY.as_bytes());
-        let special_value = self.storage_at(db, &special_key)?;
-        if !special_value.is_zero() {
-            Ok(true)
-        } else {
-            let mut key = Vec::with_capacity(Address::len_bytes() * 2);
-            key.extend_from_slice(contract_address.as_bytes());
-            key.extend_from_slice(user.as_bytes());
-            self.storage_at(db, &key).map(|x| !x.is_zero())
-        }
-    }
-
-    /// Add commission privilege of `contract_address` to `user`.
-    /// We set the value to some nonzero value which will be persisted in db.
-    pub fn add_to_contract_whitelist(
-        &mut self, db: &StateDbGeneric, contract_address: Address,
-        user: Address, storage_owner: Address, substate: &mut Substate,
-    ) -> DbResult<()>
-    {
-        let mut key = Vec::with_capacity(Address::len_bytes() * 2);
-        key.extend_from_slice(contract_address.as_bytes());
-        key.extend_from_slice(user.as_bytes());
-        self.set_storage(
-            db,
-            key,
-            COMMISSION_PRIVILEGE_STORAGE_VALUE.clone(),
-            storage_owner,
-            substate,
-        )
-    }
-
-    /// Remove commission privilege of `contract_address` from `user`.
-    /// We set the value to zero, and the key/value will be released at commit
-    /// phase.
-    pub fn remove_from_contract_whitelist(
-        &mut self, db: &StateDbGeneric, contract_address: Address,
-        user: Address, storage_owner: Address, substate: &mut Substate,
-    ) -> DbResult<()>
-    {
-        let mut key = Vec::with_capacity(Address::len_bytes() * 2);
-        key.extend_from_slice(contract_address.as_bytes());
-        key.extend_from_slice(user.as_bytes());
-        self.set_storage(db, key, U256::zero(), storage_owner, substate)
     }
 }

--- a/core/executor/src/state/state_object/mod.rs
+++ b/core/executor/src/state/state_object/mod.rs
@@ -45,6 +45,7 @@ mod tests;
 pub use self::{
     collateral::{initialize_cip107, settle_collateral_for_all},
     pos::{distribute_pos_interest, update_pos_status},
+    sponsor::COMMISSION_PRIVILEGE_SPECIAL_KEY,
     staking::initialize_or_update_dao_voted_params,
 };
 #[cfg(test)]


### PR DESCRIPTION
This PR addresses a bug encountered in the historical replay tests. The system experienced a panic during the initialization of the DAO parameter, which was caused by the initialization of the DAO parameter preceding the initialization of the System Storage contract (responsible for storing parameters). Writing to an uninitialized contract is evidently incorrect behavior. However, this incident also reveals potential compatibility risks in our recent refinements.

Previously, this panic issue was avoided because the implementation compared the new value with the old value (defaulting to 0 if nonexistent) before writing the contract. If the values matched, no further action was taken. However, the restructured code first obtains a writable object from the contract and then performs the check. The process of obtaining a writable object involves setting a dirty bit, which can affect consensus consistency.

To address this, we have reverted to comparing the values before obtaining the writable object (as done previously) and have made corresponding adjustments to the interface.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/2773)
<!-- Reviewable:end -->
