### PR TITLE
chore: update ethereum-types version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,7 +976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a8a8ed6fefbeef4a8c7b460e4110e12c5e22a5b7cf32621aae6ad650c4dcf29"
 dependencies = [
  "blst",
- "byte-slice-cast 1.2.2",
+ "byte-slice-cast 1.2.3",
  "ff",
  "group",
  "pairing",
@@ -1018,9 +1018,9 @@ checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "byte-tools"
@@ -1204,7 +1204,7 @@ version = "2.0.2"
 dependencies = [
  "cfx-types",
  "primitives",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "sqlite",
  "strfmt",
  "thiserror 2.0.11",
@@ -1255,7 +1255,7 @@ dependencies = [
  "diem-types",
  "hex-literal",
  "impl-tools",
- "impl-trait-for-tuples 0.2.2",
+ "impl-trait-for-tuples 0.2.3",
  "keccak-hash",
  "lazy_static",
  "log",
@@ -1266,7 +1266,7 @@ dependencies = [
  "pow-types",
  "primitives",
  "rayon",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rustc-hex",
  "sha3-macro",
  "solidity-abi",
@@ -1289,7 +1289,7 @@ dependencies = [
  "malloc_size_of_derive",
  "parking_lot 0.12.1",
  "primitives",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rlp-derive",
  "serde",
  "serde_derive",
@@ -1351,7 +1351,7 @@ dependencies = [
  "malloc_size_of",
  "malloc_size_of_derive",
  "primitives",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rlp-derive",
  "serde",
  "strum_macros",
@@ -1456,7 +1456,7 @@ dependencies = [
  "log",
  "parity-version",
  "primitives",
- "rand 0.7.3",
+ "rand 0.8.5",
  "rustc-hex",
  "serde",
  "serde_derive",
@@ -1500,7 +1500,7 @@ dependencies = [
  "jsonrpc-core",
  "jsonrpsee",
  "primitives",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -1570,7 +1570,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.1",
  "primitives",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "tiny-keccak 2.0.2",
 ]
 
@@ -1604,7 +1604,7 @@ dependencies = [
  "rand 0.9.0",
  "rand_chacha 0.9.0",
  "random-crash",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rlp-derive",
  "rustc-hex",
  "serde",
@@ -1645,10 +1645,10 @@ dependencies = [
 name = "cfx-types"
 version = "0.2.0"
 dependencies = [
- "ethereum-types 0.9.2",
+ "ethereum-types 0.15.1",
  "hex",
  "keccak-hash",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rlp-derive",
  "serde",
  "serde_derive",
@@ -1692,7 +1692,7 @@ dependencies = [
  "cfx-types",
  "keccak-hash",
  "primitives",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "serde",
  "solidity-abi",
 ]
@@ -1781,7 +1781,7 @@ dependencies = [
  "rand_xorshift 0.4.0",
  "rangetools",
  "rayon",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rlp-derive",
  "rustc-hex",
  "safety-rules",
@@ -2061,7 +2061,7 @@ dependencies = [
  "rand 0.8.5",
  "rand 0.9.0",
  "random-crash",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rpassword",
  "rustc-hex",
  "secret-store",
@@ -2160,7 +2160,7 @@ dependencies = [
  "pos-ledger-db",
  "primitives",
  "rand 0.8.5",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rpassword",
  "rustc-hex",
  "serde_json",
@@ -2223,6 +2223,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "convert_case"
@@ -3251,19 +3271,6 @@ dependencies = [
 
 [[package]]
 name = "ethbloom"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a6567e6fd35589fea0c63b94b4cf2e55573e413901bdbe60ab15cf0e25e5df"
-dependencies = [
- "crunchy",
- "fixed-hash 0.6.1",
- "impl-rlp 0.2.1",
- "impl-serde 0.3.2",
- "tiny-keccak 2.0.2",
-]
-
-[[package]]
-name = "ethbloom"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfb684ac8fa8f6c5759f788862bb22ec6fe3cb392f6bfd08e3c64b603661e3f8"
@@ -3272,6 +3279,19 @@ dependencies = [
  "fixed-hash 0.7.0",
  "impl-rlp 0.3.0",
  "impl-serde 0.3.2",
+ "tiny-keccak 2.0.2",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c321610643004cf908ec0f5f2aa0d8f1f8e14b540562a2887a1111ff1ecbf7b"
+dependencies = [
+ "crunchy",
+ "fixed-hash 0.8.0",
+ "impl-rlp 0.4.0",
+ "impl-serde 0.5.0",
  "tiny-keccak 2.0.2",
 ]
 
@@ -3297,20 +3317,6 @@ dependencies = [
 
 [[package]]
 name = "ethereum-types"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473aecff686bd8e7b9db0165cbbb53562376b39bf35b427f0c60446a9e1634b0"
-dependencies = [
- "ethbloom 0.9.2",
- "fixed-hash 0.6.1",
- "impl-rlp 0.2.1",
- "impl-serde 0.3.2",
- "primitive-types 0.7.3",
- "uint 0.8.5",
-]
-
-[[package]]
-name = "ethereum-types"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
@@ -3321,6 +3327,20 @@ dependencies = [
  "impl-serde 0.3.2",
  "primitive-types 0.10.1",
  "uint 0.9.5",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ab15ed80916029f878e0267c3a9f92b67df55e79af370bf66199059ae2b4ee3"
+dependencies = [
+ "ethbloom 0.14.1",
+ "fixed-hash 0.8.0",
+ "impl-rlp 0.4.0",
+ "impl-serde 0.5.0",
+ "primitive-types 0.13.1",
+ "uint 0.10.0",
 ]
 
 [[package]]
@@ -3467,18 +3487,6 @@ name = "fixed-hash"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3367952ceb191f4ab95dd5685dc163ac539e36202f9fcfd0cb22f9f9c542fefc"
-dependencies = [
- "byteorder",
- "rand 0.7.3",
- "rustc-hex",
- "static_assertions",
-]
-
-[[package]]
-name = "fixed-hash"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11498d382790b7a8f2fd211780bec78619bba81cdad3a283997c0c41f836759c"
 dependencies = [
  "byteorder",
  "rand 0.7.3",
@@ -4489,7 +4497,16 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
 dependencies = [
- "parity-scale-codec 3.6.9",
+ "parity-scale-codec 3.7.5",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d40b9d5e17727407e55028eafc22b2dc68781786e6d7eb8a21103f5058e3a14"
+dependencies = [
+ "parity-scale-codec 3.7.5",
 ]
 
 [[package]]
@@ -4511,6 +4528,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-rlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54ed8ad1f3877f7e775b8cbf30ed1bd3209a95401817f19a0eb4402d13f8cf90"
+dependencies = [
+ "rlp 0.6.1",
+]
+
+[[package]]
 name = "impl-serde"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4524,6 +4550,15 @@ name = "impl-serde"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a143eada6a1ec4aefa5049037a26a6d597bfd64f8c026d07b77133e02b7dd0b"
 dependencies = [
  "serde",
 ]
@@ -4565,13 +4600,13 @@ dependencies = [
 
 [[package]]
 name = "impl-trait-for-tuples"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5053,11 +5088,11 @@ dependencies = [
 
 [[package]]
 name = "keccak-hash"
-version = "0.5.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f58a51ef3df9398cf2434bea8d4eb61fb748d0feb1571f87388579a120a4c8f"
+checksum = "3e1b8590eb6148af2ea2d75f38e7d29f5ca970d5a4df456b3ef19b8b415d0264"
 dependencies = [
- "primitive-types 0.7.3",
+ "primitive-types 0.13.1",
  "tiny-keccak 2.0.2",
 ]
 
@@ -5288,7 +5323,7 @@ dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
  "rand 0.9.0",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rlp-derive",
 ]
 
@@ -5646,7 +5681,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "priority-send-queue",
  "rand 0.9.0",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rlp-derive",
  "serde",
  "serde_derive",
@@ -6015,23 +6050,25 @@ checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec 0.20.4",
- "byte-slice-cast 1.2.2",
- "impl-trait-for-tuples 0.2.2",
+ "byte-slice-cast 1.2.3",
+ "impl-trait-for-tuples 0.2.3",
  "parity-scale-codec-derive 2.3.1",
  "serde",
 ]
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.9"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881331e34fa842a2fb61cc2db9643a8fedc615e47cfcc52597d1af0db9a7e8fe"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec 1.0.1",
- "byte-slice-cast 1.2.2",
- "impl-trait-for-tuples 0.2.2",
- "parity-scale-codec-derive 3.6.9",
+ "byte-slice-cast 1.2.3",
+ "const_format",
+ "impl-trait-for-tuples 0.2.3",
+ "parity-scale-codec-derive 3.7.5",
+ "rustversion",
  "serde",
 ]
 
@@ -6049,14 +6086,14 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.9"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be30eaf4b0a9fba5336683b38de57bb86d179a35862ba6bfcf57625d006bde5b"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6538,19 +6575,6 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd39dcacf71411ba488570da7bbc89b717225e46478b30ba99b92db6b149809"
-dependencies = [
- "fixed-hash 0.6.1",
- "impl-codec 0.4.2",
- "impl-rlp 0.2.1",
- "impl-serde 0.3.2",
- "uint 0.8.5",
-]
-
-[[package]]
-name = "primitive-types"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
@@ -6574,6 +6598,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "primitive-types"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
+dependencies = [
+ "fixed-hash 0.8.0",
+ "impl-codec 0.7.1",
+ "impl-rlp 0.4.0",
+ "impl-serde 0.5.0",
+ "uint 0.10.0",
+]
+
+[[package]]
 name = "primitives"
 version = "0.2.0"
 dependencies = [
@@ -6590,7 +6627,7 @@ dependencies = [
  "malloc_size_of",
  "once_cell",
  "rand 0.9.0",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rlp-derive",
  "serde",
  "serde_derive",
@@ -6620,15 +6657,6 @@ checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
  "toml_edit 0.19.7",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
-dependencies = [
- "toml_edit 0.20.2",
 ]
 
 [[package]]
@@ -6666,9 +6694,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -6742,9 +6770,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -7340,6 +7368,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlp"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa24e92bb2a83198bb76d661a71df9f7076b8c420b8696e4d3d97d50d94479e3"
+dependencies = [
+ "bytes 1.9.0",
+ "rustc-hex",
+]
+
+[[package]]
 name = "rlp-derive"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7390,7 +7428,7 @@ dependencies = [
  "num-bigint 0.4.4",
  "num-integer",
  "num-traits",
- "parity-scale-codec 3.6.9",
+ "parity-scale-codec 3.7.5",
  "primitive-types 0.12.2",
  "proptest",
  "rand 0.8.5",
@@ -7826,9 +7864,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -7884,9 +7922,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8785,17 +8823,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
-dependencies = [
- "indexmap 2.8.0",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
@@ -8957,7 +8984,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "primitives",
  "rand 0.9.0",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rustc-hex",
  "secret-store",
 ]
@@ -9000,6 +9027,18 @@ name = "uint"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -9570,15 +9609,6 @@ name = "winnow"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -323,7 +323,7 @@ reqwest = "0.12"
 
 # crypto & hash
 #fixed-hash = "0.5"
-keccak-hash = "0.5"
+keccak-hash = "0.11.0"
 tiny-keccak = "2.0.2"
 bls-signatures = { git = "https://github.com/Conflux-Chain/bls-signatures.git", rev = "fb52187df92d27c365642cb7e7b2aaf60437cf9c", default-features = false, features = [
     "multicore",
@@ -423,12 +423,12 @@ chrono = "0.4"
 duration-str = "0.17"
 
 # parity crates
-rlp = "0.4.0"
+rlp = "0.6.1"
 rlp_derive = { package = "rlp-derive", version = "0.2.0" }
 panic_hook = { git = "https://github.com/Conflux-Chain/conflux-parity-deps.git", rev = "09da4dfeecd754df2034d4e71a260277aaaf9783" }
 dir = { git = "https://github.com/Conflux-Chain/conflux-parity-deps.git", rev = "09da4dfeecd754df2034d4e71a260277aaaf9783" }
 unexpected = { git = "https://github.com/Conflux-Chain/conflux-parity-deps.git", rev = "09da4dfeecd754df2034d4e71a260277aaaf9783" }
-ethereum-types = "0.9"
+ethereum-types = "0.15.1"
 parity-wordlist = "1.3.0"
 parity-crypto = "0.9.0"
 parity-path = "0.1"

--- a/crates/cfx_key/src/extended.rs
+++ b/crates/cfx_key/src/extended.rs
@@ -294,7 +294,7 @@ mod derivation {
 
         // 0x00 (padding) -- private_key --  index
         //  0             --    1..33    -- 33..end
-        private.to_big_endian(&mut data[1..33]);
+        private.write_as_big_endian(&mut data[1..33]);
         index.store(&mut data[33..(33 + T::len())]);
 
         hmac_pair(&data, private_key, chain_code)

--- a/crates/cfx_types/src/contract_address.rs
+++ b/crates/cfx_types/src/contract_address.rs
@@ -64,7 +64,7 @@ pub fn cal_contract_address(
             // future.
             buffer[0] = 0x0;
             buffer[1..(1 + 20)].copy_from_slice(&sender[..]);
-            nonce.to_little_endian(&mut buffer[(1 + 20)..(1 + 20 + 32)]);
+            nonce.write_as_little_endian(&mut buffer[(1 + 20)..(1 + 20 + 32)]);
             buffer[(1 + 20 + 32)..].copy_from_slice(&code_hash[..]);
             // In Conflux, we use the first four bits to indicate the type of
             // the address. For contract address, the bits will be

--- a/crates/cfx_types/src/utils.rs
+++ b/crates/cfx_types/src/utils.rs
@@ -35,7 +35,7 @@ pub fn parse_hex_string<F: FromStr>(hex_str: &str) -> Result<F, F::Err> {
 
 pub fn u256_to_h256_be(value: U256) -> H256 {
     let mut buf = [0u8; 32];
-    value.to_big_endian(&mut buf);
+    value.write_as_big_endian(&mut buf);
     H256::from(buf)
 }
 

--- a/crates/cfxcore/core/examples/snapshot_merge_test.rs
+++ b/crates/cfxcore/core/examples/snapshot_merge_test.rs
@@ -198,7 +198,7 @@ fn main() -> Result<(), Error> {
         assert!(value.is_some(), "Address {:?} does not exist", addr);
         let account_bytes = rlp::encode(account);
         let get_bytes = value.unwrap();
-        assert_eq!(account_bytes.as_slice(), get_bytes.as_ref());
+        assert_eq!(account_bytes.as_ref(), get_bytes.as_ref());
     }
     // TODO Make snapshot3 to compare the snapshot merkle_root
     let state_root_3 = StateRootWithAuxInfo::genesis(&MERKLE_NULL_NODE);

--- a/crates/cfxcore/core/src/block_data_manager/block_data_types.rs
+++ b/crates/cfxcore/core/src/block_data_manager/block_data_types.rs
@@ -218,7 +218,7 @@ impl<Version: Decodable, T: Decodable> Decodable
 impl<Version: Encodable, T: Encodable> DatabaseEncodable
     for DataVersionTuple<Version, T>
 {
-    fn db_encode(&self) -> Vec<u8> { rlp::encode(self) }
+    fn db_encode(&self) -> Vec<u8> { rlp::encode(self).to_vec() }
 }
 
 impl<Version: Decodable, T: Decodable> DatabaseDecodable
@@ -370,7 +370,7 @@ where T: DatabaseEncodable {
     for e in list {
         rlp_stream.append_raw(&e.db_encode(), 1);
     }
-    rlp_stream.drain()
+    rlp_stream.as_raw().to_vec()
 }
 
 pub fn db_decode_list<T>(bytes: &[u8]) -> Result<Vec<T>, DecoderError>

--- a/crates/cfxcore/core/src/message.rs
+++ b/crates/cfxcore/core/src/message.rs
@@ -185,7 +185,7 @@ macro_rules! build_msg_basic {
             fn msg_name(&self) -> &'static str { $name_str }
 
             fn encode(&self) -> Vec<u8> {
-                let mut encoded = self.rlp_bytes();
+                let mut encoded = self.rlp_bytes().to_vec();
                 self.push_msg_id_leb128_encoding(&mut encoded);
                 encoded
             }

--- a/crates/cfxcore/core/src/pos/consensus/liveness/vrf_proposer_election.rs
+++ b/crates/cfxcore/core/src/pos/consensus/liveness/vrf_proposer_election.rs
@@ -39,7 +39,7 @@ impl VrfProposer {
         proposal_threshold_u256: U256, epoch_state: EpochState,
     ) -> Self {
         let mut proposal_threshold = [0 as u8; HashValue::LENGTH];
-        proposal_threshold_u256.to_big_endian(&mut proposal_threshold);
+        proposal_threshold_u256.write_as_big_endian(&mut proposal_threshold);
         Self {
             author,
             vrf_private_key,

--- a/crates/cfxcore/core/src/pow/mod.rs
+++ b/crates/cfxcore/core/src/pow/mod.rs
@@ -204,13 +204,13 @@ impl ProofOfWorkConfig {
 // withholding attack among mining pools.
 pub fn nonce_to_lower_bound(nonce: &U256) -> U256 {
     let mut buf = [0u8; 32];
-    nonce.to_big_endian(&mut buf[..]);
+    nonce.write_as_big_endian(&mut buf[..]);
     for i in 16..32 {
         buf[i] = 0;
     }
     buf[0] = buf[0] & 0x7f;
     // Note that U256::from assumes big_endian of the bytes
-    let lower_bound = U256::from(buf);
+    let lower_bound = U256::from_big_endian(buf.as_ref());
     lower_bound
 }
 
@@ -291,7 +291,7 @@ impl PowComputer {
             for i in 0..32 {
                 buf[i] = block_hash[i];
             }
-            nonce.to_little_endian(&mut buf[32..64]);
+            nonce.write_as_little_endian(&mut buf[32..64]);
             let intermediate = keccak_hash(&buf[..]);
             let mut tmp = [0u8; 32];
             for i in 0..32 {

--- a/crates/cfxcore/core/src/sync/message/message.rs
+++ b/crates/cfxcore/core/src/sync/message/message.rs
@@ -95,7 +95,7 @@ impl Message for GetBlockHashesResponse {
     fn priority(&self) -> SendQueuePriority { SendQueuePriority::Low }
 
     fn encode(&self) -> Vec<u8> {
-        let mut encoded = self.rlp_bytes();
+        let mut encoded = self.rlp_bytes().to_vec();
         self.push_msg_id_leb128_encoding(&mut encoded);
         encoded
     }
@@ -112,7 +112,7 @@ impl Message for Transactions {
     fn msg_name(&self) -> &'static str { "Transactions" }
 
     fn encode(&self) -> Vec<u8> {
-        let mut encoded = self.rlp_bytes();
+        let mut encoded = self.rlp_bytes().to_vec();
         self.push_msg_id_leb128_encoding(&mut encoded);
         encoded
     }
@@ -128,7 +128,7 @@ impl Message for GetBlocksResponse {
     fn msg_name(&self) -> &'static str { "GetBlocksResponse" }
 
     fn encode(&self) -> Vec<u8> {
-        let mut encoded = self.rlp_bytes();
+        let mut encoded = self.rlp_bytes().to_vec();
         self.push_msg_id_leb128_encoding(&mut encoded);
         encoded
     }
@@ -148,7 +148,7 @@ impl Message for GetBlocksWithPublicResponse {
     fn msg_name(&self) -> &'static str { "GetBlocksWithPublicResponse" }
 
     fn encode(&self) -> Vec<u8> {
-        let mut encoded = self.rlp_bytes();
+        let mut encoded = self.rlp_bytes().to_vec();
         self.push_msg_id_leb128_encoding(&mut encoded);
         encoded
     }
@@ -164,7 +164,7 @@ impl Message for GetBlockTxnResponse {
     fn msg_name(&self) -> &'static str { "GetBlockTxnResponse" }
 
     fn encode(&self) -> Vec<u8> {
-        let mut encoded = self.rlp_bytes();
+        let mut encoded = self.rlp_bytes().to_vec();
         self.push_msg_id_leb128_encoding(&mut encoded);
         encoded
     }
@@ -182,7 +182,7 @@ impl Message for TransactionDigests {
     fn priority(&self) -> SendQueuePriority { SendQueuePriority::Normal }
 
     fn encode(&self) -> Vec<u8> {
-        let mut encoded = self.rlp_bytes();
+        let mut encoded = self.rlp_bytes().to_vec();
         self.push_msg_id_leb128_encoding(&mut encoded);
         encoded
     }
@@ -200,7 +200,7 @@ impl Message for GetTransactionsResponse {
     fn priority(&self) -> SendQueuePriority { SendQueuePriority::Normal }
 
     fn encode(&self) -> Vec<u8> {
-        let mut encoded = self.rlp_bytes();
+        let mut encoded = self.rlp_bytes().to_vec();
         self.push_msg_id_leb128_encoding(&mut encoded);
         encoded
     }
@@ -223,7 +223,7 @@ impl Message for GetTransactionsFromTxHashesResponse {
     fn priority(&self) -> SendQueuePriority { SendQueuePriority::Normal }
 
     fn encode(&self) -> Vec<u8> {
-        let mut encoded = self.rlp_bytes();
+        let mut encoded = self.rlp_bytes().to_vec();
         self.push_msg_id_leb128_encoding(&mut encoded);
         encoded
     }

--- a/crates/cfxcore/core/src/sync/message/transactions.rs
+++ b/crates/cfxcore/core/src/sync/message/transactions.rs
@@ -313,7 +313,7 @@ impl Message for GetTransactions {
     fn priority(&self) -> SendQueuePriority { SendQueuePriority::Normal }
 
     fn encode(&self) -> Vec<u8> {
-        let mut encoded = self.rlp_bytes();
+        let mut encoded = self.rlp_bytes().to_vec();
         self.push_msg_id_leb128_encoding(&mut encoded);
         encoded
     }
@@ -472,7 +472,7 @@ impl Message for GetTransactionsFromTxHashes {
     fn priority(&self) -> SendQueuePriority { SendQueuePriority::Normal }
 
     fn encode(&self) -> Vec<u8> {
-        let mut encoded = self.rlp_bytes();
+        let mut encoded = self.rlp_bytes().to_vec();
         self.push_msg_id_leb128_encoding(&mut encoded);
         encoded
     }

--- a/crates/cfxcore/core/src/verification.rs
+++ b/crates/cfxcore/core/src/verification.rs
@@ -83,7 +83,7 @@ fn block_receipts_trie(block_receipts: &Vec<Receipt>) -> SimpleMpt {
     make_simple_mpt(
         block_receipts
             .iter()
-            .map(|receipt| receipt.rlp_bytes().into_boxed_slice())
+            .map(|receipt| receipt.rlp_bytes().to_vec().into_boxed_slice())
             .collect(),
     )
 }

--- a/crates/cfxcore/internal_common/src/block_data_db_encoding.rs
+++ b/crates/cfxcore/internal_common/src/block_data_db_encoding.rs
@@ -14,7 +14,7 @@ pub trait DatabaseDecodable: Sized {
 macro_rules! impl_db_encoding_as_rlp {
     ($type:ty) => {
         impl $crate::DatabaseEncodable for $type {
-            fn db_encode(&self) -> Vec<u8> { rlp::encode(self) }
+            fn db_encode(&self) -> Vec<u8> { rlp::encode(self).to_vec() }
         }
 
         impl $crate::DatabaseDecodable for $type {
@@ -39,7 +39,7 @@ impl DatabaseEncodable for BlockHeader {
     fn db_encode(&self) -> Bytes {
         let mut rlp_stream = RlpStream::new();
         self.stream_rlp_with_pow_hash(&mut rlp_stream);
-        rlp_stream.drain()
+        rlp_stream.as_raw().to_vec()
     }
 }
 

--- a/crates/client/src/rpc/impls/cfx/common.rs
+++ b/crates/client/src/rpc/impls/cfx/common.rs
@@ -354,7 +354,7 @@ impl RpcImpl {
                 .expect("failed to convert scaled risk to bigInt");
             let (sign, big_endian_bytes) = scaled_risk.to_bytes_be();
             assert_ne!(sign, num_bigint::Sign::Minus);
-            let rpc_result = U256::from(big_endian_bytes.as_slice());
+            let rpc_result = U256::from_big_endian(big_endian_bytes.as_slice());
             Ok(Some(rpc_result.into()))
         }
     }

--- a/crates/client/src/rpc/impls/cfx/light.rs
+++ b/crates/client/src/rpc/impls/cfx/light.rs
@@ -562,7 +562,7 @@ impl RpcImpl {
                 accounts,
             )?;
 
-            Self::send_tx_helper(light, Bytes::new(tx.rlp_bytes()))
+            Self::send_tx_helper(light, Bytes::new(tx.rlp_bytes().to_vec()))
         };
 
         fut.boxed()

--- a/crates/dbs/statedb/src/statedb_ext.rs
+++ b/crates/dbs/statedb/src/statedb_ext.rs
@@ -79,7 +79,7 @@ impl StateDbExt for StateDbGeneric {
         } else {
             self.set_raw(
                 key,
-                ::rlp::encode(value).into_boxed_slice(),
+                ::rlp::encode(value).to_vec().into_boxed_slice(),
                 debug_record,
             )
         }

--- a/crates/dbs/storage/src/impls/delta_mpt/cow_node_ref.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/cow_node_ref.rs
@@ -655,7 +655,7 @@ impl CowNodeRef {
                         .value
                         .try_into()
                         .expect("not exceed i64::MAX"),
-                    trie_node.rlp_bytes().as_slice(),
+                    trie_node.rlp_bytes().as_ref(),
                 )?;
             commit_transaction.info.row_number =
                 commit_transaction.info.row_number.get_next()?;

--- a/crates/dbs/storage/src/impls/delta_mpt/tests/children_table.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/tests/children_table.rs
@@ -70,7 +70,7 @@ fn test_no_alloc_in_empty_children_table() {
 
     let rlp_bytes = empty_children_table.to_ref().rlp_bytes();
     let rlp_parsed =
-        ChildrenTableManagedDeltaMpt::decode(&Rlp::new(rlp_bytes.as_slice()))
+        ChildrenTableManagedDeltaMpt::decode(&Rlp::new(rlp_bytes.as_ref()))
             .unwrap();
     let decoded_table = ChildrenTableDeltaMpt::from(rlp_parsed);
     decoded_table.assert_no_alloc_in_empty_children_table();

--- a/crates/dbs/storage/src/impls/delta_mpt/tests/rlp_encode_decode.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/tests/rlp_encode_decode.rs
@@ -7,7 +7,7 @@ fn test_node_ref_delta_mpt_compact_encode_decode() {
     let x = NodeRefDeltaMptCompact::new(1234);
     let rlp_bytes = x.rlp_bytes();
     assert_eq!(
-        NodeRefDeltaMptCompact::decode(&Rlp::new(rlp_bytes.as_slice()))
+        NodeRefDeltaMptCompact::decode(&Rlp::new(rlp_bytes.as_ref()))
             .unwrap(),
         x
     );
@@ -31,7 +31,7 @@ fn test_full_children_table_encode_decode() {
     }
     let rlp_bytes = children_table.to_ref().rlp_bytes();
 
-    let rlp = &Rlp::new(rlp_bytes.as_slice());
+    let rlp = &Rlp::new(rlp_bytes.as_ref());
     // Assert that the rlp has 16 items.
     assert_eq!(rlp.item_count().unwrap(), 16);
 
@@ -53,7 +53,7 @@ fn test_non_empty_children_table_encode_decode() {
     }
     let rlp_bytes = children_table.to_ref().rlp_bytes();
     let rlp_parsed =
-        ChildrenTableManagedDeltaMpt::decode(&Rlp::new(rlp_bytes.as_slice()))
+        ChildrenTableManagedDeltaMpt::decode(&Rlp::new(rlp_bytes.as_ref()))
             .unwrap();
     assert_eq!(children_table, rlp_parsed.into());
 }
@@ -63,7 +63,7 @@ fn test_empty_children_table_encode_decode() {
     let empty_children_table: ChildrenTableDeltaMpt = Default::default();
     let rlp_bytes = empty_children_table.to_ref().rlp_bytes();
     let rlp_parsed =
-        ChildrenTableManagedDeltaMpt::decode(&Rlp::new(rlp_bytes.as_slice()))
+        ChildrenTableManagedDeltaMpt::decode(&Rlp::new(rlp_bytes.as_ref()))
             .unwrap();
     assert_eq!(
         ChildrenTableDeltaMpt::from(rlp_parsed).get_children_count(),
@@ -94,7 +94,7 @@ fn test_trie_node_encode_decode() {
     );
     let rlp_bytes = x.rlp_bytes();
     let rlp_parsed = MemOptimizedTrieNode::<DeltaMptsCacheAlgoData>::decode(
-        &Rlp::new(rlp_bytes.as_slice()),
+        &Rlp::new(rlp_bytes.as_ref()),
     )
     .unwrap();
 

--- a/crates/dbs/storage/src/impls/storage_db/snapshot_mpt.rs
+++ b/crates/dbs/storage/src/impls/storage_db/snapshot_mpt.rs
@@ -180,7 +180,7 @@ impl<
         let key = mpt_node_path_to_db_key(path);
         self.db
             .borrow_mut()
-            .put(&key, &trie_node.rlp_bytes().into_boxed_slice())?;
+            .put(&key, &trie_node.rlp_bytes().to_vec().into_boxed_slice())?;
         Ok(())
     }
 }

--- a/crates/dbs/storage/src/tests/state.rs
+++ b/crates/dbs/storage/src/tests/state.rs
@@ -202,7 +202,7 @@ fn test_snapshot_random_read_performance() {
         let account_key =
             StorageKey::new_account_key(&address).with_native_space();
         state_0
-            .set(account_key, rlp::encode(&account).into())
+            .set(account_key, rlp::encode(&account).as_ref().into())
             .expect("Failed to set key");
     }
 
@@ -381,7 +381,7 @@ fn simulate_transactions(
         } else {
             account.balance += U256::one();
         }
-        values[i] = Some(rlp::encode(&account).into());
+        values[i] = Some(rlp::encode(&account).as_ref().into());
     }
     *update_ms += now.elapsed().as_millis() as u32;
 

--- a/crates/dbs/storage/src/utils/mod.rs
+++ b/crates/dbs/storage/src/utils/mod.rs
@@ -102,7 +102,7 @@ pub trait StateRootWithAuxInfoToFromRlpBytes {
 
 /// Only used by storage benchmark due to incompatibility of rlp crate version.
 impl StateRootWithAuxInfoToFromRlpBytes for StateRootWithAuxInfo {
-    fn to_rlp_bytes(&self) -> Vec<u8> { self.rlp_bytes() }
+    fn to_rlp_bytes(&self) -> Vec<u8> { self.rlp_bytes().as_ref().to_vec() }
 
     fn from_rlp_bytes(bytes: &[u8]) -> Result<Self> {
         Ok(Self::decode(&Rlp::new(bytes))?)

--- a/crates/execution/executor/src/builtin/mod.rs
+++ b/crates/execution/executor/src/builtin/mod.rs
@@ -810,7 +810,7 @@ impl Bn128PairingImpl {
         };
 
         let mut buf = [0u8; 32];
-        ret_val.to_big_endian(&mut buf);
+        ret_val.write_as_big_endian(&mut buf);
         output.write(0, &buf);
 
         Ok(())

--- a/crates/execution/executor/src/executive/tests.rs
+++ b/crates/execution/executor/src/executive/tests.rs
@@ -2325,7 +2325,7 @@ fn test_tload() {
     assert!(apply_state);
 
     let mut key = [0u8; 32];
-    U256::from(2).to_big_endian(&mut key);
+    U256::from(2).write_as_big_endian(&mut key);
     assert_eq!(
         state
             .storage_at(&contract_address_with_space, &key)

--- a/crates/execution/executor/src/internal_contract/components/storage_layout.rs
+++ b/crates/execution/executor/src/internal_contract/components/storage_layout.rs
@@ -4,8 +4,8 @@ use keccak_hash::keccak;
 // General function for solidity storage rule
 pub fn mapping_slot(base: U256, index: U256) -> U256 {
     let mut input = [0u8; 64];
-    base.to_big_endian(&mut input[32..]);
-    index.to_big_endian(&mut input[..32]);
+    base.write_as_big_endian(&mut input[32..]);
+    index.write_as_big_endian(&mut input[..32]);
     let hash = keccak(input);
     U256::from_big_endian(hash.as_ref())
 }
@@ -19,7 +19,7 @@ pub fn vector_slot(base: U256, index: usize, size: usize) -> U256 {
 
 pub fn dynamic_slot(base: U256) -> U256 {
     let mut input = [0u8; 32];
-    base.to_big_endian(&mut input);
+    base.write_as_big_endian(&mut input);
     let hash = keccak(input);
     return U256::from_big_endian(hash.as_ref());
 }
@@ -35,6 +35,6 @@ pub fn array_slot(base: U256, index: usize, element_size: usize) -> U256 {
 
 pub fn u256_to_array(input: U256) -> [u8; 32] {
     let mut answer = [0u8; 32];
-    input.to_big_endian(answer.as_mut());
+    input.write_as_big_endian(answer.as_mut());
     answer
 }

--- a/crates/execution/executor/src/state/state_object/tests.rs
+++ b/crates/execution/executor/src/state/state_object/tests.rs
@@ -41,7 +41,7 @@ pub fn get_state_for_genesis_write() -> State {
 
 fn u256_to_vec(val: &U256) -> Vec<u8> {
     let mut key = vec![0; 32];
-    val.to_big_endian(key.as_mut());
+    val.write_as_big_endian(key.as_mut());
     key
 }
 

--- a/crates/execution/geth-tracer/src/utils.rs
+++ b/crates/execution/geth-tracer/src/utils.rs
@@ -72,7 +72,7 @@ pub(crate) fn stack_push_count(
 // convert from cfx U256 to alloy U256
 pub fn to_alloy_u256(u: U256) -> RU256 {
     let mut be_bytes: [u8; 32] = [0; 32];
-    u.to_big_endian(&mut be_bytes);
+    u.write_as_big_endian(&mut be_bytes);
     RU256::from_be_bytes(be_bytes)
 }
 

--- a/crates/execution/parity-trace-types/src/trace_types.rs
+++ b/crates/execution/parity-trace-types/src/trace_types.rs
@@ -135,5 +135,5 @@ impl DatabaseDecodable for BlockExecTraces {
 }
 
 impl DatabaseEncodable for BlockExecTraces {
-    fn db_encode(&self) -> Bytes { rlp::encode(self) }
+    fn db_encode(&self) -> Bytes { rlp::encode(self).as_ref().to_vec() }
 }

--- a/crates/execution/solidity-abi/src/basic.rs
+++ b/crates/execution/solidity-abi/src/basic.rs
@@ -36,7 +36,7 @@ impl ABIVariable for U256 {
 
     fn to_abi(&self) -> LinkedBytes {
         let mut answer = vec![0u8; 32];
-        self.to_big_endian(&mut answer);
+        self.write_as_big_endian(&mut answer);
         LinkedBytes::from_bytes(answer)
     }
 

--- a/crates/execution/solidity-abi/src/utils.rs
+++ b/crates/execution/solidity-abi/src/utils.rs
@@ -14,7 +14,7 @@ pub struct LinkedBytes {
 
 pub fn padded_big_endian(length: usize) -> Vec<u8> {
     let mut bytes = [0u8; 32];
-    U256::from(length).to_big_endian(&mut bytes);
+    U256::from(length).write_as_big_endian(&mut bytes);
     bytes.to_vec()
 }
 

--- a/crates/execution/vm-interpreter/src/interpreter/gasometer.rs
+++ b/crates/execution/vm-interpreter/src/interpreter/gasometer.rs
@@ -150,7 +150,7 @@ impl<Gas: CostType> Gasometer<Gas> {
             instructions::SLOAD => {
                 let gas = if spec.cip645.eip_cold_warm_access {
                     let mut key = H256::zero();
-                    stack.peek(0).to_big_endian(&mut key.0);
+                    stack.peek(0).write_as_big_endian(&mut key.0);
                     if context.is_warm_storage_entry(&key)? {
                         spec.warm_access_gas
                     } else {
@@ -532,7 +532,7 @@ fn calc_sstore_gas<Gas: CostType>(
     }
 
     let mut key = H256::zero();
-    stack.peek(0).to_big_endian(&mut key.0);
+    stack.peek(0).write_as_big_endian(&mut key.0);
 
     let new_val = *stack.peek(1);
     let warm_val = context.is_warm_storage_entry(&key)?;

--- a/crates/execution/vm-interpreter/src/interpreter/memory.rs
+++ b/crates/execution/vm-interpreter/src/interpreter/memory.rs
@@ -68,7 +68,7 @@ impl Memory for Vec<u8> {
 
     fn read(&self, offset: U256) -> U256 {
         let off = offset.low_u64() as usize;
-        U256::from(&self[off..off + 32])
+        U256::from_big_endian(&self[off..off + 32])
     }
 
     fn writeable_slice(&mut self, offset: U256, size: U256) -> &mut [u8] {
@@ -90,7 +90,7 @@ impl Memory for Vec<u8> {
 
     fn write(&mut self, offset: U256, value: U256) {
         let off = offset.low_u64() as usize;
-        value.to_big_endian(&mut self[off..off + 32]);
+        value.write_as_big_endian(&mut self[off..off + 32]);
     }
 
     fn write_byte(&mut self, offset: U256, value: U256) {

--- a/crates/execution/vm-interpreter/src/interpreter/mod.rs
+++ b/crates/execution/vm-interpreter/src/interpreter/mod.rs
@@ -86,7 +86,7 @@ impl CodeReader {
         let pos = self.position;
         self.position += no_of_bytes;
         let max = cmp::min(pos + no_of_bytes, self.code.len());
-        U256::from(&self.code[pos..max])
+        U256::from_big_endian(&self.code[pos..max])
     }
 
     fn len(&self) -> usize { self.code.len() }
@@ -688,7 +688,7 @@ impl<Cost: CostType, const CANCUN: bool> Interpreter<Cost, CANCUN> {
                 } else {
                     // TLOAD
                     let mut key = vec![0; 32];
-                    self.stack.pop_back().to_big_endian(key.as_mut());
+                    self.stack.pop_back().write_as_big_endian(key.as_mut());
                     let word = if context.spec().cip154 {
                         context.transient_storage_at(&key)?
                     } else {
@@ -731,7 +731,7 @@ impl<Cost: CostType, const CANCUN: bool> Interpreter<Cost, CANCUN> {
                 } else {
                     // TSTORE
                     let mut key = vec![0; 32];
-                    self.stack.pop_back().to_big_endian(key.as_mut());
+                    self.stack.pop_back().write_as_big_endian(key.as_mut());
                     let val = self.stack.pop_back();
 
                     context.transient_set_storage(key, val)?;
@@ -1090,13 +1090,13 @@ impl<Cost: CostType, const CANCUN: bool> Interpreter<Cost, CANCUN> {
             }
             instructions::SLOAD => {
                 let mut key = vec![0; 32];
-                self.stack.pop_back().to_big_endian(key.as_mut());
+                self.stack.pop_back().write_as_big_endian(key.as_mut());
                 let word = context.storage_at(&key)?;
                 self.stack.push(word);
             }
             instructions::SSTORE => {
                 let mut key = vec![0; 32];
-                self.stack.pop_back().to_big_endian(key.as_mut());
+                self.stack.pop_back().write_as_big_endian(key.as_mut());
                 let val = self.stack.pop_back();
 
                 context.set_storage(key, val)?;
@@ -1139,7 +1139,7 @@ impl<Cost: CostType, const CANCUN: bool> Interpreter<Cost, CANCUN> {
                     if id < bound && big_id < U256::from(data.len()) {
                         let mut v = [0u8; 32];
                         v[0..bound - id].clone_from_slice(&data[id..bound]);
-                        self.stack.push(U256::from(&v[..]))
+                        self.stack.push(U256::from_big_endian(&v[..]))
                     } else {
                         self.stack.push(U256::zero())
                     }

--- a/crates/execution/vm-interpreter/src/tests.rs
+++ b/crates/execution/vm-interpreter/src/tests.rs
@@ -1329,7 +1329,7 @@ fn assert_set_contains<T: Debug + Eq + PartialEq + Hash>(
 
 fn assert_store(ctx: &MockContext, pos: u64, val: &str) {
     let mut key = vec![0; 32];
-    U256::from(pos).to_big_endian(key.as_mut());
+    U256::from(pos).write_as_big_endian(key.as_mut());
     assert_eq!(
         ctx.store.get(&key).unwrap(),
         &H256::from_str(val).unwrap().into_uint()

--- a/crates/network/src/discovery.rs
+++ b/crates/network/src/discovery.rs
@@ -173,7 +173,7 @@ impl Discovery {
             uio,
             PACKET_PING,
             &node.endpoint.udp_address(),
-            &rlp.drain(),
+            &rlp.as_raw(),
         )?;
 
         self.in_flight_pings.insert(
@@ -286,7 +286,7 @@ impl Discovery {
 
         response.append(&echo_hash);
         response.append(&self.config.expire_timestamp());
-        self.send_packet(uio, PACKET_PONG, from, &response.drain())?;
+        self.send_packet(uio, PACKET_PONG, from, &response.as_raw())?;
 
         let entry = NodeEntry {
             id: node_id.clone(),

--- a/crates/network/src/session.rs
+++ b/crates/network/src/session.rs
@@ -582,7 +582,7 @@ impl Session {
             None,
             ProtocolVersion::default(),
             PACKET_DISCONNECT,
-            packet,
+            packet.to_vec(),
         );
         Error::Disconnect(reason).into()
     }
@@ -607,7 +607,7 @@ impl Session {
             None,
             ProtocolVersion::default(),
             PACKET_HELLO,
-            rlp.drain(),
+            rlp.as_raw().to_vec(),
             SendQueuePriority::High,
         )
         .map(|_| ())

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -140,7 +140,7 @@ impl Block {
         for tx in &self.transactions {
             stream.append(tx.as_ref());
         }
-        stream.drain()
+        stream.as_raw().to_vec()
     }
 
     pub fn decode_body_with_tx_public(
@@ -165,7 +165,7 @@ impl Block {
             .begin_list(2)
             .append(&self.block_header)
             .append_raw(&*self.encode_body_with_tx_public(), 1);
-        stream.drain()
+        stream.as_raw().to_vec()
     }
 
     pub fn decode_with_tx_public(rlp: &Rlp) -> Result<Self, DecoderError> {

--- a/crates/primitives/src/block_header.rs
+++ b/crates/primitives/src/block_header.rs
@@ -241,14 +241,14 @@ impl BlockHeader {
     pub fn rlp_without_nonce(&self) -> Bytes {
         let mut stream = RlpStream::new();
         self.stream_rlp_without_nonce(&mut stream);
-        stream.out()
+        stream.as_raw().to_vec()
     }
 
     /// Get the RLP representation of this header.
     pub fn rlp(&self) -> Bytes {
         let mut stream = RlpStream::new();
         self.stream_rlp(&mut stream);
-        stream.out()
+        stream.as_raw().to_vec()
     }
 
     /// Place this header(except nonce) into an RLP stream `stream`.

--- a/crates/primitives/src/transaction/eth_transaction.rs
+++ b/crates/primitives/src/transaction/eth_transaction.rs
@@ -28,8 +28,8 @@ impl Eip155Transaction {
                     // phantom transactions with matching
                     // fields from different senders
                     // will have different hashes
-                    r: U256::from(from.address.as_ref()),
-                    s: U256::from(from.address.as_ref()),
+                    r: U256::from_big_endian(from.address.as_ref()),
+                    s: U256::from_big_endian(from.address.as_ref()),
                     v: 0,
                 },
                 hash: H256::zero(),

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -518,8 +518,8 @@ impl Transaction {
         TransactionWithSignature {
             transaction: TransactionWithSignatureSerializePart {
                 unsigned: self,
-                r: sig.r().into(),
-                s: sig.s().into(),
+                r: U256::from_big_endian(sig.r()),
+                s: U256::from_big_endian(sig.s()),
                 v: sig.v(),
             },
             hash: H256::zero(),

--- a/crates/rpc/rpc-cfx-types/Cargo.toml
+++ b/crates/rpc/rpc-cfx-types/Cargo.toml
@@ -28,7 +28,7 @@ cfx-util-macros = { workspace = true }
 log = { workspace = true }
 cfx-parity-trace-types = { workspace = true }
 parity-version = { workspace = true }
-rand_07 = { workspace = true }
+rand_08 = { workspace = true }
 diem-crypto = { workspace = true }
 diem-types = { workspace = true }
 rustc-hex = { workspace = true }

--- a/crates/rpc/rpc-cfx-types/src/subscriber_id.rs
+++ b/crates/rpc/rpc-cfx-types/src/subscriber_id.rs
@@ -23,9 +23,9 @@ impl SubId {
 }
 
 pub mod random {
-    use rand_07;
+    use rand_08::rngs::OsRng;
 
-    pub type Rng = rand_07::rngs::OsRng;
+    pub type Rng = OsRng;
 
-    pub fn new() -> Rng { rand_07::rngs::OsRng }
+    pub fn new() -> Rng { OsRng }
 }

--- a/crates/rpc/rpc-eth-types/src/transaction.rs
+++ b/crates/rpc/rpc-eth-types/src/transaction.rs
@@ -123,8 +123,8 @@ impl Transaction {
         // for phantom tx, it's r and s are set to 'tx.from', which lead some
         // txs r and s to 0 which is not valid in some ethereum tools,
         // so we set them to chain_id
-        let mut r: U256 = signature.r().into();
-        let mut s: U256 = signature.s().into();
+        let mut r: U256 = U256::from_big_endian(signature.r());
+        let mut s: U256 = U256::from_big_endian(signature.s());
         if r == U256::zero() || s == U256::zero() {
             let chain_id = t
                 .chain_id()
@@ -150,7 +150,7 @@ impl Transaction {
             gas: *t.gas(),
             input: Bytes::new(t.data().clone()),
             creates: exec_info.1,
-            raw: Some(Bytes::new(t.transaction.transaction.rlp_bytes())),
+            raw: Some(Bytes::new(t.transaction.transaction.rlp_bytes().to_vec())),
             public_key: t.public().map(Into::into),
             chain_id: t.chain_id().map(|x| U64::from(x as u64)),
             standard_v: Some(signature.v().into()),

--- a/crates/util/log_device/src/lib.rs
+++ b/crates/util/log_device/src/lib.rs
@@ -243,7 +243,7 @@ impl LogDevice {
     fn set_stripe_info_to_db(&self, key: &[u8], stripe_info: &StripeInfo) {
         let value = rlp::encode(stripe_info);
         let mut tx = DBTransaction::new();
-        tx.put(COL_DB, key, value.as_slice());
+        tx.put(COL_DB, key, value.as_ref());
         self.db.key_value().write(tx).expect("DB write failed.");
     }
 

--- a/tools/consensus_bench/Cargo.lock
+++ b/tools/consensus_bench/Cargo.lock
@@ -712,22 +712,12 @@ checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "bitvec"
-version = "0.17.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41262f11d771fd4a61aa3ce019fca363b4b6c282fca9da2a31186d3965a47a5c"
-dependencies = [
- "either",
- "radium 0.3.0",
-]
-
-[[package]]
-name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
- "radium 0.7.0",
+ "radium",
  "tap",
  "wyz",
 ]
@@ -813,7 +803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a8a8ed6fefbeef4a8c7b460e4110e12c5e22a5b7cf32621aae6ad650c4dcf29"
 dependencies = [
  "blst",
- "byte-slice-cast 1.2.2",
+ "byte-slice-cast",
  "ff",
  "group",
  "pairing",
@@ -849,15 +839,9 @@ checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byte-slice-cast"
-version = "0.3.5"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
-
-[[package]]
-name = "byte-slice-cast"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "byte-unit"
@@ -983,7 +967,7 @@ version = "2.0.2"
 dependencies = [
  "cfx-types",
  "primitives",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "sqlite",
  "strfmt",
  "thiserror 2.0.11",
@@ -1033,7 +1017,7 @@ dependencies = [
  "diem-types",
  "hex-literal",
  "impl-tools",
- "impl-trait-for-tuples 0.2.2",
+ "impl-trait-for-tuples 0.2.3",
  "keccak-hash",
  "lazy_static",
  "log",
@@ -1044,7 +1028,7 @@ dependencies = [
  "pow-types",
  "primitives",
  "rayon",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rustc-hex",
  "sha3-macro",
  "solidity-abi",
@@ -1067,7 +1051,7 @@ dependencies = [
  "malloc_size_of_derive",
  "parking_lot 0.12.3",
  "primitives",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rlp-derive",
  "serde",
  "serde_derive",
@@ -1124,7 +1108,7 @@ dependencies = [
  "malloc_size_of",
  "malloc_size_of_derive",
  "primitives",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rlp-derive",
  "serde",
  "strum_macros",
@@ -1148,7 +1132,7 @@ dependencies = [
  "log",
  "parity-version",
  "primitives",
- "rand 0.7.3",
+ "rand 0.8.5",
  "rustc-hex",
  "serde",
  "serde_derive",
@@ -1170,7 +1154,7 @@ dependencies = [
  "jsonrpc-core",
  "jsonrpsee",
  "primitives",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -1220,7 +1204,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.3",
  "primitives",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "tiny-keccak",
 ]
 
@@ -1254,7 +1238,7 @@ dependencies = [
  "rand 0.9.0",
  "rand_chacha 0.9.0",
  "random-crash",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rlp-derive",
  "rustc-hex",
  "serde",
@@ -1282,7 +1266,7 @@ dependencies = [
  "ethereum-types",
  "hex",
  "keccak-hash",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rlp-derive",
  "serde",
  "serde_derive",
@@ -1326,7 +1310,7 @@ dependencies = [
  "cfx-types",
  "keccak-hash",
  "primitives",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "serde",
  "solidity-abi",
 ]
@@ -1413,7 +1397,7 @@ dependencies = [
  "rand_xorshift 0.4.0",
  "rangetools",
  "rayon",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rlp-derive",
  "rustc-hex",
  "safety-rules",
@@ -1642,6 +1626,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "convert_case"
@@ -2438,12 +2442,12 @@ dependencies = [
 
 [[package]]
 name = "ethbloom"
-version = "0.9.2"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a6567e6fd35589fea0c63b94b4cf2e55573e413901bdbe60ab15cf0e25e5df"
+checksum = "8c321610643004cf908ec0f5f2aa0d8f1f8e14b540562a2887a1111ff1ecbf7b"
 dependencies = [
  "crunchy",
- "fixed-hash 0.6.1",
+ "fixed-hash",
  "impl-rlp",
  "impl-serde",
  "tiny-keccak",
@@ -2457,16 +2461,16 @@ checksum = "e957efe1e627f8ec4e253660615fd9fe3736e10026197740b8b4b26c812be2e9"
 
 [[package]]
 name = "ethereum-types"
-version = "0.9.2"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473aecff686bd8e7b9db0165cbbb53562376b39bf35b427f0c60446a9e1634b0"
+checksum = "1ab15ed80916029f878e0267c3a9f92b67df55e79af370bf66199059ae2b4ee3"
 dependencies = [
  "ethbloom",
- "fixed-hash 0.6.1",
+ "fixed-hash",
  "impl-rlp",
  "impl-serde",
- "primitive-types 0.7.3",
- "uint 0.8.5",
+ "primitive-types 0.13.1",
+ "uint 0.10.0",
 ]
 
 [[package]]
@@ -2584,7 +2588,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "bitvec 1.0.1",
+ "bitvec",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -2594,18 +2598,6 @@ name = "fiat-crypto"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93ace6ec7cc19c8ed33a32eaa9ea692d7faea05006b5356b9e2b668ec4bc3955"
-
-[[package]]
-name = "fixed-hash"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11498d382790b7a8f2fd211780bec78619bba81cdad3a283997c0c41f836759c"
-dependencies = [
- "byteorder",
- "rand 0.7.3",
- "rustc-hex",
- "static_assertions",
-]
 
 [[package]]
 name = "fixed-hash"
@@ -3423,36 +3415,36 @@ dependencies = [
 
 [[package]]
 name = "impl-codec"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be51a921b067b0eaca2fad532d9400041561aa922221cc65f95a85641c6bf53"
-dependencies = [
- "parity-scale-codec 1.3.7",
-]
-
-[[package]]
-name = "impl-codec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
 dependencies = [
- "parity-scale-codec 3.6.9",
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d40b9d5e17727407e55028eafc22b2dc68781786e6d7eb8a21103f5058e3a14"
+dependencies = [
+ "parity-scale-codec",
 ]
 
 [[package]]
 name = "impl-rlp"
-version = "0.2.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f7a72f11830b52333f36e3b09a288333888bf54380fd0ac0790a3c31ab0f3c5"
+checksum = "54ed8ad1f3877f7e775b8cbf30ed1bd3209a95401817f19a0eb4402d13f8cf90"
 dependencies = [
- "rlp 0.4.6",
+ "rlp 0.6.1",
 ]
 
 [[package]]
 name = "impl-serde"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
+checksum = "4a143eada6a1ec4aefa5049037a26a6d597bfd64f8c026d07b77133e02b7dd0b"
 dependencies = [
  "serde",
 ]
@@ -3494,13 +3486,13 @@ dependencies = [
 
 [[package]]
 name = "impl-trait-for-tuples"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3723,11 +3715,11 @@ dependencies = [
 
 [[package]]
 name = "keccak-hash"
-version = "0.5.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f58a51ef3df9398cf2434bea8d4eb61fb748d0feb1571f87388579a120a4c8f"
+checksum = "3e1b8590eb6148af2ea2d75f38e7d29f5ca970d5a4df456b3ef19b8b415d0264"
 dependencies = [
- "primitive-types 0.7.3",
+ "primitive-types 0.13.1",
  "tiny-keccak",
 ]
 
@@ -4244,7 +4236,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "priority-send-queue",
  "rand 0.9.0",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rlp-derive",
  "serde",
  "serde_derive",
@@ -4555,40 +4547,30 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "1.3.7"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b26b16c7687c3075982af47719e481815df30bc544f7a6690763a25ca16e9d"
-dependencies = [
- "arrayvec 0.5.2",
- "bitvec 0.17.4",
- "byte-slice-cast 0.3.5",
- "serde",
-]
-
-[[package]]
-name = "parity-scale-codec"
-version = "3.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881331e34fa842a2fb61cc2db9643a8fedc615e47cfcc52597d1af0db9a7e8fe"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
 dependencies = [
  "arrayvec 0.7.4",
- "bitvec 1.0.1",
- "byte-slice-cast 1.2.2",
- "impl-trait-for-tuples 0.2.2",
+ "bitvec",
+ "byte-slice-cast",
+ "const_format",
+ "impl-trait-for-tuples 0.2.3",
  "parity-scale-codec-derive",
+ "rustversion",
  "serde",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.9"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be30eaf4b0a9fba5336683b38de57bb86d179a35862ba6bfcf57625d006bde5b"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4992,26 +4974,26 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd39dcacf71411ba488570da7bbc89b717225e46478b30ba99b92db6b149809"
-dependencies = [
- "fixed-hash 0.6.1",
- "impl-codec 0.4.2",
- "impl-rlp",
- "impl-serde",
- "uint 0.8.5",
-]
-
-[[package]]
-name = "primitive-types"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
- "fixed-hash 0.8.0",
+ "fixed-hash",
  "impl-codec 0.6.0",
  "uint 0.9.5",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
+dependencies = [
+ "fixed-hash",
+ "impl-codec 0.7.1",
+ "impl-rlp",
+ "impl-serde",
+ "uint 0.10.0",
 ]
 
 [[package]]
@@ -5029,7 +5011,7 @@ dependencies = [
  "malloc_size_of",
  "once_cell",
  "rand 0.9.0",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rlp-derive",
  "serde",
  "serde_derive",
@@ -5043,20 +5025,11 @@ version = "0.1.0"
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
-dependencies = [
- "toml_edit 0.20.2",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.22.20",
+ "toml_edit",
 ]
 
 [[package]]
@@ -5085,9 +5058,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -5150,9 +5123,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -5162,12 +5135,6 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
-
-[[package]]
-name = "radium"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 
 [[package]]
 name = "radium"
@@ -5482,7 +5449,7 @@ dependencies = [
  "alloy-primitives",
  "auto_impl",
  "bitflags 2.5.0",
- "bitvec 1.0.1",
+ "bitvec",
  "c-kzg",
  "cfg-if 1.0.0",
  "derive_more",
@@ -5532,18 +5499,19 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rlp"
-version = "0.4.6"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1190dcc8c3a512f1eef5d09bb8c84c7f39e1054e174d1795482e18f5272f2e73"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
+ "bytes",
  "rustc-hex",
 ]
 
 [[package]]
 name = "rlp"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+checksum = "fa24e92bb2a83198bb76d661a71df9f7076b8c420b8696e4d3d97d50d94479e3"
 dependencies = [
  "bytes",
  "rustc-hex",
@@ -5584,7 +5552,7 @@ dependencies = [
  "num-bigint 0.4.4",
  "num-integer",
  "num-traits",
- "parity-scale-codec 3.6.9",
+ "parity-scale-codec",
  "primitive-types 0.12.2",
  "proptest",
  "rand 0.8.5",
@@ -5891,9 +5859,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -5939,9 +5907,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6176,7 +6144,7 @@ dependencies = [
 name = "solidity-abi-derive"
 version = "0.1.0"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -6640,17 +6608,6 @@ checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
-dependencies = [
- "indexmap 2.8.0",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
@@ -6758,21 +6715,21 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "uint"
-version = "0.8.5"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db035e67dfaf7edd9aebfe8676afcd63eed53c8a4044fed514c8cccf1835177"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
  "byteorder",
  "crunchy",
- "rustc-hex",
+ "hex",
  "static_assertions",
 ]
 
 [[package]]
 name = "uint"
-version = "0.9.5"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -7273,15 +7230,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/tools/evm-spec-tester/Cargo.lock
+++ b/tools/evm-spec-tester/Cargo.lock
@@ -733,22 +733,12 @@ checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "bitvec"
-version = "0.17.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41262f11d771fd4a61aa3ce019fca363b4b6c282fca9da2a31186d3965a47a5c"
-dependencies = [
- "either",
- "radium 0.3.0",
-]
-
-[[package]]
-name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
- "radium 0.7.0",
+ "radium",
  "tap",
  "wyz",
 ]
@@ -834,7 +824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a8a8ed6fefbeef4a8c7b460e4110e12c5e22a5b7cf32621aae6ad650c4dcf29"
 dependencies = [
  "blst",
- "byte-slice-cast 1.2.2",
+ "byte-slice-cast",
  "ff",
  "group",
  "pairing",
@@ -870,15 +860,9 @@ checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byte-slice-cast"
-version = "0.3.5"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
-
-[[package]]
-name = "byte-slice-cast"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "byte-unit"
@@ -1039,7 +1023,7 @@ version = "2.0.2"
 dependencies = [
  "cfx-types",
  "primitives",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "sqlite",
  "strfmt",
  "thiserror 2.0.11",
@@ -1089,7 +1073,7 @@ dependencies = [
  "diem-types",
  "hex-literal",
  "impl-tools",
- "impl-trait-for-tuples 0.2.2",
+ "impl-trait-for-tuples 0.2.3",
  "keccak-hash",
  "lazy_static",
  "log",
@@ -1100,7 +1084,7 @@ dependencies = [
  "pow-types",
  "primitives",
  "rayon",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rustc-hex",
  "sha3-macro",
  "solidity-abi",
@@ -1123,7 +1107,7 @@ dependencies = [
  "malloc_size_of_derive",
  "parking_lot 0.12.1",
  "primitives",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rlp-derive",
  "serde",
  "serde_derive",
@@ -1180,7 +1164,7 @@ dependencies = [
  "malloc_size_of",
  "malloc_size_of_derive",
  "primitives",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rlp-derive",
  "serde",
  "strum_macros",
@@ -1285,7 +1269,7 @@ dependencies = [
  "log",
  "parity-version",
  "primitives",
- "rand 0.7.3",
+ "rand 0.8.5",
  "rustc-hex",
  "serde",
  "serde_derive",
@@ -1329,7 +1313,7 @@ dependencies = [
  "jsonrpc-core",
  "jsonrpsee",
  "primitives",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -1399,7 +1383,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.1",
  "primitives",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "tiny-keccak",
 ]
 
@@ -1433,7 +1417,7 @@ dependencies = [
  "rand 0.9.0",
  "rand_chacha 0.9.0",
  "random-crash",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rlp-derive",
  "rustc-hex",
  "serde",
@@ -1461,7 +1445,7 @@ dependencies = [
  "ethereum-types",
  "hex",
  "keccak-hash",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rlp-derive",
  "serde",
  "serde_derive",
@@ -1505,7 +1489,7 @@ dependencies = [
  "cfx-types",
  "keccak-hash",
  "primitives",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "serde",
  "solidity-abi",
 ]
@@ -1592,7 +1576,7 @@ dependencies = [
  "rand_xorshift 0.4.0",
  "rangetools",
  "rayon",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rlp-derive",
  "rustc-hex",
  "safety-rules",
@@ -1851,6 +1835,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "convert_case"
@@ -2682,12 +2686,12 @@ dependencies = [
 
 [[package]]
 name = "ethbloom"
-version = "0.9.2"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a6567e6fd35589fea0c63b94b4cf2e55573e413901bdbe60ab15cf0e25e5df"
+checksum = "8c321610643004cf908ec0f5f2aa0d8f1f8e14b540562a2887a1111ff1ecbf7b"
 dependencies = [
  "crunchy",
- "fixed-hash 0.6.1",
+ "fixed-hash",
  "impl-rlp",
  "impl-serde",
  "tiny-keccak",
@@ -2701,16 +2705,16 @@ checksum = "e957efe1e627f8ec4e253660615fd9fe3736e10026197740b8b4b26c812be2e9"
 
 [[package]]
 name = "ethereum-types"
-version = "0.9.2"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473aecff686bd8e7b9db0165cbbb53562376b39bf35b427f0c60446a9e1634b0"
+checksum = "1ab15ed80916029f878e0267c3a9f92b67df55e79af370bf66199059ae2b4ee3"
 dependencies = [
  "ethbloom",
- "fixed-hash 0.6.1",
+ "fixed-hash",
  "impl-rlp",
  "impl-serde",
- "primitive-types 0.7.3",
- "uint 0.8.5",
+ "primitive-types 0.13.1",
+ "uint 0.10.0",
 ]
 
 [[package]]
@@ -2735,7 +2739,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "primitives",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "serde_json",
  "structopt",
  "thiserror 2.0.11",
@@ -2857,7 +2861,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "bitvec 1.0.1",
+ "bitvec",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -2867,18 +2871,6 @@ name = "fiat-crypto"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93ace6ec7cc19c8ed33a32eaa9ea692d7faea05006b5356b9e2b668ec4bc3955"
-
-[[package]]
-name = "fixed-hash"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11498d382790b7a8f2fd211780bec78619bba81cdad3a283997c0c41f836759c"
-dependencies = [
- "byteorder",
- "rand 0.7.3",
- "rustc-hex",
- "static_assertions",
-]
 
 [[package]]
 name = "fixed-hash"
@@ -3767,36 +3759,36 @@ dependencies = [
 
 [[package]]
 name = "impl-codec"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be51a921b067b0eaca2fad532d9400041561aa922221cc65f95a85641c6bf53"
-dependencies = [
- "parity-scale-codec 1.3.7",
-]
-
-[[package]]
-name = "impl-codec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
 dependencies = [
- "parity-scale-codec 3.6.9",
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d40b9d5e17727407e55028eafc22b2dc68781786e6d7eb8a21103f5058e3a14"
+dependencies = [
+ "parity-scale-codec",
 ]
 
 [[package]]
 name = "impl-rlp"
-version = "0.2.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f7a72f11830b52333f36e3b09a288333888bf54380fd0ac0790a3c31ab0f3c5"
+checksum = "54ed8ad1f3877f7e775b8cbf30ed1bd3209a95401817f19a0eb4402d13f8cf90"
 dependencies = [
- "rlp 0.4.6",
+ "rlp 0.6.1",
 ]
 
 [[package]]
 name = "impl-serde"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
+checksum = "4a143eada6a1ec4aefa5049037a26a6d597bfd64f8c026d07b77133e02b7dd0b"
 dependencies = [
  "serde",
 ]
@@ -3838,13 +3830,13 @@ dependencies = [
 
 [[package]]
 name = "impl-trait-for-tuples"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4132,7 +4124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d4c6bec4909c966f59f52db3655c0e9d4685faae8b49185973d9d7389bb884"
 dependencies = [
  "heck 0.5.0",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -4215,11 +4207,11 @@ dependencies = [
 
 [[package]]
 name = "keccak-hash"
-version = "0.5.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f58a51ef3df9398cf2434bea8d4eb61fb748d0feb1571f87388579a120a4c8f"
+checksum = "3e1b8590eb6148af2ea2d75f38e7d29f5ca970d5a4df456b3ef19b8b415d0264"
 dependencies = [
- "primitive-types 0.7.3",
+ "primitive-types 0.13.1",
  "tiny-keccak",
 ]
 
@@ -4745,7 +4737,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "priority-send-queue",
  "rand 0.9.0",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rlp-derive",
  "serde",
  "serde_derive",
@@ -5056,40 +5048,30 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "1.3.7"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b26b16c7687c3075982af47719e481815df30bc544f7a6690763a25ca16e9d"
-dependencies = [
- "arrayvec 0.5.2",
- "bitvec 0.17.4",
- "byte-slice-cast 0.3.5",
- "serde",
-]
-
-[[package]]
-name = "parity-scale-codec"
-version = "3.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881331e34fa842a2fb61cc2db9643a8fedc615e47cfcc52597d1af0db9a7e8fe"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
 dependencies = [
  "arrayvec 0.7.4",
- "bitvec 1.0.1",
- "byte-slice-cast 1.2.2",
- "impl-trait-for-tuples 0.2.2",
+ "bitvec",
+ "byte-slice-cast",
+ "const_format",
+ "impl-trait-for-tuples 0.2.3",
  "parity-scale-codec-derive",
+ "rustversion",
  "serde",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.9"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be30eaf4b0a9fba5336683b38de57bb86d179a35862ba6bfcf57625d006bde5b"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5493,26 +5475,26 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd39dcacf71411ba488570da7bbc89b717225e46478b30ba99b92db6b149809"
-dependencies = [
- "fixed-hash 0.6.1",
- "impl-codec 0.4.2",
- "impl-rlp",
- "impl-serde",
- "uint 0.8.5",
-]
-
-[[package]]
-name = "primitive-types"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
- "fixed-hash 0.8.0",
+ "fixed-hash",
  "impl-codec 0.6.0",
  "uint 0.9.5",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
+dependencies = [
+ "fixed-hash",
+ "impl-codec 0.7.1",
+ "impl-rlp",
+ "impl-serde",
+ "uint 0.10.0",
 ]
 
 [[package]]
@@ -5530,7 +5512,7 @@ dependencies = [
  "malloc_size_of",
  "once_cell",
  "rand 0.9.0",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rlp-derive",
  "serde",
  "serde_derive",
@@ -5544,20 +5526,11 @@ version = "0.1.0"
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
-dependencies = [
- "toml_edit 0.20.2",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.22.20",
+ "toml_edit",
 ]
 
 [[package]]
@@ -5586,9 +5559,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -5651,9 +5624,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -5663,12 +5636,6 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
-
-[[package]]
-name = "radium"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 
 [[package]]
 name = "radium"
@@ -5992,7 +5959,7 @@ dependencies = [
  "alloy-primitives",
  "auto_impl",
  "bitflags 2.5.0",
- "bitvec 1.0.1",
+ "bitvec",
  "c-kzg",
  "cfg-if 1.0.0",
  "derive_more",
@@ -6056,18 +6023,19 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rlp"
-version = "0.4.6"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1190dcc8c3a512f1eef5d09bb8c84c7f39e1054e174d1795482e18f5272f2e73"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
+ "bytes",
  "rustc-hex",
 ]
 
 [[package]]
 name = "rlp"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+checksum = "fa24e92bb2a83198bb76d661a71df9f7076b8c420b8696e4d3d97d50d94479e3"
 dependencies = [
  "bytes",
  "rustc-hex",
@@ -6114,7 +6082,7 @@ dependencies = [
  "num-bigint 0.4.4",
  "num-integer",
  "num-traits",
- "parity-scale-codec 3.6.9",
+ "parity-scale-codec",
  "primitive-types 0.12.2",
  "proptest",
  "rand 0.8.5",
@@ -6518,9 +6486,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -6566,9 +6534,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6845,7 +6813,7 @@ dependencies = [
 name = "solidity-abi-derive"
 version = "0.1.0"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -7381,17 +7349,6 @@ checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
-dependencies = [
- "indexmap 2.8.0",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
@@ -7534,7 +7491,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "primitives",
  "rand 0.9.0",
- "rlp 0.4.6",
+ "rlp 0.6.1",
  "rustc-hex",
  "secret-store",
 ]
@@ -7562,21 +7519,21 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "uint"
-version = "0.8.5"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db035e67dfaf7edd9aebfe8676afcd63eed53c8a4044fed514c8cccf1835177"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
  "byteorder",
  "crunchy",
- "rustc-hex",
+ "hex",
  "static_assertions",
 ]
 
 [[package]]
 name = "uint"
-version = "0.9.5"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -8111,15 +8068,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/tools/evm-spec-tester/Cargo.toml
+++ b/tools/evm-spec-tester/Cargo.toml
@@ -22,7 +22,7 @@ cfx-bytes = { path = "../../crates/cfx_bytes" }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 walkdir = "2.5"
 thiserror = "2.0.11"
-rlp = "0.4.0"
+rlp = "0.6.1"
 hex = "0.4.3"
 hex-literal = "0.4.1"
 

--- a/tools/evm-spec-tester/src/statetest/unit_tester/post_transact.rs
+++ b/tools/evm-spec-tester/src/statetest/unit_tester/post_transact.rs
@@ -212,7 +212,7 @@ pub fn check_execution_outcome(
         // storage check
         for (&key, &value) in &account_info.storage {
             let mut key_bytes = [0u8; 32];
-            key.to_big_endian(&mut key_bytes);
+            key.write_as_big_endian(&mut key_bytes);
             let curr_value =
                 state.storage_at(&user_addr, &key_bytes).unwrap_or_default();
             if curr_value != value {

--- a/tools/evm-spec-tester/src/statetest/unit_tester/pre_transact.rs
+++ b/tools/evm-spec-tester/src/statetest/unit_tester/pre_transact.rs
@@ -31,7 +31,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     u64,
 };
-
+use rlp::Encodable;
 pub fn make_tx(
     tx_meta: &TransactionParts, tx_part_indices: &TxPartIndices, chain_id: u64,
     unprotected: bool,
@@ -270,7 +270,7 @@ pub fn check_tx_bytes(
         return Ok(());
     };
 
-    let raw_tx = rlp::encode(&tx.transaction.transaction);
+    let raw_tx = rlp::encode(&tx.transaction.transaction.rlp_bytes());
 
     if raw_tx != txbytes {
         // trace!(


### PR DESCRIPTION
**Package Upgrades:**
*   `keccak-hash`: `0.5` -> `0.11.0`
*   `rlp`: `0.4` -> `0.6.1`
*   `ethereum-types`: `0.9` -> `0.15.1`

** Changes **
 [parity-common/uint CHANGELOG#0.10.0](https://github.com/paritytech/parity-common/blob/f0dade11ac0b2450e6a54f36035f74b2b8ce4c00/uint/CHANGELOG.md#0100---2024-09-11)
*   The function `to_big_endian` has been renamed to `write_as_big_endian`.
*   The function `to_little_endian` has been renamed to `write_as_little_endian`.
*   Usage of `drain()` has been replaced with `as_raw()`.
*   Usage of `as_slice()` has been replaced with `as_ref()`.
*   The conversion `sig.r().into()` has been updated to `U256::from_big_endian(sig.r())` for explicit construction from big-endian bytes.
