### PR TITLE
chore: upgrade clap to v4 for cfx-gen-dot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,7 +1181,7 @@ dependencies = [
  "cfx-storage",
  "cfx-types",
  "cfxcore",
- "clap",
+ "clap 2.34.0",
  "db",
  "diem-types",
  "jsonrpc-http-server",
@@ -1727,7 +1727,7 @@ dependencies = [
  "cfx-vm-types",
  "cfxkey",
  "channel",
- "clap",
+ "clap 2.34.0",
  "consensus-types",
  "crash-handler",
  "dag",
@@ -1966,6 +1966,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
 name = "client"
 version = "2.4.0"
 dependencies = [
@@ -2001,7 +2028,7 @@ dependencies = [
  "cfxcore-accounts",
  "cfxkey",
  "cfxstore",
- "clap",
+ "clap 2.34.0",
  "consensus-types",
  "criterion",
  "ctrlc",
@@ -2120,7 +2147,8 @@ dependencies = [
  "cfxcore",
  "cfxkey",
  "cfxstore",
- "clap",
+ "clap 2.34.0",
+ "clap 4.5.37",
  "client",
  "db",
  "diem-crypto",
@@ -2288,7 +2316,7 @@ checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.34.0",
  "criterion-plot",
  "csv",
  "itertools 0.10.5",
@@ -8361,12 +8389,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "lazy_static",
  "structopt-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -340,6 +340,7 @@ rand_chacha = "0.2.1"
 
 # misc
 clap = "2" # outdated, need to migrate to clap 4
+clap4 = { version = "4", package = "clap" }
 structopt = { version = "0.3", default-features = false } # unmaintained, need to migrate to clap 4
 log = "0.4"
 log4rs = "1.3.0"

--- a/bins/conflux/Cargo.toml
+++ b/bins/conflux/Cargo.toml
@@ -10,6 +10,7 @@ license-file.workspace = true
 
 [dependencies]
 clap = { workspace = true, features = ["yaml"] }
+clap4 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 parking_lot = { workspace = true }
@@ -51,7 +52,7 @@ thiserror = { workspace = true }
 cfx-bytes = { workspace = true }
 keccak-hash = { workspace = true }
 cfx-rpc-eth-types = { workspace = true }
-hex = { workspace = true}
+hex = { workspace = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies.jemallocator]
 version = "0.3.2"

--- a/bins/conflux/src/bin/cfx-gen-dot.rs
+++ b/bins/conflux/src/bin/cfx-gen-dot.rs
@@ -88,17 +88,8 @@ struct Config {
     from_block: H256,
     max_depth: u32,
 }
-
-// from /src/main.rs
-fn from_str_validator<T: std::str::FromStr>(arg: String) -> Result<(), String> {
-    match arg.parse::<T>() {
-        Ok(_) => Ok(()),
-        Err(_) => Err(arg),
-    }
-}
-
 fn parse_config() -> Config {
-    let matches = clap::App::new("cfx-gen-dot")
+    let matches = clap4::Command::new("cfx-gen-dot")
         .version("0.1")
         .about(
 "Generate Graphviz dot files from your local blockchain db
@@ -110,41 +101,35 @@ Example usage:
         > graph.dot
     dot -Tsvg graph.dot -o graph.svg")
         .arg(
-            clap::Arg::with_name("db-path")
+            clap4::Arg::new("db-path")
                 .long("db-path")
                 .value_name("PATH")
                 .help("Specifies local blockchain db directory")
-                .takes_value(true)
                 .required(true),
         )
         .arg(
-            clap::Arg::with_name("from-block")
+            clap4::Arg::new("from-block")
                 .long("from-block")
                 .value_name("HASH")
                 .help("Sets starting block of DAG traversal")
-                .takes_value(true)
                 .required(true),
         )
         .arg(
-            clap::Arg::with_name("max-depth")
+            clap4::Arg::new("max-depth")
                 .long("max-depth")
                 .value_name("NUM")
+                .value_parser(clap4::value_parser!(u32))
                 .help("Sets maximum depth for traversal")
-                .takes_value(true)
                 .required(true)
-                .validator(from_str_validator::<u32>),
         )
         .get_matches();
 
-    let db_path = matches.value_of("db-path").unwrap();
-    let max_depth = matches
-        .value_of("max-depth")
-        .unwrap()
-        .parse::<u32>()
-        .unwrap();
+    let db_path = matches.get_one::<String>("db-path").unwrap();
+    let max_depth = matches.get_one::<u32>("max-depth").unwrap().clone();
 
     let from_block = {
-        let mut from = matches.value_of("from-block").unwrap();
+        let mut from =
+            matches.get_one::<String>("from-block").unwrap().as_str();
 
         if from.starts_with("0x") {
             from = &from[2..];


### PR DESCRIPTION
Related #3200


Run `cfx-gen-dot` without arguments:

clap v2:
![010df54f-fdb2-42b8-ac21-7689e058b31c](https://github.com/user-attachments/assets/e7eec745-6453-4ef0-b61a-6119c366a443)


clap v4:
![8ac437ae-8c7d-4f7b-b64c-f48ca7641e66](https://github.com/user-attachments/assets/7b5082f8-6aad-43bc-b936-5a7f1943feaf)


Run `cfx-gen-dot  --db-path testpath  --from-block 0x1333333333333333333333333333333333333333333333333333333333333333 --max-depth 1` then print the `Config`

clap v2:

```
-----------------------------
Config { db_path: "testpath", from_block: 0x1333333333333333333333333333333333333333333333333333333333333333, max_depth: 1 }
-----------------------------
```
clap v4:
```
------------------------------------
Config { db_path: "testpath", from_block: 0x1333333333333333333333333333333333333333333333333333333333333333, max_depth: 1 }
------------------------------------
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3204)
<!-- Reviewable:end -->
