### PR TITLE
chore(dependencies): bump coincurve from 15.0.1 to 19.0.1

### DIFF
--- a/dev-support/dep_pip3.sh
+++ b/dev-support/dep_pip3.sh
@@ -11,7 +11,7 @@ function install() {
 install eth-utils
 install rlp==1.2.0
 install py-ecc==5.2.0
-install coincurve==15.0.1
+install coincurve==19.0.1
 install pysha3
 install trie==1.4.0
 install web3==5.31.1


### PR DESCRIPTION
Bump the coincurve version for M-chip compatibility