### PR TITLE
enable all cargo deny warnings

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -64,11 +64,6 @@ feature-depth = 1
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
 
-# This three options below will temporarily downgrade all errors in the project to warnings, This allow the CI to pass. if you need to test locally. comment them.
-vulnerability='warn'
-unmaintained='warn'
-unsound='warn'
-
 # The path where the advisory databases are cloned/fetched into
 #db-path = "$CARGO_HOME/advisory-dbs"
 # The url(s) of the advisory databases to use


### PR DESCRIPTION
All cargo deny check errors have been resolved. This PR now enables all cargo deny warnings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3227)
<!-- Reviewable:end -->
