### PR TITLE
unset zero gas when calling espace estimate and call

### DIFF
--- a/crates/rpc/rpc-eth-types/src/transaction_request.rs
+++ b/crates/rpc/rpc-eth-types/src/transaction_request.rs
@@ -67,9 +67,13 @@ pub struct TransactionRequest {
 }
 
 impl TransactionRequest {
-    pub fn unset_zero_gas_price(&mut self) {
+    pub fn unset_zero_gas_and_price(&mut self) {
         if self.gas_price == Some(U256::zero()) {
             self.gas_price = None;
+        }
+
+        if self.gas == Some(U256::zero()) {
+            self.gas = None;
         }
     }
 

--- a/crates/rpc/rpc/src/eth.rs
+++ b/crates/rpc/rpc/src/eth.rs
@@ -146,8 +146,8 @@ impl EthApi {
             epoch => epoch.try_into()?,
         };
 
-        // if gas_price is zero, it is considered as not set
-        request.unset_zero_gas_price();
+        // if gas_price and gas is zero, it is considered as not set
+        request.unset_zero_gas_and_price();
 
         let estimate_request = EstimateRequest {
             has_sender: request.from.is_some(),


### PR DESCRIPTION
Metamask sometimes sends estimate requests with gas set to 0, for example, during ERC20 transfers. To accommodate this, in the eSpace estimate method, if the gas value is set to 0, we will treat it as if it were not specified.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/2948)
<!-- Reviewable:end -->
