### PR TITLE
tests: test eip7702 txs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ build_clippy/
 tests/artifacts/**/*.dbg.json
 venv
 .venv
+**/node_modules/**

--- a/crates/cfxcore/executor/src/state/state_object/basic_fields.rs
+++ b/crates/cfxcore/executor/src/state/state_object/basic_fields.rs
@@ -145,6 +145,8 @@ impl State {
         let authority_code = authority_acc.code();
         let authority_code_hash = authority_acc.code_hash();
 
+        std::mem::drop(authority_acc);
+
         let (code, code_hash) = if address.space == Space::Native {
             // Core space does not support-7702
             (authority_code, authority_code_hash)

--- a/dev-support/dep_pip3.sh
+++ b/dev-support/dep_pip3.sh
@@ -4,6 +4,8 @@ set -e
 
 pip3 install cfx-account eth-utils py-ecc rlp trie coincurve safe-pysha3 conflux-web3==1.4.0b5 web3 jsonrpcclient==3.3.6 asyncio websockets pyyaml numpy
 
+cd integration_tests/test_framework/util/eip7702/viem_scripts && npm install
+
 # TODO cross platform
 #yum install clang snappy snappy-devel zlib zlib-devel bzip2 bzip2-devel lz4-devel
 #   wget https://github.com/facebook/zstd/archive/v1.1.3.tar.gz

--- a/dev-support/dep_pip3.sh
+++ b/dev-support/dep_pip3.sh
@@ -12,7 +12,7 @@ pip3 install cfx-account eth-utils py-ecc rlp trie coincurve safe-pysha3 conflux
 
 # set server path to fix ci issue
 export PATH="/home/ubuntu/.nvm/versions/node/v20.18.3/bin:$PATH"
-cd integration_tests/test_framework/util/eip7702/viem_scripts && npm install
+cd integration_tests/test_framework/util/eip7702/viem_scripts && npm install &&cd ../../../../../
 
 # TODO cross platform
 #yum install clang snappy snappy-devel zlib zlib-devel bzip2 bzip2-devel lz4-devel

--- a/dev-support/dep_pip3.sh
+++ b/dev-support/dep_pip3.sh
@@ -4,6 +4,14 @@ set -e
 
 pip3 install cfx-account eth-utils py-ecc rlp trie coincurve safe-pysha3 conflux-web3==1.4.0b5 web3 jsonrpcclient==3.3.6 asyncio websockets pyyaml numpy
 
+################################################################################
+# temporary solution to use eip7702 signing from viem implementation
+# as upstream web3.py does not support it yet
+#
+# Will remove it and switch to python implementation after web3.py supports it
+
+# set server path to fix ci issue
+export PATH="/home/ubuntu/.nvm/versions/node/v20.18.3/bin:$PATH"
 cd integration_tests/test_framework/util/eip7702/viem_scripts && npm install
 
 # TODO cross platform

--- a/integration_tests/test_framework/util/eip7702/eip7702.py
+++ b/integration_tests/test_framework/util/eip7702/eip7702.py
@@ -1,0 +1,106 @@
+import json
+import subprocess
+from pydantic import BaseModel, Field, ConfigDict
+from pathlib import Path
+from typing import TypedDict
+
+class Authorization(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    
+    chainId: int = Field(alias='chain_id')
+    nonce: int
+    contractAddress: str = Field(alias='contract_address')
+    r: str
+    s: str
+    v: int
+    yParity: int
+
+class EIP7702Transaction(TypedDict):
+    authorizationList: list[Authorization]
+    chainId: int
+    gas: int
+    nonce: int
+    to: str
+    value: int
+    maxFeePerGas: int
+    maxPriorityFeePerGas: int
+    # accessList: list[AccessList]
+    data: str
+
+def _run_node_script(command: str, args: dict) -> dict:
+    script_path = Path(__file__).parent / 'viem_scripts' / 'eip7702.js'
+    print(f"Running command: node {script_path} {command} {json.dumps(args)}")
+    result = subprocess.run(
+        ['node', str(script_path), command, json.dumps(args)],
+        capture_output=True,
+        text=True,
+        check=True
+    )
+    return json.loads(result.stdout)
+
+def sign_authorization(contract_address: str, chain_id: int, nonce: int, private_key: str) -> Authorization:
+    """
+    Sign an EIP-7702 authorization using viem
+    
+    Args:
+        contract_address: The contract address to authorize
+        chain_id: The chain ID
+        nonce: The nonce
+        private_key: The private key to sign with
+        
+    Returns:
+        An Authorization object containing the signature
+    """
+    args = {
+        'contractAddress': contract_address,
+        'chainId': chain_id,
+        'nonce': nonce,
+        'privateKey': private_key
+    }
+    
+    result = _run_node_script('signAuthorization', args)
+    return Authorization(
+        chain_id=chain_id,
+        nonce=nonce,
+        contract_address=contract_address,
+        r=result['r'],
+        s=result['s'],
+        v=result['v'],
+        yParity=result['yParity']
+    )
+
+def sign_eip7702_transaction(transaction: EIP7702Transaction, private_key: str) -> str:
+    """
+    Sign an EIP-7702 transaction using viem
+    
+    Args:
+        transaction: The transaction to sign
+        private_key: The private key to sign with
+        
+    Returns:
+        The signed transaction as a hex string
+    """
+    # Convert Authorization objects to dict with camelCase keys
+    tx_dict = dict(transaction)
+    tx_dict['authorizationList'] = [
+        {
+            'chainId': auth.chainId,
+            'nonce': auth.nonce,
+            'contractAddress': auth.contractAddress,
+            'r': auth.r,
+            's': auth.s,
+            'v': auth.v,
+            'yParity': auth.yParity
+        }
+        for auth in transaction['authorizationList']
+    ]
+    
+    args = {
+        'transaction': tx_dict,
+        'privateKey': private_key
+    }
+    
+    result = _run_node_script('signTransaction', args)
+    if isinstance(result, dict):
+        return result['signedTransaction']
+    return result

--- a/integration_tests/test_framework/util/eip7702/viem_scripts/eip7702.js
+++ b/integration_tests/test_framework/util/eip7702/viem_scripts/eip7702.js
@@ -1,0 +1,101 @@
+import { createWalletClient, custom, defineChain } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { eip7702Actions } from 'viem/experimental';
+
+// Helper function to handle BigInt serialization
+const replacer = (key, value) =>
+  typeof value === 'bigint'
+    ? value.toString()
+    : value;
+
+// Helper function to create chain config
+function createChainConfig(chainId) {
+  return defineChain({
+    id: chainId,
+    name: `Chain ${chainId}`,
+    network: `network ${chainId}`,
+    nativeCurrency: {
+      decimals: 18,
+      name: 'CFX',
+      symbol: 'CFX',
+    },
+  })
+}
+
+export async function signAuthorization({ contractAddress, chainId, nonce, privateKey }) {
+  const account = privateKeyToAccount(privateKey);
+  const chain = createChainConfig(chainId);
+  const client = createWalletClient({
+    account,
+    chain,
+    transport: custom({
+      async request({ method, params }) {
+        // Mock responses for required RPC calls
+        if (method === 'eth_chainId') {
+          return `0x${chainId.toString(16)}`;
+        }
+        throw new Error(`Unsupported method: ${method}`);
+      }
+    })
+  }).extend(eip7702Actions());
+
+  const authorization = await client.signAuthorization({
+    account,
+    chainId,
+    nonce,
+    contractAddress,
+  });
+
+  return authorization;
+}
+
+export async function signTransaction({ transaction, privateKey }) {
+  const account = privateKeyToAccount(privateKey);
+  const chain = createChainConfig(transaction.chainId);
+  const client = createWalletClient({
+    account,
+    chain,
+    transport: custom({
+      async request({ method, params }) {
+        // Mock responses for required RPC calls
+        if (method === 'eth_chainId') {
+          return `0x${transaction.chainId.toString(16)}`;
+        }
+        throw new Error(`Unsupported method: ${method}`);
+      }
+    })
+  }).extend(eip7702Actions());
+
+  const signedTransaction = await client.signTransaction({
+    ...transaction,
+    account,
+  });
+
+  return signedTransaction;
+}
+
+// CLI interface for Python to call
+const command = process.argv[2];
+const args = JSON.parse(process.argv[3]);
+
+if (command === 'signAuthorization') {
+  signAuthorization(args)
+    .then(result => {
+      console.log(JSON.stringify(result, replacer));
+      process.exit(0);
+    })
+    .catch(error => {
+      console.error(error);
+      process.exit(1);
+    });
+} else if (command === 'signTransaction') {
+  signTransaction(args)
+    .then(result => {
+      console.log(JSON.stringify(result, replacer));
+      process.exit(0);
+    })
+    .catch(error => {
+      console.error(error);
+      process.exit(1);
+    });
+} 

--- a/integration_tests/test_framework/util/eip7702/viem_scripts/package-lock.json
+++ b/integration_tests/test_framework/util/eip7702/viem_scripts/package-lock.json
@@ -1,0 +1,206 @@
+{
+  "name": "viem-wrapper",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "viem-wrapper",
+      "version": "1.0.0",
+      "dependencies": {
+        "viem": "^2.23.1"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz",
+      "integrity": "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==",
+      "license": "MIT"
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
+      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.7.1"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.4.tgz",
+      "integrity": "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.2.tgz",
+      "integrity": "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.8.1",
+        "@noble/hashes": "~1.7.1",
+        "@scure/base": "~1.2.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.4.tgz",
+      "integrity": "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.7.1",
+        "@scure/base": "~1.2.4"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.8.tgz",
+      "integrity": "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3 >=3.22.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/isows": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.6.tgz",
+      "integrity": "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/ox": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.7.tgz",
+      "integrity": "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.10.1",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/bip32": "^1.5.0",
+        "@scure/bip39": "^1.4.0",
+        "abitype": "^1.0.6",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem": {
+      "version": "2.23.1",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.23.1.tgz",
+      "integrity": "sha512-c5AyJCTA5LeNI/KCu++vkbqbh7irYjUSHxLIAHPKJ6IEcBNMt8+7sPG7gjMXpqVWnqPMzaW9CA2n+yUsKWttDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.8.1",
+        "@noble/hashes": "1.7.1",
+        "@scure/bip32": "1.6.2",
+        "@scure/bip39": "1.5.4",
+        "abitype": "1.0.8",
+        "isows": "1.0.6",
+        "ox": "0.6.7",
+        "ws": "8.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/integration_tests/test_framework/util/eip7702/viem_scripts/package.json
+++ b/integration_tests/test_framework/util/eip7702/viem_scripts/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "viem-wrapper",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "viem": "^2.23.1"
+  }
+} 

--- a/integration_tests/tests/conftest.py
+++ b/integration_tests/tests/conftest.py
@@ -140,7 +140,7 @@ def cw3(network: ConfluxTestFramework):
     return network.cw3
 
 @pytest.fixture(scope="module")
-def ew3(network: ConfluxTestFramework) -> Web3:
+def ew3(network: ConfluxTestFramework):
     return network.ew3
 
 @pytest.fixture(scope="module")

--- a/integration_tests/tests/transaction/eip7702/conftest.py
+++ b/integration_tests/tests/transaction/eip7702/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+from integration_tests.test_framework.test_framework import ConfluxTestFramework
+
+MIN_NATIVE_BASE_PRICE = 10000
+EVM_CHAIN_ID = 11
+
+@pytest.fixture(scope="module")
+def framework_class():
+    class EIP7702TestEnv(ConfluxTestFramework):
+        def set_test_params(self):
+            self.num_nodes = 1
+            self.conf_parameters["evm_chain_id"] = str(EVM_CHAIN_ID)
+            self.conf_parameters["min_native_base_price"] = MIN_NATIVE_BASE_PRICE
+            self.conf_parameters["eoa_code_transition_height"] = 1
+            self.conf_parameters["evm_transaction_block_ratio"] = str(1)
+
+        def setup_network(self):
+            self.add_nodes(self.num_nodes)
+            self.start_node(0, ["--archive"])
+
+    return EIP7702TestEnv

--- a/integration_tests/tests/transaction/eip7702/test_eip7702.py
+++ b/integration_tests/tests/transaction/eip7702/test_eip7702.py
@@ -1,0 +1,68 @@
+import pytest
+from typing import Type
+from integration_tests.test_framework.util import load_contract_metadata
+from web3 import Web3
+from web3.contract import Contract
+from integration_tests.test_framework.util.eip7702.eip7702 import (
+    sign_authorization,
+    sign_eip7702_transaction,
+    Authorization,
+    EIP7702Transaction
+)
+
+@pytest.fixture(scope="module")
+def erc20_factory(ew3: Web3) -> Type[Contract]:
+    metadata = load_contract_metadata("MyToken")  # ERC20 contract
+    contract_factory = ew3.eth.contract(
+        bytecode=metadata["bytecode"],
+        abi=metadata["abi"],
+    )
+    return contract_factory
+
+@pytest.fixture(scope="module")
+def erc20_contract(ew3: Web3, erc20_factory: Type[Contract], evm_accounts) -> Contract:
+    tx_hash = erc20_factory.constructor(
+        evm_accounts[0].address
+    ).transact()
+    receipt = ew3.eth.wait_for_transaction_receipt(tx_hash)
+    return erc20_factory(receipt["contractAddress"])
+
+# use self as erc20 contract
+# and mint self 10**18
+def test_eip7702(ew3: Web3, erc20_factory: Type[Contract], erc20_contract: Contract, evm_accounts, network):
+    
+    account = evm_accounts[0]
+    
+    chain_id = ew3.eth.chain_id
+    authorization = sign_authorization(
+        contract_address=erc20_contract.address,
+        chain_id=chain_id,
+        nonce=ew3.eth.get_transaction_count(account.address) + 1,
+        private_key=account.key.to_0x_hex(),
+    )
+    
+    transaction: EIP7702Transaction = {
+        "authorizationList": [authorization],
+        "chainId": chain_id,
+        "gas": 1000000,
+        "nonce": ew3.eth.get_transaction_count(account.address),
+        "to": "0x0000000000000000000000000000000000000000",
+        "value": 0,
+        "maxFeePerGas": 1000000000,
+        "maxPriorityFeePerGas": 100000000,
+        "data": "0x"
+    }
+    
+    tx_raw = sign_eip7702_transaction(transaction, account.key.to_0x_hex())
+    tx_hash = ew3.eth.send_raw_transaction(tx_raw)
+    receipt = ew3.eth.wait_for_transaction_receipt(tx_hash, timeout=10, poll_latency=1)
+    
+    assert receipt["status"] == 1
+    
+    self_contract = erc20_factory(evm_accounts[0].address)
+    
+    code = ew3.eth.get_code(self_contract.address)
+    assert code.to_0x_hex() == "0xef0100" + erc20_contract.address[2:].lower()
+    
+    assert self_contract.functions.balanceOf(account.address).call() == 0
+    

--- a/integration_tests/tests/transaction/eip7702/test_eip7702_internal_util.py
+++ b/integration_tests/tests/transaction/eip7702/test_eip7702_internal_util.py
@@ -1,0 +1,48 @@
+import pytest
+from integration_tests.test_framework.util.eip7702.eip7702 import (
+    sign_authorization,
+    sign_eip7702_transaction,
+    Authorization,
+    EIP7702Transaction
+)
+
+# Test private key (DO NOT USE IN PRODUCTION)
+TEST_PRIVATE_KEY = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+
+@pytest.fixture
+def authorization() -> Authorization:
+    contract_address = '0x1234567890123456789012345678901234567890'
+    chain_id = 1
+    nonce = 0
+    
+    result = sign_authorization(
+        contract_address=contract_address,
+        chain_id=chain_id,
+        nonce=nonce,
+        private_key=TEST_PRIVATE_KEY
+    )
+    return result
+
+def test_sign_authorization(authorization: Authorization):
+    assert authorization.chainId == 1
+    assert authorization.nonce == 0
+    assert authorization.contractAddress == '0x1234567890123456789012345678901234567890'
+    assert isinstance(authorization, Authorization)
+
+def test_sign_eip7702_transaction(authorization: Authorization):
+    transaction: EIP7702Transaction = {
+        'authorizationList': [authorization],
+        'chainId': 1,
+        'gas': 21000,
+        'nonce': 0,
+        'to': '0x1234567890123456789012345678901234567890',
+        'value': 0,
+        'maxFeePerGas': 1000000000,
+        'maxPriorityFeePerGas': 100000000,
+        'data': '0x'
+    }
+    
+    result = sign_eip7702_transaction(transaction, TEST_PRIVATE_KEY)
+    
+    assert isinstance(result, str)
+    assert result.startswith('0x')


### PR DESCRIPTION
As the upstream web3.py does not implement EIP7702 yet (https://github.com/ethereum/web3.py/issues/3603). This pull request bridges viem's implementation for EIP7702 transaction test. Relating implementation would switch to python version after web3.py implements it.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3069)
<!-- Reviewable:end -->
