### PR TITLE
move parity crate dependencies to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,8 +159,6 @@ cfx-rpc-utils = { path = "./crates/rpc/rpc-utils" }
 serde = { version = "1.0", features = ["derive", "alloc"] }
 serde_json = "1.0"
 serde_derive = "1.0"
-rlp = "0.4.0"
-rlp_derive = { git = "https://github.com/Conflux-Chain/conflux-parity-deps.git", rev = "1597a9cab02343eb2322ca0ac58d39b64e3f42d1"  }
 hex = "0.4.3"
 rustc-hex = "2.1"
 
@@ -212,3 +210,21 @@ itertools = "0.10.0"
 once_cell = "1.17.1"
 chrono = "=0.4.38"
 byteorder = "1.2.7"
+
+# conflux forked crates
+rocksdb = { git = "https://github.com/Conflux-Chain/rust-rocksdb.git", rev = "3773afe5b953997188f37c39308105b5deb0faac" }
+
+# parity crates
+rlp = "0.4.0"
+rlp_derive = { git = "https://github.com/Conflux-Chain/conflux-parity-deps.git", rev = "1597a9cab02343eb2322ca0ac58d39b64e3f42d1"  }
+panic_hook = { git = "https://github.com/Conflux-Chain/conflux-parity-deps.git", rev = "1597a9cab02343eb2322ca0ac58d39b64e3f42d1"  }
+dir = { git = "https://github.com/Conflux-Chain/conflux-parity-deps.git", rev = "1597a9cab02343eb2322ca0ac58d39b64e3f42d1"  }
+unexpected = { git = "https://github.com/Conflux-Chain/conflux-parity-deps.git", rev = "1597a9cab02343eb2322ca0ac58d39b64e3f42d1"  }
+ethereum-types = "0.9"
+parity-wordlist = "1.3.0"
+parity-crypto = "0.9.0"
+parity-path = "0.1"
+parity-util-mem = { version = "0.5", default-features = false }
+parity-secp256k1 = { git = "https://github.com/paritytech/rust-secp256k1.git" }
+ctrlc = { git = "https://github.com/paritytech/rust-ctrlc.git", rev="b523017108bb2d571a7a69bd97bc406e63bc7a9d" }
+substrate-bn = { git = "https://github.com/paritytech/bn", rev="63f8c587356a67b33c7396af98e065b66fca5dda", default-features = false }

--- a/bins/cfx_key/Cargo.toml
+++ b/bins/cfx_key/Cargo.toml
@@ -8,8 +8,8 @@ authors = ["Parity Technologies <admin@parity.io>"]
 docopt = "1.0"
 env_logger = "0.5"
 cfxkey = { workspace = true }
-panic_hook = { git = "https://github.com/Conflux-Chain/conflux-parity-deps.git", rev = "1597a9cab02343eb2322ca0ac58d39b64e3f42d1"  }
-parity-wordlist="1.2"
+panic_hook = { workspace = true }
+parity-wordlist={ workspace = true }
 rustc-hex = "2.1"
 serde = "1.0"
 serde_derive = "1.0"

--- a/bins/cfx_store/Cargo.toml
+++ b/bins/cfx_store/Cargo.toml
@@ -13,8 +13,8 @@ serde = "1.0"
 serde_derive = "1.0"
 parking_lot = { workspace = true }
 cfxstore = { workspace = true }
-panic_hook = { git = "https://github.com/Conflux-Chain/conflux-parity-deps.git", rev = "1597a9cab02343eb2322ca0ac58d39b64e3f42d1"  }
-dir = { git = "https://github.com/Conflux-Chain/conflux-parity-deps.git", rev = "1597a9cab02343eb2322ca0ac58d39b64e3f42d1"  }
+panic_hook = { workspace = true }
+dir = { workspace = true }
 
 [[bin]]
 name = "cfxstore"

--- a/bins/conflux/Cargo.toml
+++ b/bins/conflux/Cargo.toml
@@ -15,15 +15,15 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 parking_lot = { workspace = true }
-panic_hook = { git = "https://github.com/Conflux-Chain/conflux-parity-deps.git", rev = "1597a9cab02343eb2322ca0ac58d39b64e3f42d1"  }
+panic_hook = { workspace = true }
 app_dirs = "1.2.1"
-dir = { git = "https://github.com/Conflux-Chain/conflux-parity-deps.git", rev = "1597a9cab02343eb2322ca0ac58d39b64e3f42d1"  }
+dir = { workspace = true }
 cfxstore = { workspace = true }
 cfxcore-accounts = { workspace = true }
 home = "0.5.0"
 rpassword = "4.0.1"
 io = { workspace = true }
-ctrlc = { git = "https://github.com/paritytech/rust-ctrlc.git", rev="b523017108bb2d571a7a69bd97bc406e63bc7a9d" }
+ctrlc = { workspace = true }
 jsonrpc-core = "18.0.0"
 jsonrpc-tcp-server = "18.0.0"
 jsonrpc-http-server = "18.0.0"
@@ -47,7 +47,7 @@ client = { workspace = true }
 cfx-types = { workspace = true }
 docopt = "1.0"
 cfxkey = { workspace = true }
-parity-wordlist = "1.3.0"
+parity-wordlist = { workspace = true }
 rustc-hex = "2.1"
 env_logger = "0.5"
 malloc_size_of = { workspace = true }

--- a/crates/cfx_key/Cargo.toml
+++ b/crates/cfx_key/Cargo.toml
@@ -7,11 +7,11 @@ authors = ["Conflux Foundation"]
 [dependencies]
 cfx-types = { workspace = true }
 edit-distance = "2.0"
-parity-crypto = "0.9.0"
-parity-secp256k1 = { git = "https://github.com/paritytech/rust-secp256k1.git" }
+parity-crypto = { workspace = true }
+parity-secp256k1 = { workspace = true }
 lazy_static = "1.4"
 log = "0.4"
-parity-wordlist = "1.3"
+parity-wordlist = { workspace = true }
 quick-error = "1.2.2"
 rand = "0.7"
 rustc-hex = "2.1"
@@ -23,6 +23,6 @@ malloc_size_of_derive = { workspace = true }
 malloc_size_of = { workspace = true }
 docopt = "1.0"
 env_logger = "0.5"
-panic_hook = { git = "https://github.com/Conflux-Chain/conflux-parity-deps.git", rev = "1597a9cab02343eb2322ca0ac58d39b64e3f42d1"  }
+panic_hook = { workspace = true }
 threadpool = "1.7"
 

--- a/crates/cfx_store/Cargo.toml
+++ b/crates/cfx_store/Cargo.toml
@@ -17,10 +17,10 @@ rustc-hex = "2.1"
 tiny-keccak = "1.4"
 time = "0.1.34"
 parking_lot = { workspace = true }
-parity-crypto = { version = "0.9.0", features = ["publickey"] }
-dir = { git = "https://github.com/Conflux-Chain/conflux-parity-deps.git", rev = "1597a9cab02343eb2322ca0ac58d39b64e3f42d1"  }
+parity-crypto = { workspace = true, features = ["publickey"] }
+dir = { workspace = true }
 smallvec = "1.4"
-parity-wordlist = "1.0"
+parity-wordlist = { workspace = true }
 tempdir = "0.3"
 
 [dev-dependencies]

--- a/crates/cfx_types/Cargo.toml
+++ b/crates/cfx_types/Cargo.toml
@@ -5,7 +5,7 @@ license = "GPL-3.0"
 description = "Conflux types"
 
 [dependencies]
-ethereum-types = "0.9"
+ethereum-types = { workspace = true }
 serde_derive = { workspace = true }
 serde = { workspace = true }
 rlp = { workspace = true }

--- a/crates/cfxcore/core/Cargo.toml
+++ b/crates/cfxcore/core/Cargo.toml
@@ -3,12 +3,12 @@ description = "Conflux core library"
 homepage = "https://www.confluxnetwork.org"
 license = "GPL-3.0"
 name = "cfxcore"
-version = { workspace = true}
+version = { workspace = true }
 edition = "2021"
 
 [dependencies]
 bit-set = "0.4"
-substrate-bn = { git = "https://github.com/paritytech/bn", default-features = false, rev="63f8c587356a67b33c7396af98e065b66fca5dda" }
+substrate-bn = { workspace = true, default-features = false }
 byteorder = { workspace = true }
 cfxkey = { workspace = true }
 cfx-addr = { workspace = true }
@@ -57,7 +57,7 @@ metrics = { workspace = true }
 network = { workspace = true }
 num = "0.2"
 num-traits = { version = "0.2.8", default-features = false }
-parity-crypto = "0.9.0"
+parity-crypto = { workspace = true }
 parking_lot = { workspace = true }
 primal = "0.2.3"
 primitives = { workspace = true }
@@ -92,7 +92,7 @@ toml = "0.5.8"
 tokio = { version = "1.6", features = ["full"] }
 tokio-timer = "0.2.13"
 tokio-stream = "0.1.4"
-unexpected = { git = "https://github.com/Conflux-Chain/conflux-parity-deps.git", rev = "1597a9cab02343eb2322ca0ac58d39b64e3f42d1"  }
+unexpected = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 smart-default = "0.6.0"
@@ -143,6 +143,7 @@ cfx-rpc-cfx-types = { workspace = true }
 cfx-rpc-eth-types = { workspace = true }
 jsonrpsee = { workspace = true, features = ["jsonrpsee-types"] }
 cfx-rpc-utils = { workspace = true }
+parity-util-mem = { workspace = true, default-features = false }
 
 
 [dev-dependencies]
@@ -153,10 +154,6 @@ proptest = "1.0.0"
 proptest-derive = "0.3.0"
 consensus-types = { path = "src/pos/consensus/consensus-types", features = ["fuzzing"] }
 #tokio = { version = "0.2.11", features = ["time"] }
-
-[dependencies.parity-util-mem]
-version = "0.5"
-default-features = false
 
 [features]
 default = []

--- a/crates/cfxcore/core/benchmark/storage/Cargo.toml
+++ b/crates/cfxcore/core/benchmark/storage/Cargo.toml
@@ -22,13 +22,13 @@ ethcore = { package = "ethcore", git = "https://github.com/paritytech/parity-eth
 ethkey = { package = "ethkey", git = "https://github.com/paritytech/parity-ethereum", tag = "v2.4.0" }
 ethcore_types = { package = "common-types", git = "https://github.com/paritytech/parity-ethereum", tag = "v2.4.0" }
 ethjson = { package = "ethjson", git = "https://github.com/paritytech/parity-ethereum", tag = "v2.4.0" }
-ethereum-types = "0.4"
+ethereum-types = { workspace = true }
 heapsize = "0.4"
 kvdb = "0.4"
 lazy_static = "1.4"
 log = "0.4"
 parking_lot = { workspace = true }
-rlp = { version = "0.3.0", feature = ["ethereum"] }
+rlp = { workspace = true, feature = ["ethereum"] }
 serde_json = "1.0"
 base64ct = "=1.1.1"
 bevy = "0.11.3"

--- a/crates/cfxcore/core/src/pos/storage/schemadb/Cargo.toml
+++ b/crates/cfxcore/core/src/pos/storage/schemadb/Cargo.toml
@@ -15,10 +15,7 @@ once_cell = "1.7.2"
 diem-config = { path = "../../config" }
 diem-logger = { path = "../../common/logger" }
 diem-metrics = { path = "../../common/metrics" }
-
-[dependencies.rocksdb]
-git = "https://github.com/Conflux-Chain/rust-rocksdb.git"
-rev = "3773afe5b953997188f37c39308105b5deb0faac"
+rocksdb = { workspace = true }
 
 [dev-dependencies]
 byteorder = "1.4.3"

--- a/crates/cfxcore/executor/Cargo.toml
+++ b/crates/cfxcore/executor/Cargo.toml
@@ -7,7 +7,7 @@ version = "2.0.2"
 edition = "2021"
 
 [dependencies]
-substrate-bn = { git = "https://github.com/paritytech/bn", default-features = false, rev="63f8c587356a67b33c7396af98e065b66fca5dda" }
+substrate-bn = { workspace = true, default-features = false }
 byteorder = "1.0"
 cfxkey = { workspace = true }
 cfx-bytes = { workspace = true }
@@ -26,7 +26,7 @@ log = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 num = "0.2"
-parity-crypto = "0.9.0"
+parity-crypto = { workspace = true }
 parking_lot = { workspace = true }
 primitives = { workspace = true }
 rlp ={ workspace = true }
@@ -40,7 +40,7 @@ solidity-abi-derive = { workspace = true }
 sha3-macro = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
-bls-signatures = {git = "https://github.com/Conflux-Chain/bls-signatures.git", rev = "fb52187df92d27c365642cb7e7b2aaf60437cf9c", default-features = false, features = ["multicore"]}
+bls-signatures = { workspace = true }
 tiny-keccak = { workspace = true,  features = ["keccak"]}
 diem-crypto = { path = "../core/src/pos/crypto/crypto" }
 diem-types = { path = "../core/src/pos/types" }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -25,8 +25,8 @@ cfx-statedb = { workspace = true }
 cfx-storage = { workspace = true }
 cfx-vm-types = { workspace = true }
 app_dirs = "1.2.1"
-dir = { git = "https://github.com/Conflux-Chain/conflux-parity-deps.git", rev = "1597a9cab02343eb2322ca0ac58d39b64e3f42d1"  }
-ctrlc = { git = "https://github.com/paritytech/rust-ctrlc.git", rev="b523017108bb2d571a7a69bd97bc406e63bc7a9d" }
+dir = { workspace = true }
+ctrlc = { workspace = true }
 jsonrpc-core = { workspace = true }
 jsonrpc-tcp-server = { workspace = true }
 jsonrpc-http-server = { workspace = true }

--- a/crates/dbs/kvdb-rocksdb/Cargo.toml
+++ b/crates/dbs/kvdb-rocksdb/Cargo.toml
@@ -17,14 +17,8 @@ parking_lot = { workspace = true }
 regex = "1.3.1"
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
-
-[dependencies.parity-util-mem]
-version = "0.5"
-default-features = false
+parity-util-mem = { workspace = true, default-features = false }
+rocksdb = { workspace = true }
 
 [dev-dependencies]
 tempdir = "0.3.7"
-
-[dependencies.rocksdb]
-git = "https://github.com/Conflux-Chain/rust-rocksdb.git"
-rev = "3773afe5b953997188f37c39308105b5deb0faac"

--- a/crates/dbs/storage/Cargo.toml
+++ b/crates/dbs/storage/Cargo.toml
@@ -43,13 +43,10 @@ sqlite3-sys = "0.12"
 strfmt = "0.1"
 tokio = { version = "0.2", features = ["full"] }
 once_cell = "1.10.0"
+parity-util-mem = { workspace = true, default-features = false }
 
 [dev-dependencies]
 primitives = { workspace = true, features = ["test_no_account_length_check"] }
-
-[dependencies.parity-util-mem]
-version = "0.5"
-default-features = false
 
 [features]
 default = ["primitives"]

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -24,7 +24,7 @@ serde_derive = "1.0"
 igd = "0.10"
 libc = "0.2.66"
 rand = "0.7"
-parity-path = "0.1"
+parity-path = { workspace = true }
 keccak-hash = { workspace = true }
 enum-map = "0.4.0"
 enum-map-derive = "0.4.0"

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -19,7 +19,7 @@ rlp_derive = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_derive = { workspace = true }
 siphasher = "0.3"
-unexpected = { git = "https://github.com/Conflux-Chain/conflux-parity-deps.git", rev = "1597a9cab02343eb2322ca0ac58d39b64e3f42d1"  }
+unexpected = { workspace = true }
 once_cell = { workspace = true }
 cfx-parameters = { workspace = true }
 


### PR DESCRIPTION
Consolidate project dependencies related to Parity into the workspace for declaration to facilitate unified management and ease future upgrades.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/2940)
<!-- Reviewable:end -->
