### PR TITLE
chore: remove check_fmt_and_clippy and check_unit_tests from test.sh

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,9 +91,38 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-build-workspace-release-
 
-
       - name: Setup Docker
         uses: ./.github/actions/setup-docker
+
+      - name: Run build documentation
+        run: |
+          docker run --rm \
+            -v $(pwd):/app \
+            -v ~/.cargo/registry:/root/.cargo/registry \
+            -v ~/.cargo/git:/root/.cargo/git \
+            -e RUST_BACKTRACE=1 \
+            -w /app base-builder:latest \
+            bash -c "cargo doc --document-private-items"
+
+      - name: Run build test
+        run: |
+          docker run --rm \
+            -v $(pwd):/app \
+            -v ~/.cargo/registry:/root/.cargo/registry \
+            -v ~/.cargo/git:/root/.cargo/git \
+            -e RUST_BACKTRACE=1 \
+            -w /app base-builder:latest \
+            bash -c "cargo test --release --all --no-run"
+
+      - name: Run build bench
+        run: |
+          docker run --rm \
+            -v $(pwd):/app \
+            -v ~/.cargo/registry:/root/.cargo/registry \
+            -v ~/.cargo/git:/root/.cargo/git \
+            -e RUST_BACKTRACE=1 \
+            -w /app base-builder:latest \
+            bash -c "cargo bench --all --no-run"
 
       - name: Run workspace tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,16 +94,6 @@ jobs:
       - name: Setup Docker
         uses: ./.github/actions/setup-docker
 
-      - name: Run build documentation
-        run: |
-          docker run --rm \
-            -v $(pwd):/app \
-            -v ~/.cargo/registry:/root/.cargo/registry \
-            -v ~/.cargo/git:/root/.cargo/git \
-            -e RUST_BACKTRACE=1 \
-            -w /app base-builder:latest \
-            bash -c "cargo doc --document-private-items"
-
       - name: Run build test
         run: |
           docker run --rm \
@@ -177,6 +167,32 @@ jobs:
             -e RUST_BACKTRACE=1 \
             -w /app base-builder:latest \
             cargo nextest run --no-fail-fast -p cfx-addr --no-default-features
+
+      - name: Ensure cache files are accessible
+        run: |
+          sudo chown -R $(id -u):$(id -g) target/debug 
+          sudo chown -R $(id -u):$(id -g) ~/.cargo
+
+  build-documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Cargo Cache
+        uses: ./.github/actions/setup-cargo-cache
+
+      - name: Setup Docker
+        uses: ./.github/actions/setup-docker
+
+      - name: Run build documentation
+        run: |
+          docker run --rm \
+            -v $(pwd):/app \
+            -v ~/.cargo/registry:/root/.cargo/registry \
+            -v ~/.cargo/git:/root/.cargo/git \
+            -e RUST_BACKTRACE=1 \
+            -w /app base-builder:latest \
+            bash -c "cargo doc --document-private-items"
 
       - name: Ensure cache files are accessible
         run: |

--- a/dev-support/test.sh
+++ b/dev-support/test.sh
@@ -43,46 +43,6 @@ function check_build {
     inner_result=($exit_code "$result")
 }
 
-function check_fmt_and_clippy {
-    local -n inner_result=$1
-
-    pushd $ROOT_DIR > /dev/null
-    local result
-    SAVED_RUSTFLAGS=$RUSTFLAGS
-    SAVED_CARGO_DIR=$CARGO_TARGET_DIR
-    export RUSTFLAGS="-g"
-    export CARGO_TARGET_DIR="$ROOT_DIR/build_clippy"
-    result=$(
-        ./cargo_fmt.sh --install && ./cargo_fmt.sh -- --check && cargo clippy --release --all -- -A warnings | tee /dev/stderr
-    )
-    export RUSTFLAGS=$SAVED_RUSTFLAGS
-    export CARGO_TARGET_DIR=$SAVED_CARGO_DIR
-    local exit_code=$?
-    popd > /dev/null
-
-    if [[ $exit_code -ne 0 ]]; then
-        result="fmt and clippy tests failed."$'\n'"$result"
-    fi
-    inner_result=($exit_code "$result")
-}
-
-function check_unit_tests {
-    local -n inner_result=$1
-
-    pushd $ROOT_DIR > /dev/null
-    local result
-    result=$(
-       cargo test --release --all && cargo test -p cfx-addr --no-default-features | tee /dev/stderr
-    )
-    local exit_code=$?
-    popd > /dev/null
-
-    if [[ $exit_code -ne 0 ]]; then
-        result="Unit tests failed."$'\n'"$result"
-    fi
-    inner_result=($exit_code "$result")
-}
-
 function check_integration_tests {
     local -n inner_result=$1
 
@@ -140,10 +100,6 @@ mkdir -p $ROOT_DIR/build
 
 # Build
 declare -a test_result; check_build test_result; save_test_result test_result $CHECK_BUILD
-# fmt and clippy tests
-declare -a test_result; check_fmt_and_clippy test_result; save_test_result test_result $CHECK_CLIPPY
-# Unit tests
-declare -a test_result; check_unit_tests test_result; save_test_result test_result $CHECK_UNIT_TEST
 # Integration test
 declare -a test_result; check_integration_tests test_result; save_test_result test_result $CHECK_INT_TEST
 # Pytest

--- a/dev-support/test.sh
+++ b/dev-support/test.sh
@@ -14,10 +14,8 @@ export CARGO_TARGET_DIR=$ROOT_DIR/build
 export RUSTFLAGS="-g -D warnings"
 
 CHECK_BUILD=1
-CHECK_CLIPPY=2
-CHECK_UNIT_TEST=3
-CHECK_INT_TEST=4
-CHECK_PY_TEST=5
+CHECK_INT_TEST=2
+CHECK_PY_TEST=3
 
 function check_build {
     local -n inner_result=$1
@@ -28,7 +26,7 @@ function check_build {
     local result
 
     result=$(
-        cargo build --release && cargo doc --document-private-items && cargo test --release --all --no-run && cargo bench --all --no-run && ./dev-support/check-crates.sh | tee /dev/stderr
+        cargo build --release| tee /dev/stderr
     )
 
     local exit_code=$?


### PR DESCRIPTION
1. Removed the check_fmt_and_clippy and check_unit_tests functions from test.sh, as they have been migrated to GitHub Actions workflows
2. Split the check_build from test.sh into separate steps and jobs in the GitHub Actions workflow:
    1. Step 1: Run build test
        Move the command cargo test --release --all --no-run into a step named "Run build test".
    2. Step 2: Run build bench
        Move the command cargo bench --all --no-run into a separate step named "Run build bench".
    3. Job: build-documentation
       Place the command cargo doc --document-private-items in a dedicated job named "build-documentation".


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3119)
<!-- Reviewable:end -->
