### PR TITLE
ci: bump Rust version to fix doc build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
           CMAKE_POLICY_VERSION_MINIMUM: 3.5
           RUSTDOCFLAGS: '--enable-index-page -Z unstable-options'
         run: |
-          rustup default nightly-2024-02-04 && cargo +nightly-2024-02-04 doc --no-deps
+          rustup default nightly-2024-04-22 && cargo +nightly-2024-04-22 doc --no-deps
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
The update to the serde version in https://github.com/Conflux-Chain/conflux-rust/pull/3151  caused the document build to fail.

This PR update the Rust version used for document build to fix doc build.

see: `https://github.com/serde-rs/serde/issues/2770#issuecomment-2245991505`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3162)
<!-- Reviewable:end -->
