### PR TITLE
chore: remove redundant backticks

### DIFF
--- a/crates/cfxcore/core/src/consensus/pivot_hint/mod.rs
+++ b/crates/cfxcore/core/src/consensus/pivot_hint/mod.rs
@@ -19,7 +19,7 @@
 //! * `page_interval`: Number of consecutive blocks in each page
 //! * Each page contains:
 //!   - Major section: Full hashes for blocks every `major_interval` heights
-//!   - Minor section: Hash prefixes (in length of `minor_hash_length``) for
+//!   - Minor section: Hash prefixes (in length of `minor_hash_length`) for
 //!     blocks every `minor_interval` heights
 //!
 //! # Parameter Constraints

--- a/crates/util/hibitset/src/util.rs
+++ b/crates/util/hibitset/src/util.rs
@@ -57,7 +57,7 @@ pub fn offsets(bit: Index) -> (usize, usize, usize) {
 /// Returns `None` if the `usize` has only one or zero set bits.
 ///
 /// # Examples
-/// ````rust,ignore
+/// ```rust,ignore
 /// use hibitset::util::average_ones;
 ///
 /// assert_eq!(Some(4), average_ones(0b10110));


### PR DESCRIPTION
remove redundant backticks

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3153)
<!-- Reviewable:end -->
