### PR TITLE
Keep era genesis snapshot optional

### DIFF
--- a/client/src/configuration.rs
+++ b/client/src/configuration.rs
@@ -371,6 +371,7 @@ build_config! {
         (use_isolated_db_for_mpt_table_height, (Option<u64>), None)
         // Recover the latest MPT snapshot from the era checkpoint
         (recovery_latest_mpt_snapshot, (bool), false)
+        (keep_era_genesis_snapshot, (bool), false)
     }
     {
         // Development related section.
@@ -791,6 +792,7 @@ impl Configuration {
             use_isolated_db_for_mpt_table_height: self
                 .raw_conf
                 .use_isolated_db_for_mpt_table_height,
+            keep_era_genesis_snapshot: self.raw_conf.keep_era_genesis_snapshot,
         }
     }
 

--- a/core/storage/src/impls/storage_manager/storage_manager.rs
+++ b/core/storage/src/impls/storage_manager/storage_manager.rs
@@ -861,8 +861,7 @@ impl StorageManager {
     {
         let additional_state_height_gap =
             (self.storage_conf.additional_maintained_snapshot_count
-                * self.storage_conf.consensus_param.snapshot_epoch_count)
-                as u64;
+                * self.get_snapshot_epoch_count()) as u64;
         let maintained_state_height_lower_bound =
             if confirmed_height > additional_state_height_gap {
                 confirmed_height - additional_state_height_gap
@@ -950,10 +949,10 @@ impl StorageManager {
             ) as u64;
 
         let confirmed_snapshot_height = if confirmed_intermediate_height
-            > self.storage_conf.consensus_param.snapshot_epoch_count as u64
+            > self.get_snapshot_epoch_count() as u64
         {
             confirmed_intermediate_height
-                - self.storage_conf.consensus_param.snapshot_epoch_count as u64
+                - self.get_snapshot_epoch_count() as u64
         } else {
             0
         };
@@ -1510,6 +1509,22 @@ fn extra_snapshots_to_keep_predicate(
                         == 0
                 {
                     return storage_conf.keep_snapshot_before_stable_checkpoint;
+                }
+
+                if storage_conf.keep_era_genesis_snapshot {
+                    let era_genesis_snapshot_height =
+                        if stable_checkpoint_height
+                            >= storage_conf.consensus_param.era_epoch_count
+                        {
+                            stable_checkpoint_height
+                                - storage_conf.consensus_param.era_epoch_count
+                        } else {
+                            0
+                        };
+
+                    if era_genesis_snapshot_height == height {
+                        return true;
+                    }
                 }
             }
             ProvideExtraSnapshotSyncConfig::EpochNearestMultipleOf(

--- a/core/storage/src/lib.rs
+++ b/core/storage/src/lib.rs
@@ -128,6 +128,7 @@ pub struct StorageConfiguration {
     pub keep_snapshot_before_stable_checkpoint: bool,
     pub use_isolated_db_for_mpt_table: bool,
     pub use_isolated_db_for_mpt_table_height: Option<u64>,
+    pub keep_era_genesis_snapshot: bool,
 }
 
 impl StorageConfiguration {
@@ -175,6 +176,7 @@ impl StorageConfiguration {
             keep_snapshot_before_stable_checkpoint: true,
             use_isolated_db_for_mpt_table: false,
             use_isolated_db_for_mpt_table_height: None,
+            keep_era_genesis_snapshot: false,
         }
     }
 


### PR DESCRIPTION
When Genesis snapshot is just converted from stable snapshot, it might be still in using for nodes syncing, so keep it last longer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/2795)
<!-- Reviewable:end -->
