### PR TITLE
op espace complete same tx resend error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1953,7 +1953,6 @@ dependencies = [
  "dir",
  "executor",
  "executor-types",
- "fail",
  "futures 0.3.30",
  "futures01",
  "geth-tracer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,6 @@ rustc-hex = "2.1"
 fail = "0.4.0"
 thiserror = "1.0.63"
 anyhow = "1.0"
-error-chain = { version = "0.12" }
 
 # parallelism
 parking_lot = "0.11"

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -89,7 +89,6 @@ diem-types = { path = "../cfxcore/core/src/pos/types" }
 pow-types = {path = "../cfxcore/core/src/pos/types/pow-types" }
 executor-types = { path = "../cfxcore/core/src/pos/types/executor-types" }
 executor = { path = "../cfxcore/core/src/pos/consensus/executor" }
-fail = { workspace = true }
 storage-interface = { path = "../cfxcore/core/src/pos/storage/storage-interface" }
 consensus-types = {path = "../cfxcore/core/src/pos/consensus/consensus-types" }
 rpassword = { workspace = true }

--- a/crates/rpc/rpc/src/eth.rs
+++ b/crates/rpc/rpc/src/eth.rs
@@ -237,7 +237,7 @@ impl EthApi {
         } else if signed_trans.len() + failed_trans.len() == 0 {
             // For tx in transactions_pubkey_cache, we simply ignore them
             bail!(RpcError::from(EthApiError::PoolError(
-                RpcPoolError::ReplaceUnderpriced
+                RpcPoolError::AlreadyKnown
             )));
         } else if signed_trans.is_empty() {
             let tx_err = failed_trans.into_iter().next().expect("Not empty").1;

--- a/tests/evm_space/rpc_error_test.py
+++ b/tests/evm_space/rpc_error_test.py
@@ -103,7 +103,7 @@ class RpcErrorTest(Web3Base):
             wait_ms(1000)
             self.w3.eth.send_raw_transaction(signed["raw_transaction"])
         except Exception as e:
-            assert_equal(str(e), "{'code': -32603, 'message': 'replacement transaction underpriced'}")
+            assert_equal(str(e), "{'code': -32603, 'message': 'already known'}")
             return
         
     def zero_gas_price(self):


### PR DESCRIPTION
When a same tx resend second time, the error should be different with "replacement tx underpriced", we follow reth use "already known" for this case

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/2965)
<!-- Reviewable:end -->
