### PR TITLE
chore: upgrade rand version to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,7 +935,7 @@ dependencies = [
  "metrics",
  "parking_lot 0.12.1",
  "primitives",
- "rand 0.7.3",
+ "rand 0.9.0",
  "txgen",
 ]
 
@@ -1193,7 +1193,7 @@ dependencies = [
  "network",
  "parking_lot 0.12.1",
  "primitives",
- "rand 0.7.3",
+ "rand 0.9.0",
  "toml",
  "txgen",
 ]
@@ -1321,8 +1321,8 @@ dependencies = [
  "malloc_size_of",
  "malloc_size_of_derive",
  "primitives",
- "rand 0.7.3",
- "rand_xorshift 0.2.0",
+ "rand 0.9.0",
+ "rand_xorshift 0.4.0",
  "treap-map",
  "typenum",
 ]
@@ -1414,7 +1414,7 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "log",
- "rand 0.7.3",
+ "rand 0.9.0",
  "serde",
  "strum",
  "thiserror 2.0.11",
@@ -1603,8 +1603,8 @@ dependencies = [
  "parity-util-mem",
  "parking_lot 0.12.1",
  "primitives",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
+ "rand 0.9.0",
+ "rand_chacha 0.9.0",
  "random-crash",
  "rlp 0.4.6",
  "rlp-derive",
@@ -1780,9 +1780,9 @@ dependencies = [
  "priority-send-queue",
  "proptest",
  "proptest-derive",
- "rand 0.7.3",
  "rand 0.8.5",
- "rand_xorshift 0.2.0",
+ "rand 0.9.0",
+ "rand_xorshift 0.4.0",
  "rangetools",
  "rayon",
  "rlp 0.4.6",
@@ -1864,7 +1864,7 @@ dependencies = [
  "parity-crypto",
  "parity-wordlist",
  "parking_lot 0.12.1",
- "rand 0.7.3",
+ "rand 0.9.0",
  "rustc-hex",
  "serde",
  "serde_derive",
@@ -2068,8 +2068,8 @@ dependencies = [
  "parity-version",
  "parking_lot 0.12.1",
  "primitives",
- "rand 0.7.3",
  "rand 0.8.5",
+ "rand 0.9.0",
  "random-crash",
  "rlp 0.4.6",
  "rpassword",
@@ -4048,7 +4048,7 @@ version = "0.6.0"
 dependencies = [
  "atom",
  "malloc_size_of",
- "rand 0.7.3",
+ "rand 0.9.0",
  "rayon",
 ]
 
@@ -5262,7 +5262,7 @@ version = "0.1.0"
 dependencies = [
  "malloc_size_of",
  "parking_lot 0.12.1",
- "rand 0.7.3",
+ "rand 0.9.0",
 ]
 
 [[package]]
@@ -5310,7 +5310,7 @@ dependencies = [
  "db",
  "kvdb",
  "parking_lot 0.12.1",
- "rand 0.7.3",
+ "rand 0.9.0",
  "rlp 0.4.6",
  "rlp-derive",
 ]
@@ -5470,7 +5470,7 @@ dependencies = [
  "lazy_static",
  "log",
  "parking_lot 0.12.1",
- "rand 0.7.3",
+ "rand 0.9.0",
  "reqwest 0.12.9",
  "serde",
  "timer",
@@ -5668,7 +5668,7 @@ dependencies = [
  "parity-path",
  "parking_lot 0.12.1",
  "priority-send-queue",
- "rand 0.7.3",
+ "rand 0.9.0",
  "rlp 0.4.6",
  "rlp-derive",
  "serde",
@@ -6612,7 +6612,7 @@ dependencies = [
  "log",
  "malloc_size_of",
  "once_cell",
- "rand 0.7.3",
+ "rand 0.9.0",
  "rlp 0.4.6",
  "rlp-derive",
  "serde",
@@ -7005,20 +7005,20 @@ dependencies = [
 
 [[package]]
 name = "rand_xorshift"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -7028,7 +7028,7 @@ dependencies = [
  "lazy_static",
  "log",
  "parking_lot 0.12.1",
- "rand 0.7.3",
+ "rand 0.9.0",
 ]
 
 [[package]]
@@ -8939,9 +8939,9 @@ dependencies = [
  "criterion",
  "malloc_size_of",
  "primitives",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
- "rand_xorshift 0.2.0",
+ "rand 0.9.0",
+ "rand_chacha 0.9.0",
+ "rand_xorshift 0.4.0",
 ]
 
 [[package]]
@@ -8979,7 +8979,7 @@ dependencies = [
  "metrics",
  "parking_lot 0.12.1",
  "primitives",
- "rand 0.7.3",
+ "rand 0.9.0",
  "rlp 0.4.6",
  "rustc-hex",
  "secret-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -338,10 +338,13 @@ clap = "4"
 clap-verbosity-flag = "3"
 
 # rand & rng
-rand = "0.7"
-rand_xorshift = "0.2"
+rand = "0.9"
+rand_xorshift = "0.4"
+rand_chacha = "0.9.0"
+
+# old rand
+rand_07 = { package = "rand", version = "0.7" }
 rand_08 = { package = "rand", version = "0.8" }
-rand_chacha = "0.2.1"
 
 # misc
 log = "0.4"

--- a/crates/cfx_key/Cargo.toml
+++ b/crates/cfx_key/Cargo.toml
@@ -14,7 +14,7 @@ parity-secp256k1 = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
 parity-wordlist = { workspace = true }
-rand = { workspace = true }
+rand_07 = { workspace = true }
 rustc-hex = { workspace = true }
 serde = { workspace = true }
 tiny-keccak = { workspace = true }

--- a/crates/cfx_key/src/random.rs
+++ b/crates/cfx_key/src/random.rs
@@ -15,7 +15,7 @@
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::{KeyPair, KeyPairGenerator, SECP256K1};
-use rand::rngs::OsRng;
+use rand_07::rngs::OsRng;
 
 /// Randomly generates new keypair, instantiating the RNG each time.
 pub struct Random;

--- a/crates/cfx_store/src/random.rs
+++ b/crates/cfx_store/src/random.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
-use rand::{distributions::Alphanumeric, rngs::OsRng, Rng, RngCore};
+use rand::{distr::Alphanumeric, rngs::OsRng, Rng, TryRngCore};
 
 pub trait Random {
     fn random() -> Self
@@ -24,7 +24,7 @@ pub trait Random {
 impl Random for [u8; 16] {
     fn random() -> Self {
         let mut result = [0u8; 16];
-        OsRng.fill_bytes(&mut result);
+        OsRng.try_fill_bytes(&mut result).unwrap();
         result
     }
 }
@@ -32,12 +32,17 @@ impl Random for [u8; 16] {
 impl Random for [u8; 32] {
     fn random() -> Self {
         let mut result = [0u8; 32];
-        OsRng.fill_bytes(&mut result);
+        OsRng.try_fill_bytes(&mut result).unwrap();
         result
     }
 }
 
 /// Generate a random string of given length.
 pub fn random_string(length: usize) -> String {
-    OsRng.sample_iter(&Alphanumeric).take(length).collect()
+    let mut rng = rand::rng();
+    (&mut rng)
+        .sample_iter(Alphanumeric)
+        .take(length)
+        .map(char::from)
+        .collect()
 }

--- a/crates/cfx_store/tests/util/transient_dir.rs
+++ b/crates/cfx_store/tests/util/transient_dir.rs
@@ -18,12 +18,16 @@ use cfxstore::{
     accounts_dir::{KeyDirectory, RootDiskDirectory},
     Error, SafeAccount,
 };
-use rand::{rngs::OsRng, RngCore};
+use rand::{rngs::OsRng, TryRngCore};
 use std::{env, fs, path::PathBuf};
 
 pub fn random_dir() -> PathBuf {
     let mut dir = env::temp_dir();
-    dir.push(format!("{:x}-{:x}", OsRng.next_u64(), OsRng.next_u64()));
+    dir.push(format!(
+        "{:x}-{:x}",
+        OsRng.try_next_u64().unwrap(),
+        OsRng.try_next_u64().unwrap()
+    ));
     dir
 }
 

--- a/crates/cfxcore/core/src/channel.rs
+++ b/crates/cfxcore/core/src/channel.rs
@@ -256,9 +256,9 @@ mod tests {
 
         // create async sender
         let fut3 = async move {
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
             let mut sent = vec![];
-            for t in (0..100).map(|_| rng.gen()) {
+            for t in (0..100).map(|_| rng.random()) {
                 chan.send(t);
                 sent.push(t);
             }
@@ -285,9 +285,9 @@ mod tests {
 
         // create async sender
         let fut_a = async move {
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
 
-            for t in (0..100).map(|_| rng.gen()) {
+            for t in (0..100).map(|_| rng.random()) {
                 send_a.send(t);
                 let t2 = rec_a.recv().await;
 

--- a/crates/cfxcore/core/src/consensus/pivot_hint/tests.rs
+++ b/crates/cfxcore/core/src/consensus/pivot_hint/tests.rs
@@ -1,4 +1,4 @@
-use rand::{thread_rng, RngCore};
+use rand::{rng, RngCore};
 use std::{
     fs::File,
     io::{Read, Seek, SeekFrom},
@@ -53,7 +53,7 @@ fn test_pivot_hint() {
     let pivot_hint = make_test_pivot_hint();
     let mut test_file = TestHashFile::new();
 
-    let mut rng = thread_rng();
+    let mut rng = rng();
     for _ in 0..100_000 {
         let fork_at = rng.next_u64() % 1_500_000;
         if fork_at == 0 {

--- a/crates/cfxcore/core/src/light_protocol/common/peers.rs
+++ b/crates/cfxcore/core/src/light_protocol/common/peers.rs
@@ -15,7 +15,7 @@ use crate::message::MsgId;
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use malloc_size_of_derive::MallocSizeOf as DeriveMallocSizeOf;
 use network::{node_table::NodeId, service::ProtocolVersion};
-use rand::prelude::SliceRandom;
+use rand::prelude::IndexedRandom;
 use smart_default::SmartDefault;
 use throttling::token_bucket::{ThrottledManager, TokenBucketManager};
 
@@ -121,9 +121,7 @@ impl FullPeerFilter {
     }
 
     pub fn select(self, peers: Arc<Peers<FullPeerState>>) -> Option<NodeId> {
-        self.select_all(peers)
-            .choose(&mut rand::thread_rng())
-            .cloned()
+        self.select_all(peers).choose(&mut rand::rng()).cloned()
     }
 
     pub fn select_all(self, peers: Arc<Peers<FullPeerState>>) -> Vec<NodeId> {

--- a/crates/cfxcore/core/src/light_protocol/handler/sync/headers.rs
+++ b/crates/cfxcore/core/src/light_protocol/handler/sync/headers.rs
@@ -459,7 +459,7 @@ mod tests {
         headers.push(h5.clone());
         headers.push(h6.clone());
 
-        headers.shuffle(&mut rand::thread_rng());
+        headers.shuffle(&mut rand::rng());
         let mut queue = PriorityQueue::new();
         queue.extend(headers);
 

--- a/crates/cfxcore/core/src/light_protocol/provider.rs
+++ b/crates/cfxcore/core/src/light_protocol/provider.rs
@@ -928,7 +928,7 @@ impl Provider {
                 "Apply throttling for broadcast, total: {}, allowed: {}",
                 total, allowed
             );
-            peers.shuffle(&mut rand::thread_rng());
+            peers.shuffle(&mut rand::rng());
             peers.truncate(allowed);
         }
 

--- a/crates/cfxcore/core/src/pos/consensus/block_storage/sync_manager.rs
+++ b/crates/cfxcore/core/src/pos/consensus/block_storage/sync_manager.rs
@@ -25,7 +25,7 @@ use diem_types::{
     account_address::AccountAddress, epoch_change::EpochChangeProof,
     ledger_info::LedgerInfoWithSignatures,
 };
-use rand::{prelude::*, Rng};
+use rand::{prelude::*, rng};
 use std::{clone::Clone, sync::Arc, time::Duration};
 
 pub const BLOCK_FETCH_BATCH_MAX_SIZE: u64 = 60;
@@ -354,7 +354,7 @@ impl BlockRetriever {
             return self.preferred_peer;
         }
 
-        let peer_idx = thread_rng().gen_range(0, peers.len());
+        let peer_idx = rng().random_range(0..peers.len());
         peers.remove(peer_idx)
     }
 }

--- a/crates/cfxcore/core/src/pos/consensus/test_utils/mock_txn_manager.rs
+++ b/crates/cfxcore/core/src/pos/consensus/test_utils/mock_txn_manager.rs
@@ -53,7 +53,7 @@ fn mock_transaction_status(count: usize) -> Vec<TransactionStatus> {
     let mut statuses = vec![];
     // generate count + 1 status to mock the block metadata txn in mempool proxy
     for _ in 0..=count {
-        let random_status = match rand::thread_rng().gen_range(0, 1000) {
+        let random_status = match rand::rng().random_range(0..1000) {
             0 => TransactionStatus::Discard(
                 StatusCode::UNKNOWN_VALIDATION_STATUS,
             ),

--- a/crates/cfxcore/core/src/sync/mod.rs
+++ b/crates/cfxcore/core/src/sync/mod.rs
@@ -63,7 +63,7 @@ pub const SYNC_PROTO_V3: ProtocolVersion = ProtocolVersion(3);
 
 pub mod random {
     use rand;
-    pub fn new() -> rand::prelude::ThreadRng { rand::thread_rng() }
+    pub fn new() -> rand::prelude::ThreadRng { rand::rng() }
 }
 
 pub mod msg_sender {

--- a/crates/cfxcore/core/src/sync/state/state_sync_manifest/snapshot_manifest_manager.rs
+++ b/crates/cfxcore/core/src/sync/state/state_sync_manifest/snapshot_manifest_manager.rs
@@ -29,7 +29,11 @@ use primitives::{
     BlockHeaderBuilder, BlockReceipts, EpochId, EpochNumber, StateRoot,
     StorageKey, StorageKeyWithSpace, NULL_EPOCH,
 };
-use rand::{seq::SliceRandom, thread_rng};
+use rand::{
+    rng,
+    seq::{IndexedRandom, SliceRandom},
+};
+
 use std::{
     collections::HashSet,
     fmt::{Debug, Formatter},
@@ -247,7 +251,7 @@ impl SnapshotManifestManager {
         let available_peers = PeerFilter::new(msgid::GET_SNAPSHOT_MANIFEST)
             .choose_from(&self.active_peers)
             .select_all(&sync_handler.syn);
-        let maybe_peer = available_peers.choose(&mut thread_rng()).map(|p| *p);
+        let maybe_peer = available_peers.choose(&mut rng()).map(|p| *p);
         if let Some(peer) = maybe_peer {
             self.manifest_request_status = Some((Instant::now(), peer));
             sync_handler.request_manager.request_with_delay(

--- a/crates/cfxcore/core/src/sync/synchronization_protocol_handler.rs
+++ b/crates/cfxcore/core/src/sync/synchronization_protocol_handler.rs
@@ -1353,7 +1353,7 @@ impl SynchronizationProtocolHandler {
 
         // 29 since the remaining bytes is 29.
         let mut nonces: Vec<(u64, u64)> = (0..lucky_peers.len())
-            .map(|_| (rand::thread_rng().gen(), rand::thread_rng().gen()))
+            .map(|_| (rand::rng().random(), rand::rng().random()))
             .collect();
 
         let mut short_ids_part: Vec<Vec<u8>> = vec![vec![]; lucky_peers.len()];

--- a/crates/cfxcore/core/src/sync/synchronization_state.rs
+++ b/crates/cfxcore/core/src/sync/synchronization_state.rs
@@ -17,7 +17,7 @@ use network::{
     node_table::NodeId, service::ProtocolVersion, Error as NetworkError,
 };
 use parking_lot::RwLock;
-use rand::prelude::SliceRandom;
+use rand::prelude::{IndexedRandom, SliceRandom};
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,

--- a/crates/cfxcore/core/src/transaction_pool/deferred_pool/mod.rs
+++ b/crates/cfxcore/core/src/transaction_pool/deferred_pool/mod.rs
@@ -112,7 +112,7 @@ impl DeferredPool {
         let mut minimum_unit_gas_limit = U256::from(21000);
         let mut minimum_unit_tx_size = 80;
 
-        let mut rng = XorShiftRng::from_entropy();
+        let mut rng = XorShiftRng::from_os_rng();
 
         // When a sampled transaction exceeds the remaining capacity (gas limit
         // or size) in a block, we skip it and look for the next transaction.

--- a/crates/cfxcore/core/src/transaction_pool/garbage_collector.rs
+++ b/crates/cfxcore/core/src/transaction_pool/garbage_collector.rs
@@ -294,7 +294,7 @@ mod garbage_collector_test {
 
     #[test]
     fn test_correctness() {
-        let mut rng = XorShiftRng::from_entropy();
+        let mut rng = XorShiftRng::from_os_rng();
         let mut addr = Vec::new();
         for _ in 0..10000 {
             addr.push(Address::random().with_native_space());

--- a/crates/cfxcore/core/src/transaction_pool/nonce_pool/mod.rs
+++ b/crates/cfxcore/core/src/transaction_pool/nonce_pool/mod.rs
@@ -834,7 +834,7 @@ mod nonce_pool_test {
     #[test]
     fn test_correctness() {
         let me = Random.generate().unwrap();
-        let mut rng = XorShiftRng::from_entropy();
+        let mut rng = XorShiftRng::from_os_rng();
         let mut tx = Vec::new();
         let storage_limit = 5000;
         let gas_price = U256::from(10);

--- a/crates/cfxcore/packing-pool/Cargo.toml
+++ b/crates/cfxcore/packing-pool/Cargo.toml
@@ -20,7 +20,7 @@ rand = { workspace = true }
 
 [dev-dependencies]
 treap-map = { workspace = true, features = ["testonly_code"] }
-rand = { workspace = true, features = ["getrandom"] }
+rand = { workspace = true, features = ["os_rng"] }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/cfxcore/packing-pool/benches/bench.rs
+++ b/crates/cfxcore/packing-pool/benches/bench.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::AtomicUsize;
 
 use cfx_packing_pool::{MockTransaction, PackingPool, PackingPoolConfig};
 use criterion::{criterion_group, criterion_main, Criterion};
-use rand::{distributions::Uniform, Rng, RngCore, SeedableRng};
+use rand::{distr::Uniform, Rng, RngCore, SeedableRng};
 use rand_xorshift::XorShiftRng;
 
 fn default_tx(sender: u64, gas_limit: u64, gas_price: u64) -> MockTransaction {
@@ -23,21 +23,21 @@ fn default_tx(sender: u64, gas_limit: u64, gas_price: u64) -> MockTransaction {
 fn random_tx<R: SeedableRng + RngCore>(rng: &mut R) -> MockTransaction {
     let i = rng.next_u64() % 1000;
     let mut gas_limit = 1.01f64.powf(2000.0 + i as f64) as u64;
-    gas_limit -= gas_limit / rng.sample(Uniform::new(200, 2000));
+    gas_limit -= gas_limit / rng.sample(Uniform::new(200, 2000).unwrap());
     let mut gas_price = 1.01f64.powf(3000.0 - i as f64) as u64;
-    gas_price -= gas_price / rng.sample(Uniform::new(200, 2000));
+    gas_price -= gas_price / rng.sample(Uniform::new(200, 2000).unwrap());
     default_tx(i, gas_price, gas_limit)
 }
 
 fn bench_pool() -> PackingPool<MockTransaction> {
-    let mut rand = XorShiftRng::from_entropy();
+    let mut rand = XorShiftRng::from_os_rng();
     let mut pool =
         PackingPool::new(PackingPoolConfig::new(3_000_000.into(), 20, 4));
     for i in 0..10000 {
         let mut gas_limit = 1.001f64.powf(20000.0 + i as f64) as u64;
-        gas_limit -= gas_limit / rand.sample(Uniform::new(500, 2000));
+        gas_limit -= gas_limit / rand.sample(Uniform::new(500, 2000).unwrap());
         let mut gas_price = 1.001f64.powf(30000.0 - i as f64) as u64;
-        gas_price -= gas_price / rand.sample(Uniform::new(500, 2000));
+        gas_price -= gas_price / rand.sample(Uniform::new(500, 2000).unwrap());
 
         let tx = default_tx(i, gas_limit, gas_price);
 
@@ -48,14 +48,14 @@ fn bench_pool() -> PackingPool<MockTransaction> {
 
 fn bench_insert(c: &mut Criterion) {
     c.bench_function("Make random TX", move |b| {
-        let mut rng = XorShiftRng::from_entropy();
+        let mut rng = XorShiftRng::from_os_rng();
         b.iter(|| {
             std::hint::black_box(random_tx(&mut rng));
         });
     });
     c.bench_function("Random pool insert", move |b| {
         let mut pool = bench_pool();
-        let mut rng = XorShiftRng::from_entropy();
+        let mut rng = XorShiftRng::from_os_rng();
         b.iter(|| {
             let _ = pool.insert(random_tx(&mut rng));
         });
@@ -65,10 +65,10 @@ fn bench_insert(c: &mut Criterion) {
 fn bench_sample(c: &mut Criterion) {
     c.bench_function("Make sampler", move |b| {
         let pool = bench_pool();
-        let mut rng = XorShiftRng::from_entropy();
+        let mut rng = XorShiftRng::from_os_rng();
         b.iter(|| {
             let block_gas_limit = 1.001f64
-                .powf(rng.sample(Uniform::new(19000, 33000)) as f64)
+                .powf(rng.sample(Uniform::new(19000, 33000).unwrap()) as f64)
                 as u64;
             let _ = std::hint::black_box(
                 pool.tx_sampler(&mut rng, block_gas_limit.into()),
@@ -78,7 +78,7 @@ fn bench_sample(c: &mut Criterion) {
 
     c.bench_function("Random pool sample (all random pick) (100x)", move |b| {
         let pool = bench_pool();
-        let mut rng = XorShiftRng::from_entropy();
+        let mut rng = XorShiftRng::from_os_rng();
         let block_gas_limit = 1.001f64.powf(27000.0) as u64;
         b.iter(|| {
             let mut sampler = pool.tx_sampler(&mut rng, block_gas_limit.into());
@@ -92,7 +92,7 @@ fn bench_sample(c: &mut Criterion) {
         "Random pool sample (2/3 random pick + 1/3 candidate) (10000x)",
         move |b| {
             let pool = bench_pool();
-            let mut rng = XorShiftRng::from_entropy();
+            let mut rng = XorShiftRng::from_os_rng();
             let block_gas_limit = 1.001f64.powf(35299.0) as u64;
             b.iter(|| {
                 let mut sampler =

--- a/crates/cfxcore/packing-pool/src/pool.rs
+++ b/crates/cfxcore/packing-pool/src/pool.rs
@@ -491,7 +491,7 @@ mod pool_tests {
         let pool = default_pool(5, 100000);
 
         let pack_txs = || {
-            let mut rng = XorShiftRng::from_entropy();
+            let mut rng = XorShiftRng::from_os_rng();
 
             let mut packed = HashSet::new();
             for (_, txs, tag) in pool.tx_sampler(&mut rng, 40000.into()) {
@@ -532,7 +532,7 @@ mod sample_tests {
         transaction::PackingPoolTransaction, PackingPool, PackingPoolConfig,
     };
     use cfx_types::U256;
-    use rand::{distributions::Uniform, Rng, SeedableRng};
+    use rand::{distr::Uniform, Rng, SeedableRng};
     use rand_xorshift::XorShiftRng;
 
     #[derive(Default)]
@@ -577,14 +577,16 @@ mod sample_tests {
 
     #[test]
     fn test_truncate_price_and_sample() {
-        let mut rand = XorShiftRng::from_entropy();
+        let mut rand = XorShiftRng::from_os_rng();
         let mut pool = PackingPool::new(PackingPoolConfig::new_for_test());
         let mut mock_pool = MockPriceBook::default();
         for i in 0..1000 {
             let mut gas_limit = 1.01f64.powf(2000.0 + i as f64) as u64;
-            gas_limit -= gas_limit / rand.sample(Uniform::new(50, 200));
+            gas_limit -=
+                gas_limit / rand.sample(Uniform::new(50, 200).unwrap());
             let mut gas_price = 1.01f64.powf(3000.0 - i as f64) as u64;
-            gas_price -= gas_price / rand.sample(Uniform::new(50, 200));
+            gas_price -=
+                gas_price / rand.sample(Uniform::new(50, 200).unwrap());
 
             let tx = default_tx(i, gas_limit, gas_price);
 
@@ -597,7 +599,7 @@ mod sample_tests {
         for i in 1900..3500 {
             let mut total_gas_limit = 1.01f64.powf(i as f64) as u64;
             total_gas_limit -=
-                total_gas_limit / rand.sample(Uniform::new(50, 200));
+                total_gas_limit / rand.sample(Uniform::new(50, 200).unwrap());
             assert_eq!(
                 pool.truncate_loss_ratio(total_gas_limit.into()),
                 mock_pool.truncate_loss_ratio(total_gas_limit as usize)

--- a/crates/client/src/rpc/authcodes.rs
+++ b/crates/client/src/rpc/authcodes.rs
@@ -20,7 +20,7 @@ use cfx_types::H256;
 use itertools::Itertools;
 use keccak_hash::keccak;
 use log::{trace, warn};
-use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
+use rand::{distr::Alphanumeric, Rng};
 use std::{
     fs,
     io::{self, Read, Write},
@@ -186,10 +186,13 @@ impl<T: TimeProvider> AuthCodes<T> {
 
     /// Generates and returns a new code that can be used by `SignerUIs`
     pub fn generate_new(&mut self) -> io::Result<String> {
-        let code = OsRng
+        let mut rng = rand::rng();
+
+        let code: String = (&mut rng)
             .sample_iter(&Alphanumeric)
             .take(TOKEN_LENGTH)
-            .collect::<String>();
+            .map(char::from)
+            .collect();
         let readable_code = code
             .as_bytes()
             .chunks(4)

--- a/crates/config/src/configuration.rs
+++ b/crates/config/src/configuration.rs
@@ -628,7 +628,7 @@ impl Configuration {
                     let chain_id = self
                         .raw_conf
                         .chain_id
-                        .unwrap_or_else(|| rand::thread_rng().gen());
+                        .unwrap_or_else(|| rand::rng().random());
                     let evm_chain_id =
                         self.raw_conf.evm_chain_id.unwrap_or(chain_id);
                     *to_init = Some(ChainIdParamsInner::new_simple(

--- a/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/recent_lfu.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/recent_lfu.rs
@@ -537,7 +537,7 @@ impl<PosT: PrimitiveNum, CacheIndexT: CacheIndexTrait>
             capacity,
             frequency_heap: RemovableHeap::new(lru_capacity),
             frequency_lru: LRU::new(lru_capacity),
-            counter_rng: ChaChaRng::from_entropy(),
+            counter_rng: ChaChaRng::from_os_rng(),
         }
     }
 

--- a/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/tests/lru.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/tests/lru.rs
@@ -6,9 +6,11 @@ use super::{
     super::{lru::*, *},
     *,
 };
-use rand::distributions::{uniform::*, *};
+use rand::distr::{uniform::*, weighted::WeightedIndex};
 
 mod test_lru_algorithm_size_1 {
+    use rand::distr::Distribution;
+
     use super::*;
 
     #[derive(Default)]
@@ -170,7 +172,7 @@ mod test_lru_algorithm_size_1 {
 
 mod test_lru_algorithm {
     use super::*;
-    use rand::prelude::SliceRandom;
+    use rand::{distr::Distribution, prelude::SliceRandom};
 
     struct CacheUtil<'a> {
         cache_algo_data: &'a mut [LRUHandle<u32>],
@@ -252,8 +254,8 @@ mod test_lru_algorithm {
 
         let mut considered_keys = vec![0; key_range as usize];
 
-        let candidate_sampler = Uniform::new(0, key_range);
-        let probability_sampler = Uniform::new(0.0, 1.0);
+        let candidate_sampler = Uniform::new(0, key_range).unwrap();
+        let probability_sampler = Uniform::new(0.0, 1.0).unwrap();
         while most_recent_keys.len() < cache_size as usize {
             let key = loop {
                 let key = candidate_sampler.sample(&mut rng);

--- a/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/tests/recent_lfu.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/tests/recent_lfu.rs
@@ -6,7 +6,7 @@ use super::{
     super::{recent_lfu::*, *},
     *,
 };
-use rand::distributions::{uniform::*, *};
+use rand::distr::{uniform::*, *};
 
 struct CacheUtil<'a> {
     cache_algo_data: &'a mut [RecentLFUHandle<u32>],
@@ -124,8 +124,8 @@ fn r_lfu_algorithm_smoke_test() {
 
     let mut rng = get_rng_for_test();
 
-    let candidate_sampler = Uniform::new(0, key_range);
-    let probability_sampler = Uniform::new(0.0, 1.0);
+    let candidate_sampler = Uniform::new(0, key_range).unwrap();
+    let probability_sampler = Uniform::new(0.0, 1.0).unwrap();
     let delete_probability = 0.1;
     for _actions in 1..10000 {
         let key = candidate_sampler.sample(&mut rng);

--- a/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/tests/removable_heap.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/tests/removable_heap.rs
@@ -22,7 +22,7 @@ fn initialize_heap(
         let mut hole: Hole<TrivialValueWithHeapHandle<i64, u32>> =
             Hole::<_>::new_uninit_pointer(
                 TrivialValueWithHeapHandle::<i64, u32>::new(
-                    rng.gen_range(-100, -1),
+                    rng.random_range(-100..-1),
                 ),
             );
         unsafe {
@@ -34,7 +34,7 @@ fn initialize_heap(
     // Save the sum in the last value.
     let mut sum = 0i64;
     for _i in non_heap_size..capacity - 1 {
-        let value = rng.gen_range(0, 1000000);
+        let value = rng.random_range(0..1000000);
         sum += value;
         heap.insert(
             TrivialValueWithHeapHandle::<i64, u32>::new(value),
@@ -163,7 +163,7 @@ fn initialize_heap_with_removals_and_updates(
 
     let mut sum = 0i64;
     for _i in 0..init_size + insert_size {
-        let value = rng.gen_range(0, 1000000);
+        let value = rng.random_range(0..1000000);
         sum += value;
         values.push(TrivialValueWithHeapHandle::new(value));
     }
@@ -172,7 +172,7 @@ fn initialize_heap_with_removals_and_updates(
         let mut removals_set = HashSet::new();
         for _i in 0..kept_removals {
             loop {
-                let pos = rng.gen_range(0, init_size as usize);
+                let pos = rng.random_range(0..init_size as usize);
                 if removals_set.get(&pos).is_none() {
                     removals_set.insert(pos);
                     sum -= *values[pos].as_ref();
@@ -184,7 +184,8 @@ fn initialize_heap_with_removals_and_updates(
 
         for _i in 0..removals {
             loop {
-                let pos = rng.gen_range(0, (init_size + insert_size) as usize);
+                let pos =
+                    rng.random_range(0..(init_size + insert_size) as usize);
                 if removals_set.get(&pos).is_none() {
                     removals_set.insert(pos);
                     sum -= *values[pos].as_ref();
@@ -196,7 +197,8 @@ fn initialize_heap_with_removals_and_updates(
 
         for _i in 0..updates {
             loop {
-                let pos = rng.gen_range(0, (init_size + insert_size) as usize);
+                let pos =
+                    rng.random_range(0..(init_size + insert_size) as usize);
                 if removals_set.get(&pos).is_none() {
                     removals_set.insert(pos);
                     sum -= *values[pos].as_ref();

--- a/crates/dbs/storage/src/tests/proofs.rs
+++ b/crates/dbs/storage/src/tests/proofs.rs
@@ -247,7 +247,7 @@ fn get_invalid_hash(rng: &mut ChaChaRng, hash: H256) -> H256 {
     let mut new_hash = hash;
 
     while new_hash == hash {
-        new_hash.as_bytes_mut()[rng.gen_range(0, 32)] = rng.gen::<u8>();
+        new_hash.as_bytes_mut()[rng.random_range(0..32)] = rng.gen::<u8>();
     }
 
     new_hash
@@ -281,7 +281,7 @@ fn get_invalid_state_root(
     // trie), we only mutate the delta root. if two or three were provided, we
     // randomly mutate one of the corresponding roots.
 
-    match rng.gen_range(0, num_proofs) {
+    match rng.random_range(0..num_proofs) {
         0 => root.delta_root = get_invalid_hash(rng, root.delta_root),
         1 => {
             root.intermediate_delta_root =

--- a/crates/dbs/storage/src/tests/sharded_iter_merger.rs
+++ b/crates/dbs/storage/src/tests/sharded_iter_merger.rs
@@ -52,7 +52,7 @@ fn test_sharded_iter_merger() -> Result<()> {
     let max_keys = 500000;
     let mut shard_sizes = vec![max_keys, max_keys, max_keys, 1, 1, 1, 1, 1];
     shard_sizes.resize_with(num_shards, || 0);
-    let mut rng = ChaChaRng::from_entropy();
+    let mut rng = ChaChaRng::from_os_rng();
     shard_sizes.shuffle(&mut rng);
     let mut shards = vec![];
     for _i in 0..num_shards {

--- a/crates/dbs/storage/src/tests/snapshot/slicer.rs
+++ b/crates/dbs/storage/src/tests/snapshot/slicer.rs
@@ -39,7 +39,7 @@ fn test_slicing_position() {
                 (
                     k[..].into(),
                     [&k[..], &k[..], &k[..], &k[..]].concat()
-                        [0..(6 + rng.gen::<usize>() % 10)]
+                        [0..(6 + rng.random_range(0..10))]
                         .into(),
                 )
             })

--- a/crates/dbs/storage/src/tests/snapshot/verifier.rs
+++ b/crates/dbs/storage/src/tests/snapshot/verifier.rs
@@ -42,7 +42,7 @@ fn test_slice_verifier_zero_or_one_chunk() {
                 (
                     k[..].into(),
                     [&k[..], &k[..], &k[..], &k[..]].concat()
-                        [0..(6 + rng.gen::<usize>() % 10)]
+                        [0..(6 + rng.random_range(0..10))]
                         .into(),
                 )
             })
@@ -95,7 +95,7 @@ fn test_slice_verifier() {
                 (
                     k[..].into(),
                     [&k[..], &k[..], &k[..], &k[..]].concat()
-                        [0..(6 + rng.gen::<usize>() % 10)]
+                        [0..(6 + rng.random_range(0..10))]
                         .into(),
                 )
             })
@@ -595,7 +595,7 @@ fn test_full_sync_verifier_one_chunk() {
                 (
                     k[..].into(),
                     [&k[..], &k[..], &k[..], &k[..]].concat()
-                        [0..(6 + rng.gen::<usize>() % 10)]
+                        [0..(6 + rng.random_range(0..10))]
                         .into(),
                 )
             })
@@ -657,7 +657,7 @@ fn test_full_sync_verifier() {
                 (
                     k[..].into(),
                     [&k[..], &k[..], &k[..], &k[..]].concat()
-                        [0..(6 + rng.gen::<usize>() % 10)]
+                        [0..(6 + rng.random_range(0..10))]
                         .into(),
                 )
             })

--- a/crates/dbs/storage/src/tests/state.rs
+++ b/crates/dbs/storage/src/tests/state.rs
@@ -174,7 +174,7 @@ fn test_snapshot_random_read_performance() {
         2 * EPOCHS
     );
     let mut rng = get_rng_for_test();
-    let range = Uniform::from(0..keys.len());
+    let range = Uniform::new(0, keys.len()).unwrap();
     const TXS: u32 = 20000;
     let mut epoch_keys = Vec::with_capacity(EPOCHS as usize * 2);
     for _epoch in 0..EPOCHS * 2 {
@@ -534,7 +534,7 @@ fn test_set_delete_all() {
     println!("Testing with {} delete_all operations.", keys.len());
     let mut values = Vec::with_capacity(keys.len());
     for key in &keys {
-        let key_prefix = &key[0..(2 + rng.gen::<usize>() % 2)];
+        let key_prefix = &key[0..(2 + rng.random_range(0..2))];
 
         let value = state
             .delete_all(StorageKey::AccountKey(key_prefix).with_native_space())
@@ -758,7 +758,7 @@ use cfx_types::{
 };
 use primitives::{Account, StorageKey, StorageKeyWithSpace};
 use rand::{
-    distributions::{Distribution, Uniform},
+    distr::{Distribution, Uniform},
     seq::SliceRandom,
     Rng,
 };

--- a/crates/network/src/ip/bucket.rs
+++ b/crates/network/src/ip/bucket.rs
@@ -66,13 +66,13 @@ impl NodeBucket {
 
         // evict out-of-date node with high priority
         if !long_time_nodes.is_empty() {
-            let index = rng.gen_range(0, long_time_nodes.len());
+            let index = rng.random_range(0..long_time_nodes.len());
             return Some(long_time_nodes[index].clone());
         }
 
         // randomly evict one
         if !evictable_nodes.is_empty() {
-            let index = rng.gen_range(0, evictable_nodes.len());
+            let index = rng.random_range(0..evictable_nodes.len());
             return Some(evictable_nodes[index].clone());
         }
 

--- a/crates/network/src/ip/sample.rs
+++ b/crates/network/src/ip/sample.rs
@@ -54,7 +54,7 @@ impl<K: Hash + Eq + Clone, V> SampleHashMap<K, V> {
             return None;
         }
 
-        let index = rng.gen_range(0, self.items.len());
+        let index = rng.random_range(0..self.items.len());
         Some(&self.items[index].1)
     }
 
@@ -100,7 +100,7 @@ impl<T: Hash + Eq + Clone> SampleHashSet<T> {
             return None;
         }
 
-        let index = rng.gen_range(0, self.items.len());
+        let index = rng.random_range(0..self.items.len());
         Some(self.items[index].clone())
     }
 

--- a/crates/network/src/node_table.rs
+++ b/crates/network/src/node_table.rs
@@ -458,11 +458,11 @@ impl NodeTable {
         let mut nodes: Vec<NodeEntry> = Vec::new();
         for _i in 0..count {
             let mut rng = rand::thread_rng();
-            let node_rep_idx = rng.gen::<usize>() % NODE_REPUTATION_LEVEL_COUNT;
+            let node_rep_idx = rng.random_range(0..NODE_REPUTATION_LEVEL_COUNT);
             let node_rep = NodeReputation::iter().nth(node_rep_idx).unwrap();
             let node_rep_vec = &self.node_reputation_table[node_rep];
             if !node_rep_vec.is_empty() {
-                let idx = rng.gen::<usize>() % node_rep_vec.len();
+                let idx = rng.random_range(0..node_rep_vec.len());
                 let n = &node_rep_vec[idx];
                 nodes.push(NodeEntry {
                     id: n.id,
@@ -488,11 +488,11 @@ impl NodeTable {
         let mut node_id_set: HashSet<NodeId> = HashSet::new();
         let mut rng = rand::thread_rng();
         for _i in 0..count {
-            let node_rep_idx = rng.gen::<usize>() % NODE_REPUTATION_LEVEL_COUNT;
+            let node_rep_idx = rng.random_range(0..NODE_REPUTATION_LEVEL_COUNT);
             let node_rep = NodeReputation::iter().nth(node_rep_idx).unwrap();
             let node_rep_vec = &self.node_reputation_table[node_rep];
             if !node_rep_vec.is_empty() {
-                let idx = rng.gen::<usize>() % node_rep_vec.len();
+                let idx = rng.random_range(0..node_rep_vec.len());
                 let n = &node_rep_vec[idx];
                 if !node_id_set.contains(&n.id) {
                     node_id_set.insert(n.id);

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -118,7 +118,7 @@ impl Block {
     /// This block will be relayed with the new compact block to prevent
     /// adversaries to make tx shortId collision
     pub fn to_compact(&self) -> CompactBlock {
-        let nonce: u64 = rand::thread_rng().gen();
+        let nonce: u64 = rand::rng().random();
         let (k0, k1) =
             CompactBlock::get_shortid_key(&self.block_header, &nonce);
         CompactBlock {

--- a/crates/rpc/rpc-cfx-types/Cargo.toml
+++ b/crates/rpc/rpc-cfx-types/Cargo.toml
@@ -28,7 +28,7 @@ cfx-util-macros = { workspace = true }
 log = { workspace = true }
 cfx-parity-trace-types = { workspace = true }
 parity-version = { workspace = true }
-rand = { workspace = true }
+rand_07 = { workspace = true }
 diem-crypto = { workspace = true }
 diem-types = { workspace = true }
 rustc-hex = { workspace = true }

--- a/crates/rpc/rpc-cfx-types/src/subscriber_id.rs
+++ b/crates/rpc/rpc-cfx-types/src/subscriber_id.rs
@@ -23,9 +23,9 @@ impl SubId {
 }
 
 pub mod random {
-    use rand;
+    use rand_07;
 
-    pub type Rng = rand::rngs::OsRng;
+    pub type Rng = rand_07::rngs::OsRng;
 
-    pub fn new() -> Rng { rand::rngs::OsRng }
+    pub fn new() -> Rng { rand_07::rngs::OsRng }
 }

--- a/crates/transactiongen/src/lib.rs
+++ b/crates/transactiongen/src/lib.rs
@@ -23,7 +23,7 @@ use primitives::{
     transaction::{native_transaction::NativeTransaction, Action},
     Account, SignedTransaction, Transaction,
 };
-use rand::prelude::*;
+use rand::{prelude::*, random_range};
 use rlp::Encodable;
 use rustc_hex::{FromHex, ToHex};
 use secret_store::SharedSecretStore;
@@ -174,11 +174,11 @@ impl TransactionGenerator {
 
             // Randomly select sender and receiver.
             // Sender and receiver must exist in the account list.
-            let mut receiver_index: usize = random();
+            let mut receiver_index: usize = random_range(0..usize::MAX);
             receiver_index %= account_count;
             let receiver_address = addresses[receiver_index];
 
-            let mut sender_index: usize = random();
+            let mut sender_index: usize = random_range(0..usize::MAX);
             sender_index %= account_count;
             let sender_address = addresses[sender_index];
 
@@ -335,7 +335,7 @@ impl DirectTransactionGenerator {
         while num_txs_simple > 0 {
             let number_of_accounts = self.address_by_index.len();
 
-            let sender_index: usize = random::<usize>() % number_of_accounts;
+            let sender_index: usize = random_range(0..number_of_accounts);
             let sender_address =
                 self.address_by_index.get(sender_index).unwrap().clone();
             let sender_kp;
@@ -366,11 +366,11 @@ impl DirectTransactionGenerator {
             let is_send_to_new_address = (number_of_accounts
                 <= Self::MAX_TOTAL_ACCOUNTS)
                 && ((number_of_accounts < 10)
-                    || (rand::thread_rng().gen_range(0, 10) == 0));
+                    || (rand::thread_rng().random_range(0..10) == 0));
 
             let receiver_address = match is_send_to_new_address {
                 false => {
-                    let index: usize = random::<usize>() % number_of_accounts;
+                    let index: usize = random_range(0..number_of_accounts);
                     self.address_by_index.get(index).unwrap().clone()
                 }
                 true => loop {
@@ -433,7 +433,7 @@ impl DirectTransactionGenerator {
         while num_txs_erc20 > 0 {
             let number_of_accounts = self.address_by_index.len();
 
-            let sender_index: usize = random::<usize>() % number_of_accounts;
+            let sender_index: usize = random_range(0..number_of_accounts);
             let sender_address =
                 self.address_by_index.get(sender_index).unwrap().clone();
             let sender_kp;
@@ -468,7 +468,7 @@ impl DirectTransactionGenerator {
                 .unwrap()
             };
 
-            let receiver_index = random::<usize>() % number_of_accounts;
+            let receiver_index = random_range(0..number_of_accounts);
             let receiver_address =
                 self.address_by_index.get(receiver_index).unwrap().clone();
 

--- a/crates/util/hibitset/src/iter/mod.rs
+++ b/crates/util/hibitset/src/iter/mod.rs
@@ -110,6 +110,8 @@ impl<T: BitSetLike> BitIter<T> {
 
 #[cfg(test)]
 mod tests {
+    use rand::rng;
+
     use crate::{BitSet, BitSetLike};
 
     #[test]
@@ -117,10 +119,10 @@ mod tests {
         use rand::prelude::*;
 
         let mut set = BitSet::new();
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let limit = 1_048_576;
         for _ in 0..(limit / 10) {
-            set.add(rng.gen_range(0, limit));
+            set.add(rng.random_range(0..limit));
         }
         (&mut set).iter().clear();
         assert_eq!(0, set.layer3);

--- a/crates/util/hibitset/src/lib.rs
+++ b/crates/util/hibitset/src/lib.rs
@@ -438,6 +438,8 @@ impl Eq for BitSet {}
 
 #[cfg(test)]
 mod tests {
+    use rand::rng;
+
     use super::{BitSet, BitSetAnd, BitSetLike, BitSetNot, BITS};
 
     #[test]
@@ -517,11 +519,11 @@ mod tests {
         use rand::prelude::*;
 
         let mut set = BitSet::new();
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let limit = 1_048_576;
         let mut added = 0;
         for _ in 0..(limit / 10) {
-            let index = rng.gen_range(0, limit);
+            let index = rng.random_range(0..limit);
             if !set.add(index) {
                 added += 1;
             }
@@ -563,6 +565,7 @@ mod tests {
 #[cfg(all(test, feature = "parallel"))]
 mod test_parallel {
     use super::{BitSet, BitSetAnd, BitSetLike, BITS};
+    use rand::rng;
     use rayon::iter::ParallelIterator;
 
     #[test]
@@ -590,10 +593,10 @@ mod test_parallel {
 
         let mut set = BitSet::new();
         let mut check_set = HashSet::new();
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let limit = 1_048_576;
         for _ in 0..(limit / 10) {
-            let index = rng.gen_range(0, limit);
+            let index = rng.random_range(0..limit);
             set.add(index);
             check_set.insert(index);
         }

--- a/crates/util/link-cut-tree/src/lib.rs
+++ b/crates/util/link-cut-tree/src/lib.rs
@@ -415,7 +415,7 @@ mod tests {
         let mut value: Vec<i64> = Vec::new();
         parent.push(NULL);
         for i in 1..n {
-            let p: usize = rand::thread_rng().gen_range(0, i) as usize;
+            let p: usize = rand::rng().random_range(0..i) as usize;
             parent.push(p);
         }
         value.resize(n, 0);
@@ -426,28 +426,28 @@ mod tests {
         }
         assert_eq!(tree.size(), n);
         for _ in 0..80000 {
-            let op: u32 = rand::thread_rng().gen_range(0, 7);
+            let op: u32 = rand::rng().random_range(0..7);
             if op == 0 {
                 // path apply
-                let u: usize = rand::thread_rng().gen_range(0, n) as usize;
-                let v: i64 = rand::thread_rng().gen_range(-bound, bound);
+                let u: usize = rand::rng().random_range(0..n) as usize;
+                let v: i64 = rand::rng().random_range(-bound..bound);
                 tree.path_apply(u as usize, v as i128);
                 path_apply_brutal(&parent, &mut value, u, v);
             } else if op == 1 {
                 // query min
-                let u: usize = rand::thread_rng().gen_range(0, n) as usize;
+                let u: usize = rand::rng().random_range(0..n) as usize;
                 assert_eq!(
                     query_min_brutal(&parent, &value, u),
                     tree.path_aggregate(u) as i64
                 );
             } else if op == 2 {
                 // lca
-                let u: usize = rand::thread_rng().gen_range(0, n) as usize;
-                let v: usize = rand::thread_rng().gen_range(0, n) as usize;
+                let u: usize = rand::rng().random_range(0..n) as usize;
+                let v: usize = rand::rng().random_range(0..n) as usize;
                 assert_eq!(lca_brutal(&parent, u, v), tree.lca(u, v));
             } else if op == 3 {
                 // query chop
-                let u: usize = rand::thread_rng().gen_range(0, n) as usize;
+                let u: usize = rand::rng().random_range(0..n) as usize;
                 let mut p = u;
                 let mut v = value[p];
                 while p != NULL {
@@ -459,16 +459,16 @@ mod tests {
                 }
             } else if op == 4 {
                 // set
-                let u: usize = rand::thread_rng().gen_range(0, n) as usize;
-                let v: i64 = rand::thread_rng().gen_range(-bound, bound);
+                let u: usize = rand::rng().random_range(0..n) as usize;
+                let v: i64 = rand::rng().random_range(-bound..bound);
                 tree.set(u, v as i128);
                 value[u] = v;
             } else if op == 5 {
                 // get
-                let u: usize = rand::thread_rng().gen_range(0, n) as usize;
+                let u: usize = rand::rng().random_range(0..n) as usize;
                 assert_eq!(value[u], tree.get(u) as i64);
             } else if op == 6 {
-                let p: usize = rand::thread_rng().gen_range(0, n) as usize;
+                let p: usize = rand::rng().random_range(0..n) as usize;
                 parent.push(p);
                 value.push(0);
                 tree.make_tree(n);
@@ -486,7 +486,7 @@ mod tests {
         let mut value: Vec<i64> = Vec::new();
         parent.push(NULL);
         for i in 1..n {
-            let p: usize = rand::thread_rng().gen_range(0, i) as usize;
+            let p: usize = rand::rng().random_range(0..i) as usize;
             parent.push(p);
         }
         value.resize(n, 0);
@@ -497,28 +497,28 @@ mod tests {
         }
         assert_eq!(tree.size(), n);
         for _ in 0..80000 {
-            let op: u32 = rand::thread_rng().gen_range(0, 8);
+            let op: u32 = rand::rng().random_range(0..8);
             if op == 0 {
                 // path apply
-                let u: usize = rand::thread_rng().gen_range(0, n) as usize;
-                let v: i64 = rand::thread_rng().gen_range(-bound, bound);
+                let u: usize = rand::rng().random_range(0..n) as usize;
+                let v: i64 = rand::rng().random_range(-bound..bound);
                 tree.path_apply(u as usize, v as i128);
                 path_apply_brutal(&parent, &mut value, u, v);
             } else if op == 1 {
                 // query min
-                let u: usize = rand::thread_rng().gen_range(0, n) as usize;
+                let u: usize = rand::rng().random_range(0..n) as usize;
                 assert_eq!(
                     query_min_brutal(&parent, &value, u),
                     tree.path_aggregate(u) as i64
                 );
             } else if op == 2 {
                 // lca
-                let u: usize = rand::thread_rng().gen_range(0, n) as usize;
-                let v: usize = rand::thread_rng().gen_range(0, n) as usize;
+                let u: usize = rand::rng().random_range(0..n) as usize;
+                let v: usize = rand::rng().random_range(0..n) as usize;
                 assert_eq!(lca_brutal(&parent, u, v), tree.lca(u, v));
             } else if op == 3 {
                 // query chop
-                let u: usize = rand::thread_rng().gen_range(0, n) as usize;
+                let u: usize = rand::rng().random_range(0..n) as usize;
                 let mut p = u;
                 let mut v = value[p];
                 while p != NULL {
@@ -530,24 +530,24 @@ mod tests {
                 }
             } else if op == 4 {
                 // set
-                let u: usize = rand::thread_rng().gen_range(0, n) as usize;
-                let v: i64 = rand::thread_rng().gen_range(-bound, bound);
+                let u: usize = rand::rng().random_range(0..n) as usize;
+                let v: i64 = rand::rng().random_range(-bound..bound);
                 tree.set(u, v as i128);
                 value[u] = v;
             } else if op == 5 {
                 // ancestor at
-                let u: usize = rand::thread_rng().gen_range(0, n) as usize;
-                let at: usize = rand::thread_rng().gen_range(0, 100) as usize;
+                let u: usize = rand::rng().random_range(0..n) as usize;
+                let at: usize = rand::rng().random_range(0..100) as usize;
                 assert_eq!(
                     ancestor_at_brutal(&parent, u, at),
                     tree.ancestor_at(u as usize, at)
                 );
             } else if op == 6 {
                 // get
-                let u: usize = rand::thread_rng().gen_range(0, n) as usize;
+                let u: usize = rand::rng().random_range(0..n) as usize;
                 assert_eq!(value[u], tree.get(u) as i64);
             } else if op == 7 {
-                let p: usize = rand::thread_rng().gen_range(0, n) as usize;
+                let p: usize = rand::rng().random_range(0..n) as usize;
                 parent.push(p);
                 value.push(0);
                 tree.make_tree(n);
@@ -565,7 +565,7 @@ mod tests {
         let mut value: Vec<i64> = Vec::new();
         parent.push(NULL);
         for i in 1..n {
-            let p: usize = rand::thread_rng().gen_range(0, i) as usize;
+            let p: usize = rand::rng().random_range(0..i) as usize;
             parent.push(p);
         }
         value.resize(n, 0);
@@ -577,29 +577,29 @@ mod tests {
         }
         assert_eq!(tree.size(), n);
         for _ in 0..80000 {
-            let op: u32 = rand::thread_rng().gen_range(0, 9);
+            let op: u32 = rand::rng().random_range(0..9);
             if op == 0 {
                 // path apply
-                let u: usize = rand::thread_rng().gen_range(0, n) as usize;
-                let v: i64 = rand::thread_rng().gen_range(-bound, bound);
+                let u: usize = rand::rng().random_range(0..n) as usize;
+                let v: i64 = rand::rng().random_range(-bound..bound);
                 tree.path_apply(u as usize, v as i128);
                 path_apply_brutal(&parent, &mut value, u, v);
             } else if op == 1 {
                 // caterpillar apply
-                let u: usize = rand::thread_rng().gen_range(0, n) as usize;
-                let v: i64 = rand::thread_rng().gen_range(-bound, bound);
+                let u: usize = rand::rng().random_range(0..n) as usize;
+                let v: i64 = rand::rng().random_range(-bound..bound);
                 tree.caterpillar_apply(u, v as i128);
                 caterpillar_apply_brutal(&parent, &mut value, u, v);
             } else if op == 2 {
                 // query min
-                let u: usize = rand::thread_rng().gen_range(0, n) as usize;
+                let u: usize = rand::rng().random_range(0..n) as usize;
                 assert_eq!(
                     query_min_brutal(&parent, &value, u),
                     tree.path_aggregate(u) as i64
                 );
             } else if op == 3 {
                 // query chop
-                let u: usize = rand::thread_rng().gen_range(0, n) as usize;
+                let u: usize = rand::rng().random_range(0..n) as usize;
                 let mut p = u;
                 let mut v = value[p];
                 while p != NULL {
@@ -611,17 +611,17 @@ mod tests {
                 }
             } else if op == 4 {
                 // set
-                let u: usize = rand::thread_rng().gen_range(0, n) as usize;
-                let v: i64 = rand::thread_rng().gen_range(-bound, bound);
+                let u: usize = rand::rng().random_range(0..n) as usize;
+                let v: i64 = rand::rng().random_range(-bound..bound);
                 tree.set(u, v as i128);
                 value[u] = v;
             } else if op == 5 {
                 // get
-                let u: usize = rand::thread_rng().gen_range(0, n) as usize;
+                let u: usize = rand::rng().random_range(0..n) as usize;
                 assert_eq!(value[u], tree.get(u) as i64);
             } else if op == 6 {
                 // make tree
-                let p: usize = rand::thread_rng().gen_range(0, n) as usize;
+                let p: usize = rand::rng().random_range(0..n) as usize;
                 parent.push(p);
                 value.push(0);
                 tree.make_tree(n);
@@ -629,7 +629,7 @@ mod tests {
                 n += 1;
             } else if op == 7 {
                 // split root
-                let i: usize = rand::thread_rng().gen_range(0, n) as usize;
+                let i: usize = rand::rng().random_range(0..n) as usize;
                 if parent[i] != NULL {
                     tree.split_root(parent[i], i);
                     parent[i] = NULL;
@@ -644,9 +644,8 @@ mod tests {
                     }
                 }
                 if null_vec.len() != 1 {
-                    let i: usize = rand::thread_rng()
-                        .gen_range(0, null_vec.len())
-                        as usize;
+                    let i: usize =
+                        rand::rng().random_range(0..null_vec.len()) as usize;
                     let i = null_vec[i];
                     let mut can = Vec::new();
                     for v in 0..n {
@@ -655,7 +654,7 @@ mod tests {
                         }
                     }
                     let p: usize =
-                        rand::thread_rng().gen_range(0, can.len()) as usize;
+                        rand::rng().random_range(0..can.len()) as usize;
                     let p = can[p];
                     tree.link(p, i);
                     parent[i] = p;

--- a/crates/util/log_device/src/lib.rs
+++ b/crates/util/log_device/src/lib.rs
@@ -464,7 +464,7 @@ mod tests {
     ) {
         for i in start..end {
             let mut stripe: Vec<u8> = Vec::new();
-            let stripe_size = rand::thread_rng().gen_range(4, 1024 * 64);
+            let stripe_size = rand::rng().random_range(4..1024 * 64);
             stripe.resize(stripe_size, i as u8);
             let payload_size = stripe_size - 4;
             LittleEndian::write_u32(&mut stripe[0..4], payload_size as u32);

--- a/crates/util/metrics/src/histogram.rs
+++ b/crates/util/metrics/src/histogram.rs
@@ -7,7 +7,7 @@ use crate::{
     registry::{DEFAULT_GROUPING_REGISTRY, DEFAULT_REGISTRY},
 };
 use parking_lot::RwLock;
-use rand::{thread_rng, Rng};
+use rand::{rng, Rng};
 use std::{
     cmp::Ordering,
     collections::BinaryHeap,
@@ -209,8 +209,8 @@ impl Histogram for UniformSample {
         if data.values.len() < self.reservoir_size {
             data.values.push(v);
         } else {
-            let mut rng = thread_rng();
-            let r = rng.gen_range(0, data.count);
+            let mut rng = rng();
+            let r = rng.random_range(0..data.count);
 
             // replace probability is reservoir_size/1+count
             if let Some(replaced) = data.values.get_mut(r) {
@@ -323,7 +323,7 @@ impl Histogram for ExpDecaySample {
         let k = (now - data.t0).as_nanos() as f64
             / Duration::from_secs(1).as_nanos() as f64
             * self.alpha;
-        let k = k.exp() * rand::thread_rng().gen_range(0.0, 1.0);
+        let k = k.exp() * rand::rng().random_range(0.0..1.0);
         if k.is_normal() {
             data.values.push(ExpDecaySampleItem { k, v });
         }

--- a/crates/util/metrics/src/report.rs
+++ b/crates/util/metrics/src/report.rs
@@ -39,7 +39,7 @@ pub fn report_async<R: 'static + Reporter>(reporter: R, interval: Duration) {
     thread::spawn(move || loop {
         // sleep random time on different nodes to reduce competition.
         thread::sleep(
-            interval.mul_f64(0.5 + rand::thread_rng().gen_range(0.0, 1.0)),
+            interval.mul_f64(0.5 + rand::rng().random_range(0.0..1.0)),
         );
 
         let start = Instant::now();

--- a/crates/util/random_crash/src/lib.rs
+++ b/crates/util/random_crash/src/lib.rs
@@ -8,7 +8,7 @@ use lazy_static::lazy_static;
 use log::info;
 
 use parking_lot::Mutex;
-use rand::{thread_rng, Rng};
+use rand::{rng, Rng};
 lazy_static! {
     /// The process exit code set for random crash.
     pub static ref CRASH_EXIT_CODE: Mutex<i32> = Mutex::new(100);
@@ -21,7 +21,7 @@ lazy_static! {
 /// Randomly crash with the probability and exit code already set.
 pub fn random_crash_if_enabled(exit_str: &str) {
     if let Some(p) = *CRASH_EXIT_PROBABILITY.lock() {
-        if thread_rng().gen_bool(p) {
+        if rng().random_bool(p) {
             info!("exit before {}", exit_str);
             std::process::exit(*CRASH_EXIT_CODE.lock());
         }

--- a/crates/util/treap-map/benches/map_cmp.rs
+++ b/crates/util/treap-map/benches/map_cmp.rs
@@ -20,8 +20,8 @@ const SIZE: usize = 1 << 20 - 1;
 fn make_combined_map(mut rng: impl Rng) -> TreapMap<CombinedMap> {
     let mut treap_map = TreapMap::<CombinedMap>::new();
     for _ in 0..SIZE {
-        let key = rng.gen::<usize>() % (SIZE * 2);
-        treap_map.insert(key, key, rng.gen::<u64>() % u32::MAX as u64);
+        let key = rng.random_range(0..(SIZE * 2));
+        treap_map.insert(key, key, rng.random_range(0..u32::MAX as u64));
     }
     treap_map
 }
@@ -39,7 +39,7 @@ fn make_seperate_map(
     let mut treap_map = TreapMap::<SepreateMap>::new();
     let mut btree_map: BTreeMap<usize, usize> = BTreeMap::new();
     for _ in 0..SIZE {
-        let key = rng.gen::<usize>() % (SIZE * 2);
+        let key = rng.random_range(0..SIZE * 2);
         btree_map.insert(key, key);
         treap_map.insert(key, (), rng.gen::<u64>() % u32::MAX as u64);
     }
@@ -52,7 +52,7 @@ fn bench_combined_treap_map_query(c: &mut Criterion) {
         let mut key = 0usize;
         b.iter(|| {
             black_box({
-                key = rand::random::<usize>() % (SIZE * 2);
+                key = rand::random_range(0..SIZE * 2);
                 black_box(treap_map.get(&key).unwrap_or(&key));
             })
         });
@@ -63,14 +63,14 @@ fn bench_combined_treap_map_update(c: &mut Criterion) {
     let mut treap_map = make_combined_map(StdRng::from_seed([123; 32]));
     c.bench_function("Combined Treapmap update", move |b| {
         b.iter(|| {
-            let key = rand::random::<usize>() % (SIZE * 2);
+            let key = rand::random_range(0..(SIZE * 2));
             if treap_map.len() > SIZE {
                 treap_map.remove(&key);
             } else {
                 treap_map.insert(
                     key,
-                    rand::random(),
-                    rand::random::<u64>() % u32::MAX as u64,
+                    rand::random_range(0..usize::MAX),
+                    rand::random_range(0..u32::MAX as u64),
                 );
             }
         });
@@ -82,7 +82,7 @@ fn bench_sepreate_treap_map_query(c: &mut Criterion) {
         make_seperate_map(StdRng::from_seed([123; 32]));
     c.bench_function("Seperate Treapmap get", move |b| {
         b.iter(|| {
-            let key = rand::random::<usize>() % (SIZE * 2);
+            let key = rand::random_range(0..(SIZE * 2));
             black_box(btree_map.get(&key));
         })
     });
@@ -94,16 +94,16 @@ fn bench_sepreate_treap_map_update(c: &mut Criterion) {
         make_seperate_map(StdRng::from_seed([123; 32]));
     c.bench_function("Seperate Treapmap update", move |b| {
         b.iter(|| {
-            let key = rand::random::<usize>() % (SIZE * 2);
+            let key = rand::random_range(0..(SIZE * 2));
             if treap_map.len() > SIZE {
                 treap_map.remove(&key);
                 btree_map.remove(&key);
             } else {
-                btree_map.insert(key, rand::random());
+                btree_map.insert(key, rand::random_range(0..usize::MAX));
                 treap_map.insert(
                     key,
                     (),
-                    rand::random::<u64>() % u32::MAX as u64,
+                    rand::random_range(0..u32::MAX as u64),
                 );
             }
         });

--- a/crates/util/treap-map/benches/map_cmp.rs
+++ b/crates/util/treap-map/benches/map_cmp.rs
@@ -41,7 +41,7 @@ fn make_seperate_map(
     for _ in 0..SIZE {
         let key = rng.random_range(0..SIZE * 2);
         btree_map.insert(key, key);
-        treap_map.insert(key, (), rng.gen::<u64>() % u32::MAX as u64);
+        treap_map.insert(key, (), rng.random::<u64>() % u32::MAX as u64);
     }
     (treap_map, btree_map)
 }

--- a/crates/util/treap-map/benches/useless_weight.rs
+++ b/crates/util/treap-map/benches/useless_weight.rs
@@ -33,7 +33,7 @@ const SIZE: usize = 1 << 12 - 1;
 fn make_small_weight_map(mut rng: impl Rng) -> TreapMap<SmallWeight> {
     let mut treap_map = TreapMap::<SmallWeight>::new();
     for _ in 0..SIZE {
-        let key = rng.gen::<usize>() % (SIZE * 2);
+        let key = rng.random_range(0..(SIZE * 2));
         treap_map.insert(key, key, rng.gen::<u64>() >> 14);
     }
     treap_map
@@ -42,7 +42,7 @@ fn make_small_weight_map(mut rng: impl Rng) -> TreapMap<SmallWeight> {
 fn make_large_weight_map(mut rng: impl Rng) -> TreapMap<LargeWeight> {
     let mut treap_map = TreapMap::<LargeWeight>::new();
     for _ in 0..SIZE {
-        let key = rng.gen::<usize>() % (SIZE * 2);
+        let key = rng.random_range(0..(SIZE * 2));
         treap_map.insert(key, key, U512(rng.gen::<[u64; 8]>()) >> 14);
     }
     treap_map
@@ -51,7 +51,7 @@ fn make_large_weight_map(mut rng: impl Rng) -> TreapMap<LargeWeight> {
 fn make_no_weight_map(mut rng: impl Rng) -> TreapMap<NoWeight> {
     let mut treap_map = TreapMap::<NoWeight>::new();
     for _ in 0..SIZE {
-        let key = rng.gen::<usize>() % (SIZE * 2);
+        let key = rng.random_range(0..(SIZE * 2));
         treap_map.insert(key, key, treap_map::NoWeight);
     }
     treap_map
@@ -62,7 +62,7 @@ fn bench_small_weight_search(c: &mut Criterion) {
         "Search with u64 Weight (Actual Compute Weight)",
         move |b| {
             let treap_map = make_small_weight_map(StdRng::from_seed([123; 32]));
-            let mut rand = XorShiftRng::from_entropy();
+            let mut rand = XorShiftRng::from_os_rng();
             b.iter(|| {
                 black_box({
                     let key = rand.next_u64() as usize % (SIZE * 2);
@@ -87,7 +87,7 @@ fn bench_large_weight_search(c: &mut Criterion) {
         "Search with U512 Weight (Actual Compute Weight)",
         move |b| {
             let treap_map = make_large_weight_map(StdRng::from_seed([123; 32]));
-            let mut rand = XorShiftRng::from_entropy();
+            let mut rand = XorShiftRng::from_os_rng();
             b.iter(|| {
                 black_box({
                     let key = rand.next_u64() as usize % (SIZE * 2);
@@ -107,7 +107,7 @@ fn bench_large_weight_search(c: &mut Criterion) {
     );
 
     c.bench_function("`search_no_weight` function", move |b| {
-        let mut rand = XorShiftRng::from_entropy();
+        let mut rand = XorShiftRng::from_os_rng();
         let treap_map = make_large_weight_map(StdRng::from_seed([123; 32]));
 
         b.iter(|| {
@@ -128,7 +128,7 @@ fn bench_large_weight_search(c: &mut Criterion) {
 fn bench_no_weight_search(c: &mut Criterion) {
     c.bench_function("Search treap-map without weight", move |b| {
         let treap_map = make_no_weight_map(StdRng::from_seed([123; 32]));
-        let mut rand = XorShiftRng::from_entropy();
+        let mut rand = XorShiftRng::from_os_rng();
         b.iter(|| {
             black_box({
                 let key = rand.next_u64() as usize % (SIZE * 2);

--- a/crates/util/treap-map/benches/useless_weight.rs
+++ b/crates/util/treap-map/benches/useless_weight.rs
@@ -34,7 +34,7 @@ fn make_small_weight_map(mut rng: impl Rng) -> TreapMap<SmallWeight> {
     let mut treap_map = TreapMap::<SmallWeight>::new();
     for _ in 0..SIZE {
         let key = rng.random_range(0..(SIZE * 2));
-        treap_map.insert(key, key, rng.gen::<u64>() >> 14);
+        treap_map.insert(key, key, rng.random::<u64>() >> 14);
     }
     treap_map
 }
@@ -43,7 +43,7 @@ fn make_large_weight_map(mut rng: impl Rng) -> TreapMap<LargeWeight> {
     let mut treap_map = TreapMap::<LargeWeight>::new();
     for _ in 0..SIZE {
         let key = rng.random_range(0..(SIZE * 2));
-        treap_map.insert(key, key, U512(rng.gen::<[u64; 8]>()) >> 14);
+        treap_map.insert(key, key, U512(rng.random::<[u64; 8]>()) >> 14);
     }
     treap_map
 }

--- a/crates/util/treap-map/src/map.rs
+++ b/crates/util/treap-map/src/map.rs
@@ -48,7 +48,7 @@ impl<C: TreapMapConfig> TreapMap<C> {
     pub fn new() -> TreapMap<C> {
         TreapMap {
             root: None,
-            rng: XorShiftRng::from_entropy(),
+            rng: XorShiftRng::from_os_rng(),
             ext_map: Default::default(),
         }
     }

--- a/crates/util/treap-map/src/tests.rs
+++ b/crates/util/treap-map/src/tests.rs
@@ -11,7 +11,7 @@ use primitives::{
     transaction::native_transaction::NativeTransaction, Action,
     SignedTransaction, Transaction,
 };
-use rand::{seq::SliceRandom, thread_rng, Rng, RngCore, SeedableRng};
+use rand::{rng, seq::SliceRandom, Rng, RngCore, SeedableRng};
 use rand_chacha::ChaChaRng;
 use rand_xorshift::XorShiftRng;
 use std::{
@@ -198,7 +198,7 @@ fn test_insert_query_random() {
     let mut tx_vec: Vec<SignedTransaction> = vec![];
 
     for _ in 0..operation_num {
-        let operation = match operation_rng.gen::<u32>() % 4 {
+        let operation = match operation_rng.random::<u32>() % 4 {
             0 => Operation::Len,
             1 => Operation::ContainsKey,
             2 => Operation::Insert,
@@ -267,7 +267,7 @@ fn test_insert_remove_query_random() {
     let mut tx_vec: Vec<SignedTransaction> = vec![];
 
     for _ in 0..operation_num {
-        let operation = match operation_rng.gen::<u32>() % 7 {
+        let operation = match operation_rng.random::<u32>() % 7 {
             0 => Operation::Len,
             1 => Operation::ContainsKey,
             2..=3 => Operation::Insert,
@@ -391,7 +391,7 @@ fn test_apply_op_change_value() {
     }
     // Test update value
     let mut indicies: Vec<_> = (0u32..200).collect();
-    indicies.shuffle(&mut thread_rng());
+    indicies.shuffle(&mut rng());
     for i in indicies {
         let should_fail = i % 3 == 0;
         let update = |node: &mut Node<_>| {
@@ -439,7 +439,7 @@ fn test_apply_op_change_weight() {
     }
     // Test update value
     let mut indicies: Vec<_> = (0u32..200).collect();
-    indicies.shuffle(&mut thread_rng());
+    indicies.shuffle(&mut rng());
     for i in indicies {
         let should_fail = i % 3 == 0;
         let update = |node: &mut Node<_>| {
@@ -489,7 +489,7 @@ fn test_apply_op_change_key() {
     }
     // Test update value
     let mut indicies: Vec<_> = (0u32..200).collect();
-    indicies.shuffle(&mut thread_rng());
+    indicies.shuffle(&mut rng());
     for i in indicies {
         let should_fail = i % 3 == 0;
         let delete_item = i % 5 == 0;
@@ -578,7 +578,7 @@ fn test_apply_op_change_key_for_shared_key() {
     }
     // Test update value
     let mut indicies: Vec<_> = (0u32..200).collect();
-    indicies.shuffle(&mut thread_rng());
+    indicies.shuffle(&mut rng());
     for i in indicies {
         let should_fail = i % 3 == 0;
         let delete_item = i % 5 == 0;

--- a/tools/consensus_bench/Cargo.lock
+++ b/tools/consensus_bench/Cargo.lock
@@ -1094,8 +1094,8 @@ dependencies = [
  "malloc_size_of",
  "malloc_size_of_derive",
  "primitives",
- "rand 0.7.3",
- "rand_xorshift 0.2.0",
+ "rand 0.9.0",
+ "rand_xorshift 0.4.0",
  "treap-map",
  "typenum",
 ]
@@ -1251,8 +1251,8 @@ dependencies = [
  "parity-util-mem",
  "parking_lot 0.12.3",
  "primitives",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
+ "rand 0.9.0",
+ "rand_chacha 0.9.0",
  "random-crash",
  "rlp 0.4.6",
  "rlp-derive",
@@ -1410,9 +1410,9 @@ dependencies = [
  "primal",
  "primitives",
  "priority-send-queue",
- "rand 0.7.3",
  "rand 0.8.5",
- "rand_xorshift 0.2.0",
+ "rand 0.9.0",
+ "rand_xorshift 0.4.0",
  "rangetools",
  "rayon",
  "rlp 0.4.6",
@@ -3918,7 +3918,7 @@ version = "0.1.0"
 dependencies = [
  "malloc_size_of",
  "parking_lot 0.12.3",
- "rand 0.7.3",
+ "rand 0.9.0",
 ]
 
 [[package]]
@@ -4096,7 +4096,7 @@ dependencies = [
  "lazy_static",
  "log",
  "parking_lot 0.12.3",
- "rand 0.7.3",
+ "rand 0.9.0",
  "serde",
  "timer",
  "tokio",
@@ -4253,7 +4253,7 @@ dependencies = [
  "parity-path",
  "parking_lot 0.12.3",
  "priority-send-queue",
- "rand 0.7.3",
+ "rand 0.9.0",
  "rlp 0.4.6",
  "rlp-derive",
  "serde",
@@ -5038,7 +5038,7 @@ dependencies = [
  "log",
  "malloc_size_of",
  "once_cell",
- "rand 0.7.3",
+ "rand 0.9.0",
  "rlp 0.4.6",
  "rlp-derive",
  "serde",
@@ -5288,20 +5288,20 @@ dependencies = [
 
 [[package]]
 name = "rand_xorshift"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -5311,7 +5311,7 @@ dependencies = [
  "lazy_static",
  "log",
  "parking_lot 0.12.3",
- "rand 0.7.3",
+ "rand 0.9.0",
 ]
 
 [[package]]
@@ -6735,8 +6735,8 @@ version = "0.1.0"
 dependencies = [
  "malloc_size_of",
  "primitives",
- "rand 0.7.3",
- "rand_xorshift 0.2.0",
+ "rand 0.9.0",
+ "rand_xorshift 0.4.0",
 ]
 
 [[package]]

--- a/tools/evm-spec-tester/Cargo.lock
+++ b/tools/evm-spec-tester/Cargo.lock
@@ -1028,7 +1028,7 @@ dependencies = [
  "network",
  "parking_lot 0.12.1",
  "primitives",
- "rand 0.7.3",
+ "rand 0.9.0",
  "toml",
  "txgen",
 ]
@@ -1150,8 +1150,8 @@ dependencies = [
  "malloc_size_of",
  "malloc_size_of_derive",
  "primitives",
- "rand 0.7.3",
- "rand_xorshift 0.2.0",
+ "rand 0.9.0",
+ "rand_xorshift 0.4.0",
  "treap-map",
  "typenum",
 ]
@@ -1243,7 +1243,7 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "log",
- "rand 0.7.3",
+ "rand 0.9.0",
  "serde",
  "strum",
  "thiserror 2.0.11",
@@ -1432,8 +1432,8 @@ dependencies = [
  "parity-util-mem",
  "parking_lot 0.12.1",
  "primitives",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
+ "rand 0.9.0",
+ "rand_chacha 0.9.0",
  "random-crash",
  "rlp 0.4.6",
  "rlp-derive",
@@ -1591,9 +1591,9 @@ dependencies = [
  "primal",
  "primitives",
  "priority-send-queue",
- "rand 0.7.3",
  "rand 0.8.5",
- "rand_xorshift 0.2.0",
+ "rand 0.9.0",
+ "rand_xorshift 0.4.0",
  "rangetools",
  "rayon",
  "rlp 0.4.6",
@@ -4412,7 +4412,7 @@ version = "0.1.0"
 dependencies = [
  "malloc_size_of",
  "parking_lot 0.12.1",
- "rand 0.7.3",
+ "rand 0.9.0",
 ]
 
 [[package]]
@@ -4599,7 +4599,7 @@ dependencies = [
  "lazy_static",
  "log",
  "parking_lot 0.12.1",
- "rand 0.7.3",
+ "rand 0.9.0",
  "serde",
  "timer",
  "tokio",
@@ -4756,7 +4756,7 @@ dependencies = [
  "parity-path",
  "parking_lot 0.12.1",
  "priority-send-queue",
- "rand 0.7.3",
+ "rand 0.9.0",
  "rlp 0.4.6",
  "rlp-derive",
  "serde",
@@ -5541,7 +5541,7 @@ dependencies = [
  "log",
  "malloc_size_of",
  "once_cell",
- "rand 0.7.3",
+ "rand 0.9.0",
  "rlp 0.4.6",
  "rlp-derive",
  "serde",
@@ -5791,20 +5791,20 @@ dependencies = [
 
 [[package]]
 name = "rand_xorshift"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -5814,7 +5814,7 @@ dependencies = [
  "lazy_static",
  "log",
  "parking_lot 0.12.1",
- "rand 0.7.3",
+ "rand 0.9.0",
 ]
 
 [[package]]
@@ -7521,8 +7521,8 @@ version = "0.1.0"
 dependencies = [
  "malloc_size_of",
  "primitives",
- "rand 0.7.3",
- "rand_xorshift 0.2.0",
+ "rand 0.9.0",
+ "rand_xorshift 0.4.0",
 ]
 
 [[package]]
@@ -7545,7 +7545,7 @@ dependencies = [
  "metrics",
  "parking_lot 0.12.1",
  "primitives",
- "rand 0.7.3",
+ "rand 0.9.0",
  "rlp 0.4.6",
  "rustc-hex",
  "secret-store",


### PR DESCRIPTION
Upgrade `rand` `rand_xorshift` `rand_chacha` version, resolve #3187.

rand updating to 0.8: https://rust-random.github.io/book/update-0.8.html
rand updating to 0.9: https://rust-random.github.io/book/update-0.9.html


Key changes:
1. upgrade rand to 0.9.
2. rand::distributions -> rand::distr
3. `OsRng.fill_bytes(&mut result)` -> `OsRng.try_fill_bytes(&mut result).unwrap()`;
In rand 0.8 the  fill_bytes like this:
```rust
    fn fill_bytes(&mut self, dest: &mut [u8]) {
        if let Err(e) = self.try_fill_bytes(dest) {
            panic!("Error: {}", e);
        }
    }
```
4. `OsRng.sample_iter(&Alphanumeric).take(length).collect()` ->
 ```rust
 let mut rng = rand::rng();
    (&mut rng)
        .sample_iter(Alphanumeric)
        .take(length)
        .map(char::from)
        .collect()`
```
doc: https://docs.rs/rand/latest/rand/trait.Rng.html#method.sample_iter
        
5. `rand::thread_rng` -> `rand::rng()`
6.  `gen_range(0, peers.len())` -> `random_range(0..peers.len())`
7. `gen()` -> `random()`
8. `from_entropy` -> `from_os_rng`
9. features `getrandom`  ->  `os_rng`
10. fn new, fn new_inclusive for Uniform and UniformSampler now return a Result
11. `rng.gen::<usize>() % 10 `-> `rng.random_range(0..10)` ,  gen(random) not implement usize (the trait bound `StandardUniform: rand::distr::Distribution<usize>` is not satisfied
the following other types implement trait `rand::distr::Distribution<T>)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3233)
<!-- Reviewable:end -->
