### PR TITLE
Add Feature Flag for Ethereum Test Suite Alignment

### DIFF
--- a/crates/cfxcore/core/src/consensus/consensus_inner/consensus_executor/epoch_execution.rs
+++ b/crates/cfxcore/core/src/consensus/consensus_inner/consensus_executor/epoch_execution.rs
@@ -212,6 +212,7 @@ impl ConsensusExecutionHandler {
             // Temporarily set `transaction_hash` to zero; it will be updated
             // with the actual transaction hash for each transaction.
             transaction_hash: H256::zero(),
+            ..Default::default()
         }
     }
 

--- a/crates/cfxcore/core/src/consensus/consensus_inner/consensus_executor/mod.rs
+++ b/crates/cfxcore/core/src/consensus/consensus_inner/consensus_executor/mod.rs
@@ -1670,6 +1670,7 @@ impl ConsensusExecutionHandler {
             base_gas_price,
             burnt_gas_price,
             transaction_hash: tx.hash(),
+            ..Default::default()
         };
         if evm_overrides.has_block() {
             ExecutiveContext::apply_env_overrides(

--- a/crates/cfxcore/executor/Cargo.toml
+++ b/crates/cfxcore/executor/Cargo.toml
@@ -54,3 +54,4 @@ cfx-vm-types = { workspace = true, features = ["testonly_code"]}
 
 [features]
 testonly_code = []
+align_evm = ["cfx-vm-interpreter/align_evm"]

--- a/crates/cfxcore/executor/src/builtin/mod.rs
+++ b/crates/cfxcore/executor/src/builtin/mod.rs
@@ -440,9 +440,17 @@ impl Impl for EcRecover {
         let r = H256::from_slice(&input[64..96]);
         let s = H256::from_slice(&input[96..128]);
 
+        if &v.0[..31] != &[0; 31] {
+            return Ok(());
+        }
+
         let bit = match v[31] {
-            0 | 1 if &v.0[..31] == &[0; 31] => v[31],
-            27 | 28 if &v.0[..31] == &[0; 31] => v[31] - 27,
+            0 | 1
+                if self.0 == Space::Native || !cfg!(feature = "align_evm") =>
+            {
+                v[31]
+            }
+            27 | 28 => v[31] - 27,
             _ => {
                 return Ok(());
             }

--- a/crates/cfxcore/executor/src/context.rs
+++ b/crates/cfxcore/executor/src/context.rs
@@ -702,6 +702,8 @@ mod tests {
             base_gas_price: Default::default(),
             burnt_gas_price: Default::default(),
             transaction_hash: MOCK_TX_HASH,
+            #[cfg(feature = "align_evm")]
+            blob_gas_fee: 0.into(),
         }
     }
 

--- a/crates/cfxcore/vm-interpreter/Cargo.toml
+++ b/crates/cfxcore/vm-interpreter/Cargo.toml
@@ -21,3 +21,6 @@ rustc-hex = { workspace = true }
 
 [dev-dependencies]
 cfx-vm-types = { workspace = true, features = ["testonly_code"] }
+
+[features]
+align_evm = ["cfx-vm-types/align_evm"]

--- a/crates/cfxcore/vm-interpreter/src/interpreter/mod.rs
+++ b/crates/cfxcore/vm-interpreter/src/interpreter/mod.rs
@@ -1221,6 +1221,9 @@ impl<Cost: CostType, const CANCUN: bool> Interpreter<Cost, CANCUN> {
                 self.stack.push(U256::zero());
             }
             Instruction::BLOBBASEFEE => {
+                #[cfg(feature = "align_evm")]
+                self.stack.push(context.env().blob_gas_fee);
+                #[cfg(not(feature = "align_evm"))]
                 self.stack.push(U256::zero());
             }
             instructions::BLOCKHASH => {

--- a/crates/cfxcore/vm-types/Cargo.toml
+++ b/crates/cfxcore/vm-types/Cargo.toml
@@ -18,3 +18,4 @@ solidity-abi = { workspace = true }
 
 [features]
 testonly_code = []
+align_evm = []

--- a/crates/cfxcore/vm-types/src/env.rs
+++ b/crates/cfxcore/vm-types/src/env.rs
@@ -65,6 +65,9 @@ pub struct Env {
     pub burnt_gas_price: SpaceMap<U256>,
     /// Transaction hash for the executing transaction, required by CIP-152
     pub transaction_hash: H256,
+    #[cfg(feature = "align_evm")]
+    /// Blob gas fee, required by EIP-4844 (for test only)
+    pub blob_gas_fee: U256,
 }
 
 #[cfg(test)]

--- a/crates/client/benches/benchmark.rs
+++ b/crates/client/benches/benchmark.rs
@@ -67,6 +67,7 @@ fn txexe_benchmark(c: &mut Criterion) {
         base_gas_price: Default::default(),
         burnt_gas_price: Default::default(),
         transaction_hash: tx.hash(),
+        ..Default::default()
     };
     let mut group = c.benchmark_group("Execute 1 transaction");
     group


### PR DESCRIPTION
This PR introduces a Rust feature flag to enable stricter alignment with Ethereum's behavior specifically for running Ethereum's test suite. This allows us to reuse their test cases to verify compatibility, while maintaining our intended differences on the mainnet.

The feature flag enables conditional compilation for:

1.  **EIP-4844 Blob Fee Simulation:** Mimics Ethereum's blob base fee mechanism (adjusting types/behavior) required by certain tests. This is enabled only under the flag, as our mainnet does not implement the blob mechanism.
2.  **Precompile `Spec` Access Workaround:** Modifies behavior in tests where precompiles cannot access the `Spec` object, bypassing the need for extensive built-in logic refactoring solely for test compatibility.

When this feature flag is disabled (the default for mainnet builds), the code behaves as intended for our network, ensuring test-specific adjustments do not impact production.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3180)
<!-- Reviewable:end -->
