### PR TITLE
Fix incorrect unsafe behaviour and warnings in higher rust versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,8 +222,8 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a047897373be4bbb0224c1afdabca92648dc57a9c9ef6e7b0be3aff7a859c83"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
 ]
 
@@ -276,8 +276,8 @@ dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error",
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
 ]
 
@@ -292,8 +292,8 @@ dependencies = [
  "heck 0.5.0",
  "indexmap 2.8.0",
  "proc-macro-error",
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
  "syn-solidity",
  "tiny-keccak 2.0.2",
@@ -308,8 +308,8 @@ dependencies = [
  "const-hex",
  "dunce",
  "heck 0.5.0",
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
  "syn-solidity",
 ]
@@ -467,7 +467,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
 dependencies = [
- "quote 1.0.36",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -477,7 +477,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
- "quote 1.0.36",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -489,7 +489,7 @@ checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
  "num-bigint 0.4.4",
  "num-traits",
- "quote 1.0.36",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -501,8 +501,8 @@ checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
  "num-bigint 0.4.4",
  "num-traits",
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -598,8 +598,8 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -609,8 +609,8 @@ version = "0.1.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
 ]
 
@@ -664,8 +664,8 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
 ]
 
@@ -772,8 +772,8 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
@@ -1289,7 +1289,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "primitives",
  "rlp 0.4.6",
- "rlp_derive",
+ "rlp-derive",
  "serde",
  "serde_derive",
  "toml",
@@ -1351,7 +1351,7 @@ dependencies = [
  "malloc_size_of_derive",
  "primitives",
  "rlp 0.4.6",
- "rlp_derive",
+ "rlp-derive",
  "serde",
  "strum_macros",
 ]
@@ -1606,7 +1606,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "random-crash",
  "rlp 0.4.6",
- "rlp_derive",
+ "rlp-derive",
  "rustc-hex",
  "serde",
  "sqlite",
@@ -1650,7 +1650,7 @@ dependencies = [
  "hex",
  "keccak-hash",
  "rlp 0.4.6",
- "rlp_derive",
+ "rlp-derive",
  "serde",
  "serde_derive",
 ]
@@ -1680,7 +1680,7 @@ dependencies = [
 name = "cfx-vm-tracer-derive"
 version = "0.1.0"
 dependencies = [
- "quote 1.0.36",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1785,7 +1785,7 @@ dependencies = [
  "rangetools",
  "rayon",
  "rlp 0.4.6",
- "rlp_derive",
+ "rlp-derive",
  "rustc-hex",
  "safety-rules",
  "schemadb",
@@ -2092,7 +2092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2516,8 +2516,8 @@ dependencies = [
  "cc",
  "codespan-reporting",
  "once_cell",
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "scratch",
  "syn 2.0.96",
 ]
@@ -2534,8 +2534,8 @@ version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "631569015d0d8d54e6c241733f944042623ab6df7bc3be7466874b05fcdb1c5f"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
 ]
 
@@ -2559,8 +2559,8 @@ dependencies = [
 name = "delegate"
 version = "0.4.2"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -2570,8 +2570,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fd733b5bf0bb5ca3c7cdea2135c91234c80b730e6e8a270851455a63b46c830"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -2609,8 +2609,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -2621,8 +2621,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "rustc_version 0.4.0",
  "syn 1.0.109",
 ]
@@ -2700,8 +2700,8 @@ dependencies = [
 name = "diem-crypto-derive"
 version = "0.1.0"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -2753,8 +2753,8 @@ dependencies = [
 name = "diem-log-derive"
 version = "0.1.0"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -3018,8 +3018,8 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
 ]
 
@@ -3163,8 +3163,8 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5c450cf304c9e18d45db562025a14fb1ca0f5c769b6f609309f81d4c31de455"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -3175,8 +3175,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11f36e95862220b211a6e2aa5eca09b4fa391b13cd52ceb8035a24bf65a79de2"
 dependencies = [
  "once_cell",
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -3186,8 +3186,8 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
 ]
 
@@ -3419,8 +3419,8 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
  "synstructure 0.12.6",
 ]
@@ -3699,8 +3699,8 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
 ]
 
@@ -4464,8 +4464,8 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
 ]
 
@@ -4584,8 +4584,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85d3946d886eaab0702fa0c6585adcced581513223fa9df7ccfabbd9fa331a88"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
 ]
 
@@ -4595,8 +4595,8 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef5550a42e3740a0e71f909d4c861056a284060af885ae7aa6242820f920d9d"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -4606,8 +4606,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -4819,8 +4819,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b939a78fa820cdfcb7ee7484466746a7377760970f6f9c6fe19f9edcc8a38d2"
 dependencies = [
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -4999,8 +4999,8 @@ checksum = "a0d4c6bec4909c966f59f52db3655c0e9d4685faae8b49185973d9d7389bb884"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-crate 3.2.0",
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
 ]
 
@@ -5326,7 +5326,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "rand 0.7.3",
  "rlp 0.4.6",
- "rlp_derive",
+ "rlp-derive",
 ]
 
 [[package]]
@@ -5406,7 +5406,7 @@ dependencies = [
 name = "malloc_size_of_derive"
 version = "0.1.1"
 dependencies = [
- "proc-macro2 1.0.93",
+ "proc-macro2",
  "syn 1.0.109",
  "synstructure 0.12.6",
 ]
@@ -5684,7 +5684,7 @@ dependencies = [
  "priority-send-queue",
  "rand 0.7.3",
  "rlp 0.4.6",
- "rlp_derive",
+ "rlp-derive",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5782,13 +5782,13 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-derive"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
- "syn 1.0.109",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5850,8 +5850,8 @@ dependencies = [
 name = "num-variants"
 version = "0.1.0"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -5938,8 +5938,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -6079,8 +6079,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
 dependencies = [
  "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -6091,8 +6091,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be30eaf4b0a9fba5336683b38de57bb86d179a35862ba6bfcf57625d006bde5b"
 dependencies = [
  "proc-macro-crate 2.0.0",
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -6125,7 +6125,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
- "proc-macro2 1.0.93",
+ "proc-macro2",
  "syn 1.0.109",
  "synstructure 0.12.6",
 ]
@@ -6346,8 +6346,8 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
 ]
 
@@ -6628,7 +6628,7 @@ dependencies = [
  "once_cell",
  "rand 0.7.3",
  "rlp 0.4.6",
- "rlp_derive",
+ "rlp-derive",
  "serde",
  "serde_derive",
  "serde_json",
@@ -6684,8 +6684,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
  "version_check",
 ]
@@ -6696,18 +6696,9 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -6755,13 +6746,13 @@ dependencies = [
 
 [[package]]
 name = "proptest-derive"
-version = "0.3.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90b46295382dc76166cb7cf2bb4a97952464e4b7ed5a43e6cd34e1fec3349ddc"
+checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
 dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6788,20 +6779,11 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
- "proc-macro2 1.0.93",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -7139,8 +7121,8 @@ version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d2275aab483050ab2a7364c1a46604865ee7d6906684e08db0f090acf74f9e7"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
 ]
 
@@ -7393,13 +7375,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "rlp_derive"
-version = "0.1.0"
-source = "git+https://github.com/Conflux-Chain/conflux-parity-deps.git?rev=09da4dfeecd754df2034d4e71a260277aaaf9783#09da4dfeecd754df2034d4e71a260277aaaf9783"
+name = "rlp-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "652db34deaaa57929e10ca18e5454a32cb0efc351ae80d320334bbf907b908b3"
 dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -7940,8 +7923,8 @@ version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
 ]
 
@@ -8068,7 +8051,7 @@ name = "sha3-macro"
 version = "0.1.0"
 dependencies = [
  "keccak-hash",
- "quote 1.0.36",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -8196,8 +8179,8 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -8254,8 +8237,8 @@ name = "solidity-abi-derive"
 version = "0.1.0"
 dependencies = [
  "proc-macro-crate 3.2.0",
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -8398,8 +8381,8 @@ checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck 0.3.3",
  "proc-macro-error",
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -8419,8 +8402,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
  "heck 0.5.0",
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "rustversion",
  "syn 2.0.96",
 ]
@@ -8467,23 +8450,12 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -8493,8 +8465,8 @@ version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -8505,8 +8477,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6fe08d08d84f2c0a77f1e7c46518789d745c2e87a2721791ed7c3c9bc78df28"
 dependencies = [
  "paste",
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
 ]
 
@@ -8525,10 +8497,10 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
- "unicode-xid 0.2.4",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -8537,8 +8509,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
 ]
 
@@ -8630,8 +8602,8 @@ version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
 ]
 
@@ -8641,8 +8613,8 @@ version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
 ]
 
@@ -8790,8 +8762,8 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
 ]
 
@@ -8969,8 +8941,8 @@ version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
 ]
 
@@ -9159,12 +9131,6 @@ checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
@@ -9185,7 +9151,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad948c1cb799b1a70f836077721a92a35ac177d4daddf4c20a633786d4cf618"
 dependencies = [
- "quote 1.0.36",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -9375,8 +9341,8 @@ checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
  "wasm-bindgen-shared",
 ]
@@ -9399,7 +9365,7 @@ version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
- "quote 1.0.36",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -9409,8 +9375,8 @@ version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -9848,8 +9814,8 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
  "synstructure 0.13.1",
 ]
@@ -9878,8 +9844,8 @@ version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
 ]
 
@@ -9889,8 +9855,8 @@ version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
 ]
 
@@ -9909,8 +9875,8 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
  "synstructure 0.13.1",
 ]
@@ -9930,8 +9896,8 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
  "synstructure 0.12.6",
 ]
@@ -9953,8 +9919,8 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.96",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -382,7 +382,7 @@ derive_more = "0.99"
 c-kzg = { version = "1.0.2", default-features = false }
 strfmt = "0.1"
 smart-default = "0.6.0"
-num-derive = { version = "0.3.3", default-features = false }
+num-derive = { version = "0.4.2", default-features = false }
 mirai-annotations = { version = "1.10.1", default-features = false }
 rangetools = "0.1.4"
 # prometheus = { version = "0.7.0", default-features = false }
@@ -419,7 +419,7 @@ duration-str = "0.17"
 
 # parity crates
 rlp = "0.4.0"
-rlp_derive = { git = "https://github.com/Conflux-Chain/conflux-parity-deps.git", rev = "09da4dfeecd754df2034d4e71a260277aaaf9783" }
+rlp_derive = { package = "rlp-derive", version = "0.2.0" }
 panic_hook = { git = "https://github.com/Conflux-Chain/conflux-parity-deps.git", rev = "09da4dfeecd754df2034d4e71a260277aaaf9783" }
 dir = { git = "https://github.com/Conflux-Chain/conflux-parity-deps.git", rev = "09da4dfeecd754df2034d4e71a260277aaaf9783" }
 unexpected = { git = "https://github.com/Conflux-Chain/conflux-parity-deps.git", rev = "09da4dfeecd754df2034d4e71a260277aaaf9783" }
@@ -437,7 +437,7 @@ ethcore-bytes = "0.1.1"
 similar-asserts = "1.5"
 criterion = "0.3.0"
 proptest = "1.0.0"
-proptest-derive = "0.3.0"
+proptest-derive = "0.5.1"
 
 # dbs
 sqlite = "0.25"

--- a/bins/conflux/src/command/rpc.rs
+++ b/bins/conflux/src/command/rpc.rs
@@ -4,8 +4,7 @@
 
 use crate::command::helpers::{input_password, password_prompt};
 use clap::ArgMatches;
-use jsonrpsee::core::client::ClientT;
-use jsonrpsee::http_client::HttpClientBuilder;
+use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder};
 use serde_json::{Map, Value};
 use std::str::FromStr;
 

--- a/cargo_fmt.sh
+++ b/cargo_fmt.sh
@@ -6,5 +6,6 @@ then
     rustup component add rustfmt --toolchain nightly-2024-02-04
     rustup component add clippy
     shift
+else
+    cargo +nightly-2024-02-04 fmt --all $@
 fi
-cargo +nightly-2024-02-04 fmt --all $@

--- a/crates/blockgen/src/miner/stratum.rs
+++ b/crates/blockgen/src/miner/stratum.rs
@@ -100,6 +100,7 @@ impl SubmitPayload {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum PayloadError {
     ArgumentsAmountUnexpected(usize),
     InvalidNonce(String),

--- a/crates/cfxcore/core/Cargo.toml
+++ b/crates/cfxcore/core/Cargo.toml
@@ -132,3 +132,6 @@ default = []
 # https://users.rust-lang.org/t/cfg-test-doesnt-propagate-to-external-crates/13046
 testonly_code = []
 fuzzing = ["proptest", "proptest-derive"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }

--- a/crates/cfxcore/core/Cargo.toml
+++ b/crates/cfxcore/core/Cargo.toml
@@ -133,5 +133,5 @@ default = []
 testonly_code = []
 fuzzing = ["proptest", "proptest-derive"]
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }
+# [lints.rust]
+# unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }

--- a/crates/cfxcore/core/src/pos/consensus/epoch_manager.rs
+++ b/crates/cfxcore/core/src/pos/consensus/epoch_manager.rs
@@ -415,39 +415,31 @@ impl EpochManager {
         // TODO(lpl): Decide key management.
         // txn manager is required both by proposal generator (to pull the
         // proposers) and by event processor (to update their status).
-        let proposal_generator = match epoch_state
-            .verifier()
-            .get_public_key(&self.author)
-        {
-            Some(public_key) => {
-                // TODO(lpl): Handle no vrf.
-                let vrf_key =
-                    self.config.safety_rules.vrf_private_key.as_ref().unwrap();
-                let private_key = self
-                    .config
-                    .safety_rules
-                    .test
-                    .as_ref()
-                    .expect("test config set")
-                    .consensus_key
-                    .as_ref()
-                    .expect("private key set in pos")
-                    .private_key();
-                Some(ProposalGenerator::new(
-                    self.author,
-                    block_store.clone(),
-                    self.txn_manager.clone(),
-                    self.time_service.clone(),
-                    self.config.max_block_size,
-                    self.pow_handler.clone(),
-                    private_key,
-                    public_key,
-                    vrf_key.private_key(),
-                    vrf_key.public_key(),
-                ))
-            }
-            None => None,
-        };
+        let proposal_generator =
+            match epoch_state.verifier().get_public_key(&self.author) {
+                Some(_public_key) => {
+                    let private_key = self
+                        .config
+                        .safety_rules
+                        .test
+                        .as_ref()
+                        .expect("test config set")
+                        .consensus_key
+                        .as_ref()
+                        .expect("private key set in pos")
+                        .private_key();
+                    Some(ProposalGenerator::new(
+                        self.author,
+                        block_store.clone(),
+                        self.txn_manager.clone(),
+                        self.time_service.clone(),
+                        self.config.max_block_size,
+                        self.pow_handler.clone(),
+                        private_key,
+                    ))
+                }
+                None => None,
+            };
 
         diem_info!(epoch = epoch, "Create RoundState");
         let round_state = self.create_round_state(

--- a/crates/cfxcore/core/src/pos/consensus/liveness/proposal_generator.rs
+++ b/crates/cfxcore/core/src/pos/consensus/liveness/proposal_generator.rs
@@ -19,10 +19,7 @@ use diem_infallible::Mutex;
 use diem_logger::{debug as diem_debug, error as diem_error};
 use diem_types::{
     transaction::{RawTransaction, SignedTransaction, TransactionPayload},
-    validator_config::{
-        ConsensusPrivateKey, ConsensusPublicKey, ConsensusVRFPrivateKey,
-        ConsensusVRFPublicKey,
-    },
+    validator_config::ConsensusPrivateKey,
     validator_verifier::ValidatorVerifier,
 };
 use pow_types::PowInterface;
@@ -64,9 +61,6 @@ pub struct ProposalGenerator {
     pow_handler: Arc<dyn PowInterface>,
     // TODO(lpl): Where to put them?
     pub private_key: ConsensusPrivateKey,
-    pub public_key: ConsensusPublicKey,
-    pub vrf_private_key: ConsensusVRFPrivateKey,
-    pub vrf_public_key: ConsensusVRFPublicKey,
 }
 
 impl ProposalGenerator {
@@ -74,9 +68,7 @@ impl ProposalGenerator {
         author: Author, block_store: Arc<dyn BlockReader + Send + Sync>,
         txn_manager: Arc<dyn TxnManager>, time_service: Arc<dyn TimeService>,
         max_block_size: u64, pow_handler: Arc<dyn PowInterface>,
-        private_key: ConsensusPrivateKey, public_key: ConsensusPublicKey,
-        vrf_private_key: ConsensusVRFPrivateKey,
-        vrf_public_key: ConsensusVRFPublicKey,
+        private_key: ConsensusPrivateKey,
     ) -> Self {
         Self {
             author,
@@ -87,9 +79,6 @@ impl ProposalGenerator {
             last_round_generated: Mutex::new(0),
             pow_handler,
             private_key,
-            public_key,
-            vrf_private_key,
-            vrf_public_key,
         }
     }
 

--- a/crates/cfxcore/core/src/transaction_pool/deferred_pool/mod.rs
+++ b/crates/cfxcore/core/src/transaction_pool/deferred_pool/mod.rs
@@ -433,8 +433,8 @@ impl DeferredPool {
         self.packing_pool.in_space(addr.space).contains(addr)
     }
 
-    pub fn ready_transactions_by_address<'a>(
-        &'a self, address: AddressWithSpace,
+    pub fn ready_transactions_by_address(
+        &self, address: AddressWithSpace,
     ) -> Option<&[Arc<SignedTransaction>]> {
         self.packing_pool
             .in_space(address.space)

--- a/crates/cfxcore/geth-tracer/Cargo.toml
+++ b/crates/cfxcore/geth-tracer/Cargo.toml
@@ -23,3 +23,6 @@ cfx-executor = { workspace = true }
 typemap = { workspace = true }
 cfx-vm-interpreter = { workspace = true }
 primitives = { workspace = true }
+
+[features]
+serde = []

--- a/crates/cfxcore/vm-interpreter/Cargo.toml
+++ b/crates/cfxcore/vm-interpreter/Cargo.toml
@@ -24,3 +24,4 @@ cfx-vm-types = { workspace = true, features = ["testonly_code"] }
 
 [features]
 align_evm = ["cfx-vm-types/align_evm"]
+evm-debug = []

--- a/crates/dbs/db-errors/src/storage.rs
+++ b/crates/dbs/db-errors/src/storage.rs
@@ -121,9 +121,11 @@ pub enum Error {
     )]
     SemaphoreTryAcquireError,
 
-    #[error("tokio::sync::Semaphore::acquire(): the semaphore is unavailable.")]
+    #[error(
+        "tokio::sync::Semaphore::acquire(): the semaphore is unavailable."
+    )]
     SemaphoreAcquireError,
-    
+
     #[error("{0}")]
     Msg(String),
 }

--- a/crates/dbs/statedb/src/tests.rs
+++ b/crates/dbs/statedb/src/tests.rs
@@ -142,7 +142,7 @@ impl StorageStateTrait for MockStorage {
 type StateDbTest = StateDbGeneric;
 
 // convert `key` to storage interface format
-fn storage_key(key: &'static [u8]) -> StorageKeyWithSpace {
+fn storage_key(key: &'static [u8]) -> StorageKeyWithSpace<'static> {
     StorageKey::AccountKey(key).with_native_space()
 }
 

--- a/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/recent_lfu.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/recent_lfu.rs
@@ -187,7 +187,7 @@ impl<
 
     fn get_key_for_comparison<'x>(
         &'x self, value: &'x RecentLFUMetadata<PosT, CacheIndexT>,
-    ) -> &Self::KeyType {
+    ) -> &'x Self::KeyType {
         &value.frequency
     }
 }
@@ -552,7 +552,7 @@ impl<PosT: PrimitiveNum, CacheIndexT: CacheIndexTrait>
     >(
         &'a mut self, cache_store_util: &'b mut CacheStoreUtilT,
     ) -> (
-        &mut RemovableHeap<PosT, RecentLFUMetadata<PosT, CacheIndexT>>,
+        &'a mut RemovableHeap<PosT, RecentLFUMetadata<PosT, CacheIndexT>>,
         MetadataHeapUtil<'a, 'b, PosT, CacheIndexT, CacheStoreUtilT>,
     ) {
         (

--- a/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/removable_heap.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/removable_heap.rs
@@ -102,7 +102,7 @@ pub trait HeapValueUtil<ValueType, PosT: PrimitiveNum> {
 
     fn get_key_for_comparison<'a>(
         &'a self, value: &'a ValueType,
-    ) -> &Self::KeyType;
+    ) -> &'a Self::KeyType;
 }
 
 /// A demo of heap value util for heap which directly maintains value where the
@@ -157,7 +157,7 @@ impl<PosT: PrimitiveNum, ValueType: Ord + Clone>
 
     fn get_key_for_comparison<'a>(
         &'a self, value: &'a TrivialValueWithHeapHandle<ValueType, PosT>,
-    ) -> &ValueType {
+    ) -> &'a ValueType {
         value.as_ref()
     }
 }

--- a/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/tests/removable_heap.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/tests/removable_heap.rs
@@ -139,7 +139,9 @@ impl<
         }
     }
 
-    fn get_key_for_comparison<'x>(&'x self, value: &'x PosT) -> &'x Self::KeyType {
+    fn get_key_for_comparison<'x>(
+        &'x self, value: &'x PosT,
+    ) -> &'x Self::KeyType {
         unsafe { self.array.get_unchecked(MyInto::<usize>::into(*value)) }
             .as_ref()
     }

--- a/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/tests/removable_heap.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/tests/removable_heap.rs
@@ -139,7 +139,7 @@ impl<
         }
     }
 
-    fn get_key_for_comparison<'x>(&'x self, value: &'x PosT) -> &Self::KeyType {
+    fn get_key_for_comparison<'x>(&'x self, value: &'x PosT) -> &'x Self::KeyType {
         unsafe { self.array.get_unchecked(MyInto::<usize>::into(*value)) }
             .as_ref()
     }

--- a/crates/dbs/storage/src/impls/merkle_patricia_trie/compressed_path.rs
+++ b/crates/dbs/storage/src/impls/merkle_patricia_trie/compressed_path.rs
@@ -290,7 +290,7 @@ impl CompressedPathRaw {
                     let ptr = value_box.as_mut_ptr();
                     // Don't free the buffer since it's stored in the return
                     // value.
-                    Box::into_raw(value_box);
+                    let _ = Box::into_raw(value_box);
                     path = MaybeInPlaceByteArray { ptr };
                     slice = std::slice::from_raw_parts_mut(ptr, size);
                 } else {

--- a/crates/dbs/storage/src/impls/merkle_patricia_trie/maybe_in_place_byte_array.rs
+++ b/crates/dbs/storage/src/impls/merkle_patricia_trie/maybe_in_place_byte_array.rs
@@ -199,7 +199,7 @@ impl MaybeInPlaceByteArray {
     pub fn new(mut value: Box<[u8]>, size: usize) -> Self {
         if size > Self::MAX_INPLACE_SIZE {
             let ptr = value.as_mut_ptr();
-            Box::into_raw(value);
+            let _ = Box::into_raw(value);
             Self { ptr }
         } else {
             let mut in_place: [u8; Self::MAX_INPLACE_SIZE] = Default::default();
@@ -216,7 +216,7 @@ impl MaybeInPlaceByteArray {
         if size > Self::MAX_INPLACE_SIZE {
             let mut owned_copy = Box::<[u8]>::from(value);
             let ptr = owned_copy.as_mut_ptr();
-            Box::into_raw(owned_copy);
+            let _ = Box::into_raw(owned_copy);
             Self { ptr }
         } else {
             let mut x: Self = Self {

--- a/crates/dbs/storage/src/impls/storage_db/kvdb_sqlite_sharded.rs
+++ b/crates/dbs/storage/src/impls/storage_db/kvdb_sqlite_sharded.rs
@@ -538,20 +538,24 @@ impl<
             debug_assert!(i > 0);
             unsafe {
                 let pos = i - 1;
-                std::ptr::copy(
-                    self.ordered_iter_ids.get_unchecked(1),
-                    self.ordered_iter_ids.get_unchecked_mut(0),
-                    pos,
-                );
+                if pos > 0 {
+                    std::ptr::copy(
+                        self.ordered_iter_ids.get_unchecked(1),
+                        self.ordered_iter_ids.get_unchecked_mut(0),
+                        pos,
+                    );
+                }
                 std::ptr::write(
                     self.ordered_iter_ids.get_unchecked_mut(pos),
                     iter_id,
                 );
-                std::ptr::copy(
-                    self.ordered_key_prefixes_to_map.get_unchecked(1),
-                    self.ordered_key_prefixes_to_map.get_unchecked_mut(0),
-                    pos,
-                );
+                if pos > 0 {
+                    std::ptr::copy(
+                        self.ordered_key_prefixes_to_map.get_unchecked(1),
+                        self.ordered_key_prefixes_to_map.get_unchecked_mut(0),
+                        pos,
+                    );
+                }
                 std::ptr::write(
                     self.ordered_key_prefixes_to_map.get_unchecked_mut(pos),
                     this_key_prefix_to_map,
@@ -559,11 +563,13 @@ impl<
                 let popped = Ok(std::ptr::read(
                     self.maybe_next_key_values.get_unchecked(0),
                 ));
-                std::ptr::copy(
-                    self.maybe_next_key_values.get_unchecked(1),
-                    self.maybe_next_key_values.get_unchecked_mut(0),
-                    pos,
-                );
+                if pos > 0 {
+                    std::ptr::copy(
+                        self.maybe_next_key_values.get_unchecked(1),
+                        self.maybe_next_key_values.get_unchecked_mut(0),
+                        pos,
+                    );
+                }
                 std::ptr::write(
                     self.maybe_next_key_values.get_unchecked_mut(pos),
                     kv,

--- a/crates/dbs/storage/src/impls/storage_db/snapshot_db_manager_sqlite.rs
+++ b/crates/dbs/storage/src/impls/storage_db/snapshot_db_manager_sqlite.rs
@@ -1018,13 +1018,9 @@ impl SnapshotDbManagerTrait for SnapshotDbManagerSqlite {
     type SnapshotDb = SnapshotDbSqlite;
     type SnapshotDbWrite = SnapshotDbWriteable;
 
-    fn get_snapshot_dir(&self) -> &Path {
-        self.snapshot_path.as_path()
-    }
+    fn get_snapshot_dir(&self) -> &Path { self.snapshot_path.as_path() }
 
-    fn get_mpt_snapshot_dir(&self) -> &Path {
-        self.mpt_snapshot_path.as_path()
-    }
+    fn get_mpt_snapshot_dir(&self) -> &Path { self.mpt_snapshot_path.as_path() }
 
     fn get_latest_mpt_snapshot_db_name(&self) -> String {
         Self::SNAPSHOT_DB_SQLITE_DIR_PREFIX.to_string()

--- a/crates/dbs/storage/src/utils/deref_plus_impl_or_borrow_self.rs
+++ b/crates/dbs/storage/src/utils/deref_plus_impl_or_borrow_self.rs
@@ -168,7 +168,7 @@ mod test {
     }
     struct Test {}
     mod my_vec {
-        pub struct MyVec<T>(pub Vec<T>);
+        pub struct MyVec<T>(#[allow(unused)] pub Vec<T>);
     }
 
     impl TestTrait for Test {}

--- a/crates/network/src/node_table.rs
+++ b/crates/network/src/node_table.rs
@@ -119,7 +119,8 @@ impl NodeEndpoint {
                 rlp.append(&(&a.ip().octets()[..]));
             }
             SocketAddr::V6(a) => unsafe {
-                let o: *const u8 = a.ip().segments().as_ptr() as *const u8;
+                let segments = a.ip().segments();
+                let o: *const u8 = segments.as_ptr() as *const u8;
                 rlp.append(&slice::from_raw_parts(o, 16));
             },
         };

--- a/crates/pos/common/crash-handler/src/lib.rs
+++ b/crates/pos/common/crash-handler/src/lib.rs
@@ -11,7 +11,7 @@
 use backtrace::Backtrace;
 use diem_logger::prelude::*;
 use serde::Serialize;
-use std::panic::{self, PanicInfo};
+use std::panic::{self, PanicHookInfo};
 
 #[derive(Debug, Serialize)]
 pub struct CrashInfo {
@@ -25,13 +25,13 @@ pub struct CrashInfo {
 /// function will ensure that all subsequent thread panics (even Tokio threads)
 /// will report the details/backtrace and then exit.
 pub fn setup_panic_handler() {
-    panic::set_hook(Box::new(move |pi: &PanicInfo<'_>| {
+    panic::set_hook(Box::new(move |pi: &PanicHookInfo<'_>| {
         handle_panic(pi);
     }));
 }
 
 // Formats and logs panic information
-fn handle_panic(panic_info: &PanicInfo<'_>) {
+fn handle_panic(panic_info: &PanicHookInfo<'_>) {
     // The Display formatter for a PanicInfo contains the message, payload and
     // location.
     let details = format!("{}", panic_info);

--- a/crates/pos/common/crash-handler/src/lib.rs
+++ b/crates/pos/common/crash-handler/src/lib.rs
@@ -11,7 +11,7 @@
 use backtrace::Backtrace;
 use diem_logger::prelude::*;
 use serde::Serialize;
-use std::panic::{self, PanicHookInfo};
+use std::panic::{self, PanicInfo as PanicHookInfo};
 
 #[derive(Debug, Serialize)]
 pub struct CrashInfo {

--- a/crates/pos/common/proptest-helpers/Cargo.toml
+++ b/crates/pos/common/proptest-helpers/Cargo.toml
@@ -12,4 +12,4 @@ edition = "2018"
 [dependencies]
 crossbeam = "0.8.0"
 proptest = "1.0.0"
-proptest-derive = "0.3.0"
+proptest-derive = "0.5.1"

--- a/crates/pos/common/short-hex-str/Cargo.toml
+++ b/crates/pos/common/short-hex-str/Cargo.toml
@@ -18,3 +18,6 @@ thiserror = "1.0.24"
 [dev-dependencies]
 hex = "0.4.3"
 proptest = "1.0.0"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }

--- a/crates/pos/common/short-hex-str/Cargo.toml
+++ b/crates/pos/common/short-hex-str/Cargo.toml
@@ -19,5 +19,5 @@ thiserror = "1.0.24"
 hex = "0.4.3"
 proptest = "1.0.0"
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }
+# [lints.rust]
+# unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }

--- a/crates/pos/common/time-service/Cargo.toml
+++ b/crates/pos/common/time-service/Cargo.toml
@@ -32,3 +32,4 @@ tokio-test = { workspace = true }
 default = []
 async = ["futures", "pin-project", "tokio"]
 testing = ["async"]
+fuzzing = []

--- a/crates/pos/consensus/consensus-types/Cargo.toml
+++ b/crates/pos/consensus/consensus-types/Cargo.toml
@@ -31,5 +31,5 @@ diem-types = { workspace = true, features = ["fuzzing"] }
 default = []
 fuzzing = ["proptest", "diem-types/fuzzing", "diem-crypto/fuzzing"]
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }
+# [lints.rust]
+# unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }

--- a/crates/pos/consensus/consensus-types/Cargo.toml
+++ b/crates/pos/consensus/consensus-types/Cargo.toml
@@ -30,3 +30,6 @@ diem-types = { workspace = true, features = ["fuzzing"] }
 [features]
 default = []
 fuzzing = ["proptest", "diem-types/fuzzing", "diem-crypto/fuzzing"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }

--- a/crates/pos/crypto/crypto/Cargo.toml
+++ b/crates/pos/crypto/crypto/Cargo.toml
@@ -52,6 +52,9 @@ sha3 = "0.9.1"
 serde_json = "1.0.64"
 trybuild = "1.0.41"
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }
+
 [features]
 default = ["fiat"]
 assert-private-keys-not-cloneable = []
@@ -60,6 +63,7 @@ fuzzing = ["proptest", "proptest-derive", "cloneable-private-keys"]
 fiat = ["curve25519-dalek/fiat_u64_backend", "ed25519-dalek/fiat_u64_backend", "x25519-dalek/fiat_u64_backend"]
 u64 = ["curve25519-dalek/u64_backend", "ed25519-dalek/u64_backend", "x25519-dalek/u64_backend"]
 u32 = ["curve25519-dalek/u32_backend", "ed25519-dalek/u32_backend", "x25519-dalek/u32_backend"]
+batch = []
 
 [[bench]]
 name = "noise"

--- a/crates/pos/crypto/crypto/Cargo.toml
+++ b/crates/pos/crypto/crypto/Cargo.toml
@@ -52,8 +52,8 @@ sha3 = "0.9.1"
 serde_json = "1.0.64"
 trybuild = "1.0.41"
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }
+# [lints.rust]
+# unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }
 
 [features]
 default = ["fiat"]

--- a/crates/pos/crypto/crypto/Cargo.toml
+++ b/crates/pos/crypto/crypto/Cargo.toml
@@ -20,7 +20,7 @@ hkdf = "0.10.0"
 once_cell = "1.7.2"
 mirai-annotations = "1.10.1"
 proptest = { version = "1.0.0", optional = true }
-proptest-derive = { version = "0.3.0", optional = true }
+proptest-derive = { version = "0.5.1", optional = true }
 rand = "0.8.0"
 serde = { version = "1.0.124", features = ["derive"] }
 serde_bytes = "0.11.5"
@@ -46,7 +46,7 @@ pkcs8 = {version = "0.7.5", features = ["encryption", "std"]}
 [dev-dependencies]
 bitvec = "1.0.1"
 proptest = "1.0.0"
-proptest-derive = "0.3.0"
+proptest-derive = "0.5.1"
 criterion = "0.3.4"
 sha3 = "0.9.1"
 serde_json = "1.0.64"

--- a/crates/pos/crypto/crypto/src/hash.rs
+++ b/crates/pos/crypto/crypto/src/hash.rs
@@ -197,6 +197,7 @@ impl HashValue {
     }
 
     #[cfg(test)]
+    #[allow(missing_docs)]
     pub fn from_iter_sha3<'a, I>(buffers: I) -> Self
     where I: IntoIterator<Item = &'a [u8]> {
         let mut sha3 = Sha3::v256();

--- a/crates/pos/storage/accumulator/Cargo.toml
+++ b/crates/pos/storage/accumulator/Cargo.toml
@@ -25,5 +25,5 @@ diem-crypto = { workspace = true, features = ["fuzzing"] }
 default = []
 fuzzing = ["proptest", "diem-crypto/fuzzing", "diem-types/fuzzing"]
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }
+# [lints.rust]
+# unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }

--- a/crates/pos/storage/accumulator/Cargo.toml
+++ b/crates/pos/storage/accumulator/Cargo.toml
@@ -24,3 +24,6 @@ diem-crypto = { workspace = true, features = ["fuzzing"] }
 [features]
 default = []
 fuzzing = ["proptest", "diem-crypto/fuzzing", "diem-types/fuzzing"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }

--- a/crates/pos/storage/jellyfish-merkle/Cargo.toml
+++ b/crates/pos/storage/jellyfish-merkle/Cargo.toml
@@ -50,5 +50,5 @@ fuzzing = [
     "diem-nibble/fuzzing",
 ]
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }
+# [lints.rust]
+# unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }

--- a/crates/pos/storage/jellyfish-merkle/Cargo.toml
+++ b/crates/pos/storage/jellyfish-merkle/Cargo.toml
@@ -13,11 +13,11 @@ edition = "2018"
 anyhow = "1.0.38"
 byteorder = "1.4.3"
 mirai-annotations = "1.10.1"
-num-derive = "0.3.3"
+num-derive = "0.4.2"
 num-traits = "0.2.14"
 once_cell = "1.7.2"
 proptest = { version = "1.0.0", optional = true }
-proptest-derive = { version = "0.3.0", optional = true }
+proptest-derive = { version = "0.5.1", optional = true }
 rand = { version = "0.8.3", optional = true }
 serde = { version = "1.0.124", features = ["derive"] }
 thiserror = "1.0.24"
@@ -33,7 +33,7 @@ diem-types = { workspace = true }
 [dev-dependencies]
 rand = "0.8.3"
 proptest = "1.0.0"
-proptest-derive = "0.3.0"
+proptest-derive = "0.5.1"
 
 diem-crypto = { workspace = true, features = ["fuzzing"] }
 diem-nibble = { workspace = true, features = ["fuzzing"] }
@@ -49,3 +49,6 @@ fuzzing = [
     "diem-types/fuzzing",
     "diem-nibble/fuzzing",
 ]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }

--- a/crates/pos/storage/pos-ledger-db/Cargo.toml
+++ b/crates/pos/storage/pos-ledger-db/Cargo.toml
@@ -15,10 +15,10 @@ arc-swap = "1.2.0"
 byteorder = "1.4.3"
 itertools = { workspace = true }
 once_cell = { workspace = true }
-num-derive = "0.3.3"
+num-derive = "0.4.2"
 num-traits = "0.2.14"
 proptest = { version = "1.0.0", optional = true }
-proptest-derive = { version = "0.3.0", optional = true }
+proptest-derive = { version = "0.5.1", optional = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 
@@ -39,7 +39,7 @@ storage-interface = { workspace = true }
 
 [dev-dependencies]
 proptest = "1.0.0"
-proptest-derive = "0.3.0"
+proptest-derive = "0.5.1"
 rand = "0.8.3"
 
 diem-jellyfish-merkle = { workspace = true, features = ["fuzzing"] }

--- a/crates/pos/types/move-core-types/Cargo.toml
+++ b/crates/pos/types/move-core-types/Cargo.toml
@@ -16,7 +16,7 @@ hex = "0.4.3"
 mirai-annotations = "1.10.1"
 once_cell = "1.7.2"
 proptest = { version = "1.0.0", default-features = false, optional = true }
-proptest-derive = { version = "0.3.0", default-features = false, optional = true }
+proptest-derive = { version = "0.5.1", default-features = false, optional = true }
 rand = "0.8.3"
 ref-cast = "1.0.6"
 serde = { workspace = true, default-features = false }
@@ -24,10 +24,13 @@ serde_bytes = "0.11.5"
 
 [dev-dependencies]
 proptest = "1.0.0"
-proptest-derive = "0.3.0"
+proptest-derive = "0.5.1"
 regex = "1.4.3"
 serde_json = "1.0.64"
 
 [features]
 default = []
 fuzzing = ["proptest", "proptest-derive"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }

--- a/crates/pos/types/move-core-types/Cargo.toml
+++ b/crates/pos/types/move-core-types/Cargo.toml
@@ -32,5 +32,5 @@ serde_json = "1.0.64"
 default = []
 fuzzing = ["proptest", "proptest-derive"]
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }
+# [lints.rust]
+# unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }

--- a/crates/pos/types/types/Cargo.toml
+++ b/crates/pos/types/types/Cargo.toml
@@ -53,5 +53,5 @@ fuzzing = [
     "move-core-types/fuzzing",
 ]
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }
+# [lints.rust]
+# unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }

--- a/crates/pos/types/types/Cargo.toml
+++ b/crates/pos/types/types/Cargo.toml
@@ -18,7 +18,7 @@ itertools = { workspace = true }
 once_cell = "1.7.2"
 mirai-annotations = "1.10.1"
 proptest = { version = "1.0.0", optional = true }
-proptest-derive = { version = "0.3.0", default-features = false, optional = true }
+proptest-derive = { version = "0.5.1", default-features = false, optional = true }
 rand = "0.8.3"
 serde = { workspace = true, default-features = false }
 serde_json = "1.0.64"
@@ -38,7 +38,7 @@ diem-logger = { workspace = true }
 
 [dev-dependencies]
 proptest = "1.0.0"
-proptest-derive = "0.3.0"
+proptest-derive = "0.5.1"
 serde_json = "1.0.64"
 
 diem-crypto = { workspace = true, features = ["fuzzing"] }
@@ -52,3 +52,6 @@ fuzzing = [
     "diem-crypto/fuzzing",
     "move-core-types/fuzzing",
 ]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }

--- a/crates/pos/types/types/src/account_state_blob.rs
+++ b/crates/pos/types/types/src/account_state_blob.rs
@@ -225,6 +225,6 @@ mod tests {
 
     #[test]
     fn test_debug_does_not_panic() {
-        format!("{:#?}", AccountStateBlob::from(vec![1u8, 2u8, 3u8]));
+        let _ = format!("{:#?}", AccountStateBlob::from(vec![1u8, 2u8, 3u8]));
     }
 }

--- a/crates/rpc/rpc-primitives/src/variadic_value.rs
+++ b/crates/rpc/rpc-primitives/src/variadic_value.rs
@@ -45,7 +45,9 @@ where T: DeserializeOwned
 }
 
 impl<T> VariadicValue<T> {
-    pub fn iter<'a>(&'a self) -> Box<dyn std::iter::Iterator<Item = &'a T> + 'a> {
+    pub fn iter<'a>(
+        &'a self,
+    ) -> Box<dyn std::iter::Iterator<Item = &'a T> + 'a> {
         match self {
             VariadicValue::Null => Box::new(std::iter::empty()),
             VariadicValue::Single(x) => Box::new(std::iter::once(x)),

--- a/crates/rpc/rpc-primitives/src/variadic_value.rs
+++ b/crates/rpc/rpc-primitives/src/variadic_value.rs
@@ -45,7 +45,7 @@ where T: DeserializeOwned
 }
 
 impl<T> VariadicValue<T> {
-    pub fn iter<'a>(&'a self) -> Box<dyn std::iter::Iterator<Item = &T> + 'a> {
+    pub fn iter<'a>(&'a self) -> Box<dyn std::iter::Iterator<Item = &'a T> + 'a> {
         match self {
             VariadicValue::Null => Box::new(std::iter::empty()),
             VariadicValue::Single(x) => Box::new(std::iter::once(x)),

--- a/crates/rpc/rpc-utils/Cargo.toml
+++ b/crates/rpc/rpc-utils/Cargo.toml
@@ -26,3 +26,6 @@ jsonrpsee-core = { workspace = true }
 futures.workspace = true
 tokio.workspace = true
 cfx-tasks = { workspace = true }
+
+[features]
+accounts = []

--- a/crates/stratum/src/lib.rs
+++ b/crates/stratum/src/lib.rs
@@ -266,9 +266,7 @@ impl Default for SocketMetadata {
 }
 
 impl SocketMetadata {
-    pub fn addr(&self) -> &SocketAddr {
-        &self.addr
-    }
+    pub fn addr(&self) -> &SocketAddr { &self.addr }
 }
 
 impl Metadata for SocketMetadata {}
@@ -306,9 +304,7 @@ mod tests {
     pub struct VoidManager;
 
     impl JobDispatcher for VoidManager {
-        fn submit(&self, _payload: Vec<String>) -> Result<(), Error> {
-            Ok(())
-        }
+        fn submit(&self, _payload: Vec<String>) -> Result<(), Error> { Ok(()) }
     }
 
     fn dummy_request(addr: &SocketAddr, data: &str) -> Vec<u8> {
@@ -368,9 +364,7 @@ mod tests {
     }
 
     impl JobDispatcher for DummyManager {
-        fn submit(&self, _payload: Vec<String>) -> Result<(), Error> {
-            Ok(())
-        }
+        fn submit(&self, _payload: Vec<String>) -> Result<(), Error> { Ok(()) }
     }
 
     fn terminated_str(origin: &'static str) -> String {

--- a/crates/util/solidity-abi-derive/src/lib.rs
+++ b/crates/util/solidity-abi-derive/src/lib.rs
@@ -45,11 +45,6 @@ pub fn keccak(input_stream: TokenStream) -> TokenStream {
         }
     };
 
-    let dummy_const = syn::Ident::new(
-        &format!("_IMPL_ABI_VARIABLE_DUMMY_{}", ident),
-        Span::call_site(),
-    );
-
     let env = quote! {
         use #abi_crate::{ABIDecodeError, ABIListWriter, ABIVariable, LinkedBytes, read_abi_list};
         #(type #dummy_types = #types;)*
@@ -91,10 +86,8 @@ pub fn keccak(input_stream: TokenStream) -> TokenStream {
     };
 
     let answer = quote! {
-        #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-        const #dummy_const: () = {
+        const _: () = {
             #env
-
             #impl_abi
         };
     };


### PR DESCRIPTION
This pull request resolves compatibility issues encountered during an attempted upgrade from Rust version 1.77.2 to 1.86, , as well as addressing an issue with the CI pipeline. The upgrade efforts surfaced key challenges related to undefined behavior, dangling pointer warnings, and other code patterns that Rust 1.86 has started to detect and warn against more rigorously. 

With these fixes in place, the updated codebase demonstrates compatibility with Rust 1.86. However, the decision to proceed with the actual upgrade remains open for discussion. The current implementation retains the use of Rust 1.77.2 as a baseline version, allowing for further evaluation of the upgrade's potential impact.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3199)
<!-- Reviewable:end -->
