### PR TITLE
Remove asyncore

### DIFF
--- a/tests/conflux/messages.py
+++ b/tests/conflux/messages.py
@@ -5,7 +5,6 @@
 P2PInterface: A high-level interface object for communicating to a node over P2P
 """
 
-import asyncore
 from collections import defaultdict
 from io import BytesIO
 

--- a/tests/crash_archive_era150_test.py
+++ b/tests/crash_archive_era150_test.py
@@ -64,7 +64,6 @@ class CrashArchiveNodeTest(ConfluxTestFramework):
         self.log.info("Stopped all other nodes except node 0")
         genesis = self.nodes[0].cfx_getBlockByEpochNumber("0x0", False)["hash"]
         self.nodes[0].add_p2p_connection(P2PInterface(genesis))
-        network_thread_start()
         self.nodes[0].p2p.wait_for_status()
         self.log.info("p2p connection to node 0 connected")
         gas_price = 1

--- a/tests/crash_archive_test.py
+++ b/tests/crash_archive_test.py
@@ -57,7 +57,6 @@ class CrashFullNodeTest(ConfluxTestFramework):
             self.stop_node(i)
         genesis = self.nodes[0].cfx_getBlockByEpochNumber("0x0", False)["hash"]
         self.nodes[0].add_p2p_connection(P2PInterface(genesis))
-        network_thread_start()
         self.nodes[0].p2p.wait_for_status()
         client = RpcClient(self.nodes[0])
         gas_price = 1

--- a/tests/crash_test.py
+++ b/tests/crash_test.py
@@ -56,7 +56,6 @@ class CrashTest(ConfluxTestFramework):
             self.stop_node(i, kill=True)
         genesis = self.nodes[0].cfx_getBlockByEpochNumber("0x0", False)["hash"]
         self.nodes[0].add_p2p_connection(P2PInterface(genesis))
-        network_thread_start()
         self.nodes[0].p2p.wait_for_status()
         client = RpcClient(self.nodes[0])
         gas_price = 1

--- a/tests/evm_space/filter_block_test.py
+++ b/tests/evm_space/filter_block_test.py
@@ -124,7 +124,7 @@ class FilterBlockTest(Web3Base):
 
 
     def run_test(self):
-        asyncio.get_event_loop().run_until_complete(self.run_async())
+        asyncio.run(self.run_async())
 
 
 if __name__ == "__main__":

--- a/tests/evm_space/filter_fork_finalize_state_after_fork_test.py
+++ b/tests/evm_space/filter_fork_finalize_state_after_fork_test.py
@@ -117,7 +117,7 @@ class FilterForkTest(DefaultConfluxTestFramework):
             idx -= 1
 
     def run_test(self):
-        asyncio.get_event_loop().run_until_complete(self.run_async())
+        asyncio.run(self.run_async())
 
 
 if __name__ == "__main__":

--- a/tests/evm_space/filter_fork_finalize_state_in_fork_test.py
+++ b/tests/evm_space/filter_fork_finalize_state_in_fork_test.py
@@ -119,7 +119,7 @@ class FilterForkTest(DefaultConfluxTestFramework):
             idx -= 1
 
     def run_test(self):
-        asyncio.get_event_loop().run_until_complete(self.run_async())
+        asyncio.run(self.run_async())
 
 
 if __name__ == "__main__":

--- a/tests/evm_space/filter_lifetime_test.py
+++ b/tests/evm_space/filter_lifetime_test.py
@@ -81,7 +81,7 @@ class FilterLifetimeTest(Web3Base):
             raise AssertionError("Expected exception")
 
     def run_test(self):
-        asyncio.get_event_loop().run_until_complete(self.run_async())
+        asyncio.run(self.run_async())
 
 
 if __name__ == "__main__":

--- a/tests/evm_space/filter_log_test.py
+++ b/tests/evm_space/filter_log_test.py
@@ -172,7 +172,7 @@ class FilterLogTest(Web3Base):
         assert_equal(len(logs2), 2 * NUM_CALLS + 2)
 
     def run_test(self):
-        asyncio.get_event_loop().run_until_complete(self.run_async())
+        asyncio.run(self.run_async())
 
     def deploy_evm_space(self, data_hex):
         nonce = self.w3.eth.get_transaction_count(self.evmAccount.address)

--- a/tests/evm_space/filter_transaction_test.py
+++ b/tests/evm_space/filter_transaction_test.py
@@ -132,7 +132,7 @@ class FilterTransactionTest(Web3Base):
         assert_equal(len(filter_txs), 0)
 
     def run_test(self):
-        asyncio.get_event_loop().run_until_complete(self.run_async())
+        asyncio.run(self.run_async())
 
 
 if __name__ == "__main__":

--- a/tests/evm_space/ws_test.py
+++ b/tests/evm_space/ws_test.py
@@ -46,7 +46,7 @@ class EthWsTest(Web3Base):
         self.log.info("Pass")
 
     def run_test(self):
-        asyncio.get_event_loop().run_until_complete(self.test_ws())
+        asyncio.run(self.test_ws())
 
 if __name__ == "__main__":
     EthWsTest().main()

--- a/tests/expire_block_test.py
+++ b/tests/expire_block_test.py
@@ -25,7 +25,6 @@ class ExpireBlockTest(ConfluxTestFramework):
         genesis = self.nodes[0].cfx_getBlockByEpochNumber("0x0", False)["hash"]
         self.nodes[0].add_p2p_connection(P2PInterface(genesis))
         self.nodes[1].add_p2p_connection(P2PInterface(genesis))
-        network_thread_start()
         self.nodes[0].p2p.wait_for_status()
         self.nodes[1].p2p.wait_for_status()
 

--- a/tests/invalid_block_sync_test.py
+++ b/tests/invalid_block_sync_test.py
@@ -84,7 +84,6 @@ class InvalidBodySyncTest(ConfluxTestFramework):
         conn0 = InvalidBodyNode(genesis)
         conn1 = DefaultNode(genesis)
         self.nodes[1].add_p2p_connection(conn1)
-        network_thread_start()
         conn1.wait_for_status()
         for (h, b) in conn0.block_map.items():
             if h != conn0.invalid_block and h != decode_hex(genesis):

--- a/tests/invalid_message_test.py
+++ b/tests/invalid_message_test.py
@@ -40,7 +40,6 @@ class InvalidMessageTest(ConfluxTestFramework):
         time.sleep(0.5)
         genesis = node.cfx_getBlockByEpochNumber("0x0", False)["hash"]
         node.add_p2p_connection(DefaultNode(genesis))
-        network_thread_start()
         node.p2p.wait_for_status()
 
     def _test_invalid_packet(self):

--- a/tests/issue2159_test.py
+++ b/tests/issue2159_test.py
@@ -13,6 +13,8 @@ from test_framework.util import pubsub_url
 FULLNODE = 0
 
 def block_on(op):
+    # will raise DeprecationWarning in python higher version (e.g. 3.13)
+    # ignore it so far
     return asyncio.get_event_loop().run_until_complete(op)
 
 class Issue2159Test(ConfluxTestFramework):

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -82,18 +82,18 @@ class MessageTest(ConfluxTestFramework):
 
         # empty packet
         buf = struct.pack("<L", 0)[:3]
-        assert node.p2p.state == "connected"
-        node.p2p.send(buf)
+        assert node.p2p.is_connected
+        node.p2p.send_data(buf)
         # node should disconnect this p2p connection
-        wait_until(lambda: node.p2p.state != "connected", timeout=3)
+        wait_until(lambda: node.p2p.is_connected == False, timeout=3)
 
         p2p = start_p2p_connection([self.nodes[0]])[0]
         p2p.send_packet(PACKET_DISCONNECT, b'')
-        wait_until(lambda: p2p.state != "connected", timeout=3)
+        wait_until(lambda: p2p.is_connected == False, timeout=3)
 
         p2p = start_p2p_connection([self.nodes[0]])[0]
         p2p.send_packet(PACKET_PROTOCOL, b'')
-        wait_until(lambda: p2p.state != "connected", timeout=3)
+        wait_until(lambda: p2p.is_connected == False, timeout=3)
 
 if __name__ == "__main__":
     MessageTest().main()

--- a/tests/network_tests/handshake.py
+++ b/tests/network_tests/handshake.py
@@ -5,7 +5,7 @@ import sys
 sys.path.insert(1, os.path.dirname(sys.path[0]))
 
 from test_framework.test_framework import ConfluxTestFramework
-from test_framework.mininode import DefaultNode, network_thread_start
+from test_framework.mininode import DefaultNode
 from test_framework.util import wait_until, connect_nodes
 
 class HandshakeTests(ConfluxTestFramework):
@@ -20,7 +20,6 @@ class HandshakeTests(ConfluxTestFramework):
         # mininode handshake
         peer = DefaultNode(genesis)
         self.nodes[0].add_p2p_connection(peer)
-        network_thread_start()
         wait_until(lambda: peer.had_status, timeout=3)
 
         # full node handshake

--- a/tests/network_tests/node_reputation_test.py
+++ b/tests/network_tests/node_reputation_test.py
@@ -6,7 +6,6 @@ import time
 sys.path.insert(1, os.path.dirname(sys.path[0]))
 
 from test_framework.test_framework import ConfluxTestFramework
-from test_framework.mininode import DefaultNode, network_thread_start
 from test_framework.util import connect_nodes, get_peer_addr, wait_until
 from conflux.rpc import RpcClient
 

--- a/tests/network_tests/session_ip_limit_test.py
+++ b/tests/network_tests/session_ip_limit_test.py
@@ -5,7 +5,7 @@ import sys
 sys.path.insert(1, os.path.dirname(sys.path[0]))
 
 from test_framework.test_framework import ConfluxTestFramework
-from test_framework.mininode import DefaultNode, network_thread_start
+from test_framework.mininode import DefaultNode
 from test_framework.util import wait_until
 from conflux.rpc import RpcClient
 
@@ -30,14 +30,13 @@ class SessionIpLimitTests(ConfluxTestFramework):
         peers = [DefaultNode(genesis) for _ in range(self.num_peers)]
         for p in peers:
             self.nodes[0].add_p2p_connection(p)
-        network_thread_start()
 
         # One peer will be refused due to IP limit
         wait_until(lambda: [p.had_status for p in peers].count(False) == 1, timeout=3)
         assert len(RpcClient(self.nodes[0]).get_peers()) == self.num_peers - 1
         for p in peers:
             if not p.had_status:
-                wait_until(lambda: p.state == "closed", timeout=3)
+                wait_until(lambda: p.is_connected == False, timeout=3)
 
 if __name__ == "__main__":
     # 1 node for a single IP address

--- a/tests/pubsub/epochs_test.py
+++ b/tests/pubsub/epochs_test.py
@@ -199,8 +199,8 @@ class PubSubTest(ConfluxTestFramework):
 
     def run_test(self):
         assert(SHORT_FORK_LEN < LONG_FORK_LEN)
-        asyncio.get_event_loop().run_until_complete(self.test_forks())
-        asyncio.get_event_loop().run_until_complete(self.test_latest_state())
+        asyncio.run(self.test_forks())
+        asyncio.run(self.test_latest_state())
 
     def generate_chain(self, parent, len):
         hashes = [parent]

--- a/tests/pubsub/eth_logs_test.py
+++ b/tests/pubsub/eth_logs_test.py
@@ -194,7 +194,7 @@ class PubSubTest(ConfluxTestFramework):
         self.log.info(f"Pass -- test #1989 fix")
 
     def run_test(self):
-        asyncio.get_event_loop().run_until_complete(self.run_async())
+        asyncio.run(self.run_async())
 
     def deploy_evm_space(self, data_hex):
         nonce = self.w3.eth.get_transaction_count(self.evmAccount.address)

--- a/tests/pubsub/eth_newHeads_test.py
+++ b/tests/pubsub/eth_newHeads_test.py
@@ -75,7 +75,7 @@ class PubSubTest(ConfluxTestFramework):
         self.log.info("Pass -- 2")
 
     def run_test(self):
-        asyncio.get_event_loop().run_until_complete(self.run_async())
+        asyncio.run(self.run_async())
 
 if __name__ == "__main__":
     PubSubTest().main()

--- a/tests/pubsub/logs_test.py
+++ b/tests/pubsub/logs_test.py
@@ -152,7 +152,7 @@ class PubSubTest(ConfluxTestFramework):
         self.log.info(f"Pass -- test #1989 fix")
 
     def run_test(self):
-        asyncio.get_event_loop().run_until_complete(self.run_async())
+        asyncio.run(self.run_async())
 
     def deploy_contract(self, sender, priv_key, data_hex):
         tx = self.rpc[FULLNODE0].new_contract_tx(receiver="", data_hex=data_hex, sender=sender, priv_key=priv_key, storage_limit=20000)

--- a/tests/pubsub/newHeads_test.py
+++ b/tests/pubsub/newHeads_test.py
@@ -86,7 +86,7 @@ class PubSubTest(ConfluxTestFramework):
         await sub_light.unsubscribe()
 
     def run_test(self):
-        asyncio.get_event_loop().run_until_complete(self.run_async())
+        asyncio.run(self.run_async())
 
 if __name__ == "__main__":
     PubSubTest().main()

--- a/tests/rpc/filter_block_test.py
+++ b/tests/rpc/filter_block_test.py
@@ -123,7 +123,7 @@ class FilterBlockTest(ConfluxTestFramework):
             idx -= 1
 
     def run_test(self):
-        asyncio.get_event_loop().run_until_complete(self.run_async())
+        asyncio.run(self.run_async())
 
 
 if __name__ == "__main__":

--- a/tests/rpc/filter_fork_finalize_state_after_fork_test.py
+++ b/tests/rpc/filter_fork_finalize_state_after_fork_test.py
@@ -121,7 +121,7 @@ class FilterForkTest(DefaultConfluxTestFramework):
             idx -= 1
 
     def run_test(self):
-        asyncio.get_event_loop().run_until_complete(self.run_async())
+        asyncio.run(self.run_async())
 
 
 if __name__ == "__main__":

--- a/tests/rpc/filter_fork_finalize_state_in_fork_test.py
+++ b/tests/rpc/filter_fork_finalize_state_in_fork_test.py
@@ -114,7 +114,7 @@ class FilterForkTest(DefaultConfluxTestFramework):
             idx -= 1
 
     def run_test(self):
-        asyncio.get_event_loop().run_until_complete(self.run_async())
+        asyncio.run(self.run_async())
 
 
 if __name__ == "__main__":

--- a/tests/rpc/filter_lifetime_test.py
+++ b/tests/rpc/filter_lifetime_test.py
@@ -70,7 +70,7 @@ class FilterLifetimeTest(ConfluxTestFramework):
             raise AssertionError("Expected exception")
 
     def run_test(self):
-        asyncio.get_event_loop().run_until_complete(self.run_async())
+        asyncio.run(self.run_async())
 
 
 if __name__ == "__main__":

--- a/tests/rpc/filter_log_test.py
+++ b/tests/rpc/filter_log_test.py
@@ -151,7 +151,7 @@ class FilterLogTest(ConfluxTestFramework):
         assert_equal(len(logs2), 2 * NUM_CALLS + 2)
 
     def run_test(self):
-        asyncio.get_event_loop().run_until_complete(self.run_async())
+        asyncio.run(self.run_async())
 
     def deploy_contract(self, client, data_hex):
         tx = client.new_contract_tx("", data_hex, storage_limit=200000)

--- a/tests/rpc/filter_transaction_test.py
+++ b/tests/rpc/filter_transaction_test.py
@@ -101,7 +101,7 @@ class FilterTransactionTest(ConfluxTestFramework):
         assert_equal(len(filter_txs), 0)
 
     def run_test(self):
-        asyncio.get_event_loop().run_until_complete(self.run_async())
+        asyncio.run(self.run_async())
 
 
 if __name__ == "__main__":

--- a/tests/test_framework/mininode.py
+++ b/tests/test_framework/mininode.py
@@ -4,13 +4,16 @@
 `P2PConnection: A low-level connection object to a node's P2P interface
 P2PInterface: A high-level interface object for communicating to a node over P2P
 """
+
+"""This file forks from bitcoin/test/functional/test_framework/mininode.py"""
+
 import time
 from eth_utils import decode_hex
 
 from conflux import utils
 from conflux.config import DEFAULT_PY_TEST_CHAIN_ID
 from conflux.messages import *
-import asyncore
+import asyncio
 from collections import defaultdict
 from io import BytesIO
 import rlp
@@ -30,7 +33,7 @@ from test_framework.util import wait_until, get_ip_address
 logger = logging.getLogger("TestFramework.mininode")
 
 
-class P2PConnection(asyncore.dispatcher):
+class P2PConnection(asyncio.Protocol):
     """A low-level connection object to a node's P2P interface.
 
     This class is responsible for:
@@ -42,76 +45,70 @@ class P2PConnection(asyncore.dispatcher):
 
     This class contains no logic for handling the P2P message payloads. It must be
     sub-classed and the on_message() callback overridden."""
+    
+    protocol: bytes
 
     def __init__(self):
         self.chain_id = None
-        assert not network_thread_running()
-
-        super().__init__(map=mininode_socket_map)
+        self._transport = None
 
     def set_chain_id(self, chain_id):
         self.chain_id = chain_id
+    
+    @property
+    def is_connected(self):
+        return self._transport is not None
 
     def peer_connect(self, dstaddr, dstport):
+        assert not self.is_connected
         self.dstaddr = dstaddr
         self.dstport = dstport
-        self.create_socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-        self.sendbuf = b""
         self.recvbuf = b""
-        self.state = "connecting"
-        self.disconnect = False
         self.had_hello = False
 
         logger.debug('Connecting to Conflux Node: %s:%d' %
                      (self.dstaddr, self.dstport))
+        
+        loop = NetworkThread.network_event_loop
+        conn_gen_unsafe = loop.create_connection(lambda: self, host=self.dstaddr, port=self.dstport)
+        conn_gen = lambda: loop.call_soon_threadsafe(loop.create_task, conn_gen_unsafe)
+        return conn_gen
 
-        try:
-            self.connect((dstaddr, dstport))
-        except Exception as e:
-            logger.debug("network connect error" + str(e))
-            self.handle_close()
 
     def peer_disconnect(self):
-        # Connection could have already been closed by other end.
-        if self.state == "connected":
-            self.disconnect_node()
+        NetworkThread.network_event_loop.call_soon_threadsafe(lambda: self._transport and self._transport.abort())
 
     # Connection and disconnection methods
 
-    def handle_connect(self):
-        """asyncore callback when a connection is opened."""
-        if self.state != "connected":
-            logger.debug("Connected & Listening: %s:%d" %
-                         (self.dstaddr, self.dstport))
-            self.state = "connected"
-            self.on_open()
+    def connection_made(self, transport):
+        """asyncio callback when a connection is opened."""
+        assert not self._transport
+        logger.debug("Connected & Listening: %s:%d" %
+                        (self.dstaddr, self.dstport))
+        self._transport = transport
+        self.on_open()
+        
+    def on_open(self):
+        pass
 
-    def handle_close(self):
-        """asyncore callback when a connection is closed."""
-        logger.debug("Closing connection to: %s:%d" %
-                     (self.dstaddr, self.dstport))
-        self.state = "closed"
+    def connection_lost(self, exc):
+        """asyncio callback when a connection is closed."""
+        if exc:
+            logger.warning("Connection lost to {}:{} due to {}".format(self.dstaddr, self.dstport, exc))
+        else:
+            logger.debug("Closed connection to: %s:%d" % (self.dstaddr, self.dstport))
+        self._transport = None
         self.recvbuf = b""
-        self.sendbuf = b""
-        try:
-            self.close()
-        except:
-            pass
         self.on_close()
 
-    def disconnect_node(self):
-        """Disconnect the p2p connection.
 
-        Called by the test logic thread. Causes the p2p connection
-        to be disconnected on the next iteration of the asyncore loop."""
-        self.disconnect = True
+    def on_close(self):
+        pass
 
     # Socket read methods
 
-    def handle_read(self):
-        """asyncore callback when data is read from the socket."""
-        buf = self.recv(8192)
+    def data_received(self, buf):
+        """asyncio callback when data is read from the socket."""
         if len(buf) > 0:
             self.recvbuf += buf
             self._on_data()
@@ -206,34 +203,7 @@ class P2PConnection(asyncore.dispatcher):
         """Callback for processing a protocol-specific P2P payload. Must be overridden by derived class."""
         raise NotImplementedError
 
-    # Socket write methods
-
-    def writable(self):
-        """asyncore method to determine whether the handle_write() callback should be called on the next loop."""
-        with mininode_lock:
-            pre_connection = self.state == "connecting"
-            length = len(self.sendbuf)
-        return (length > 0 or pre_connection)
-
-    def handle_write(self):
-        """asyncore callback when data should be written to the socket."""
-        with mininode_lock:
-            # asyncore does not expose socket connection, only the first read/write
-            # event, thus we must check connection manually here to know when we
-            # actually connect
-            if self.state == "connecting":
-                self.handle_connect()
-            if not self.writable():
-                return
-
-            try:
-                sent = self.send(self.sendbuf)
-            except:
-                self.handle_close()
-                return
-            self.sendbuf = self.sendbuf[sent:]
-
-    def send_packet(self, packet_id, payload, pushbuf=False):
+    def send_packet(self, packet_id, payload):
         """Send a P2P message over the socket.
 
         This method takes a P2P payload, builds the P2P header and adds
@@ -244,21 +214,13 @@ class P2PConnection(asyncore.dispatcher):
         self.send_data(buf)
 
 
-    def send_data(self, data, pushbuf=False):
-        if self.state != "connected" and not pushbuf:
+    def send_data(self, data):
+        if not self.is_connected:
             raise IOError('Not connected, no pushbuf')
 
         buf = self.assemble_connection_packet(data)
 
-        with mininode_lock:
-            if (len(self.sendbuf) == 0 and not pushbuf):
-                try:
-                    sent = self.send(buf)
-                    self.sendbuf = buf[sent:]
-                except BlockingIOError:
-                    self.sendbuf = buf
-            else:
-                self.sendbuf += buf
+        NetworkThread.network_event_loop.call_soon_threadsafe(lambda: self._transport and self._transport.write(buf))
 
     def send_protocol_packet(self, payload):
         """Send packet of protocols"""
@@ -321,7 +283,7 @@ class P2PInterface(P2PConnection):
         self.remote = remote
 
     def peer_connect(self, *args, **kwargs):
-        super().peer_connect(*args, **kwargs)
+        return super().peer_connect(*args, **kwargs)
 
     def wait_for_status(self, timeout=60):
         wait_until(lambda: self.had_status, timeout=timeout, lock=mininode_lock)
@@ -465,10 +427,6 @@ class P2PInterface(P2PConnection):
         resp = BlockHashes(reqid=msg.reqid, hashes=[])
         self.send_protocol_msg(resp)
 
-# Keep our own socket map for asyncore, so that we can track disconnects
-# ourselves (to work around an issue with closing an asyncore socket when
-# using select)
-mininode_socket_map = dict()
 
 # One lock for synchronizing all data access between the networking thread (see
 # NetworkThread below) and the thread running the test logic.  For simplicity,
@@ -483,46 +441,26 @@ class DefaultNode(P2PInterface):
         super().__init__(genesis, remote)
 
 class NetworkThread(threading.Thread):
+    network_event_loop: asyncio.AbstractEventLoop = None  # type: ignore
 
     def __init__(self):
         super().__init__(name="NetworkThread")
+        # There is only one event loop and no more than one thread must be created
+        assert not self.network_event_loop
+
+        NetworkThread.network_event_loop = asyncio.new_event_loop()
 
     def run(self):
-        while mininode_socket_map:
-            # We check for whether to disconnect outside of the asyncore
-            # loop to work around the behavior of asyncore when using
-            # select
-            disconnected = []
-            for fd, obj in mininode_socket_map.items():
-                if obj.disconnect:
-                    disconnected.append(obj)
-            [obj.handle_close() for obj in disconnected]
-            asyncore.loop(0.1, use_poll=True, map=mininode_socket_map, count=1)
-        logger.debug("Network thread closing")
+        """Start the network thread."""
+        self.network_event_loop.run_forever()
 
+    def close(self, timeout=10):
+        """Close the connections and network event loop."""
+        self.network_event_loop.call_soon_threadsafe(self.network_event_loop.stop)
+        wait_until(lambda: not self.network_event_loop.is_running(), timeout=timeout)
+        self.network_event_loop.close()
+        self.join(timeout)
 
-def network_thread_running():
-    """Return whether the network thread is running."""
-    return any([thread.name == "NetworkThread" for thread in threading.enumerate()])
-
-
-def network_thread_start():
-    """Start the network thread."""
-    assert not network_thread_running()
-
-    NetworkThread().start()
-
-
-def network_thread_join(timeout=10):
-    """Wait timeout seconds for the network thread to terminate.
-
-    Throw if network thread doesn't terminate in timeout seconds."""
-    network_threads = [
-        thread for thread in threading.enumerate() if thread.name == "NetworkThread"]
-    assert len(network_threads) <= 1
-    for thread in network_threads:
-        thread.join(timeout)
-        assert not thread.is_alive()
 
 def start_p2p_connection(nodes: list, remote=False):
     if len(nodes) == 0:
@@ -537,8 +475,6 @@ def start_p2p_connection(nodes: list, remote=False):
         p2p_connections.append(conn)
         node.add_p2p_connection(conn)
 
-    network_thread_start()
-    
     for p2p in p2p_connections:
         p2p.wait_for_status()
 

--- a/tests/test_framework/test_framework.py
+++ b/tests/test_framework/test_framework.py
@@ -21,7 +21,7 @@ import random
 
 from .authproxy import JSONRPCException
 from . import coverage
-from .mininode import start_p2p_connection
+from .mininode import start_p2p_connection, NetworkThread
 from .test_node import TestNode
 from .util import (
     CONFLUX_RPC_WAIT_TIMEOUT,
@@ -197,6 +197,10 @@ class ConfluxTestFramework:
                 default=tempfile.mkdtemp(prefix="conflux_test_"))
 
         self._start_logging()
+        
+        self.log.debug('Setting up network thread')
+        self.network_thread = NetworkThread()
+        self.network_thread.start()
 
         success = TestStatus.FAILED
 
@@ -232,6 +236,9 @@ class ConfluxTestFramework:
             print(
                 "Testcase failed. Attaching python debugger. Enter ? for help")
             pdb.set_trace()
+        
+        self.log.debug('Closing down network thread')
+        self.network_thread.close()
 
         self.log.debug('Closing down network thread')
         if not self.options.noshutdown:

--- a/tests/test_framework/test_node.py
+++ b/tests/test_framework/test_node.py
@@ -24,7 +24,6 @@ from conflux.config import DEFAULT_PY_TEST_CHAIN_ID
 from .authproxy import JSONRPCException
 from .util import *
 
-
 class FailedToStartError(Exception):
     """Raised when a node fails to start correctly."""
 
@@ -389,7 +388,7 @@ class TestNode:
         # if self.ip is not None:
         #     kwargs['dstaddr'] = self.ip
         # print(args, kwargs)
-        p2p_conn.peer_connect(*args, **kwargs)
+        p2p_conn.peer_connect(*args, **kwargs)()
         self.p2ps.append(p2p_conn)
 
         return p2p_conn


### PR DESCRIPTION
This PR removes deprecated `asyncore` in favor of `asyncio`.

This modification is based on bitcoin's commit https://github.com/bitcoin/bitcoin/commit/fa87da2f172ae2e6dc15e9ed156a3564a8ecfbdd#diff-0be0a11a850d4efed38840c744a0c1847296d87a97e1e405e1df08781d2d4dbf.

This commit also removes the `p2p.state` property in favor of `p2p.is_connected` (following bitcoin's change).

Changes shall be done in the submodule `extra-test-toolkits` where `network_thread_start()` should be removed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/2953)
<!-- Reviewable:end -->
