### PR TITLE
chore: update crossbeam-channel to fix cargo deny error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,9 +2265,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils 0.8.21",
 ]


### PR DESCRIPTION
relate #3155 

This PR update `crossbeam-channel` to 0.5.15 to fix cargo deny error, see: https://github.com/crossbeam-rs/crossbeam/releases/tag/crossbeam-channel-0.5.15