### PR TITLE
chore: fixed runner version to 24.04 add env to cmake

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ jobs:
   deploy:
     permissions:
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
   
@@ -22,8 +22,11 @@ jobs:
         uses: ./.github/actions/install-dependencies
 
       - name: Generate documentation
+        env:
+          CMAKE_POLICY_VERSION_MINIMUM: 3.5
+          RUSTDOCFLAGS: '--enable-index-page -Z unstable-options'
         run: |
-          rustup default nightly-2024-02-04 && RUSTDOCFLAGS='--enable-index-page -Z unstable-options' cargo +nightly-2024-02-04 doc --no-deps
+          rustup default nightly-2024-02-04 && cargo +nightly-2024-02-04 doc --no-deps
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   check-crates:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -56,7 +56,7 @@ jobs:
           ./dev-support/check-crates.sh
 
   workspace-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Free up space
@@ -97,7 +97,7 @@ jobs:
           cargo nextest run --no-fail-fast --release --workspace
 
   cfx-addr-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Free up space
@@ -131,7 +131,7 @@ jobs:
           cargo nextest run --no-fail-fast -p cfx-addr --no-default-features
 
   build-documentation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -142,5 +142,7 @@ jobs:
         uses: ./.github/actions/install-dependencies
 
       - name: Run build documentation
+        env:
+          CMAKE_POLICY_VERSION_MINIMUM: 3.5
         run: |
           cargo doc --document-private-items


### PR DESCRIPTION
1. Fixed the github action runner version to 24.01
2. Added CMAKE_POLICY_VERSION_MINIMUM： 3.5 to the environment to resolve  doc build error

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3132)
<!-- Reviewable:end -->
