### PR TITLE
update espace block gas_limit to compatible with web3.py

### DIFF
--- a/changelogs/JSONRPC.md
+++ b/changelogs/JSONRPC.md
@@ -2,6 +2,7 @@
 
 ## vNext
 1. Support gasFee in transaction receipt for espace RPC
+2. eSpace block.gasLimit revert to the consensus gas limit, add block.espaceGasLimit to return the real gas limit for eSpace transactions.
 
 ## v2.4.1
 

--- a/crates/rpc/rpc-eth-types/src/block.rs
+++ b/crates/rpc/rpc-eth-types/src/block.rs
@@ -82,6 +82,9 @@ pub struct Block {
     pub gas_used: U256,
     /// Gas Limit
     pub gas_limit: U256,
+    /// Conflux espace gas limit, this is the real gas limit of the block
+    /// This is a conflux espace custom field
+    pub espace_gas_limit: U256,
     /// Extra data
     pub extra_data: Bytes,
     /// Logs bloom
@@ -219,7 +222,8 @@ impl Block {
                 .last()
                 .map(|r| r.accumulated_gas_used)
                 .unwrap_or_default(),
-            gas_limit: pb.total_gas_limit,
+            gas_limit: pb.pivot_header.gas_limit().into(),
+            espace_gas_limit: pb.total_gas_limit,
             extra_data: Default::default(),
             logs_bloom: pb.bloom,
             timestamp: pb.pivot_header.timestamp().into(),


### PR DESCRIPTION
The newest version web3.py will check block.gasLimit bigger than tx.gasLimit when sending tx. The previous update to block.gasLimit will lead some block.gasLimit is 0, so we reverse it, and add a new field called espaceGasLimit to return the real block gas limit 