### PR TITLE
Introducing Feature Flags Struct for CIP-645

### DIFF
--- a/crates/cfxcore/core/src/consensus/consensus_inner/consensus_executor/epoch_execution.rs
+++ b/crates/cfxcore/core/src/consensus/consensus_inner/consensus_executor/epoch_execution.rs
@@ -291,7 +291,7 @@ impl ConsensusExecutionHandler {
         let execution_outcome =
             ExecutiveContext::new(state, env, machine, &spec)
                 .transact(transaction, options)?;
-        state.update_state_post_tx_execution(!spec.cip645);
+        state.update_state_post_tx_execution(!spec.cip645.fix_eip1153);
         execution_outcome.log(transaction, &block_context.block.hash());
 
         if let Some(burnt_fee) = execution_outcome

--- a/crates/cfxcore/executor/src/context.rs
+++ b/crates/cfxcore/executor/src/context.rs
@@ -298,7 +298,7 @@ impl<'a> ContextTrait for Context<'a> {
         };
 
         if conflict_address {
-            if self.spec.cip645 {
+            if self.spec.cip645.fix_eip684 {
                 self.state.inc_nonce(&caller)?;
             }
             debug!("Contract address conflict!");

--- a/crates/cfxcore/executor/src/executive/fresh_executive.rs
+++ b/crates/cfxcore/executor/src/executive/fresh_executive.rs
@@ -304,12 +304,12 @@ impl<'a, O: ExecutiveObserver> FreshExecutive<'a, O> {
         };
 
         // EIP-1559 requires the user balance can afford "max gas price * gas limit", instead of "effective gas price * gas limit", this variable represents "(effective gas price - max gas price) * gas limit"
-        let additional_gas_required_1559 = if settings.charge_gas && spec.cip645
-        {
-            (max_gas_price - gas_price).full_mul(*tx.gas_limit())
-        } else {
-            0.into()
-        };
+        let additional_gas_required_1559 =
+            if settings.charge_gas && spec.cip645.fix_eip1559 {
+                (max_gas_price - gas_price).full_mul(*tx.gas_limit())
+            } else {
+                0.into()
+            };
         let storage_cost =
             if let (Transaction::Native(tx), ChargeCollateral::Normal) = (
                 &tx.transaction.transaction.unsigned,

--- a/crates/cfxcore/executor/src/executive/mod.rs
+++ b/crates/cfxcore/executor/src/executive/mod.rs
@@ -119,7 +119,7 @@ pub fn gas_required_for(
     let data_word = (data.len() as u64 + 31) / 32;
 
     // CIP-645i: EIP-3860: Limit and meter initcode
-    let initcode_gas = if spec.cip645 && is_create {
+    let initcode_gas = if spec.cip645.eip3860 && is_create {
         data_word * spec.init_code_word_gas as u64
     } else {
         0

--- a/crates/cfxcore/executor/src/executive/pre_checked_executive.rs
+++ b/crates/cfxcore/executor/src/executive/pre_checked_executive.rs
@@ -523,8 +523,7 @@ impl<'a, O: ExecutiveObserver> PreCheckedExecutive<'a, O> {
         // gas_used is only used to estimate gas needed
         let mut gas_used = tx.gas() - gas_left;
 
-        // CIP-645g: EIP-3529
-        if spec.cip645 {
+        if spec.cip645.eip_sstore_and_refund_gas {
             let substate_refund = if self.substate.refund_gas > 0 {
                 self.substate.refund_gas as u128
             } else {

--- a/crates/cfxcore/executor/src/machine/mod.rs
+++ b/crates/cfxcore/executor/src/machine/mod.rs
@@ -160,7 +160,7 @@ fn new_builtin_map(
 
     // CIP-645e: EIP-2565
     let mod_exp_pricer = IfPricer::new(
-        |spec| spec.cip645,
+        |spec| spec.cip645.eip2565,
         ModexpPricer::new_berlin(200),
         ModexpPricer::new_byzantium(20),
     );
@@ -175,7 +175,7 @@ fn new_builtin_map(
 
     // CIP-645a: EIP-1108
     let bn_add_pricer = IfPricer::new(
-        |spec| spec.cip645,
+        |spec| spec.cip645.eip1108,
         Linear::new(150, 0),
         Linear::new(500, 0),
     );
@@ -190,7 +190,7 @@ fn new_builtin_map(
 
     // CIP-645a: EIP-1108
     let bn_mul_pricer = IfPricer::new(
-        |spec| spec.cip645,
+        |spec| spec.cip645.eip1108,
         Linear::new(6_000, 0),
         Linear::new(40_000, 0),
     );
@@ -205,7 +205,7 @@ fn new_builtin_map(
 
     // CIP-645a: EIP-1108
     let bn_pair_pricer = IfPricer::new(
-        |spec| spec.cip645,
+        |spec| spec.cip645.eip1108,
         AltBn128PairingPricer::new(45_000, 34_000),
         AltBn128PairingPricer::new(100_000, 80_000),
     );

--- a/crates/cfxcore/executor/src/spec.rs
+++ b/crates/cfxcore/executor/src/spec.rs
@@ -18,7 +18,7 @@ use cfx_parameters::{
     },
 };
 use cfx_types::{AllChainID, Space, SpaceMap, U256, U512};
-use cfx_vm_types::{ConsensusGasSpec, Spec};
+use cfx_vm_types::{CIP645Spec, ConsensusGasSpec, Spec};
 use primitives::{block::BlockHeight, BlockNumber};
 use std::collections::BTreeMap;
 
@@ -220,13 +220,13 @@ impl CommonParams {
         spec.cip152 = height >= self.transition_heights.cip152;
         spec.cip154 = height >= self.transition_heights.cip154;
         spec.cip7702 = height >= self.transition_heights.cip7702;
-        spec.cip645 = height >= self.transition_heights.cip645;
+        let cip645 = height >= self.transition_heights.cip645;
+        spec.cip645 = CIP645Spec::new(cip645);
         spec.eip2935 = height >= self.transition_heights.eip2935;
         spec.eip7623 = height >= self.transition_heights.eip7623;
         spec.cip_c2_fix = number >= self.transition_heights.cip_c2_fix;
         spec.cancun_opcodes = number >= self.transition_numbers.cancun_opcodes;
-        spec.align_evm =
-            height >= self.transition_heights.align_evm && spec.cip645;
+        spec.align_evm = height >= self.transition_heights.align_evm && cip645;
 
         spec.overwrite_gas_plan_by_cip();
 
@@ -236,9 +236,10 @@ impl CommonParams {
     pub fn consensus_spec(&self, height: BlockHeight) -> ConsensusGasSpec {
         let mut spec = ConsensusGasSpec::genesis_spec();
         spec.cip1559 = height >= self.transition_heights.cip1559;
-        spec.cip645 = height >= self.transition_heights.cip645;
-        spec.align_evm =
-            height >= self.transition_heights.align_evm && spec.cip645;
+        let cip645 = height >= self.transition_heights.cip645;
+        spec.cip645 = CIP645Spec::new(cip645);
+
+        spec.align_evm = height >= self.transition_heights.align_evm && cip645;
 
         spec.overwrite_gas_plan_by_cip();
 

--- a/crates/cfxcore/geth-tracer/src/tracing_inspector.rs
+++ b/crates/cfxcore/geth-tracer/src/tracing_inspector.rs
@@ -426,7 +426,7 @@ impl TracingInspector {
             let num_pushed = stack_push_count(
                 step.op.get(),
                 spec.cancun_opcodes,
-                spec.cip645,
+                spec.cip645.opcode_update,
             );
             let start = interp.stack().len() - num_pushed;
             let push_stack = interp.stack()[start..].to_vec();

--- a/crates/cfxcore/vm-interpreter/src/interpreter/mod.rs
+++ b/crates/cfxcore/vm-interpreter/src/interpreter/mod.rs
@@ -592,7 +592,8 @@ impl<Cost: CostType, const CANCUN: bool> Interpreter<Cost, CANCUN> {
             }
         };
 
-        let info = instruction.info::<CANCUN>(context.spec().cip645);
+        let info =
+            instruction.info::<CANCUN>(context.spec().cip645.opcode_update);
         self.last_stack_ret_len = info.ret;
         if let Err(e) = self.verify_instruction(context, instruction, info) {
             return Err(InterpreterResult::Done(Err(e)));
@@ -741,7 +742,7 @@ impl<Cost: CostType, const CANCUN: bool> Interpreter<Cost, CANCUN> {
                 let init_off = self.stack.pop_back();
                 let init_size = self.stack.pop_back();
                 let spec = context.spec();
-                if spec.cip645
+                if spec.cip645.eip3860
                     && init_size > U256::from(spec.init_code_data_limit)
                 {
                     return Err(vm::Error::CreateInitCodeSizeLimit);

--- a/crates/cfxcore/vm-types/src/lib.rs
+++ b/crates/cfxcore/vm-types/src/lib.rs
@@ -31,8 +31,8 @@ pub use self::{
     interpreter_info::InterpreterInfo,
     return_data::{GasLeft, ReturnData},
     spec::{
-        extract_7702_payload, CleanDustMode, ConsensusGasSpec, Spec,
-        CODE_PREFIX_7702,
+        extract_7702_payload, CIP645Spec, CleanDustMode, ConsensusGasSpec,
+        Spec, CODE_PREFIX_7702,
     },
 };
 


### PR DESCRIPTION
This PR introduces a new `struct` to represent the feature flags associated with the CIP-645 implementation. The primary goal is to enhance code maintainability and improve readability by explicitly naming and separating the features involved in this upgrade.

Although the protocol itself treats these features as a singular, atomic upgrade, this structured representation aids in making the implementation more self-documenting. Each feature flag is encapsulated as a distinct field within the `struct`, ensuring clarity in understanding and modifying the codebase where necessary.

**Important Implementation Note:**  
All feature flag fields in this `struct` must consistently align to either `true` (enabled) or `false` (disabled). Mixed states are not supported and will result in undefined behavior. This is due to the protocol-level assumption that all features under CIP-645 are designed to be activated simultaneously as a coordinated bundle.

This addition is a foundational part of the CIP-645 upgrade and does not introduce any behavior changes on its own. However, it serves as a critical step toward better organization and maintainability of the associated code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3195)
<!-- Reviewable:end -->
