### PR TITLE
ci: decrease CONFLUX_GRACEFUL_SHUTDOWN_TIMEOUT

### DIFF
--- a/integration_tests/test_framework/util/__init__.py
+++ b/integration_tests/test_framework/util/__init__.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from conflux.rpc import RpcClient
 
 CONFLUX_RPC_WAIT_TIMEOUT = 60
-CONFLUX_GRACEFUL_SHUTDOWN_TIMEOUT = 1220
+CONFLUX_GRACEFUL_SHUTDOWN_TIMEOUT = 120
 
 logger = logging.getLogger("TestFramework.utils")
 

--- a/tests/test_framework/util.py
+++ b/tests/test_framework/util.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from conflux.rpc import RpcClient
 
 CONFLUX_RPC_WAIT_TIMEOUT = 60
-CONFLUX_GRACEFUL_SHUTDOWN_TIMEOUT = 1220
+CONFLUX_GRACEFUL_SHUTDOWN_TIMEOUT = 120
 
 logger = logging.getLogger("TestFramework.utils")
 


### PR DESCRIPTION
In https://github.com/Conflux-Chain/conflux-rust/pull/1052, the node shutdown timeout is set to 20 minutes to ensure rocksdb writing as the previous 10 seconds is somewhat too short especially when multiple nodes are running.

But this timeout is too big for a normal shutdown and tests might got stuck without any information for more than 10 minutes.

This pull request decreases the number to 2 minutes, which might be more appropriate, especially for the case we have  already limited the node count simultaneous running in the test by using the option --max-nodes

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3273)
<!-- Reviewable:end -->
