### PR TITLE
Fix Inconsistency in Historical Replay Test Related to CIP-78

### DIFF
--- a/core/executor/src/executive/executed.rs
+++ b/core/executor/src/executive/executed.rs
@@ -152,13 +152,17 @@ impl Executed {
             fees_value: fee,
             ..
         } = refund_info;
-        let storage_sponsor_paid = if spec.cip78a {
+        let mut storage_sponsor_paid = if spec.cip78a {
             cost.storage_sponsored
         } else {
             cost.storage_sponsor_eligible
         };
 
-        let gas_sponsor_paid = cost.gas_sponsored;
+        let mut gas_sponsor_paid = cost.gas_sponsored;
+        if !r.apply_state && !spec.cip78b {
+            gas_sponsor_paid = false;
+            storage_sponsor_paid = false;
+        }
 
         Executed {
             gas_used,


### PR DESCRIPTION
This PR addresses a bug identified in the historical replay tests. The issue stems from the implementation of CIP-78, which corrected certain erroneous behaviors. However, the code refactoring introduced inconsistencies within pre-cip78 (erroneous) behaviors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/2774)
<!-- Reviewable:end -->
