### PR TITLE
chore: migrate docopt to clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,6 +1972,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -1984,6 +1985,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2500,7 +2513,7 @@ name = "ctxkey-cli"
 version = "0.1.0"
 dependencies = [
  "cfxkey",
- "docopt",
+ "clap 4.5.37",
  "env_logger",
  "panic_hook",
  "rustc-hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,7 +2510,7 @@ dependencies = [
 
 [[package]]
 name = "ctxkey-cli"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "cfxkey",
  "clap 4.5.37",

--- a/bins/cfx_key/Cargo.toml
+++ b/bins/cfx_key/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Conflux Core Space Keys Generator CLI"
 name = "ctxkey-cli"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license-file.workspace = true

--- a/bins/cfx_key/Cargo.toml
+++ b/bins/cfx_key/Cargo.toml
@@ -7,13 +7,14 @@ edition = "2021"
 license-file.workspace = true
 
 [dependencies]
-docopt = { workspace = true }
 env_logger = { workspace = true }
 cfxkey = { workspace = true }
 panic_hook = { workspace = true }
 rustc-hex = { workspace = true }
 serde = { workspace = true }
 threadpool = { workspace = true }
+# todo use workspace version
+clap = { version = "4", features = ["derive"] }
 
 [[bin]]
 name = "cfxkey"

--- a/bins/cfx_key/README.md
+++ b/bins/cfx_key/README.md
@@ -6,33 +6,25 @@ address scheme is different from Ethereum. You cannot directly import Ethereum k
 ### Usage
 
 ```
-Conflux Keys Generator.
-  Copyright 2020 Conflux Foundation
+Conflux Core Space Keys Generator CLI
 
-Usage:
-    cfxkey info <secret-or-phrase> [options]
-    cfxkey generate random [options]
-    cfxkey generate prefix <prefix> [options]
-    cfxkey sign <secret> <message>
-    cfxkey verify public <public> <signature> <message>
-    cfxkey verify address <address> <signature> <message>
-    cfxkey recover <address> <known-phrase>
-    cfxkey [-h | --help]
-
-Options:
-    -h, --help         Display this message and exit.
-    -s, --secret       Display only the secret key.
-    -p, --public       Display only the public key.
-    -a, --address      Display only the address.
-    -b, --brain        Use parity brain wallet algorithm. Not recommended.
+Usage: cfxkey [OPTIONS] <COMMAND>
 
 Commands:
-    info               Display public key and address of the secret.
-    generate random    Generates new random Ethereum key.
-    generate prefix    Random generation, but address must start with a prefix ("vanity address").
-    sign               Sign message using a secret key.
-    verify             Verify signer of the signature by public key or address.
-    recover            Try to find brain phrase matching given address from partial phrase.
+  info      Display public key and address of the secret
+  generate  
+  sign      Sign message using a secret key
+  verify    Verify signer of the signature by public key or address
+  recover   Try to find brain phrase matching given address from partial phrase
+  help      Print this message or the help of the given subcommand(s)
+
+Options:
+  -s, --secret   Display only the secret key
+  -p, --public   Display only the public key
+  -a, --address  Display only the address
+  -b, --brain    Use parity brain wallet algorithm. Not recommended
+  -h, --help     Print help
+  -V, --version  Print version
 ```
 
 ### Examples
@@ -49,7 +41,7 @@ cfxkey info 17d08f5fe8c77af811caa0c9a187e668ce3b74a99acc3f6d976f075fa8e0be55
 ```
 secret:  17d08f5fe8c77af811caa0c9a187e668ce3b74a99acc3f6d976f075fa8e0be55
 public:  689268c0ff57a20cd299fa60d3fb374862aff565b20b5f1767906a99e6e09f3ff04ca2b2a5cd22f62941db103c0356df1a8ed20ce322cab2483db67685afd124
-address: 26d1ec50b4e62c1d1a40d16e7cacc6a6580757d5
+address: 16d1ec50b4e62c1d1a40d16e7cacc6a6580757d5
 ```
 
 --
@@ -61,7 +53,7 @@ address: 26d1ec50b4e62c1d1a40d16e7cacc6a6580757d5
 - `<phrase>` - Parity recovery phrase, 12 words
 
 ```
-cfxkey info --brain "this is sparta"
+cfxkey  --brain info  "this is sparta"
 ```
 
 ```
@@ -93,14 +85,14 @@ address: a8fa5dd30a87bb9e3288d604eb74949c515ab66e
 *Generate new keypair with recovery phrase randomly.*
 
 ```
-cfxkey generate random --brain
+cfxkey --brain generate random
 ```
 
 ```
-recovery phrase: thwarting scandal creamer nuzzle asparagus blast crouch trusting anytime elixir frenzied octagon
-secret:  001ce488d50d2f7579dc190c4655f32918d505cee3de63bddc7101bc91c0c2f0
-public:  4e19a5fdae82596e1485c69b687c9cc52b5078e5b0668ef3ce8543cd90e712cb00df822489bc1f1dcb3623538a54476c7b3def44e1a51dc174e86448b63f42d0
-address: 00cf3711cbd3a1512570639280758118ba0b2bcb
+recovery phrase: enhance ascent acts riveter frugality python prude overpass elusive smilingly unleash aspirin
+secret:  90110fa58d0967f924a23df60150cf39e738643e6115d3400615e3a6ff3d6b43
+public:  6981b523e989eeffa059d76c88211c20580034bfa6a1fd69b5d978197690ac679fee15dc276cbda59ec3acd769ebdf5b3fe4fe3614a851aced3b771cd25692fb
+address: 10bab0da50e5c72939048dfacc700d5902769284
 ```
 
 
@@ -112,13 +104,13 @@ address: 00cf3711cbd3a1512570639280758118ba0b2bcb
 - `<prefix>` - desired address prefix, 0 - 32 bytes long.
 
 ```
-cfxkey generate prefix ff
+cfxkey generate prefix 10ff
 ```
 
 ```
-secret:  2075b1d9c124ea673de7273758ed6de14802a9da8a73ceb74533d7c312ff6acd
-public:  48dbce4508566a05509980a5dd1335599fcdac6f9858ba67018cecb9f09b8c4066dc4c18ae2722112fd4d9ac36d626793fffffb26071dfeb0c2300df994bd173
-address: fff7e25dff2aa60f61f9d98130c8646a01f31649
+secret:  0c566d692da1331ce6be334520aa216c35e40deefd494943e39a6d5ff6be357c
+public:  035eeb11e020c3461f13b4e9e302a710e18cbdf484ca9f503f3cba6c792e02ca8a1405f1bf269010878499614c45e111efc56fb506da181dda95bfd09c32d68a
+address: 10fff9140be305f1e07f64e5343b99f951386267
 ```
 
 --
@@ -129,14 +121,14 @@ address: fff7e25dff2aa60f61f9d98130c8646a01f31649
 - `<prefix>` - desired address prefix, 0 - 32 bytes long.
 
 ```
-cfxkey generate prefix --brain 00cf
+cfxkey --brain  generate prefix 10ff
 ```
 
 ```
-recovery phrase: thwarting scandal creamer nuzzle asparagus blast crouch trusting anytime elixir frenzied octagon
-secret:  001ce488d50d2f7579dc190c4655f32918d505cee3de63bddc7101bc91c0c2f0
-public:  4e19a5fdae82596e1485c69b687c9cc52b5078e5b0668ef3ce8543cd90e712cb00df822489bc1f1dcb3623538a54476c7b3def44e1a51dc174e86448b63f42d0
-address: 00cf3711cbd3a1512570639280758118ba0b2bcb
+recovery phrase: coat elixir gander deferral strut voter postwar huddle tigress scarecrow kabob cuddle
+secret:  e2b820b59fe47738e81db5e1396c4e907e21a83de67fd855abea120673242d66
+public:  61cb56efbd05c66e4b6412dcbc1b577b1df1ca04c3ac00d79f71be4e173faacb937477b1e8dab365bb5ea6b5fb4844a33dd42d8b0531dbdbe2211cca0bb8ebdd
+address: 10ff239b0f55ac54566ac1155f00ccc76aaf2c0b
 ```
 
 --
@@ -182,7 +174,7 @@ true
 - `<message>` - message, 32 bytes long
 
 ```
-cfxkey verify address 689268c0ff57a20cd299fa60d3fb374862aff565b20b5f1767906a99e6e09f3ff04ca2b2a5cd22f62941db103c0356df1a8ed20ce322cab2483db67685afd124 c1878cf60417151c766a712653d26ef350c8c75393458b7a9be715f053215af63dfd3b02c2ae65a8677917a8efa3172acb71cb90196e42106953ea0363c5aaf200 bd50b7370c3f96733b31744c6c45079e7ae6c8d299613246d28ebcef507ec987
+cfxkey verify address 131568754ef57c9a7e9e83a3b3d705ece01ab1f8 72b02a550f2fb4c20d6dff069c9fa2a4350081e147c04a2ab2283ab0c896db1f77bf1c366eb60df4bd7d2544d5f0f30606fe477c6c1c8385e48dccfc28e7a6ac00 bd50b7370c3f96733b31744c6c45079e7ae6c8d299613246d28ebcef507ec987
 ```
 
 ```

--- a/bins/cfx_key/src/main.rs
+++ b/bins/cfx_key/src/main.rs
@@ -252,7 +252,6 @@ fn execute_generate(
         }
         GenerateCommands::Prefix { prefix } => {
             let prefix: Vec<u8> = prefix.from_hex()?;
-            let brain = brain;
             in_threads(move || {
                 let iterations = 1024;
                 let prefix = prefix.clone();
@@ -323,7 +322,6 @@ fn execute_verify(command: &VerifyCommands) -> Result<String, Error> {
 fn execute_recover(
     known_phrase: &str, address: &str, display_mode: DisplayMode,
 ) -> Result<String, Error> {
-    let known_phrase = known_phrase;
     let address = address.parse().map_err(|_| EthkeyError::InvalidAddress)?;
     let (phrase, keypair) = in_threads(move || {
         let mut it = brain_recover::PhrasesIterator::from_known_phrase(

--- a/bins/cfx_key/src/main.rs
+++ b/bins/cfx_key/src/main.rs
@@ -18,68 +18,100 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{env, fmt, io, num::ParseIntError, process, sync};
+use std::{fmt, io, num::ParseIntError, process, sync};
 
 use cfxkey::{
     brain_recover, sign, verify_address, verify_public, Brain, BrainPrefix,
     Error as EthkeyError, Generator, KeyPair, Prefix, Random,
 };
-use docopt::Docopt;
+use clap::{Parser, Subcommand};
 use rustc_hex::{FromHex, FromHexError};
-use serde::Deserialize;
 
-const USAGE: &str = r#"
-Conflux keys generator.
+#[derive(Parser)]
+#[command(version, about)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
 
-Usage:
-    cfxkey info <secret-or-phrase> [options]
-    cfxkey generate random [options]
-    cfxkey generate prefix <prefix> [options]
-    cfxkey sign <secret> <message>
-    cfxkey verify public <public> <signature> <message>
-    cfxkey verify address <address> <signature> <message>
-    cfxkey recover <address> <known-phrase>
-    cfxkey [-h | --help]
+    /// Display only the secret key.
+    #[arg(short, long, default_value_t = false)]
+    secret: bool,
+    /// Display only the public key.
+    #[arg(short, long, default_value_t = false)]
+    public: bool,
+    /// Display only the address.
+    #[arg(short, long, default_value_t = false)]
+    address: bool,
+    /// Use parity brain wallet algorithm. Not recommended.
+    #[arg(short, long, default_value_t = false)]
+    brain: bool,
+}
 
-Options:
-    -h, --help         Display this message and exit.
-    -s, --secret       Display only the secret key.
-    -p, --public       Display only the public key.
-    -a, --address      Display only the address.
-    -b, --brain        Use parity brain wallet algorithm. Not recommended.
+#[derive(Subcommand)]
+enum Commands {
+    /// Display public key and address of the secret.
+    Info {
+        #[arg()]
+        secret_or_phrase: String,
+    },
+    Generate {
+        #[command(subcommand)]
+        command: GenerateCommands,
+    },
 
-Commands:
-    info               Display public key and address of the secret.
-    generate random    Generates new random Ethereum key.
-    generate prefix    Random generation, but address must start with a prefix ("vanity address").
-    sign               Sign message using a secret key.
-    verify             Verify signer of the signature by public key or address.
-    recover            Try to find brain phrase matching given address from partial phrase.
-"#;
+    /// Sign message using a secret key.
+    Sign {
+        #[arg()]
+        secret: String,
+        #[arg()]
+        message: String,
+    },
 
-#[derive(Debug, Deserialize)]
-struct Args {
-    cmd_info: bool,
-    cmd_generate: bool,
-    cmd_random: bool,
-    cmd_prefix: bool,
-    cmd_sign: bool,
-    cmd_verify: bool,
-    cmd_public: bool,
-    cmd_address: bool,
-    cmd_recover: bool,
-    arg_prefix: String,
-    arg_secret: String,
-    arg_secret_or_phrase: String,
-    arg_known_phrase: String,
-    arg_message: String,
-    arg_public: String,
-    arg_address: String,
-    arg_signature: String,
-    flag_secret: bool,
-    flag_public: bool,
-    flag_address: bool,
-    flag_brain: bool,
+    /// Verify signer of the signature by public key or address.
+    Verify {
+        #[command(subcommand)]
+        command: VerifyCommands,
+    },
+
+    ///  Try to find brain phrase matching given address from partial phrase.
+    Recover {
+        #[arg()]
+        known_phrase: String,
+        #[arg()]
+        address: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum GenerateCommands {
+    /// Generates new random Ethereum key.
+    Random {},
+    /// Random generation, but address must start with a prefix ("vanity
+    /// address").
+    Prefix {
+        #[arg()]
+        prefix: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum VerifyCommands {
+    Public {
+        #[arg()]
+        public: String,
+        #[arg()]
+        signature: String,
+        #[arg()]
+        message: String,
+    },
+    Address {
+        #[arg()]
+        address: String,
+        #[arg()]
+        signature: String,
+        #[arg()]
+        message: String,
+    },
 }
 
 #[derive(Debug)]
@@ -87,7 +119,6 @@ enum Error {
     Ethkey(EthkeyError),
     FromHex(FromHexError),
     ParseInt(ParseIntError),
-    Docopt(docopt::Error),
     Io(io::Error),
 }
 
@@ -103,10 +134,6 @@ impl From<ParseIntError> for Error {
     fn from(err: ParseIntError) -> Self { Error::ParseInt(err) }
 }
 
-impl From<docopt::Error> for Error {
-    fn from(err: docopt::Error) -> Self { Error::Docopt(err) }
-}
-
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Self { Error::Io(err) }
 }
@@ -117,7 +144,6 @@ impl fmt::Display for Error {
             Error::Ethkey(ref e) => write!(f, "{}", e),
             Error::FromHex(ref e) => write!(f, "{}", e),
             Error::ParseInt(ref e) => write!(f, "{}", e),
-            Error::Docopt(ref e) => write!(f, "{}", e),
             Error::Io(ref e) => write!(f, "{}", e),
         }
     }
@@ -131,12 +157,12 @@ enum DisplayMode {
 }
 
 impl DisplayMode {
-    fn new(args: &Args) -> Self {
-        if args.flag_secret {
+    fn new(args: &Cli) -> Self {
+        if args.secret {
             DisplayMode::Secret
-        } else if args.flag_public {
+        } else if args.public {
             DisplayMode::Public
-        } else if args.flag_address {
+        } else if args.address {
             DisplayMode::Address
         } else {
             DisplayMode::KeyPair
@@ -147,10 +173,9 @@ impl DisplayMode {
 fn main() {
     panic_hook::set_abort();
     env_logger::try_init().expect("Logger initialized only once.");
-
-    match execute(env::args()) {
+    let cli = Cli::parse();
+    match execute(cli) {
         Ok(ok) => println!("{}", ok),
-        Err(Error::Docopt(ref e)) => e.exit(),
         Err(err) => {
             eprintln!("{}", err);
             process::exit(1);
@@ -171,140 +196,155 @@ fn display(result: (KeyPair, Option<String>), mode: DisplayMode) -> String {
     }
 }
 
-fn execute<S, I>(command: I) -> Result<String, Error>
-where
-    I: IntoIterator<Item = S>,
-    S: AsRef<str>,
-{
-    let args: Args =
-        Docopt::new(USAGE).and_then(|d| d.argv(command).deserialize())?;
-
-    if args.cmd_info {
-        let display_mode = DisplayMode::new(&args);
-
-        let result = if args.flag_brain {
-            let phrase = args.arg_secret_or_phrase;
-            let phrase_info = validate_phrase(&phrase);
-            let keypair = Brain::new(phrase)
-                .generate()
-                .expect("Brain wallet generator is infallible; qed");
-            (keypair, Some(phrase_info))
-        } else {
-            let secret = args
-                .arg_secret_or_phrase
-                .parse()
-                .map_err(|_| EthkeyError::InvalidSecret)?;
-            (KeyPair::from_secret(secret)?, None)
-        };
-        Ok(display(result, display_mode))
-    } else if args.cmd_generate {
-        let display_mode = DisplayMode::new(&args);
-        let result = if args.cmd_random {
-            if args.flag_brain {
-                let mut brain =
-                    BrainPrefix::new(vec![0], usize::max_value(), BRAIN_WORDS);
-                let keypair = brain.generate()?;
-                let phrase = format!("recovery phrase: {}", brain.phrase());
-                (keypair, Some(phrase))
+fn execute(cli: Cli) -> Result<String, Error> {
+    let display_mode = DisplayMode::new(&cli);
+    return match &cli.command {
+        Commands::Info { secret_or_phrase } => {
+            let result = if cli.brain {
+                let phrase = secret_or_phrase;
+                let phrase_info = validate_phrase(&phrase);
+                let keypair = Brain::new(phrase.clone())
+                    .generate()
+                    .expect("Brain wallet generator is infallible; qed");
+                (keypair, Some(phrase_info))
             } else {
-                (Random.generate()?, None)
-            }
-        } else if args.cmd_prefix {
-            let prefix: Vec<u8> = args.arg_prefix.from_hex()?;
-            let brain = args.flag_brain;
-            in_threads(move || {
-                let iterations = 1024;
-                let prefix = prefix.clone();
-                move || {
-                    let prefix = prefix.clone();
-                    let res = if brain {
-                        let mut brain =
-                            BrainPrefix::new(prefix, iterations, BRAIN_WORDS);
-                        let result = brain.generate();
+                let secret = secret_or_phrase
+                    .parse()
+                    .map_err(|_| EthkeyError::InvalidSecret)?;
+                (KeyPair::from_secret(secret)?, None)
+            };
+            Ok(display(result, display_mode))
+        }
+        Commands::Generate { command } => {
+            let result = match &command {
+                GenerateCommands::Random {} => {
+                    if cli.brain {
+                        let mut brain = BrainPrefix::new(
+                            vec![0],
+                            usize::max_value(),
+                            BRAIN_WORDS,
+                        );
+                        let keypair = brain.generate()?;
                         let phrase =
                             format!("recovery phrase: {}", brain.phrase());
-                        result.map(|keypair| (keypair, Some(phrase)))
+                        (keypair, Some(phrase))
                     } else {
-                        let result = Prefix::new(prefix, iterations).generate();
-                        result.map(|res| (res, None))
-                    };
-
-                    Ok(res.map(Some).unwrap_or(None))
-                }
-            })?
-        } else {
-            return Ok(USAGE.to_string());
-        };
-        Ok(display(result, display_mode))
-    } else if args.cmd_sign {
-        let secret = args
-            .arg_secret
-            .parse()
-            .map_err(|_| EthkeyError::InvalidSecret)?;
-        let message = args
-            .arg_message
-            .parse()
-            .map_err(|_| EthkeyError::InvalidMessage)?;
-        let signature = sign(&secret, &message)?;
-        Ok(format!("{}", signature))
-    } else if args.cmd_verify {
-        let signature = args
-            .arg_signature
-            .parse()
-            .map_err(|_| EthkeyError::InvalidSignature)?;
-        let message = args
-            .arg_message
-            .parse()
-            .map_err(|_| EthkeyError::InvalidMessage)?;
-        let ok = if args.cmd_public {
-            let public = args
-                .arg_public
-                .parse()
-                .map_err(|_| EthkeyError::InvalidPublic)?;
-            verify_public(&public, &signature, &message)?
-        } else if args.cmd_address {
-            let address = args
-                .arg_address
-                .parse()
-                .map_err(|_| EthkeyError::InvalidAddress)?;
-            verify_address(&address, &signature, &message)?
-        } else {
-            return Ok(USAGE.to_string());
-        };
-        Ok(format!("{}", ok))
-    } else if args.cmd_recover {
-        let display_mode = DisplayMode::new(&args);
-        let known_phrase = args.arg_known_phrase;
-        let address = args
-            .arg_address
-            .parse()
-            .map_err(|_| EthkeyError::InvalidAddress)?;
-        let (phrase, keypair) = in_threads(move || {
-            let mut it = brain_recover::PhrasesIterator::from_known_phrase(
-                &known_phrase,
-                BRAIN_WORDS,
-            )
-            .enumerate();
-            move || {
-                for (i, phrase) in &mut it {
-                    let keypair =
-                        Brain::new(phrase.clone()).generate().unwrap();
-                    if keypair.address() == address {
-                        return Ok(Some((phrase, keypair)));
-                    }
-
-                    if i >= 1024 {
-                        return Ok(None);
+                        (Random.generate()?, None)
                     }
                 }
+                GenerateCommands::Prefix { prefix } => {
+                    let prefix: Vec<u8> = prefix.from_hex()?;
+                    let brain = cli.brain;
+                    in_threads(move || {
+                        let iterations = 1024;
+                        let prefix = prefix.clone();
+                        move || {
+                            let prefix = prefix.clone();
+                            let res = if brain {
+                                let mut brain = BrainPrefix::new(
+                                    prefix,
+                                    iterations,
+                                    BRAIN_WORDS,
+                                );
+                                let result = brain.generate();
+                                let phrase = format!(
+                                    "recovery phrase: {}",
+                                    brain.phrase()
+                                );
+                                result.map(|keypair| (keypair, Some(phrase)))
+                            } else {
+                                let result =
+                                    Prefix::new(prefix, iterations).generate();
+                                result.map(|res| (res, None))
+                            };
 
-                Err(EthkeyError::Custom("Couldn't find any results.".into()))
-            }
-        })?;
-        Ok(display((keypair, Some(phrase)), display_mode))
-    } else {
-        Ok(USAGE.to_string())
-    }
+                            Ok(res.map(Some).unwrap_or(None))
+                        }
+                    })?
+                }
+            };
+            Ok(display(result, display_mode))
+        }
+        Commands::Sign { secret, message } => {
+            let secret =
+                secret.parse().map_err(|_| EthkeyError::InvalidSecret)?;
+            let message =
+                message.parse().map_err(|_| EthkeyError::InvalidMessage)?;
+            let signature = sign(&secret, &message)?;
+            Ok(format!("{}", signature))
+        }
+        Commands::Verify { command } => {
+            let result = match &command {
+                VerifyCommands::Public {
+                    public,
+                    signature,
+                    message,
+                } => {
+                    let signature = signature
+                        .parse()
+                        .map_err(|_| EthkeyError::InvalidSignature)?;
+                    let message = message
+                        .parse()
+                        .map_err(|_| EthkeyError::InvalidMessage)?;
+
+                    let public = public
+                        .parse()
+                        .map_err(|_| EthkeyError::InvalidPublic)?;
+                    verify_public(&public, &signature, &message)?
+                }
+                VerifyCommands::Address {
+                    address,
+                    signature,
+                    message,
+                } => {
+                    let signature = signature
+                        .parse()
+                        .map_err(|_| EthkeyError::InvalidSignature)?;
+                    let message = message
+                        .parse()
+                        .map_err(|_| EthkeyError::InvalidMessage)?;
+                    let address = address
+                        .parse()
+                        .map_err(|_| EthkeyError::InvalidAddress)?;
+                    verify_address(&address, &signature, &message)?
+                }
+            };
+            Ok(format!("{}", result))
+        }
+        Commands::Recover {
+            known_phrase,
+            address,
+        } => {
+            let known_phrase = known_phrase;
+            let address =
+                address.parse().map_err(|_| EthkeyError::InvalidAddress)?;
+            let (phrase, keypair) = in_threads(move || {
+                let mut it = brain_recover::PhrasesIterator::from_known_phrase(
+                    &known_phrase,
+                    BRAIN_WORDS,
+                )
+                .enumerate();
+                move || {
+                    for (i, phrase) in &mut it {
+                        let keypair =
+                            Brain::new(phrase.clone()).generate().unwrap();
+                        if keypair.address() == address {
+                            return Ok(Some((phrase, keypair)));
+                        }
+
+                        if i >= 1024 {
+                            return Ok(None);
+                        }
+                    }
+
+                    Err(EthkeyError::Custom(
+                        "Couldn't find any results.".into(),
+                    ))
+                }
+            })?;
+            Ok(display((keypair, Some(phrase)), display_mode))
+        }
+    };
 }
 
 const BRAIN_WORDS: usize = 12;
@@ -362,32 +402,31 @@ where
 
 #[cfg(test)]
 mod tests {
+    use clap::Parser;
+
+    use crate::Cli;
+
     use super::execute;
 
     #[test]
     fn info() {
-        let command = vec![
+        let cli = Cli::parse_from([
             "cfxkey",
             "info",
             "17d08f5fe8c77af811caa0c9a187e668ce3b74a99acc3f6d976f075fa8e0be55",
-        ]
-        .into_iter()
-        .map(Into::into)
-        .collect::<Vec<String>>();
+        ]);
 
         let expected =
             "secret:  17d08f5fe8c77af811caa0c9a187e668ce3b74a99acc3f6d976f075fa8e0be55
 public:  689268c0ff57a20cd299fa60d3fb374862aff565b20b5f1767906a99e6e09f3ff04ca2b2a5cd22f62941db103c0356df1a8ed20ce322cab2483db67685afd124
 address: 16d1ec50b4e62c1d1a40d16e7cacc6a6580757d5".to_owned();
-        assert_eq!(execute(command).unwrap(), expected);
+        assert_eq!(execute(cli).unwrap(), expected);
     }
 
     #[test]
     fn brain() {
-        let command = vec!["cfxkey", "info", "--brain", "this is sparta"]
-            .into_iter()
-            .map(Into::into)
-            .collect::<Vec<String>>();
+        let cli =
+            Cli::parse_from(["cfxkey", "--brain", "info", "this is sparta"]);
 
         let expected =
             "The recover phrase was not generated by Conflux: The word 'this' does not come from the dictionary.
@@ -395,93 +434,87 @@ address: 16d1ec50b4e62c1d1a40d16e7cacc6a6580757d5".to_owned();
 secret:  a6bb621db2721ee05c44de651dde50ef85feefc5e91ae23bedcae69b874a22e7
 public:  756cb3f7ad1516b7c0ee34bd5e8b3a519922d3737192a58115e47df57ff3270873360a61de523ce08c0ebd7d3801bcb1d03c0364431d2b8633067f3d79e1fb25
 address: 10a33d9f95b22fe53024331c036db6e824a25bab".to_owned();
-        assert_eq!(execute(command).unwrap(), expected);
+        assert_eq!(execute(cli).unwrap(), expected);
     }
 
     #[test]
     fn secret() {
-        let command =
-            vec!["cfxkey", "info", "--brain", "this is sparta", "--secret"]
-                .into_iter()
-                .map(Into::into)
-                .collect::<Vec<String>>();
+        let cli = Cli::parse_from([
+            "cfxkey",
+            "--brain",
+            "--secret",
+            "info",
+            "this is sparta",
+        ]);
 
         let expected =
             "a6bb621db2721ee05c44de651dde50ef85feefc5e91ae23bedcae69b874a22e7"
                 .to_owned();
-        assert_eq!(execute(command).unwrap(), expected);
+        assert_eq!(execute(cli).unwrap(), expected);
     }
 
     #[test]
     fn public() {
-        let command =
-            vec!["cfxkey", "info", "--brain", "this is sparta", "--public"]
-                .into_iter()
-                .map(Into::into)
-                .collect::<Vec<String>>();
+        let cli = Cli::parse_from([
+            "cfxkey",
+            "--brain",
+            "--public",
+            "info",
+            "this is sparta",
+        ]);
 
         let expected = "756cb3f7ad1516b7c0ee34bd5e8b3a519922d3737192a58115e47df57ff3270873360a61de523ce08c0ebd7d3801bcb1d03c0364431d2b8633067f3d79e1fb25".to_owned();
-        assert_eq!(execute(command).unwrap(), expected);
+        assert_eq!(execute(cli).unwrap(), expected);
     }
 
     #[test]
     fn address() {
-        let command =
-            vec!["cfxkey", "info", "-b", "this is sparta", "--address"]
-                .into_iter()
-                .map(Into::into)
-                .collect::<Vec<String>>();
+        let cli = Cli::parse_from([
+            "cfxkey",
+            "-b",
+            "--address",
+            "info",
+            "this is sparta",
+        ]);
 
         let expected = "10a33d9f95b22fe53024331c036db6e824a25bab".to_owned();
-        assert_eq!(execute(command).unwrap(), expected);
+        assert_eq!(execute(cli).unwrap(), expected);
     }
 
     #[test]
     fn sign() {
-        let command = vec![
+        let cli = Cli::parse_from([
             "cfxkey",
             "sign",
             "17d08f5fe8c77af811caa0c9a187e668ce3b74a99acc3f6d976f075fa8e0be55",
             "bd50b7370c3f96733b31744c6c45079e7ae6c8d299613246d28ebcef507ec987",
-        ]
-        .into_iter()
-        .map(Into::into)
-        .collect::<Vec<String>>();
+        ]);
 
         let expected = "c1878cf60417151c766a712653d26ef350c8c75393458b7a9be715f053215af63dfd3b02c2ae65a8677917a8efa3172acb71cb90196e42106953ea0363c5aaf200".to_owned();
-        assert_eq!(execute(command).unwrap(), expected);
+        assert_eq!(execute(cli).unwrap(), expected);
     }
 
     #[test]
     fn verify_valid_public() {
-        let command = vec!["cfxkey", "verify", "public", "689268c0ff57a20cd299fa60d3fb374862aff565b20b5f1767906a99e6e09f3ff04ca2b2a5cd22f62941db103c0356df1a8ed20ce322cab2483db67685afd124", "c1878cf60417151c766a712653d26ef350c8c75393458b7a9be715f053215af63dfd3b02c2ae65a8677917a8efa3172acb71cb90196e42106953ea0363c5aaf200", "bd50b7370c3f96733b31744c6c45079e7ae6c8d299613246d28ebcef507ec987"]
-            .into_iter()
-            .map(Into::into)
-            .collect::<Vec<String>>();
+        let cli = Cli::parse_from(["cfxkey", "verify", "public", "689268c0ff57a20cd299fa60d3fb374862aff565b20b5f1767906a99e6e09f3ff04ca2b2a5cd22f62941db103c0356df1a8ed20ce322cab2483db67685afd124", "c1878cf60417151c766a712653d26ef350c8c75393458b7a9be715f053215af63dfd3b02c2ae65a8677917a8efa3172acb71cb90196e42106953ea0363c5aaf200", "bd50b7370c3f96733b31744c6c45079e7ae6c8d299613246d28ebcef507ec987"]);
 
         let expected = "true".to_owned();
-        assert_eq!(execute(command).unwrap(), expected);
+        assert_eq!(execute(cli).unwrap(), expected);
     }
 
     #[test]
     fn verify_valid_address() {
-        let command = vec!["cfxkey", "verify", "address", "16d1ec50b4e62c1d1a40d16e7cacc6a6580757d5", "c1878cf60417151c766a712653d26ef350c8c75393458b7a9be715f053215af63dfd3b02c2ae65a8677917a8efa3172acb71cb90196e42106953ea0363c5aaf200", "bd50b7370c3f96733b31744c6c45079e7ae6c8d299613246d28ebcef507ec987"]
-            .into_iter()
-            .map(Into::into)
-            .collect::<Vec<String>>();
+        let cli = Cli::parse_from(["cfxkey", "verify", "address", "16d1ec50b4e62c1d1a40d16e7cacc6a6580757d5", "c1878cf60417151c766a712653d26ef350c8c75393458b7a9be715f053215af63dfd3b02c2ae65a8677917a8efa3172acb71cb90196e42106953ea0363c5aaf200", "bd50b7370c3f96733b31744c6c45079e7ae6c8d299613246d28ebcef507ec987"]);
 
         let expected = "true".to_owned();
-        assert_eq!(execute(command).unwrap(), expected);
+        assert_eq!(execute(cli).unwrap(), expected);
     }
 
     #[test]
     fn verify_invalid() {
-        let command = vec!["cfxkey", "verify", "public", "689268c0ff57a20cd299fa60d3fb374862aff565b20b5f1767906a99e6e09f3ff04ca2b2a5cd22f62941db103c0356df1a8ed20ce322cab2483db67685afd124", "c1878cf60417151c766a712653d26ef350c8c75393458b7a9be715f053215af63dfd3b02c2ae65a8677917a8efa3172acb71cb90196e42106953ea0363c5aaf200", "bd50b7370c3f96733b31744c6c45079e7ae6c8d299613246d28ebcef507ec986"]
-            .into_iter()
-            .map(Into::into)
-            .collect::<Vec<String>>();
+        let cli = Cli::parse_from(["cfxkey", "verify", "public", "689268c0ff57a20cd299fa60d3fb374862aff565b20b5f1767906a99e6e09f3ff04ca2b2a5cd22f62941db103c0356df1a8ed20ce322cab2483db67685afd124", "c1878cf60417151c766a712653d26ef350c8c75393458b7a9be715f053215af63dfd3b02c2ae65a8677917a8efa3172acb71cb90196e42106953ea0363c5aaf200", "bd50b7370c3f96733b31744c6c45079e7ae6c8d299613246d28ebcef507ec986"]);
 
         let expected = "false".to_owned();
-        assert_eq!(execute(command).unwrap(), expected);
+        assert_eq!(execute(cli).unwrap(), expected);
     }
 }

--- a/bins/cfx_key/src/main.rs
+++ b/bins/cfx_key/src/main.rs
@@ -124,27 +124,19 @@ enum Error {
 }
 
 impl From<EthkeyError> for Error {
-    fn from(err: EthkeyError) -> Self {
-        Error::Ethkey(err)
-    }
+    fn from(err: EthkeyError) -> Self { Error::Ethkey(err) }
 }
 
 impl From<FromHexError> for Error {
-    fn from(err: FromHexError) -> Self {
-        Error::FromHex(err)
-    }
+    fn from(err: FromHexError) -> Self { Error::FromHex(err) }
 }
 
 impl From<ParseIntError> for Error {
-    fn from(err: ParseIntError) -> Self {
-        Error::ParseInt(err)
-    }
+    fn from(err: ParseIntError) -> Self { Error::ParseInt(err) }
 }
 
 impl From<io::Error> for Error {
-    fn from(err: io::Error) -> Self {
-        Error::Io(err)
-    }
+    fn from(err: io::Error) -> Self { Error::Io(err) }
 }
 
 impl fmt::Display for Error {
@@ -255,11 +247,8 @@ fn execute_generate(
     let result = match &command {
         GenerateCommands::Random {} => {
             if brain {
-                let mut brain = BrainPrefix::new(
-                    vec![],
-                    usize::max_value(),
-                    BRAIN_WORDS,
-                );
+                let mut brain =
+                    BrainPrefix::new(vec![], usize::max_value(), BRAIN_WORDS);
                 let keypair = brain.generate()?;
                 let phrase = format!("recovery phrase: {}", brain.phrase());
                 (keypair, Some(phrase))

--- a/bins/cfx_key/src/main.rs
+++ b/bins/cfx_key/src/main.rs
@@ -241,8 +241,11 @@ fn execute_generate(
     let result = match &command {
         GenerateCommands::Random {} => {
             if brain {
-                let mut brain =
-                    BrainPrefix::new(vec![0], usize::max_value(), BRAIN_WORDS);
+                let mut brain = BrainPrefix::new(
+                    vec![0x10],
+                    usize::max_value(),
+                    BRAIN_WORDS,
+                );
                 let keypair = brain.generate()?;
                 let phrase = format!("recovery phrase: {}", brain.phrase());
                 (keypair, Some(phrase))
@@ -436,6 +439,19 @@ address: 10a33d9f95b22fe53024331c036db6e824a25bab".to_owned();
         assert_eq!(execute(cli).unwrap(), expected);
     }
 
+    #[test]
+    fn test_generate_random_brain() {
+        let cli = Cli::parse_from(["cfxkey", "--brain", "generate", "random"]);
+        let result = execute(cli).unwrap();
+        assert!(result.contains("recovery phrase: "));
+    }
+
+    #[test]
+    fn test_generate_prefix() {
+        let cli = Cli::parse_from(["cfxkey", "generate", "prefix", "10ff"]);
+        let result = execute(cli).unwrap();
+        assert!(result.contains("address: 10ff"));
+    }
     #[test]
     fn secret() {
         let cli = Cli::parse_from([

--- a/changelogs/CHANGELOG-2.0.x.md
+++ b/changelogs/CHANGELOG-2.0.x.md
@@ -1,3 +1,10 @@
+# 2.6.0
+
+## Improvements
+
+### Address Generation
+- Upgrade ctxkey to 1.0.0. Now `generate` method only returns 0x1-prefixed addresses. When specifying prefix for randomly generated addresses, the prefix must start with '1'.
+
 # 2.0.3
 
 # 2.0.2

--- a/crates/cfx_key/src/brain_prefix.rs
+++ b/crates/cfx_key/src/brain_prefix.rs
@@ -35,9 +35,7 @@ impl BrainPrefix {
         }
     }
 
-    pub fn phrase(&self) -> &str {
-        &self.last_phrase
-    }
+    pub fn phrase(&self) -> &str { &self.last_phrase }
 }
 
 impl KeyPairGenerator for BrainPrefix {
@@ -52,7 +50,7 @@ impl KeyPairGenerator for BrainPrefix {
                 self.last_phrase = phrase;
                 return Ok(keypair);
             }
-            
+
             if keypair.address().as_ref().starts_with(&self.prefix) {
                 self.last_phrase = phrase;
                 return Ok(keypair);

--- a/crates/cfx_key/src/brain_prefix.rs
+++ b/crates/cfx_key/src/brain_prefix.rs
@@ -35,7 +35,9 @@ impl BrainPrefix {
         }
     }
 
-    pub fn phrase(&self) -> &str { &self.last_phrase }
+    pub fn phrase(&self) -> &str {
+        &self.last_phrase
+    }
 }
 
 impl KeyPairGenerator for BrainPrefix {
@@ -45,12 +47,17 @@ impl KeyPairGenerator for BrainPrefix {
         for _ in 0..self.iterations {
             let phrase = wordlist::random_phrase(self.no_of_words);
             let keypair = Brain::new(phrase.clone()).generate().unwrap();
+
+            if self.prefix.is_empty() {
+                self.last_phrase = phrase;
+                return Ok(keypair);
+            }
+            
             if keypair.address().as_ref().starts_with(&self.prefix) {
                 self.last_phrase = phrase;
                 return Ok(keypair);
             }
         }
-
         Err(Error::Custom("Could not find keypair".into()))
     }
 }

--- a/crates/cfx_key/src/prefix.rs
+++ b/crates/cfx_key/src/prefix.rs
@@ -34,6 +34,10 @@ impl KeyPairGenerator for Prefix {
     fn generate(&mut self) -> Result<KeyPair, Error> {
         for _ in 0..self.iterations {
             let keypair = Random.generate()?;
+
+            if self.prefix.is_empty() {
+                return Ok(keypair);
+            }
             if keypair.address().as_ref().starts_with(&self.prefix) {
                 return Ok(keypair);
             }


### PR DESCRIPTION
Related #3200


![image](https://github.com/user-attachments/assets/06a36a97-014a-467d-8247-a5b724c85eac)


Here is a key difference between `docopt` and `clap` whenuseing flags:

- With `docopt` you can put a flage like `--brain` after the subcommand `info` for example: `cfxkey info --brain this is sparta`
- However `clap` need global flags like `--brain` to the before the subcommand `info`. for example: `cfxkey --brain info this is sparta`

Also the subcommand has its own arguments, such as `public` or `address` So ,I cannot simply make the flag an argument of the subcommand. because the clould create a nameing conflict .

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3211)
<!-- Reviewable:end -->
