### PR TITLE
Eliminate potential double-read-lock in dbs (#3208)

### DIFF
--- a/crates/dbs/storage/src/impls/storage_db/snapshot_db_manager_sqlite.rs
+++ b/crates/dbs/storage/src/impls/storage_db/snapshot_db_manager_sqlite.rs
@@ -369,17 +369,17 @@ impl SnapshotDbManagerSqlite {
             let (mpt_snapshot_path, create_mpt) = match mpt_snapshot_path {
                 Some(v) => (v, true),
                 _ => {
+                    let latest_snapshot_id = self.latest_snapshot_id.read();
                     debug!(
                         "new_epoch_height {}, latest_snapshot_id {} {}",
                         new_epoch_height,
-                        self.latest_snapshot_id.read().0,
-                        self.latest_snapshot_id.read().1
+                        latest_snapshot_id.0,
+                        latest_snapshot_id.1
                     );
-                    if new_epoch_height <= self.latest_snapshot_id.read().1 {
+                    if new_epoch_height <= latest_snapshot_id.1 {
                         bail!(format!(
                             "Try to write an old snapshot {}, {}",
-                            new_epoch_height,
-                            self.latest_snapshot_id.read().1
+                            new_epoch_height, latest_snapshot_id.1
                         ))
                     }
 


### PR DESCRIPTION
Fix #3208 

Eliminate the double read lock bug.
Acquire the lock once.
Then reuse the result of the lock in the following code. No need to acquire the remaining three locks.

Actually this fixes two potential bugs:
1. A potential deadlock between the first and the second locks.
2. A potential atomicity violation for the third and fourth locks, because a write lock may change the value in between the two read lock, which may cause inconsistent behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3209)
<!-- Reviewable:end -->
