### PR TITLE
Fix EXTCODEHASH Inconsistency for Empty Accounts and Restore Checkpoint Optimization

### DIFF
--- a/crates/cfxcore/executor/src/context.rs
+++ b/crates/cfxcore/executor/src/context.rs
@@ -294,7 +294,7 @@ impl<'a> ContextTrait for Context<'a> {
             self.space == Space::Native
                 && self.state.is_contract_with_code(&address_with_space)?
         } else {
-            !self.state.is_eip684_empty(&address_with_space)?
+            !self.state.is_eip158_empty(&address_with_space)?
         };
 
         if conflict_address {
@@ -409,7 +409,13 @@ impl<'a> ContextTrait for Context<'a> {
         {
             Ok(contract.code_hash())
         } else {
-            Ok(self.state.code_hash(&address)?)
+            if self.spec.cip645.fix_extcodehash
+                && self.state.is_eip158_empty(&address)?
+            {
+                Ok(H256::zero())
+            } else {
+                Ok(self.state.code_hash(&address)?)
+            }
         }
     }
 

--- a/crates/cfxcore/executor/src/executive/pre_checked_executive.rs
+++ b/crates/cfxcore/executor/src/executive/pre_checked_executive.rs
@@ -273,7 +273,7 @@ impl<'a, O: ExecutiveObserver> PreCheckedExecutive<'a, O> {
                 return Ok(false);
             }
             let address = params.address.with_space(params.space);
-            !self.context.state.is_eip684_empty(&address)?
+            !self.context.state.is_eip158_empty(&address)?
         })
     }
 }

--- a/crates/cfxcore/executor/src/state/state_object/basic_fields.rs
+++ b/crates/cfxcore/executor/src/state/state_object/basic_fields.rs
@@ -112,7 +112,7 @@ impl State {
         Ok(acc.code_hash() != KECCAK_EMPTY)
     }
 
-    pub fn is_eip684_empty(
+    pub fn is_eip158_empty(
         &self, address: &AddressWithSpace,
     ) -> DbResult<bool> {
         let Some(acc) = self.read_account_lock(address)? else {

--- a/crates/cfxcore/vm-types/src/spec.rs
+++ b/crates/cfxcore/vm-types/src/spec.rs
@@ -268,6 +268,8 @@ pub struct CIP645Spec {
     pub blockhash_gas: bool,
 
     pub opcode_update: bool,
+
+    pub fix_extcodehash: bool,
 }
 
 impl CIP645Spec {
@@ -286,6 +288,7 @@ impl CIP645Spec {
             fix_eip5656: enabled,
             blockhash_gas: enabled,
             opcode_update: enabled,
+            fix_extcodehash: enabled,
         }
     }
 }


### PR DESCRIPTION
This PR addresses two key issues: an inconsistency in the handling of the `EXTCODEHASH` opcode for empty accounts, and the restoration of a previously removed checkpoint optimization.

### `EXTCODEHASH` Behavior for Empty Accounts

According to [EIP-158](https://eips.ethereum.org/EIPS/eip-158):, an account is considered "empty" if its address, balance, and nonce are all zero. For such accounts, `EXTCODEHASH` must return `ZERO_HASH` instead of `KECCAK_EMPTY`. However, the previous implementation in Conflux would return `KECCAK_EMPTY` if the account was present in the cache and marked as anything other than `DbAbsent`. This discrepancy could be triggered, for example, by creating a contract that self-destructs during its constructor execution.

With this PR, Conflux now correctly aligns with Ethereum's behavior, returning `ZERO_HASH` for all empty accounts defined by EIP-158.

---

###  Restoration of Checkpoint Optimization

This PR also restores a checkpoint optimization originally introduced during the migration from OpenEthereum. The optimization ensures that if a `CheckpointEntry` is marked as `Unchanged` and the corresponding cache entry is clean (i.e., its dirty bit is not set), the cache entry is retained rather than discarded. This avoids unnecessary cache invalidation, improving performance.

In PR #3105 , the optimization was removed to facilitate a temporary implementation choice for [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929): the presence of an entry in the cache was used to mark storage as "warm." Later, in PR #3168 , this behavior was replaced by the introduction of a dedicated "warm bit," decoupling the optimization from the warm-up mechanism.

Upon fixing the `EXTCODEHASH` issue, we re-evaluated the impact of this checkpoint optimization on correctness. A theoretical concern arose: if a `CheckpointEntry` is `Unchanged`, its cache entry is clean, and the account is absent from the database (`DbAbsent`), the `code_hash` behavior might differ with and without this optimization. However, it was determined that this scenario cannot occur. While `DbAbsent` and empty accounts are conceptually similar (and treated as equivalent in most VM contexts), they remain distinct values in the cache, and transitioning from one to the other would inherently set the dirty bit.