### PR TITLE
update yanked crate to git url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5579,8 +5579,7 @@ dependencies = [
 [[package]]
 name = "parity-secp256k1"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fca4f82fccae37e8bbdaeb949a4a218a1bbc485d11598f193d2a908042e5fc1"
+source = "git+https://github.com/paritytech/rust-secp256k1.git#d05fd8e152f8d110b587906e3d854196b086e42a"
 dependencies = [
  "arrayvec 0.5.2",
  "cc",

--- a/crates/cfx_key/Cargo.toml
+++ b/crates/cfx_key/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Conflux Foundation"]
 cfx-types = { workspace = true }
 edit-distance = "2.0"
 parity-crypto = "0.9.0"
-parity-secp256k1 = "0.7.0"
+parity-secp256k1 = { git = "https://github.com/paritytech/rust-secp256k1.git" }
 lazy_static = "1.4"
 log = "0.4"
 parity-wordlist = "1.3"


### PR DESCRIPTION
parity-secp256k1 is yanked from crates.io https://crates.io/crates/parity-secp256k1, so directly use it's git url.
Finally it should be replaced by secp256k1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/2918)
<!-- Reviewable:end -->
