### PR TITLE
Fix incorrect implementation of CIP-151

### DIFF
--- a/crates/cfxcore/core/src/consensus/consensus_inner/consensus_executor/epoch_execution.rs
+++ b/crates/cfxcore/core/src/consensus/consensus_inner/consensus_executor/epoch_execution.rs
@@ -204,6 +204,9 @@ impl ConsensusExecutionHandler {
                 .transaction_epoch_bound,
             base_gas_price,
             burnt_gas_price,
+            // Temporarily set `transaction_hash` to zero; it will be updated
+            // with the actual transaction hash for each transaction.
+            transaction_hash: H256::zero(),
         }
     }
 
@@ -278,6 +281,7 @@ impl ConsensusExecutionHandler {
             settings: TransactSettings::all_checks(),
         };
 
+        env.transaction_hash = transaction.hash();
         let execution_outcome =
             ExecutiveContext::new(state, env, machine, &spec)
                 .transact(transaction, options)?;

--- a/crates/cfxcore/core/src/consensus/consensus_inner/consensus_executor/mod.rs
+++ b/crates/cfxcore/core/src/consensus/consensus_inner/consensus_executor/mod.rs
@@ -1670,6 +1670,7 @@ impl ConsensusExecutionHandler {
                 .transaction_epoch_bound,
             base_gas_price,
             burnt_gas_price,
+            transaction_hash: tx.hash(),
         };
         if evm_overrides.has_block() {
             ExecutiveContext::apply_env_overrides(

--- a/crates/cfxcore/core/src/genesis_block.rs
+++ b/crates/cfxcore/core/src/genesis_block.rs
@@ -488,7 +488,8 @@ pub fn register_transaction(
 fn execute_genesis_transaction(
     transaction: &SignedTransaction, state: &mut State, machine: Arc<Machine>,
 ) {
-    let env = Env::default();
+    let mut env = Env::default();
+    env.transaction_hash = transaction.hash();
 
     let options = TransactOptions::default();
     let r = {

--- a/crates/cfxcore/executor/src/executive/tests.rs
+++ b/crates/cfxcore/executor/src/executive/tests.rs
@@ -940,6 +940,7 @@ fn test_commission_privilege_all_whitelisted_across_epochs() {
     let machine = make_byzantium_machine(0);
     let mut env = Env::default();
     env.gas_limit = U256::MAX;
+    env.transaction_hash = crate::tests::MOCK_TX_HASH;
     let spec = machine.spec_for_test(env.number);
 
     let sender = Random.generate().unwrap().address();
@@ -964,7 +965,9 @@ fn test_commission_privilege_all_whitelisted_across_epochs() {
             false,
         )
         .expect(&concat!(file!(), ":", line!(), ":", column!()));
-    state.init_code(&address, code.clone(), sender).unwrap();
+    state
+        .init_code(&address, code.clone(), sender, env.transaction_hash)
+        .unwrap();
     state
         .add_balance(
             &sender_with_space,
@@ -1044,7 +1047,9 @@ fn test_commission_privilege_all_whitelisted_across_epochs() {
             false,
         )
         .unwrap();
-    state.init_code(&address, code, sender).unwrap();
+    state
+        .init_code(&address, code, sender, env.transaction_hash)
+        .unwrap();
     state
         .add_balance(
             &sender_with_space,
@@ -1147,7 +1152,9 @@ fn test_commission_privilege() {
             false,
         )
         .expect(&concat!(file!(), ":", line!(), ":", column!()));
-    state.init_code(&address, code, sender).unwrap();
+    state
+        .init_code(&address, code, sender, env.transaction_hash)
+        .unwrap();
     state
         .add_balance(
             &sender_with_space,
@@ -1540,7 +1547,9 @@ fn test_storage_commission_privilege() {
             false,
         )
         .expect(&concat!(file!(), ":", line!(), ":", column!()));
-    state.init_code(&address, code, sender.address()).unwrap();
+    state
+        .init_code(&address, code, sender.address(), env.transaction_hash)
+        .unwrap();
 
     state
         .add_balance(

--- a/crates/cfxcore/executor/src/executive/tests.rs
+++ b/crates/cfxcore/executor/src/executive/tests.rs
@@ -350,7 +350,8 @@ fn test_call_to_create() {
         * code_collateral_units(code_len)
         + *COLLATERAL_DRIPS_PER_STORAGE_KEY;
 
-    let env = Env::default();
+    let mut env = Env::default();
+    env.transaction_hash = crate::tests::MOCK_TX_HASH;
     let machine = make_byzantium_machine(5);
     let spec = machine.spec_for_test(env.number);
 

--- a/crates/cfxcore/executor/src/internal_contract/contracts/admin.rs
+++ b/crates/cfxcore/executor/src/internal_contract/contracts/admin.rs
@@ -46,6 +46,7 @@ impl SimpleExecutionTrait for Destroy {
             context.state,
             context.spec,
             context.substate,
+            context.env,
             context.tracer,
             &context.callstack,
         )

--- a/crates/cfxcore/executor/src/internal_contract/contracts/cross_space.rs
+++ b/crates/cfxcore/executor/src/internal_contract/contracts/cross_space.rs
@@ -265,6 +265,7 @@ impl SimpleExecutionTrait for DeployEip1820 {
             &address,
             eip_1820::BYTE_CODE.clone(),
             Address::zero(),
+            context.env.transaction_hash,
         )?;
         context.substate.record_contract_create(address);
         Ok(())

--- a/crates/cfxcore/executor/src/lib.rs
+++ b/crates/cfxcore/executor/src/lib.rs
@@ -61,3 +61,14 @@ pub mod state;
 
 pub use internal_contract::{InternalContractMap, InternalContractTrait};
 pub use observer as executive_observer;
+
+/// Common tools for test
+#[cfg(test)]
+mod tests {
+    use cfx_types::H256;
+    use hex_literal::hex;
+    // Mock transaction hash for tests not contruct an actual transaction.
+    pub const MOCK_TX_HASH: H256 = H256(hex!(
+        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    ));
+}

--- a/crates/cfxcore/executor/src/state/overlay_account/basic.rs
+++ b/crates/cfxcore/executor/src/state/overlay_account/basic.rs
@@ -37,7 +37,18 @@ impl OverlayAccount {
         self.admin = admin.clone();
     }
 
-    pub fn init_code(&mut self, code: Bytes, owner: Address) {
+    pub fn init_code(
+        &mut self, code: Bytes, owner: Address, transaction_hash: H256,
+    ) {
+        self.code_hash = keccak(&code);
+        self.code = Some(CodeInfo {
+            code: Arc::new(code),
+            owner,
+        });
+        self.create_transaction_hash = Some(transaction_hash);
+    }
+
+    pub fn override_code(&mut self, code: Bytes, owner: Address) {
         self.code_hash = keccak(&code);
         self.code = Some(CodeInfo {
             code: Arc::new(code),
@@ -70,6 +81,10 @@ impl OverlayAccount {
     }
 
     pub fn code_hash(&self) -> H256 { self.code_hash.clone() }
+
+    pub fn create_transaction_hash(&self) -> Option<H256> {
+        self.create_transaction_hash
+    }
 
     pub fn is_null(&self) -> bool {
         self.balance.is_zero()

--- a/crates/cfxcore/executor/src/state/overlay_account/factory.rs
+++ b/crates/cfxcore/executor/src/state/overlay_account/factory.rs
@@ -31,6 +31,7 @@ impl Default for OverlayAccount {
             is_newly_created_contract: false,
             pending_db_clear: false,
             storage_overrided: false,
+            create_transaction_hash: None,
         }
     }
 }
@@ -159,6 +160,7 @@ impl OverlayAccount {
             ),
             storage_layout_change: self.storage_layout_change.clone(),
             storage_overrided: self.storage_overrided,
+            create_transaction_hash: self.create_transaction_hash.clone(),
         }
     }
 
@@ -191,6 +193,7 @@ impl OverlayAccount {
             transient_storage_checkpoint: None,
             storage_layout_change: self.storage_layout_change.clone(),
             storage_overrided: self.storage_overrided,
+            create_transaction_hash: self.create_transaction_hash.clone(),
         }
     }
 }

--- a/crates/cfxcore/executor/src/state/overlay_account/mod.rs
+++ b/crates/cfxcore/executor/src/state/overlay_account/mod.rs
@@ -164,6 +164,15 @@ pub struct OverlayAccount {
     /// When this flag is set, the storage entries will only be read from the
     /// cache
     storage_overrided: bool,
+
+    /* ---------------
+    -  Helper fields -
+    --------------- */
+    /// For CIP-151, `None` indicates that this is either a non-contract, a
+    /// contract in the process of being created, or a contract not created
+    /// in the current epoch. A `Some(_)` value indicates that this is a
+    /// contract created by a specific transaction.
+    create_transaction_hash: Option<H256>,
 }
 
 impl OverlayAccount {

--- a/crates/cfxcore/executor/src/state/overlay_account/state_override.rs
+++ b/crates/cfxcore/executor/src/state/overlay_account/state_override.rs
@@ -41,7 +41,7 @@ impl OverlayAccount {
         }
 
         if let Some(code) = acc_overrides.code.as_ref() {
-            acc.init_code(code.clone(), address.address);
+            acc.override_code(code.clone(), address.address);
         }
 
         match &acc_overrides.state {

--- a/crates/cfxcore/executor/src/state/state_object/basic_fields.rs
+++ b/crates/cfxcore/executor/src/state/state_object/basic_fields.rs
@@ -168,9 +168,28 @@ impl State {
 
     pub fn init_code(
         &mut self, address: &AddressWithSpace, code: Bytes, owner: Address,
+        transaction_hash: H256,
     ) -> DbResult<()> {
-        self.write_account_lock(address)?.init_code(code, owner);
+        self.write_account_lock(address)?.init_code(
+            code,
+            owner,
+            transaction_hash,
+        );
         Ok(())
+    }
+
+    pub fn created_at_transaction(
+        &self, address: &AddressWithSpace, transaction_hash: H256,
+    ) -> DbResult<bool> {
+        Ok(
+            if let Some(acc) =
+                self.read_account_ext_lock(&address, RequireFields::None)?
+            {
+                acc.create_transaction_hash() == Some(transaction_hash)
+            } else {
+                false
+            }
+        )
     }
 
     pub fn set_authorization(

--- a/crates/cfxcore/executor/src/state/state_object/basic_fields.rs
+++ b/crates/cfxcore/executor/src/state/state_object/basic_fields.rs
@@ -188,7 +188,7 @@ impl State {
                 acc.create_transaction_hash() == Some(transaction_hash)
             } else {
                 false
-            }
+            },
         )
     }
 

--- a/crates/cfxcore/executor/src/state/state_object/contract_manager.rs
+++ b/crates/cfxcore/executor/src/state/state_object/contract_manager.rs
@@ -57,7 +57,12 @@ impl State {
         &mut self, contract: &AddressWithSpace, balance: U256,
     ) -> DbResult<()> {
         self.new_contract(contract, balance)?;
-        self.init_code(&contract, vec![0x12, 0x34], Address::zero())?;
+        self.init_code(
+            &contract,
+            vec![0x12, 0x34],
+            Address::zero(),
+            crate::tests::MOCK_TX_HASH,
+        )?;
         Ok(())
     }
 

--- a/crates/cfxcore/executor/src/state/state_object/tests.rs
+++ b/crates/cfxcore/executor/src/state/state_object/tests.rs
@@ -814,7 +814,9 @@ fn check_result_of_simple_payment_to_killed_account() {
     state_0.checkpoint();
     let mut substate = Substate::new();
     state_0.new_contract(&a_s, U256::zero()).unwrap();
-    state_0.init_code(&a_s, code, sender_addr).unwrap();
+    state_0
+        .init_code(&a_s, code, sender_addr, crate::tests::MOCK_TX_HASH)
+        .unwrap();
     state_0
         .set_storage(&a_s, k.clone(), U256::one(), a, &mut substate)
         .unwrap();

--- a/crates/cfxcore/executor/src/substate.rs
+++ b/crates/cfxcore/executor/src/substate.rs
@@ -29,7 +29,6 @@ pub struct Substate {
     pub logs: Vec<LogEntry>,
     /// Created contracts.
     contracts_created: Vec<AddressWithSpace>,
-    contracts_created_set: HashSet<AddressWithSpace>,
 }
 
 impl Substate {
@@ -38,7 +37,6 @@ impl Substate {
         self.touched.extend(s.touched);
         self.logs.extend(s.logs);
         self.contracts_created.extend(s.contracts_created);
-        self.contracts_created_set.extend(s.contracts_created_set);
         for (address, amount) in s.storage_collateralized {
             *self.storage_collateralized.entry(address).or_insert(0) += amount;
         }
@@ -96,13 +94,8 @@ impl Substate {
         &self.contracts_created
     }
 
-    pub fn contains_contract_create(&self, address: &AddressWithSpace) -> bool {
-        self.contracts_created_set.contains(address)
-    }
-
     pub fn record_contract_create(&mut self, address: AddressWithSpace) {
         self.contracts_created.push(address);
-        self.contracts_created_set.insert(address);
     }
 
     pub fn record_storage_occupy(

--- a/crates/cfxcore/vm-types/src/env.rs
+++ b/crates/cfxcore/vm-types/src/env.rs
@@ -63,6 +63,8 @@ pub struct Env {
     pub base_gas_price: SpaceMap<U256>,
     /// Base gas price to miner according to in CIP-137
     pub burnt_gas_price: SpaceMap<U256>,
+    /// Transaction hash for the executing transaction, required by CIP-152
+    pub transaction_hash: H256,
 }
 
 #[cfg(test)]

--- a/crates/client/benches/benchmark.rs
+++ b/crates/client/benches/benchmark.rs
@@ -66,6 +66,7 @@ fn txexe_benchmark(c: &mut Criterion) {
         transaction_epoch_bound: TRANSACTION_DEFAULT_EPOCH_BOUND,
         base_gas_price: Default::default(),
         burnt_gas_price: Default::default(),
+        transaction_hash: tx.hash(),
     };
     let mut group = c.benchmark_group("Execute 1 transaction");
     group

--- a/crates/client/src/configuration.rs
+++ b/crates/client/src/configuration.rs
@@ -193,6 +193,7 @@ build_config! {
         (min_eth_base_price, (Option<u64>), None)
         // V2.5
         (eoa_code_transition_height, (Option<u64>), None)
+        (cip151_transition_height, (Option<u64>), None)
 
 
         // Mining section.
@@ -1497,7 +1498,10 @@ impl Configuration {
         set_conf!(
             self.raw_conf.eoa_code_transition_height.unwrap_or(default_transition_time);
             params.transition_heights => { cip150, cip151, cip152, cip7702 }
-        )
+        );
+        if let Some(x) = self.raw_conf.cip151_transition_height {
+            params.transition_heights.cip151 = x;
+        }
     }
 }
 

--- a/tests/admin_control_test.py
+++ b/tests/admin_control_test.py
@@ -7,6 +7,7 @@ from test_framework.util import assert_equal
 class AdminControlTest(ConfluxTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
+        self.conf_parameters["cip151_transition_height"] = str(99999999)
 
     def run_test(self):
         self.w3 = self.cw3

--- a/tests/cip107_test.py
+++ b/tests/cip107_test.py
@@ -147,6 +147,7 @@ class CIP107Test(ConfluxTestFramework):
         self.conf_parameters["params_dao_vote_period"] = CIP104_PERIOD
         self.conf_parameters["dao_vote_transition_number"] = 1
         self.conf_parameters["dao_vote_transition_height"] = 1
+        self.conf_parameters["cip151_transition_height"] = str(99999999)
 
     def run_test(self):
         self.w3 = self.cw3

--- a/tests/contract_remove_test.py
+++ b/tests/contract_remove_test.py
@@ -17,6 +17,7 @@ class ContractRemoveTest(ConfluxTestFramework):
         super().__init__()
         self.has_range_delete_bug = False
         self.has_collateral_bug = True
+        self.conf_parameters["cip151_transition_height"] = str(99999999)
 
     @property
     def correct_wl_value(self):

--- a/tests/rpc_test.py
+++ b/tests/rpc_test.py
@@ -21,6 +21,7 @@ class RpcTest(ConfluxTestFramework):
             "public_rpc_apis": "\"cfx,debug,test,pubsub,trace\"",
             # Disable 1559 for RPC tests temporarily
             "cip1559_transition_height": str(99999999),
+            "cip151_transition_height": str(99999999),
         }
 
     def setup_network(self):

--- a/tests/storage_root_test.py
+++ b/tests/storage_root_test.py
@@ -23,6 +23,8 @@ class StorageRootTest(ConfluxTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.conf_parameters["dev_snapshot_epoch_count"] = str(SNAPSHOT_EPOCH_COUNT)
+        self.conf_parameters["cip151_transition_height"] = str(99999999)
+
 
     def setup_network(self):
         self.add_nodes(self.num_nodes)


### PR DESCRIPTION
This PR addresses an implementation issue of CIP-151, modifying the `SELFDESTRUCT` opcode to preserve its original functionality only when executed in the same transaction as contract creation.

The previous implementation incorrectly used Substate for detecting whether a contract was created in the current transaction. This approach doesn't work because each message call frame's Substate only collects information for that specific frame and can't be aware of other frames' execution results.

This PR fixes the issue by adding a new field to `OverlayAccount` to temporarily record the transaction hash when a contract is created. This properly handles both cases:
- When a contract is still being created (code field not yet written)
- When a contract has already been created within the same transaction

----
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3095)
<!-- Reviewable:end -->
