### PR TITLE
Fix EIP-2929 Warm/Cold State Handling During Reverts

### DIFF
--- a/crates/cfxcore/executor/src/state/overlay_account/account_entry.rs
+++ b/crates/cfxcore/executor/src/state/overlay_account/account_entry.rs
@@ -2,7 +2,26 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
+use std::ops::{Deref, DerefMut};
+
 use super::OverlayAccount;
+
+#[derive(Debug)]
+#[cfg_attr(test, derive(Clone))]
+pub struct AccountEntryWithWarm {
+    pub warm: bool,
+    pub entry: AccountEntry,
+}
+
+impl Deref for AccountEntryWithWarm {
+    type Target = AccountEntry;
+
+    fn deref(&self) -> &Self::Target { &self.entry }
+}
+
+impl DerefMut for AccountEntryWithWarm {
+    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.entry }
+}
 
 /// Entry object in cache and checkpoint layers, adding additional markers
 /// like dirty bits to the `OverlayAccount` structure.
@@ -104,5 +123,9 @@ impl AccountEntry {
             DbAbsent => DbAbsent,
             Cached(acc, dirty_bit) => Cached(acc.clone_account(), *dirty_bit),
         }
+    }
+
+    pub fn with_warm(self, warm: bool) -> AccountEntryWithWarm {
+        AccountEntryWithWarm { warm, entry: self }
     }
 }

--- a/crates/cfxcore/executor/src/state/overlay_account/checkpoints.rs
+++ b/crates/cfxcore/executor/src/state/overlay_account/checkpoints.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, fmt::Debug, hash::Hash};
+use std::{
+    collections::{hash_map, HashMap},
+    fmt::Debug,
+    hash::Hash,
+};
 
 use cfx_types::U256;
 use primitives::{storage::WriteCacheItem, StorageValue};
@@ -73,7 +77,19 @@ impl OverlayAccount {
             .write()
             .insert(key.clone(), WriteCacheItem::Write(value));
         unwrap_or_return!(self.storage_write_checkpoint.as_mut())
+            .get_mut()
             .notify_cache_change(key, old_value);
+    }
+
+    pub(super) fn mark_storage_warm(&self, key: &[u8]) {
+        if let hash_map::Entry::Vacant(v) =
+            self.storage_write_cache.write().entry(key.to_vec())
+        {
+            v.insert(WriteCacheItem::Read);
+            unwrap_or_return!(self.storage_write_checkpoint.as_ref())
+                .write()
+                .notify_cache_change(key.to_vec(), None);
+        }
     }
 
     pub(super) fn insert_transient_write_cache(
@@ -94,7 +110,7 @@ impl OverlayAccount {
 
     pub fn revert_checkpoint(&mut self, state_checkpoint_id: usize) {
         if let Some(ct) = self.storage_write_checkpoint.take() {
-            ct.revert_checkpoint(
+            ct.into_inner().revert_checkpoint(
                 state_checkpoint_id,
                 &mut self.storage_write_cache.write(),
             )

--- a/crates/cfxcore/executor/src/state/overlay_account/factory.rs
+++ b/crates/cfxcore/executor/src/state/overlay_account/factory.rs
@@ -152,8 +152,8 @@ impl OverlayAccount {
             is_newly_created_contract: self.is_newly_created_contract,
             pending_db_clear: self.pending_db_clear,
             storage_write_cache: self.storage_write_cache.clone(),
-            storage_write_checkpoint: Some(WriteCheckpointLayer::new_empty(
-                checkpoint_id,
+            storage_write_checkpoint: Some(RwLock::new(
+                WriteCheckpointLayer::new_empty(checkpoint_id),
             )),
             storage_committed_cache: self.storage_committed_cache.clone(),
             storage_read_cache: self.storage_read_cache.clone(),

--- a/crates/cfxcore/executor/src/state/overlay_account/mod.rs
+++ b/crates/cfxcore/executor/src/state/overlay_account/mod.rs
@@ -50,7 +50,7 @@ mod state_override;
 #[cfg(test)]
 mod tests;
 
-pub use account_entry::AccountEntry;
+pub use account_entry::{AccountEntry, AccountEntryWithWarm};
 pub use ext_fields::RequireFields;
 
 use crate::substate::Substate;
@@ -71,7 +71,6 @@ use cfx_types::AddressSpaceUtil;
 use self::checkpoints::WriteCheckpointLayer;
 
 #[derive(Debug)]
-#[cfg_attr(test, derive(Clone))]
 /// The access and manipulation object during execution, which includes both
 /// database-stored information and in-execution data of an account. It is a
 /// basic unit of state caching map and the checkpoint layers (more
@@ -145,7 +144,7 @@ pub struct OverlayAccount {
     /// changed values.
     storage_write_cache: Arc<RwLock<HashMap<Vec<u8>, WriteCacheItem>>>,
     storage_write_checkpoint:
-        Option<WriteCheckpointLayer<Vec<u8>, WriteCacheItem>>,
+        Option<RwLock<WriteCheckpointLayer<Vec<u8>, WriteCacheItem>>>,
 
     /// Transient storage from CIP-142
     transient_storage_cache: Arc<RwLock<HashMap<Vec<u8>, U256>>>,
@@ -216,6 +215,44 @@ impl OverlayAccount {
 
     #[cfg(test)]
     pub fn is_basic(&self) -> bool { self.code_hash == KECCAK_EMPTY }
+}
+
+#[cfg(test)]
+impl Clone for OverlayAccount {
+    fn clone(&self) -> Self {
+        Self {
+            address: self.address.clone(),
+            balance: self.balance.clone(),
+            nonce: self.nonce.clone(),
+            code_hash: self.code_hash.clone(),
+            staking_balance: self.staking_balance.clone(),
+            collateral_for_storage: self.collateral_for_storage.clone(),
+            accumulated_interest_return: self
+                .accumulated_interest_return
+                .clone(),
+            admin: self.admin.clone(),
+            sponsor_info: self.sponsor_info.clone(),
+            deposit_list: self.deposit_list.clone(),
+            vote_stake_list: self.vote_stake_list.clone(),
+            code: self.code.clone(),
+            storage_layout_change: self.storage_layout_change.clone(),
+            storage_read_cache: self.storage_read_cache.clone(),
+            storage_committed_cache: self.storage_committed_cache.clone(),
+            storage_write_cache: self.storage_write_cache.clone(),
+            storage_write_checkpoint: self
+                .storage_write_checkpoint
+                .as_ref()
+                .map(|x| RwLock::new(x.read().clone())),
+            transient_storage_cache: self.transient_storage_cache.clone(),
+            transient_storage_checkpoint: self
+                .transient_storage_checkpoint
+                .clone(),
+            is_newly_created_contract: self.is_newly_created_contract.clone(),
+            pending_db_clear: self.pending_db_clear.clone(),
+            storage_overrided: self.storage_overrided.clone(),
+            create_transaction_hash: self.create_transaction_hash.clone(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/cfxcore/executor/src/state/state_object/checkpoints.rs
+++ b/crates/cfxcore/executor/src/state/state_object/checkpoints.rs
@@ -6,11 +6,11 @@ use std::collections::{hash_map::Entry::*, HashMap};
 
 use super::{
     super::checkpoints::CheckpointEntry::{self, Recorded, Unchanged},
-    AccountEntry, GlobalStat, OverlayAccount, State,
+    AccountEntry, AccountEntryWithWarm, GlobalStat, OverlayAccount, State,
 };
 use crate::{state::checkpoints::CheckpointLayerTrait, unwrap_or_return};
 
-pub(super) type AccountCheckpointEntry = CheckpointEntry<AccountEntry>;
+pub(super) type AccountCheckpointEntry = CheckpointEntry<AccountEntryWithWarm>;
 
 /// Represents a recoverable point within a checkpoint. including
 /// and. The addition of account entries to the checkpoint is lazy; they are
@@ -33,7 +33,7 @@ pub(super) struct CheckpointLayer {
 
 impl CheckpointLayerTrait for CheckpointLayer {
     type Key = AddressWithSpace;
-    type Value = AccountEntry;
+    type Value = AccountEntryWithWarm;
 
     fn as_hash_map(&self) -> &HashMap<Self::Key, CheckpointEntry<Self::Value>> {
         &self.entries
@@ -68,7 +68,7 @@ impl State {
         // all discard all checkpoints
         for addr in cleared_addresses {
             if let Some(AccountEntry::Cached(ref mut overlay_account, true)) =
-                self.cache.get_mut().get_mut(&addr)
+                self.cache.get_mut().get_mut(&addr).map(|x| &mut x.entry)
             {
                 overlay_account.clear_checkpoint();
             }
@@ -98,7 +98,7 @@ impl State {
         let old_account_entry = self
             .cache
             .get_mut()
-            .insert(address, AccountEntry::new_dirty(account));
+            .insert(address, AccountEntry::new_dirty(account).with_warm(true));
 
         self.checkpoints
             .get_mut()
@@ -111,20 +111,26 @@ impl State {
     /// this function to incoroprates the old version to the checkpoint in
     /// needed.
     pub(super) fn copy_cache_entry_to_checkpoint(
-        &self, address: AddressWithSpace, entry_in_cache: &mut AccountEntry,
+        &self, address: AddressWithSpace,
+        entry_in_cache: &mut AccountEntryWithWarm,
     ) {
         self.checkpoints
             .write()
             .insert_element(address, |checkpoint_id| {
                 let mut new_entry_in_cache = entry_in_cache
-                    .clone_cache_entry_for_checkpoint(checkpoint_id);
+                    .entry
+                    .clone_cache_entry_for_checkpoint(checkpoint_id)
+                    .with_warm(true);
 
                 std::mem::swap(&mut new_entry_in_cache, entry_in_cache);
                 // Rename after memswap
-                let old_entry_in_cache = new_entry_in_cache;
+                let entry_to_checkpoint = new_entry_in_cache;
 
-                Recorded(old_entry_in_cache)
+                Recorded(entry_to_checkpoint)
             });
+        // If there is no checkpoint, the above function will not be executed,
+        // so we need to mark warm bit here.
+        entry_in_cache.warm = true;
     }
 
     #[cfg(any(test, feature = "testonly_code"))]
@@ -138,7 +144,8 @@ impl State {
 
 fn apply_checkpoint_layer_to_cache(
     entries: HashMap<AddressWithSpace, AccountCheckpointEntry>,
-    cache: &mut HashMap<AddressWithSpace, AccountEntry>, checkpoint_id: usize,
+    cache: &mut HashMap<AddressWithSpace, AccountEntryWithWarm>,
+    checkpoint_id: usize,
 ) {
     for (k, v) in entries.into_iter() {
         let mut entry_in_cache = if let Occupied(e) = cache.entry(k) {
@@ -157,8 +164,7 @@ fn apply_checkpoint_layer_to_cache(
         };
         match v {
             Recorded(entry_in_checkpoint) => {
-                if let Some(acc) = entry_in_cache.get_mut().dirty_account_mut()
-                {
+                if let Some(acc) = entry_in_cache.get_mut().account_mut() {
                     acc.revert_checkpoint(checkpoint_id);
                 }
                 *entry_in_cache.get_mut() = entry_in_checkpoint;

--- a/crates/cfxcore/executor/src/state/state_object/checkpoints.rs
+++ b/crates/cfxcore/executor/src/state/state_object/checkpoints.rs
@@ -67,7 +67,7 @@ impl State {
         // cleared directly, thus, the accounts in state's cache should
         // all discard all checkpoints
         for addr in cleared_addresses {
-            if let Some(AccountEntry::Cached(ref mut overlay_account, true)) =
+            if let Some(AccountEntry::Cached(ref mut overlay_account, _dirty)) =
                 self.cache.get_mut().get_mut(&addr).map(|x| &mut x.entry)
             {
                 overlay_account.clear_checkpoint();

--- a/crates/cfxcore/executor/src/state/state_object/commit.rs
+++ b/crates/cfxcore/executor/src/state/state_object/commit.rs
@@ -126,10 +126,10 @@ impl State {
     pub fn commit_cache(&mut self, retain_transient_storage: bool) {
         assert!(self.no_checkpoint());
         for (addr, mut account) in self.cache.get_mut().drain() {
-            if let AccountEntry::Cached(ref mut acc, dirty) = account {
+            if let AccountEntry::Cached(ref mut acc, dirty) = account.entry {
                 acc.commit_cache(retain_transient_storage, dirty);
             }
-            self.committed_cache.insert(addr, account);
+            self.committed_cache.insert(addr, account.entry);
         }
     }
 }

--- a/crates/cfxcore/executor/src/state/state_object/state_override.rs
+++ b/crates/cfxcore/executor/src/state/state_object/state_override.rs
@@ -28,11 +28,15 @@ impl State {
             };
 
             let loaded_account = self.db.get_account(&addr_with_space)?;
+            // The override phase's warm bit is not important because it will
+            // soon be written from the cache to the committed cache, which does
+            // not include the warm bit.
             let account_entry = AccountEntry::from_loaded_with_override(
                 &addr_with_space,
                 loaded_account,
                 account,
-            );
+            )
+            .with_warm(false);
 
             cache.insert(addr_with_space, account_entry);
         }

--- a/crates/cfxcore/executor/src/state/state_object/warm.rs
+++ b/crates/cfxcore/executor/src/state/state_object/warm.rs
@@ -15,7 +15,7 @@ impl State {
         {
             return true;
         }
-        self.cache.read().contains_key(address)
+        self.cache.read().get(address).map_or(false, |x| x.warm)
     }
 
     pub fn is_warm_storage_entry(


### PR DESCRIPTION
This PR addresses two related bugs discovered during testing concerning the correct handling of warm/cold account and storage states according to EIP-2929, specifically when transaction execution is reverted via checkpoints.

## Bug 1: Incorrect Account Warm Status Revert

The previous implementation determined if an account was `warm` based solely on its presence in the `cache` of `State`. This approach leads to incorrect state restoration upon revert.

Specifically, when the VM accesses an account not present in the `cache` (cold), the `State` component loads it from the DB, puts its copy into the checkpoint, and places it into the `cache` for modification (making it `warm` according to the old logic). However, if a revert occurs, the account popped from the checkpoint stack and restored to the cache does not explicitly track its original `cold` status. Because the account is still in the `cache`, it is incorrectly considered `warm`, violating EIP-2929's requirement that all side effects, including the transition to `warm`, must be rolled back upon revert.

This PR fixes this by introducing an explicit `warm` bit to both cache entries and checkpoint entries. When an uncached account is accessed, the checkpoint entry pushed reflects its initial `cold` state, while the entry placed in the cache is marked `warm`. During a revert, the `cold` status from the checkpoint is correctly restored.

## Bug 2: Incorrect Storage Slot Warm Status Revert

A similar issue existed for storage entries. The previous logic marked a storage slot as `warm` by writing `StorageEntry::Read` to the `storage_write_cache`. However, this operation was not managed by the checkpoint system. Consequently, upon revert, this marker persisted, leaving the storage slot incorrectly marked as `warm`.

This PR resolves this by integrating the warm/cold status tracking for storage entries into the checkpoint mechanism. This requires modifying the storage entry checkpoint structure. Since read operations on storage slots now need the ability to update the checkpoint (to record the access within the transaction's scope for potential revert), the checkpoint requires internal mutability. Therefore, it has been changed to use an `RwLock`.

### Consequential Change

As a result of the fix for storage entry checkpoints (specifically, allowing read operations to update checkpoints), the logic for maintaining checkpoints must now be executed even for accounts whose `dirty` bit is `false`. This is because read operations on storage slots within an otherwise unmodified account can now trigger necessary checkpoint updates to correctly track warm/cold status changes.

## Other Discussion

### Continued Need for `commit_cache`

The introduction of the `warm` bit for EIP-2929 compliance does not eliminate the need for the existing `commit_cache`. This cache serves a distinct purpose related to EIP-2200, which requires tracking the original value of a storage slot before the transaction begins (for gas calculation). Therefore, the `commit_cache` remains essential for correct EIP-2200 implementation.

### Divergent Logic for Account and Storage Entries

The maintenance logic for account and storage entries, particularly concerning their cold, warm/clean, and warm/dirty states, differs significantly. The current representation in the cache and checkpoints is summarized below:

| State        | Account Entry (Cache)        | Account Entry (Checkpoint)                                     | Storage Entry (Cache) (`storage_write_cache`)       | Storage Entry (Checkpoint)                |
|--------------|------------------------------|----------------------------------------------------------------|-----------------------------|-------------------------------------------|
| **Cold**     | Not present or `warm_bit=false` | Not present, `CheckpointEntry::Unchanged`, or `CheckpointEntry::Changed` with `warm_bit=false` | Absent | `CheckpointEntry::Unchanged`              |
| **Warm/Clean**| `warm_bit=true`, `dirty_bit=false` | `CheckpointEntry::Changed` with `warm_bit=true`, `dirty_bit=false` | `StorageEntry::Read`        | `CheckpointEntry::Changed(StorageEntry::Read)` |
| **Warm/Dirty**| `warm_bit=true`, `dirty_bit=true`  | `CheckpointEntry::Changed` with `warm_bit=true`, `dirty_bit=true`  | `StorageEntry::Write(value)`| `CheckpointEntry::Changed(StorageEntry::Write(value))` |

This divergence arises from two main factors:

1.  **Intrinsic Differences:** The nature of modifications differs. Storage entries are always fully replaced by write operations. In contrast, account entries can undergo partial updates (e.g., modifying only the balance while other fields remain unchanged). This necessitates that account checkpoints often load the complete account state before modification. Thus, storing them directly in the checkpoint, rather than marking them as "Unchanged," becomes a natural choice.


2.  **Historical Implementation for Storage Entry:** The handling of storage entries carries technical debt related to the original implementation of storage collateral. This feature required knowing the storage owner before execution (a need conceptually similar to EIP-2200's requirement for original values). However, it was implemented in a complex way, aiming for minor optimizations that rarely proved effective. Since this code is live on the Conflux mainnet, major refactoring is impractical. Subsequent modifications, including this PR, must build upon this existing, albeit complex, foundation rather than adopting a potentially cleaner, unified approach used for accounts.



--- 

This structure maintains technical specificity while flowing naturally, avoids bulletpoint fatigue through section grouping, and preserves all critical details from the original material.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3168)
<!-- Reviewable:end -->
