### PR TITLE
Fixes for EVM Behavior Alignment

### DIFF
--- a/crates/cfxcore/executor/src/builtin/mod.rs
+++ b/crates/cfxcore/executor/src/builtin/mod.rs
@@ -103,10 +103,11 @@ impl ConstPricer {
 }
 
 /// A special pricing model for modular exponentiation.
+#[derive(Debug)]
 pub(crate) enum ModexpPricer {
     Byzantium { divisor: usize },
     // CIP-645e: EIP-2565
-    Berlin,
+    Berlin { base: usize },
 }
 
 impl ModexpPricer {
@@ -114,7 +115,9 @@ impl ModexpPricer {
         ModexpPricer::Byzantium { divisor }
     }
 
-    pub(crate) fn new_berlin() -> ModexpPricer { ModexpPricer::Berlin }
+    pub(crate) fn new_berlin(base: usize) -> ModexpPricer {
+        ModexpPricer::Berlin { base }
+    }
 }
 
 impl Pricer for Linear {
@@ -165,7 +168,15 @@ impl Pricer for ModexpPricer {
         let exp_len = read_len();
         let mod_len = read_len();
 
+        if mod_len.is_zero() && base_len.is_zero() {
+            return match self {
+                Self::Byzantium { .. } => 0.into(),
+                Self::Berlin { base } => (*base).into(),
+            };
+        }
+
         let max_len = U256::from(u32::max_value() / 2);
+
         if base_len > max_len || mod_len > max_len || exp_len > max_len {
             return U256::max_value();
         }
@@ -191,8 +202,8 @@ impl Pricer for ModexpPricer {
             ModexpPricer::Byzantium { divisor } => Self::byzantium_gas_calc(
                 base_len, mod_len, iter_count, *divisor,
             ),
-            ModexpPricer::Berlin => {
-                Self::berlin_gas_calc(base_len, mod_len, iter_count)
+            ModexpPricer::Berlin { base } => {
+                Self::berlin_gas_calc(base_len, mod_len, iter_count, *base)
             }
         }
     }
@@ -203,9 +214,6 @@ impl ModexpPricer {
         base_len: u64, mod_len: u64, iter_count: u64, divisor: usize,
     ) -> U256 {
         let m = max(mod_len, base_len);
-        if m == 0 {
-            return U256::zero();
-        }
         let (gas, overflow) =
             Self::mult_complexity(m).overflowing_mul(iter_count);
         if overflow {
@@ -236,7 +244,7 @@ impl ModexpPricer {
     }
 
     pub fn berlin_gas_calc(
-        base_len: u64, mod_len: u64, iter_count: u64,
+        base_len: u64, mod_len: u64, iter_count: u64, base_gas: usize,
     ) -> U256 {
         fn calculate_multiplication_complexity(
             base_len: u64, mod_len: u64,
@@ -259,7 +267,7 @@ impl ModexpPricer {
         } else {
             gas.as_u64()
         };
-        max(200, gas_u64).into()
+        max(base_gas as u64, gas_u64).into()
     }
 }
 

--- a/crates/cfxcore/executor/src/context.rs
+++ b/crates/cfxcore/executor/src/context.rs
@@ -298,6 +298,9 @@ impl<'a> ContextTrait for Context<'a> {
         };
 
         if conflict_address {
+            if self.spec.cip645 {
+                self.state.inc_nonce(&caller)?;
+            }
             debug!("Contract address conflict!");
             let err = Error::ConflictAddress(address.clone());
             return Ok(Ok(ContractCreateResult::Failed(err)));
@@ -326,7 +329,11 @@ impl<'a> ContextTrait for Context<'a> {
             if !self.spec.keep_unsigned_nonce
                 || params.sender != UNSIGNED_SENDER
             {
-                self.state.inc_nonce(&caller)?;
+                let nonce_overflow = self.state.inc_nonce(&caller)?;
+                if nonce_overflow {
+                    let err = Error::NonceOverflow(caller.address);
+                    return Ok(Ok(ContractCreateResult::Failed(err)));
+                }
             }
         }
 

--- a/crates/cfxcore/executor/src/executive/execution_outcome.rs
+++ b/crates/cfxcore/executor/src/executive/execution_outcome.rs
@@ -90,6 +90,7 @@ pub enum ExecutionError {
         /// Maximum storage limit cost.
         max_storage_limit_cost: U256,
     },
+    NonceOverflow(Address),
     VmError(vm::Error),
 }
 

--- a/crates/cfxcore/executor/src/machine/mod.rs
+++ b/crates/cfxcore/executor/src/machine/mod.rs
@@ -161,7 +161,7 @@ fn new_builtin_map(
     // CIP-645e: EIP-2565
     let mod_exp_pricer = IfPricer::new(
         |spec| spec.cip645,
-        ModexpPricer::new_berlin(),
+        ModexpPricer::new_berlin(200),
         ModexpPricer::new_byzantium(20),
     );
     btree.insert(

--- a/crates/cfxcore/executor/src/state/overlay_account/basic.rs
+++ b/crates/cfxcore/executor/src/state/overlay_account/basic.rs
@@ -14,7 +14,13 @@ impl OverlayAccount {
 
     pub fn set_nonce(&mut self, nonce: &U256) { self.nonce = *nonce; }
 
-    pub fn inc_nonce(&mut self) { self.nonce = self.nonce + U256::from(1u8); }
+    pub fn inc_nonce(&mut self) -> bool {
+        let u64_overflow = self.nonce >= U256::from(u64::MAX);
+        if !u64_overflow {
+            self.nonce = self.nonce + U256::from(1u8);
+        }
+        u64_overflow
+    }
 
     pub fn balance(&self) -> &U256 { &self.balance }
 

--- a/crates/cfxcore/executor/src/state/state_object/basic_fields.rs
+++ b/crates/cfxcore/executor/src/state/state_object/basic_fields.rs
@@ -88,9 +88,8 @@ impl State {
         Ok(*acc.nonce())
     }
 
-    pub fn inc_nonce(&mut self, address: &AddressWithSpace) -> DbResult<()> {
-        self.write_account_or_new_lock(address)?.inc_nonce();
-        Ok(())
+    pub fn inc_nonce(&mut self, address: &AddressWithSpace) -> DbResult<bool> {
+        Ok(self.write_account_or_new_lock(address)?.inc_nonce())
     }
 
     pub fn set_nonce(

--- a/crates/cfxcore/geth-tracer/src/geth_tracer.rs
+++ b/crates/cfxcore/geth-tracer/src/geth_tracer.rs
@@ -458,6 +458,7 @@ pub fn to_instruction_result(frame_result: &FrameResult) -> InstructionResult {
             Error::CreateInitCodeSizeLimit => {
                 InstructionResult::CreateInitCodeSizeLimit
             }
+            Error::NonceOverflow(_) => InstructionResult::NonceOverflow,
         },
     };
     result

--- a/crates/cfxcore/geth-tracer/src/tracing_inspector.rs
+++ b/crates/cfxcore/geth-tracer/src/tracing_inspector.rs
@@ -423,8 +423,11 @@ impl TracingInspector {
                 self.tx_exec_context.block_number,
                 self.tx_exec_context.block_height,
             );
-            let num_pushed =
-                stack_push_count(step.op.get(), spec.cancun_opcodes);
+            let num_pushed = stack_push_count(
+                step.op.get(),
+                spec.cancun_opcodes,
+                spec.cip645,
+            );
             let start = interp.stack().len() - num_pushed;
             let push_stack = interp.stack()[start..].to_vec();
             step.push_stack = Some(

--- a/crates/cfxcore/vm-interpreter/src/interpreter/gasometer.rs
+++ b/crates/cfxcore/vm-interpreter/src/interpreter/gasometer.rs
@@ -594,9 +594,9 @@ fn calc_sstore_gas<Gas: CostType>(
     let not_write_db_refund_gas = if ori_val == new_val && !is_clean {
         if ori_val.is_zero() && space == Space::Ethereum {
             // charge storage write gas + storage occupation gas
-            spec.sstore_set_gas * spec.evm_gas_ratio
+            spec.sstore_set_gas * spec.evm_gas_ratio - spec.warm_access_gas
         } else {
-            spec.sstore_reset_gas
+            spec.sstore_reset_gas - spec.warm_access_gas
         }
     } else {
         0

--- a/crates/cfxcore/vm-types/src/error.rs
+++ b/crates/cfxcore/vm-types/src/error.rs
@@ -122,6 +122,8 @@ pub enum Error {
     InvalidAddress(Address),
     /// Create a contract on an address with existing contract
     ConflictAddress(Address),
+    /// Create a contract on an address with existing contract
+    NonceOverflow(Address),
     /// CIP-150: Reject new contract code starting with the 0xEF byte
     CreateContractStartingWithEF,
 }
@@ -202,6 +204,9 @@ impl fmt::Display for Error {
             InvalidAddress(ref addr) => write!(f, "InvalidAddress: {}", addr),
             ConflictAddress(ref addr) => {
                 write!(f, "Contract creation on an existing address: {}", addr)
+            }
+            NonceOverflow(ref addr) => {
+                write!(f, "Address nonce overflow: {}", addr)
             }
             CreateContractStartingWithEF => {
                 write!(f, "Create contract starting with EF")

--- a/crates/rpc/rpc-eth-impl/src/eth.rs
+++ b/crates/rpc/rpc-eth-impl/src/eth.rs
@@ -241,6 +241,15 @@ impl EthApi {
                 ))
             }
             ExecutionOutcome::ExecutionErrorBumpNonce(
+                ExecutionError::NonceOverflow(addr),
+                _executed,
+            ) => {
+                bail!(geth_call_execution_error(
+                    format!("address nonce overflow: {})", addr),
+                    "".into()
+                ))
+            }
+            ExecutionOutcome::ExecutionErrorBumpNonce(
                 ExecutionError::VmError(VmError::Reverted),
                 executed,
             ) => bail!(geth_call_execution_error(


### PR DESCRIPTION
This PR resolves several issues identified during the EVM behavior alignment tests, ensuring consistency between Conflux's implementation and Ethereum standards.

### 1. Nonce Overflow Handling
Conflux defines the account nonce as 256 bits, whereas Ethereum uses 64 bits. To address this discrepancy, this PR introduces a 64-bit overflow check without altering Conflux's core implementation. With the new check, EVM (including Core Space) prevents any account from exceeding the 64-bit limit (except via cross-space call).  
While this adjustment is academic for now—reaching a 64-bit overflow would require over 9,000 years under maximum load (60 Mgas / second), even with `inc nonce` consuming just 1 gas—it ensures compatibility and avoids potential edge-case issues.

### 2. Gas Pricing Fixes
This PR corrects several errors in gas cost calculations for specific opcodes and operations:  
   - **MCOPY and BASEFEE:** The gas pricing for these operations has been aligned with the expected behavior.  
   - **SSTORE:** Addressed incorrect gas calculations in edge-case scenarios.  
  

### 3. Support for EIP-4844 Opcodes
The EIP-4844-related opcodes, `BLOBHASH` and `BLOBBASEFEE`, have now been implemented. They no longer produce invalid code errors but instead return consistent "zero" results:  
   - `BLOBHASH`: Outputs an all-zero hash.  
   - `BLOBBASEFEE`: Yields a fee of zero.  


### 4. Create2 Nonce Adjustment
In scenarios where `CREATE2` fails due to address conflict, this PR ensures that the sender's nonce is incremented. Previously, failed `CREATE2` operations did not increase the nonce.


### 5. Block Author Warm Address Update
For testing purposes, the block author's address in `eSpace`  has been marked as "warm" in the gas metering system. However, this change only applies in test settings and will not affect mainnet behavior. On the main network, block authors are part of Core Space, so this adjustment remains irrelevant for production use.

### 6. ModExp Gas Calculation Fix 
In the pre-EIP-2565 implementation of the `ModExp` opcode, a specific edge case was identified: when `base_len` and `mod_len` are both 0, but `exp_len` exceeds `i32::MAX`, the operation should return a trivial result instead of generating an error. Previously, our implementation aligned with the behavior under EIP-2565, which triggered an error for such cases. This PR corrects the issue。

### Undefined Behavior: Nonce Overflow vs. Create2 Conflict
One undefined edge case remains concerning the interaction between `CREATE2` conflict failures and sender nonce overflow. Specifically, when both errors occur simultaneously, it's unclear whether the gas deductions should follow the `CREATE2` failure model (which consumes all gas for the attempted create operation) or the nonce overflow model (which refunds unused gas).  
Given that nonce overflow is practically impossible under normal conditions, this ambiguity is not currently addressed and remains undefined pending future clarification.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3174)
<!-- Reviewable:end -->
