### PR TITLE
chore: upgrade revm-interpreter version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=4e22b9e#4e22b9e1de80f1b1cc5dfdcd9461d44b27cf27ca"
 dependencies = [
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 0.7.5",
  "alloy-rlp",
  "alloy-serde",
  "c-kzg",
@@ -160,11 +160,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-eip2930"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b82752a889170df67bbb36d42ca63c531eb16274f0d7299ae2a680facba17bd"
+dependencies = [
+ "alloy-primitives 1.1.2",
+ "alloy-rlp",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d4769c6ffddca380b0070d71c8b7f30bed375543fe76bb2f74ec0acf4b7cd16"
+dependencies = [
+ "alloy-primitives 1.1.2",
+ "alloy-rlp",
+ "k256",
+ "serde",
+ "thiserror 2.0.11",
+]
+
+[[package]]
 name = "alloy-eips"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=4e22b9e#4e22b9e1de80f1b1cc5dfdcd9461d44b27cf27ca"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.7.5",
  "alloy-rlp",
  "alloy-serde",
  "c-kzg",
@@ -177,7 +201,7 @@ name = "alloy-genesis"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=4e22b9e#4e22b9e1de80f1b1cc5dfdcd9461d44b27cf27ca"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.7.5",
  "alloy-serde",
  "serde",
  "serde_json",
@@ -193,7 +217,7 @@ dependencies = [
  "bytes 1.9.0",
  "cfg-if 1.0.0",
  "const-hex",
- "derive_more",
+ "derive_more 0.99.17",
  "hex-literal",
  "itoa",
  "k256",
@@ -202,6 +226,33 @@ dependencies = [
  "rand 0.8.5",
  "ruint",
  "serde",
+ "tiny-keccak 2.0.2",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18c35fc4b03ace65001676358ffbbaefe2a2b27ee50fe777c345082c7c888be8"
+dependencies = [
+ "alloy-rlp",
+ "bytes 1.9.0",
+ "cfg-if 1.0.0",
+ "const-hex",
+ "derive_more 2.0.1",
+ "foldhash",
+ "hashbrown 0.15.2",
+ "indexmap 2.8.0",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "paste",
+ "proptest",
+ "rand 0.9.0",
+ "ruint",
+ "rustc-hash 2.1.1",
+ "serde",
+ "sha3 0.10.8",
  "tiny-keccak 2.0.2",
 ]
 
@@ -235,7 +286,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives",
+ "alloy-primitives 0.7.5",
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
@@ -250,7 +301,7 @@ name = "alloy-rpc-types-trace"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=4e22b9e#4e22b9e1de80f1b1cc5dfdcd9461d44b27cf27ca"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.7.5",
  "alloy-rpc-types",
  "alloy-serde",
  "serde",
@@ -262,7 +313,7 @@ name = "alloy-serde"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=4e22b9e#4e22b9e1de80f1b1cc5dfdcd9461d44b27cf27ca"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.7.5",
  "serde",
  "serde_json",
 ]
@@ -320,7 +371,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6eb5e6234c0b62514992589fe1578f64d418dbc8ef5cd1ab2d7f2f568f599698"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.7.5",
  "alloy-sol-macro",
  "const-hex",
  "serde",
@@ -332,7 +383,7 @@ version = "0.1.0"
 dependencies = [
  "cfx-types",
  "rand 0.8.5",
- "revm-primitives 5.0.0",
+ "revm-primitives 19.0.0",
 ]
 
 [[package]]
@@ -669,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1261,7 +1312,7 @@ dependencies = [
  "cfx-vm-interpreter",
  "cfx-vm-types",
  "cfxkey",
- "derive_more",
+ "derive_more 0.99.17",
  "diem-types",
  "hex-literal",
  "impl-tools",
@@ -1276,7 +1327,9 @@ dependencies = [
  "pow-types",
  "primitives",
  "rayon",
- "revm-interpreter 6.0.0",
+ "revm-context-interface",
+ "revm-interpreter 19.1.0",
+ "revm-primitives 19.0.0",
  "rlp 0.4.6",
  "rustc-hex",
  "sha3-macro",
@@ -1414,7 +1467,7 @@ dependencies = [
 name = "cfx-rpc-builder"
 version = "2.6.0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.7.5",
  "cfx-rpc",
  "cfx-rpc-cfx-types",
  "cfx-rpc-eth-api",
@@ -1554,7 +1607,7 @@ dependencies = [
 name = "cfx-rpc-utils"
 version = "2.6.0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.7.5",
  "alloy-rpc-types",
  "alloy-sol-types",
  "cfx-tasks",
@@ -1563,7 +1616,7 @@ dependencies = [
  "jsonrpc-core",
  "jsonrpsee",
  "jsonrpsee-core",
- "revm-primitives",
+ "revm-primitives 3.1.1",
  "serde_json",
  "thiserror 2.0.11",
  "tokio",
@@ -2659,6 +2712,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+ "unicode-xid",
+]
+
+[[package]]
 name = "destructure_traitobject"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2718,7 +2792,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "sha2 0.9.9",
- "sha3",
+ "sha3 0.9.1",
  "static_assertions",
  "thiserror 1.0.63",
  "tiny-keccak 2.0.2",
@@ -3567,6 +3641,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3797,7 +3877,7 @@ dependencies = [
 name = "geth-tracer"
 version = "2.6.0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.7.5",
  "alloy-rpc-types-trace",
  "alloy-sol-types",
  "cfx-executor",
@@ -3806,8 +3886,8 @@ dependencies = [
  "cfx-vm-types",
  "primitives",
  "revm",
- "revm-interpreter",
- "revm-primitives",
+ "revm-interpreter 4.0.0",
+ "revm-primitives 3.1.1",
  "typemap-ors",
 ]
 
@@ -3987,6 +4067,9 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hdrhistogram"
@@ -5863,6 +5946,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "num_threads"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7299,6 +7403,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "revm-bytecode"
+version = "4.0.0"
+source = "git+https://github.com/Conflux-Chain/revm.git?tag=v73#37925695f4941de9654554ccea32c2d71cfc578c"
+dependencies = [
+ "bitvec 1.0.1",
+ "once_cell",
+ "phf",
+ "revm-primitives 19.0.0",
+ "serde",
+]
+
+[[package]]
+name = "revm-context-interface"
+version = "4.1.0"
+source = "git+https://github.com/Conflux-Chain/revm.git?tag=v73#37925695f4941de9654554ccea32c2d71cfc578c"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "auto_impl",
+ "either",
+ "revm-database-interface",
+ "revm-primitives 19.0.0",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-database-interface"
+version = "4.0.0"
+source = "git+https://github.com/Conflux-Chain/revm.git?tag=v73#37925695f4941de9654554ccea32c2d71cfc578c"
+dependencies = [
+ "auto_impl",
+ "revm-primitives 19.0.0",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
 name = "revm-interpreter"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7310,12 +7452,12 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "6.0.0"
-source = "git+https://github.com/Conflux-Chain/revm.git?tag=v37#99367b1db2c436359c0155ed8965c19fc5503a1b"
+version = "19.1.0"
+source = "git+https://github.com/Conflux-Chain/revm.git?tag=v73#37925695f4941de9654554ccea32c2d71cfc578c"
 dependencies = [
- "paste",
- "phf",
- "revm-primitives 5.0.0",
+ "revm-bytecode",
+ "revm-context-interface",
+ "revm-primitives 19.0.0",
  "serde",
 ]
 
@@ -7342,13 +7484,13 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbbc9640790cebcb731289afb7a7d96d16ad94afeb64b5d0b66443bd151e79d6"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.7.5",
  "auto_impl",
  "bitflags 2.9.1",
  "bitvec 1.0.1",
  "c-kzg",
  "cfg-if 1.0.0",
- "derive_more",
+ "derive_more 0.99.17",
  "dyn-clone",
  "enumn",
  "hashbrown 0.14.3",
@@ -7359,21 +7501,22 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "5.0.0"
-source = "git+https://github.com/Conflux-Chain/revm.git?tag=v37#99367b1db2c436359c0155ed8965c19fc5503a1b"
+version = "19.0.0"
+source = "git+https://github.com/Conflux-Chain/revm.git?tag=v73#37925695f4941de9654554ccea32c2d71cfc578c"
 dependencies = [
- "alloy-primitives",
- "auto_impl",
+ "alloy-primitives 1.1.2",
+ "num_enum",
+ "serde",
+]
+
+[[package]]
+name = "revm-state"
+version = "4.0.0"
+source = "git+https://github.com/Conflux-Chain/revm.git?tag=v73#37925695f4941de9654554ccea32c2d71cfc578c"
+dependencies = [
  "bitflags 2.9.1",
- "bitvec 1.0.1",
- "c-kzg",
- "cfg-if 1.0.0",
- "derive_more",
- "dyn-clone",
- "enumn",
- "hashbrown 0.14.3",
- "hex",
- "once_cell",
+ "revm-bytecode",
+ "revm-primitives 19.0.0",
  "serde",
 ]
 
@@ -7954,7 +8097,7 @@ dependencies = [
 name = "serde-utils"
 version = "2.6.0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.7.5",
  "cfx-types",
  "serde",
  "serde_json",
@@ -8106,6 +8249,16 @@ dependencies = [
  "digest 0.9.0",
  "keccak",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,7 @@ dependencies = [
 name = "alloy-type-conversions"
 version = "0.1.0"
 dependencies = [
+ "cfx-bytes",
  "cfx-types",
  "rand 0.8.5",
  "revm-primitives 19.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -289,12 +289,7 @@ alloy-sol-types = "0.7.2"
 alloy-primitives = "0.7.2"
 alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "4e22b9e" }
 alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "4e22b9e" }
-
 revm = { version = "8.0", default-features = false }
-# revm-interpreter = "6.0"
-# revm-primitives = "5.0"
-revm-interpreter = { git = "https://github.com/Conflux-Chain/revm.git", tag = "v37"}
-revm-primitives = { git = "https://github.com/Conflux-Chain/revm.git", tag = "v37"}
 
 # revm v8
 revm-primitives = "3.1.1"

--- a/crates/execution/executor/Cargo.toml
+++ b/crates/execution/executor/Cargo.toml
@@ -46,7 +46,9 @@ rayon = { workspace = true }
 cfx-parity-trace-types = { workspace = true }
 cfx-rpc-eth-types = { workspace = true }
 blst = { workspace = true }
-revm-interpreter = { workspace = true }
+revm-interpreter = { git = "https://github.com/Conflux-Chain/revm.git", tag = "v73"}
+revm-primitives = { git = "https://github.com/Conflux-Chain/revm.git", tag = "v73"}
+revm-context-interface ={ git = "https://github.com/Conflux-Chain/revm.git", tag = "v73" }
 alloy-type-conversions = { workspace = true }
 
 [dev-dependencies]

--- a/crates/execution/executor/src/context/revm.rs
+++ b/crates/execution/executor/src/context/revm.rs
@@ -5,7 +5,9 @@ use alloy_type_conversions::*;
 use cfx_statedb::Result as DbResult;
 use cfx_types::AddressSpaceUtil;
 use cfx_vm_types::Context as ContextTrait;
-use revm_interpreter::primitives::{Address, Bytes, Env, Log, B256, U256};
+use revm_context_interface::journaled_state::AccountLoad;
+use revm_interpreter::{SStoreResult, SelfDestructResult, StateLoad};
+use revm_primitives::{Address, Bytes, Log, B256, U256};
 
 pub(crate) struct EvmHost<'a> {
     context: Context<'a>,
@@ -35,30 +37,36 @@ fn unwrap_db_error(e: cfx_vm_types::Error) -> cfx_statedb::Error {
 const COLD: bool = true;
 
 impl<'a> revm_interpreter::Host for EvmHost<'a> {
-    fn env(&self) -> &Env { todo!() }
+    fn basefee(&self) -> U256 { todo!() }
 
-    fn env_mut(&mut self) -> &mut Env { todo!() }
+    fn blob_gasprice(&self) -> U256 { todo!() }
 
-    fn load_account(
-        &mut self, address: Address,
-    ) -> Option<revm_interpreter::LoadAccountResult> {
-        match self
-            .context
-            .exists_and_not_null(&from_alloy_address(address))
-        {
-            Ok(exists) => Some(revm_interpreter::LoadAccountResult {
-                is_cold: COLD,
-                is_empty: !exists,
-            }),
-            Err(e) => {
-                self.error = Err(unwrap_db_error(e));
-                None
-            }
-        }
-    }
+    fn gas_limit(&self) -> U256 { todo!() }
 
-    fn block_hash(&mut self, number: U256) -> Option<B256> {
-        match self.context.blockhash(&from_alloy_u256(number)) {
+    fn difficulty(&self) -> U256 { todo!() }
+
+    fn prevrandao(&self) -> Option<U256> { todo!() }
+
+    fn block_number(&self) -> u64 { todo!() }
+
+    fn timestamp(&self) -> U256 { todo!() }
+
+    fn beneficiary(&self) -> Address { todo!() }
+
+    fn chain_id(&self) -> U256 { todo!() }
+
+    fn effective_gas_price(&self) -> U256 { todo!() }
+
+    fn caller(&self) -> Address { todo!() }
+
+    fn blob_hash(&self, number: usize) -> Option<U256> { todo!() }
+
+    fn initcode_by_hash(&mut self, hash: B256) -> Option<Bytes> { todo!() }
+
+    fn max_initcode_size(&self) -> usize { todo!() }
+
+    fn block_hash(&mut self, number: u64) -> Option<B256> {
+        match self.context.blockhash(&cfx_types::U256::from(number)) {
             Ok(hash) => Some(to_alloy_h256(hash)),
             Err(e) => {
                 self.error = Err(unwrap_db_error(e));
@@ -67,66 +75,55 @@ impl<'a> revm_interpreter::Host for EvmHost<'a> {
         }
     }
 
-    fn balance(&mut self, address: Address) -> Option<(U256, bool)> {
-        match self.context.balance(&from_alloy_address(address)) {
-            Ok(balance) => Some((to_alloy_u256(balance), COLD)),
-            Err(e) => {
-                self.error = Err(unwrap_db_error(e));
-                None
-            }
-        }
-    }
-
-    fn code(&mut self, address: Address) -> Option<(Bytes, bool)> {
-        match self.context.extcode(&from_alloy_address(address)) {
-            Ok(None) => Some((Bytes::new(), COLD)),
-            Ok(Some(code)) => Some((Bytes::copy_from_slice(&**code), COLD)),
-            Err(e) => {
-                self.error = Err(unwrap_db_error(e));
-                None
-            }
-        }
-    }
-
-    fn code_hash(&mut self, address: Address) -> Option<(B256, bool)> {
-        match self.context.extcodehash(&from_alloy_address(address)) {
-            Ok(hash) => Some((to_alloy_h256(hash), COLD)),
-            Err(e) => {
-                self.error = Err(unwrap_db_error(e));
-                None
-            }
-        }
-    }
-
-    fn sload(&mut self, address: Address, index: U256) -> Option<(U256, bool)> {
-        let receiver =
-            from_alloy_address(address).with_space(self.context.space);
-        let key = index.to_be_bytes::<32>();
-        match self.context.state.storage_at(&receiver, &key) {
-            Ok(value) => Some((to_alloy_u256(value), COLD)),
-            Err(e) => {
-                self.error = Err(e);
-                None
-            }
-        }
-    }
-
-    fn sstore(
-        &mut self, address: Address, index: U256, value: U256,
-    ) -> Option<revm_interpreter::SStoreResult> {
-        // TODO: who checks static flag in revm?
+    fn selfdestruct(
+        &mut self, address: Address, target: Address,
+    ) -> Option<StateLoad<SelfDestructResult>> {
         todo!()
     }
 
-    fn tload(&mut self, address: Address, index: U256) -> U256 { todo!() }
-
-    fn tstore(&mut self, address: Address, index: U256, value: U256) { todo!() }
-
     fn log(&mut self, log: Log) { todo!() }
 
-    fn selfdestruct(
-        &mut self, address: Address, target: Address,
-    ) -> Option<revm_interpreter::SelfDestructResult> {
+    fn sstore(
+        &mut self, address: Address, key: U256, value: U256,
+    ) -> Option<StateLoad<SStoreResult>> {
+        todo!()
+    }
+
+    fn sload(
+        &mut self, address: Address, key: U256,
+    ) -> Option<StateLoad<U256>> {
+        todo!()
+    }
+
+    fn tstore(&mut self, address: Address, key: U256, value: U256) { todo!() }
+
+    fn tload(&mut self, address: Address, key: U256) -> U256 { todo!() }
+
+    fn balance(&mut self, address: Address) -> Option<StateLoad<U256>> {
+        match self.context.balance(&from_alloy_address(address)) {
+            Ok(balance) => Some(StateLoad::new(to_alloy_u256(balance), COLD)),
+            Err(e) => {
+                self.error = Err(unwrap_db_error(e));
+                None
+            }
+        }
+    }
+
+    fn load_account_delegated(
+        &mut self, address: Address,
+    ) -> Option<StateLoad<AccountLoad>> {
+        todo!()
+    }
+
+    fn load_account_code(
+        &mut self, address: Address,
+    ) -> Option<StateLoad<Bytes>> {
+        todo!()
+    }
+
+    fn load_account_code_hash(
+        &mut self, address: Address,
+    ) -> Option<StateLoad<B256>> {
         todo!()
     }
 }

--- a/crates/execution/executor/src/revm_wrapper/mod.rs
+++ b/crates/execution/executor/src/revm_wrapper/mod.rs
@@ -9,12 +9,12 @@ use cfx_statedb::Result as DbResult;
 use cfx_types::U256;
 use cfx_vm_interpreter::FinalizationResult;
 use cfx_vm_types::{self as vm, ActionParams};
+use revm_context_interface::result::{HaltReason, SuccessReason};
 use revm_interpreter::{
-    opcode::{make_instruction_table, InstructionTable},
-    primitives::{specification::LatestSpec, HaltReason, SuccessReason},
-    CallInputs, Host, Interpreter, InterpreterAction, InterpreterResult,
-    SharedMemory, SuccessOrHalt,
+    instruction_table, CallInputs, Host, Interpreter, InterpreterAction,
+    InterpreterResult, SharedMemory, SuccessOrHalt,
 };
+
 use vm::ReturnData;
 
 impl Executable for Interpreter {
@@ -24,10 +24,10 @@ impl Executable for Interpreter {
         let mut revm_context = EvmHost::new(context);
         let shared_memory = SharedMemory::new();
 
-        let table = &make_instruction_table::<_, LatestSpec>();
+        let table = &instruction_table();
 
         // TODO: inspect shared_memory
-        let action = self.run(shared_memory, table, &mut revm_context);
+        let action = self.run_plain(table, &mut revm_context);
 
         revm_context.take_db_error()?;
 
@@ -37,9 +37,7 @@ impl Executable for Interpreter {
 
 fn adapt_action(action: InterpreterAction) -> ExecutableOutcome {
     match action {
-        InterpreterAction::Call { inputs } => todo!(),
-        InterpreterAction::Create { inputs } => todo!(),
-        InterpreterAction::EOFCreate { inputs } => todo!(),
+        InterpreterAction::NewFrame(frame_input) => todo!(),
         InterpreterAction::Return { result } => todo!(),
         InterpreterAction::None => todo!("What should I do here"),
     }

--- a/crates/util/alloy-type-conversions/Cargo.toml
+++ b/crates/util/alloy-type-conversions/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 cfx-types = { workspace = true }
-revm-primitives = { workspace = true }
+revm-primitives = { git = "https://github.com/Conflux-Chain/revm.git", tag = "v73"}
 
 [dev-dependencies]
 rand = "0.8"

--- a/crates/util/alloy-type-conversions/Cargo.toml
+++ b/crates/util/alloy-type-conversions/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 
 [dependencies]
 cfx-types = { workspace = true }
-revm-primitives = { git = "https://github.com/Conflux-Chain/revm.git", tag = "v73"}
+cfx-bytes = { workspace = true }
+revm-primitives = { git = "https://github.com/Conflux-Chain/revm.git", tag = "v73" }
 
 [dev-dependencies]
 rand = "0.8"

--- a/crates/util/alloy-type-conversions/src/lib.rs
+++ b/crates/util/alloy-type-conversions/src/lib.rs
@@ -31,6 +31,14 @@ pub fn to_alloy_h256(value: cfx_types::H256) -> alloy_types::B256 {
     alloy_types::FixedBytes(value.0)
 }
 
+pub fn to_alloy_bytes(value: cfx_bytes::Bytes) -> alloy_types::Bytes {
+    alloy_types::Bytes::from(value)
+}
+
+pub fn from_alloy_bytes(value: alloy_types::Bytes) -> cfx_bytes::Bytes {
+    cfx_bytes::Bytes::from(value)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
1. Move `revm-interpreter` and `revm-primitives` from workspace to a sub-crate to resolve version conflicts.
2. Update `revm-interpreter` and `revm-primitives` versions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3229)
<!-- Reviewable:end -->
