### PR TITLE
Implement EIP-7623: Increase calldata cost

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   push:
-    branches: [master]
+    branches: [master, eoa_code_dev]
     paths-ignore:
       - "*.md"
       - "*.json"
@@ -13,7 +13,7 @@ on:
       - "cargo_fmt.sh"
       - "CODEOWNERS"
   pull_request:
-    branches: [master]
+    branches: [master, eoa_code_dev]
     paths-ignore:
       - "*.md"
       - "*.json"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [master]
+    branches: [master, eoa_code_dev]
     paths-ignore:
       - "*.md"
       - "*.json"
@@ -13,7 +13,7 @@ on:
       - "cargo_fmt.sh"
       - "CODEOWNERS"
   pull_request:
-    branches: [master]
+    branches: [master, eoa_code_dev]
     paths-ignore:
       - "*.md"
       - "*.json"

--- a/crates/cfxcore/execute-helper/src/estimation.rs
+++ b/crates/cfxcore/execute-helper/src/estimation.rs
@@ -402,10 +402,18 @@ impl<'a> EstimationContext<'a> {
 
 fn estimated_gas_limit(executed: &Executed, tx: &SignedTransaction) -> U256 {
     let cip130_min_gas_limit = U256::from(tx.data().len() * 100);
+    let eip7623_gas_limit = 21000
+        + tx.data()
+            .iter()
+            .map(|&x| if x == 0 { 10 } else { 40 })
+            .sum::<u64>();
     let estimated =
         executed.ext_result.get::<GasLimitEstimation>().unwrap() * 7 / 6
             + executed.base_gas;
-    U256::max(estimated, cip130_min_gas_limit)
+    U256::max(
+        eip7623_gas_limit.into(),
+        U256::max(estimated, cip130_min_gas_limit),
+    )
 }
 
 fn storage_limit(executed: &Executed) -> u64 {

--- a/crates/cfxcore/executor/src/builtin/bls12_381/pairing.rs
+++ b/crates/cfxcore/executor/src/builtin/bls12_381/pairing.rs
@@ -122,7 +122,7 @@ impl Pricer for PairingPricer {
 
 pub fn pairing_gas() -> impl Pricer {
     PairingPricer {
-        base: PAIRING_PAIRING_MULTIPLIER_BASE,
-        item_price: PAIRING_PAIRING_OFFSET_BASE,
+        base: PAIRING_PAIRING_OFFSET_BASE,
+        item_price: PAIRING_PAIRING_MULTIPLIER_BASE,
     }
 }

--- a/crates/cfxcore/executor/src/executive/fresh_executive.rs
+++ b/crates/cfxcore/executor/src/executive/fresh_executive.rs
@@ -36,7 +36,8 @@ pub struct FreshExecutive<'a, O: ExecutiveObserver> {
 pub(super) struct CostInfo {
     /// Sender balance
     pub sender_balance: U512,
-    /// The intrinsic gas (21000/53000 + tx data gas + access list gas + authorization list gas)
+    /// The intrinsic gas (21000/53000 + tx data gas + access list gas +
+    /// authorization list gas)
     pub base_gas: u64,
     /// The floor gas from EIP-7623
     pub floor_gas: u64,

--- a/crates/cfxcore/executor/src/executive/pre_checked_executive.rs
+++ b/crates/cfxcore/executor/src/executive/pre_checked_executive.rs
@@ -545,7 +545,7 @@ impl<'a, O: ExecutiveObserver> PreCheckedExecutive<'a, O> {
             let gas_charged = tx.gas() - gas_refunded;
             (gas_charged, gas_refunded)
         } else {
-            (gas_used, tx.gas() - gas_left)
+            (gas_used, tx.gas() - gas_used)
         };
 
         let fees_value = gas_charged.saturating_mul(cost.gas_price);

--- a/crates/cfxcore/executor/src/executive/pre_checked_executive.rs
+++ b/crates/cfxcore/executor/src/executive/pre_checked_executive.rs
@@ -532,6 +532,10 @@ impl<'a, O: ExecutiveObserver> PreCheckedExecutive<'a, O> {
             );
         }
 
+        if gas_used < cost.floor_gas.into() {
+            gas_used = cost.floor_gas.into()
+        }
+
         // gas_left should be smaller than 1/4 of gas_limit, otherwise
         // 3/4 of gas_limit is charged.
         let charge_all =
@@ -541,7 +545,7 @@ impl<'a, O: ExecutiveObserver> PreCheckedExecutive<'a, O> {
             let gas_charged = tx.gas() - gas_refunded;
             (gas_charged, gas_refunded)
         } else {
-            (gas_used, gas_left)
+            (gas_used, tx.gas() - gas_left)
         };
 
         let fees_value = gas_charged.saturating_mul(cost.gas_price);

--- a/crates/cfxcore/executor/src/executive/tests.rs
+++ b/crates/cfxcore/executor/src/executive/tests.rs
@@ -1192,7 +1192,7 @@ fn test_commission_privilege() {
             .into_success_executed()
             .unwrap();
 
-    assert_eq!(gas_used, U256::from(52_332));
+    assert_eq!(gas_used, U256::from(55_232));
     assert_eq!(state.nonce(&sender_with_space).unwrap(), U256::from(1));
     assert_eq!(state.balance(&address).unwrap(), U256::from(1_000_000));
     assert_eq!(
@@ -1293,7 +1293,7 @@ fn test_commission_privilege() {
             .into_success_executed()
             .unwrap();
 
-    assert_eq!(gas_used, U256::from(52_332));
+    assert_eq!(gas_used, U256::from(55_232));
     assert_eq!(
         state.nonce(&caller3.address().with_native_space()).unwrap(),
         U256::from(1)
@@ -1340,7 +1340,7 @@ fn test_commission_privilege() {
             .into_success_executed()
             .unwrap();
 
-    assert_eq!(gas_used, U256::from(52_332));
+    assert_eq!(gas_used, U256::from(55_232));
     assert_eq!(
         state.nonce(&caller1.address().with_native_space()).unwrap(),
         U256::from(1)
@@ -1385,7 +1385,7 @@ fn test_commission_privilege() {
             .into_success_executed()
             .unwrap();
 
-    assert_eq!(gas_used, U256::from(52_332));
+    assert_eq!(gas_used, U256::from(55_232));
     assert_eq!(
         state.nonce(&caller2.address().with_native_space()).unwrap(),
         U256::from(1)
@@ -1444,7 +1444,7 @@ fn test_commission_privilege() {
             .into_success_executed()
             .unwrap();
 
-    assert_eq!(gas_used, U256::from(52_332));
+    assert_eq!(gas_used, U256::from(55_232));
     assert_eq!(
         state.nonce(&caller2.address().with_native_space()).unwrap(),
         U256::from(2)
@@ -1501,7 +1501,7 @@ fn test_commission_privilege() {
             .into_success_executed()
             .unwrap();
 
-    assert_eq!(gas_used, U256::from(52_332));
+    assert_eq!(gas_used, U256::from(55_232));
     assert_eq!(
         state.nonce(&caller3.address().with_native_space()).unwrap(),
         U256::from(2)

--- a/crates/cfxcore/executor/src/executive/tests.rs
+++ b/crates/cfxcore/executor/src/executive/tests.rs
@@ -47,8 +47,7 @@ fn make_byzantium_machine(max_depth: usize) -> Machine {
         params,
         VmFactory::new(1024 * 32),
     );
-    machine
-        .set_spec_creation_rules(Box::new(move |s, _| s.max_depth = max_depth));
+    machine.set_max_depth(max_depth);
     machine
 }
 

--- a/crates/cfxcore/executor/src/internal_contract/impls/cross_space.rs
+++ b/crates/cfxcore/executor/src/internal_contract/impls/cross_space.rs
@@ -37,7 +37,7 @@ pub fn create_gas(context: &InternalRefContext, code: &[u8]) -> DbResult<U256> {
         code,
         None,
         0,
-        context.spec,
+        &context.spec.to_consensus_spec(),
     ) + context.spec.tx_gas as u64;
 
     let create_gas = U256::from(context.spec.create_gas);
@@ -77,7 +77,7 @@ pub fn call_gas(
         data,
         None,
         0,
-        context.spec,
+        &context.spec.to_consensus_spec(),
     ) + context.spec.tx_gas as u64;
 
     let new_account = !context

--- a/crates/cfxcore/executor/src/spec.rs
+++ b/crates/cfxcore/executor/src/spec.rs
@@ -18,7 +18,7 @@ use cfx_parameters::{
     },
 };
 use cfx_types::{AllChainID, Space, SpaceMap, U256, U512};
-use cfx_vm_types::Spec;
+use cfx_vm_types::{ConsensusGasSpec, Spec};
 use primitives::{block::BlockHeight, BlockNumber};
 use std::collections::BTreeMap;
 
@@ -147,10 +147,15 @@ pub struct TransitionsEpochHeight {
     pub cip154: BlockHeight,
     /// CIP-7702: Set Code for EOA
     pub cip7702: BlockHeight,
+    /// CIP-645: Align Conflux Gas Pricing with EVM
     pub cip645: BlockHeight,
     pub align_evm: BlockHeight,
+    /// EIP-2935: Serve historical block hashes from state
     pub eip2935: BlockHeight,
+    /// EIP-2537: Precompile for BLS12-381 curve operations
     pub eip2537: BlockHeight,
+    /// EIP-7623: Increase calldata cost
+    pub eip7623: BlockHeight,
     pub cip_c2_fix: BlockHeight,
 }
 
@@ -217,8 +222,21 @@ impl CommonParams {
         spec.cip7702 = height >= self.transition_heights.cip7702;
         spec.cip645 = height >= self.transition_heights.cip645;
         spec.eip2935 = height >= self.transition_heights.eip2935;
+        spec.eip7623 = height >= self.transition_heights.eip7623;
         spec.cip_c2_fix = number >= self.transition_heights.cip_c2_fix;
         spec.cancun_opcodes = number >= self.transition_numbers.cancun_opcodes;
+        spec.align_evm =
+            height >= self.transition_heights.align_evm && spec.cip645;
+
+        spec.overwrite_gas_plan_by_cip();
+
+        spec
+    }
+
+    pub fn consensus_spec(&self, height: BlockHeight) -> ConsensusGasSpec {
+        let mut spec = ConsensusGasSpec::genesis_spec();
+        spec.cip1559 = height >= self.transition_heights.cip1559;
+        spec.cip645 = height >= self.transition_heights.cip645;
         spec.align_evm =
             height >= self.transition_heights.align_evm && spec.cip645;
 

--- a/crates/cfxcore/vm-interpreter/src/interpreter/gasometer.rs
+++ b/crates/cfxcore/vm-interpreter/src/interpreter/gasometer.rs
@@ -591,7 +591,7 @@ fn calc_sstore_gas<Gas: CostType>(
         0
     };
 
-    let not_write_db_refund_gas = if ori_val == new_val {
+    let not_write_db_refund_gas = if ori_val == new_val && !is_clean {
         if ori_val.is_zero() && space == Space::Ethereum {
             // charge storage write gas + storage occupation gas
             spec.sstore_set_gas * spec.evm_gas_ratio

--- a/crates/cfxcore/vm-types/src/lib.rs
+++ b/crates/cfxcore/vm-types/src/lib.rs
@@ -31,7 +31,8 @@ pub use self::{
     interpreter_info::InterpreterInfo,
     return_data::{GasLeft, ReturnData},
     spec::{
-        extract_7702_payload, CleanDustMode, Spec, WasmCosts, CODE_PREFIX_7702,
+        extract_7702_payload, CleanDustMode, ConsensusGasSpec, Spec,
+        CODE_PREFIX_7702,
     },
 };
 

--- a/crates/cfxcore/vm-types/src/tests.rs
+++ b/crates/cfxcore/vm-types/src/tests.rs
@@ -101,12 +101,6 @@ impl MockContext {
         context
     }
 
-    /// Alter mock context to allow wasm
-    pub fn with_wasm(mut self) -> Self {
-        self.spec.wasm = Some(Default::default());
-        self
-    }
-
     pub fn with_chain_id(mut self, chain_id: u64) -> Self {
         self.chain_id = chain_id;
         self

--- a/crates/client/src/configuration.rs
+++ b/crates/client/src/configuration.rs
@@ -1506,7 +1506,7 @@ impl Configuration {
         //
         set_conf!(
             self.raw_conf.eoa_code_transition_height.unwrap_or(default_transition_time);
-            params.transition_heights => { cip150, cip151, cip152, cip154, cip7702, cip645, eip2537, eip2935 }
+            params.transition_heights => { cip150, cip151, cip152, cip154, cip7702, cip645, eip2537, eip2935, eip7623 }
         );
         if let Some(x) = self.raw_conf.cip151_transition_height {
             params.transition_heights.cip151 = x;

--- a/tests/rpc/test_send_tx.py
+++ b/tests/rpc/test_send_tx.py
@@ -32,7 +32,7 @@ class TestSendTx(RpcClient):
 
     def test_address_prefix(self):
         # call builtin address starts with 0x0
-        tx = self.new_tx(receiver="0x0000000000000000000000000000000000000002", data=b'\x00' * 32, gas=21128)
+        tx = self.new_tx(receiver="0x0000000000000000000000000000000000000002", data=b'\x00' * 32, gas=21320)
         assert_equal(self.send_tx(tx, True), tx.hash_hex())
         # non-builtin address starts with 0x0
         tx = self.new_tx(receiver="0x00e45681ac6c53d5a40475f7526bac1fe7590fb8")


### PR DESCRIPTION
This PR implements [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623), aligns gas calculation processes with Ethereum, and fixes several bugs.

1. **Added `ConsensusGasSpec`**  
   Introduced `ConsensusGasSpec`, which contains logic that depends only on the accessible `block height` during consensus. This resolves prior limitations where `Spec` was inaccessible during consensus due to its reliance on `block number`.

2. **Implemented EIP-7623**  
   Added the main logic for EIP-7623, redefining the calculation of the minimum gas limit for transactions to match Ethereum behavior.

3. **Fixed `SSTORE` Gas Calculation Bug**  

4. **Fixed `bls12-381` Gas Calculation Bug**

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3165)
<!-- Reviewable:end -->
