### PR TITLE
Remove unreachable_unchecked from cfx-storage

### DIFF
--- a/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/recent_lfu.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/recent_lfu.rs
@@ -11,7 +11,6 @@ use super::{
 use malloc_size_of_derive::MallocSizeOf as MallocSizeOfDerive;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
-use std::hint;
 
 /// In RecentLFU we keep an LRU to maintain frequency for alpha * cache_slots
 /// recently visited elements. When inserting the most recent element, evict the
@@ -492,7 +491,7 @@ impl<PosT: PrimitiveNum, CacheIndexT: CacheIndexTrait> CacheAlgorithm
                             }
                         }
                     }
-                    _ => unsafe { hint::unreachable_unchecked() },
+                    _ => unreachable!(),
                 }
             }
         }

--- a/crates/dbs/storage/src/impls/delta_mpt/cow_node_ref.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/cow_node_ref.rs
@@ -662,7 +662,7 @@ impl CowNodeRef {
 
             let slot = match &self.node_ref {
                 NodeRefDeltaMpt::Dirty { index } => *index,
-                _ => unsafe { unreachable_unchecked() },
+                _ => unreachable!(),
             };
             if let Some(children_merkles) = children_merkle_map.remove(&slot) {
                 commit_transaction.transaction.borrow_mut().put(
@@ -913,6 +913,6 @@ use parking_lot::MutexGuard;
 use primitives::{MerkleHash, MptValue, MERKLE_NULL_NODE};
 use rlp::*;
 use std::{
-    borrow::BorrowMut, cell::Cell, convert::TryInto,
-    hint::unreachable_unchecked, ops::Deref, sync::atomic::Ordering,
+    borrow::BorrowMut, cell::Cell, convert::TryInto, ops::Deref,
+    sync::atomic::Ordering,
 };

--- a/crates/dbs/storage/src/impls/delta_mpt/mem_optimized_trie_node.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/mem_optimized_trie_node.rs
@@ -488,7 +488,7 @@ impl<CacheAlgoDataT: CacheAlgoDataTrait> MemOptimizedTrieNode<CacheAlgoDataT> {
                 };
             }
         }
-        unsafe { unreachable_unchecked() }
+        unreachable!()
     }
 
     pub unsafe fn set_first_child_unchecked(
@@ -645,7 +645,6 @@ use primitives::{MerkleHash, MptValue};
 use rlp::*;
 use std::{
     fmt::{Debug, Formatter},
-    hint::unreachable_unchecked,
     marker::{Send, Sync},
     vec::Vec,
 };

--- a/crates/dbs/storage/src/impls/delta_mpt/node_memory_manager.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/node_memory_manager.rs
@@ -237,10 +237,11 @@ impl<
         match cache_mut.node_ref_map.get_cache_info((mpt_id, db_key)) {
             None => {}
             Some(cache_info) => match cache_info.get_cache_info() {
-                TrieCacheSlotOrCacheAlgoData::TrieCacheSlot(_cache_slot) => unsafe {
+                TrieCacheSlotOrCacheAlgoData::TrieCacheSlot(_cache_slot) => {
                     // This should not happen.
-                    unreachable_unchecked();
-                },
+                    unreachable!()
+                }
+
                 TrieCacheSlotOrCacheAlgoData::CacheAlgoData(
                     cache_algo_data,
                 ) => {
@@ -392,7 +393,7 @@ impl<
     ) -> &'a mut MemOptimizedTrieNode<CacheAlgoDataT> {
         match node {
             NodeRefDeltaMpt::Committed { db_key: _ } => {
-                unreachable_unchecked();
+                unreachable!();
             }
             NodeRefDeltaMpt::Dirty { ref index } => NodeMemoryManager::<
                 CacheAlgoDataT,
@@ -501,7 +502,7 @@ impl<
 
                 Ok(GuardedValue::new(cache_manager_mut_wrapped, trie_node))
             }
-            NodeRefDeltaMpt::Dirty { index: _ } => unreachable_unchecked(),
+            NodeRefDeltaMpt::Dirty { index: _ } => unreachable!(),
         }
     }
 
@@ -789,6 +790,5 @@ use rlp::*;
 use std::{
     cell::UnsafeCell,
     convert::TryInto,
-    hint::unreachable_unchecked,
     sync::atomic::{AtomicUsize, Ordering},
 };

--- a/crates/dbs/storage/src/impls/delta_mpt/subtrie_visitor.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/subtrie_visitor.rs
@@ -399,7 +399,9 @@ impl<'trie, 'db: 'trie> SubTrieVisitor<'trie, 'db> {
 
                             Ok((value, node_ref_changed, node_cow.into_child()))
                         },
-                        _ => unsafe { unreachable_unchecked() },
+                        _ => {
+                            unreachable!()
+                        }
                     }
                 } else {
                     Ok((value, false, node_cow.into_child()))
@@ -544,7 +546,9 @@ impl<'trie, 'db: 'trie> SubTrieVisitor<'trie, 'db> {
                                 node_cow.into_child(),
                             ));
                         },
-                        _ => unsafe { unreachable_unchecked() },
+                        _ => {
+                            unreachable!()
+                        }
                     }
                 } else {
                     return Ok((value, false, node_cow.into_child()));
@@ -854,4 +858,4 @@ use super::{
 };
 use parking_lot::MutexGuard;
 use primitives::{MerkleHash, MptValue, MERKLE_NULL_NODE};
-use std::{hint::unreachable_unchecked, marker::PhantomData};
+use std::marker::PhantomData;

--- a/crates/dbs/storage/src/impls/merkle_patricia_trie/mpt_cursor.rs
+++ b/crates/dbs/storage/src/impls/merkle_patricia_trie/mpt_cursor.rs
@@ -115,7 +115,9 @@ impl<Mpt: GetReadMpt, PathNode: PathNodeTrait<Mpt>> MptCursor<Mpt, PathNode> {
                 child_index: _,
                 key_remaining: _,
                 child_node: _,
-            } => unsafe { unreachable_unchecked() },
+            } => {
+                unreachable!()
+            }
             // It actually means to descent.
             WalkStop::ChildNotFound {
                 child_index,
@@ -256,9 +258,9 @@ impl<Mpt: GetReadMpt, PathNode: PathNodeTrait<Mpt>> MptCursor<Mpt, PathNode> {
                         // The scenario of Descent is classified into
                         // ChildNotFound scenario because the checking of
                         // child_index is skipped.
-                        WalkStop::Descent { .. } => unsafe {
-                            unreachable_unchecked()
-                        },
+                        WalkStop::Descent { .. } => {
+                            unreachable!()
+                        }
                         // It actually means to descent.
                         WalkStop::ChildNotFound {
                             child_index: new_child_index,
@@ -501,7 +503,9 @@ impl<Mpt: GetRwMpt, PathNode: RwPathNodeTrait<Mpt>> MptCursorRw<Mpt, PathNode> {
                     }
                 }
             }
-            _ => unsafe { unreachable_unchecked() },
+            _ => {
+                unreachable!()
+            }
         }
 
         Ok(())
@@ -1615,7 +1619,6 @@ use crate::{
 use primitives::{MerkleHash, MptValue, MERKLE_NULL_NODE};
 use std::{
     cell::Cell,
-    hint::unreachable_unchecked,
     mem,
     ops::{Deref, DerefMut},
     vec::Vec,

--- a/crates/dbs/storage/src/impls/single_mpt_state.rs
+++ b/crates/dbs/storage/src/impls/single_mpt_state.rs
@@ -10,10 +10,7 @@ use primitives::{
     EpochId, MerkleHash, MptValue, StateRoot, StorageKeyWithSpace,
     MERKLE_NULL_NODE,
 };
-use std::{
-    cell::UnsafeCell, collections::HashSet, hint::unreachable_unchecked,
-    sync::Arc,
-};
+use std::{cell::UnsafeCell, collections::HashSet, sync::Arc};
 
 pub struct SingleMptState {
     trie: Arc<DeltaMpt>,
@@ -219,9 +216,9 @@ impl SingleMptState {
         let db_key = *{
             match &self.trie_root {
                 // Dirty state are committed.
-                NodeRefDeltaMpt::Dirty { index: _ } => unsafe {
-                    unreachable_unchecked();
-                },
+                NodeRefDeltaMpt::Dirty { index: _ } => {
+                    unreachable!()
+                }
                 // Empty block's state root points to its base state.
                 NodeRefDeltaMpt::Committed { db_key } => db_key,
             }

--- a/crates/dbs/storage/src/impls/snapshot_sync/restoration/mpt_slice_verifier.rs
+++ b/crates/dbs/storage/src/impls/snapshot_sync/restoration/mpt_slice_verifier.rs
@@ -257,7 +257,7 @@ impl SnapshotMptTraitReadAndIterate for SliceMptRebuilder {
     ) -> Result<Box<dyn SnapshotMptIteraterTrait>> {
         // The validator runs the MptCursorRW in in-place mode, where subtree
         // iteration is unnecessary.
-        unsafe { unreachable_unchecked() }
+        unreachable!()
     }
 }
 
@@ -354,5 +354,4 @@ use primitives::MerkleHash;
 use std::{
     borrow::Borrow,
     collections::{hash_map::RandomState, HashMap},
-    hint::unreachable_unchecked,
 };

--- a/crates/dbs/storage/src/impls/state.rs
+++ b/crates/dbs/storage/src/impls/state.rs
@@ -709,9 +709,9 @@ impl State {
                 let db_key = *{
                     match self.delta_trie_root.as_ref().unwrap() {
                         // Dirty state are committed.
-                        NodeRefDeltaMpt::Dirty { index: _ } => unsafe {
-                            unreachable_unchecked();
-                        },
+                        NodeRefDeltaMpt::Dirty { index: _ } => {
+                            unreachable!();
+                        }
                         // Empty block's state root points to its base state.
                         NodeRefDeltaMpt::Committed { db_key } => db_key,
                     }
@@ -983,6 +983,5 @@ use rustc_hex::ToHex;
 use std::{
     cell::UnsafeCell,
     collections::{BTreeMap, HashSet},
-    hint::unreachable_unchecked,
     sync::{atomic::Ordering, Arc},
 };

--- a/crates/dbs/storage/src/impls/storage_db/snapshot_db_manager_sqlite.rs
+++ b/crates/dbs/storage/src/impls/storage_db/snapshot_db_manager_sqlite.rs
@@ -1291,11 +1291,8 @@ impl SnapshotDbManagerTrait for SnapshotDbManagerSqlite {
                     // This should not happen because Conflux always write on a
                     // snapshot db under a temporary name. All completed
                     // snapshots are readonly.
-                    if cfg!(debug_assertions) {
-                        unreachable!("Try to destroy a snapshot being open exclusively for write.")
-                    } else {
-                        unsafe { unreachable_unchecked() }
-                    }
+
+                    unreachable!("Try to destroy a snapshot being open exclusively for write.")
                 }
                 None => break None,
             };
@@ -1331,11 +1328,7 @@ impl SnapshotDbManagerTrait for SnapshotDbManagerSqlite {
                         Some(snapshot) => break Some(snapshot),
                     },
                     Some(None) => {
-                        if cfg!(debug_assertions) {
-                            unreachable!("Try to destroy a snapshot being open exclusively for write.")
-                        } else {
-                            unsafe { unreachable_unchecked() }
-                        }
+                        unreachable!("Try to destroy a snapshot being open exclusively for write.")
                     }
                     None => break None,
                 };
@@ -1576,7 +1569,6 @@ use rustc_hex::ToHex;
 use std::{
     collections::HashMap,
     fs,
-    hint::unreachable_unchecked,
     path::{Path, PathBuf},
     process::Command,
     str::FromStr,

--- a/crates/stratum/src/lib.rs
+++ b/crates/stratum/src/lib.rs
@@ -529,7 +529,7 @@ mod tests {
 
     #[test]
     fn test_can_submit() {
-        let addr = "127.0.0.1:19972".parse().unwrap();
+        let addr = "127.0.0.1:19973".parse().unwrap();
 
         struct TestDispatcher {
             submissions: Arc<RwLock<Vec<Vec<String>>>>,


### PR DESCRIPTION
This PR addresses a critical aspect of code safety in `cfx-storage` by eliminating the use of `unreachable_unchecked`. The extensive application of unsafe code in the project had posed risks to the overall reliability of the codebase.  

In every instance, the code surrounding `unreachable_unchecked` already includes other operations—such as `if` statements, `match` expressions, or lock acquisition—that are equal to or slower in terms of performance. Because these operations inherently overshadow any performance gain from `unreachable_unchecked`, it is not a performance bottleneck here.  
