### PR TITLE
optimize evm interpreter div operation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1675,6 +1675,7 @@ dependencies = [
  "cfx-bytes",
  "cfx-types",
  "cfx-vm-types",
+ "criterion",
  "keccak-hash",
  "lazy_static",
  "log",

--- a/crates/execution/vm-interpreter/Cargo.toml
+++ b/crates/execution/vm-interpreter/Cargo.toml
@@ -21,7 +21,12 @@ rustc-hex = { workspace = true }
 
 [dev-dependencies]
 cfx-vm-types = { workspace = true, features = ["testonly_code"] }
+criterion = { workspace = true, features = ["html_reports"] }
 
 [features]
 align_evm = ["cfx-vm-types/align_evm"]
 evm-debug = []
+
+[[bench]]
+name = "u256"
+harness = false

--- a/crates/execution/vm-interpreter/benches/u256.rs
+++ b/crates/execution/vm-interpreter/benches/u256.rs
@@ -1,0 +1,91 @@
+use cfx_types::U256;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+
+const ONE: U256 = U256([1, 0, 0, 0]);
+const TWO: U256 = U256([2, 0, 0, 0]);
+const TWO_POW_5: U256 = U256([0x20, 0, 0, 0]);
+const TWO_POW_8: U256 = U256([0x100, 0, 0, 0]);
+const TWO_POW_16: U256 = U256([0x10000, 0, 0, 0]);
+const TWO_POW_24: U256 = U256([0x1000000, 0, 0, 0]);
+const TWO_POW_64: U256 = U256([0, 0x1, 0, 0]); // 0x1 00000000 00000000
+const TWO_POW_96: U256 = U256([0, 0x100000000, 0, 0]); //0x1 00000000 00000000 00000000
+const TWO_POW_224: U256 = U256([0, 0, 0, 0x100000000]); //0x1 00000000 00000000 00000000 00000000 00000000 00000000 00000000
+const TWO_POW_248: U256 = U256([0, 0, 0, 0x100000000000000]); //0x1 00000000 00000000 00000000 00000000 00000000 00000000 00000000 000000
+
+fn optimized_div(a: U256, b: U256) -> U256 {
+    if !b.is_zero() {
+        // match b {
+        //     ONE => a,
+        //     TWO => a >> 1,
+        //     TWO_POW_5 => a >> 5,
+        //     TWO_POW_8 => a >> 8,
+        //     TWO_POW_16 => a >> 16,
+        //     TWO_POW_24 => a >> 24,
+        //     TWO_POW_64 => a >> 64,
+        //     TWO_POW_96 => a >> 96,
+        //     TWO_POW_224 => a >> 224,
+        //     TWO_POW_248 => a >> 248,
+        //     _ => a / b,
+        // }
+        if b == ONE {
+            a
+        } else if b == TWO {
+            a >> 1
+        } else if b == TWO_POW_5 {
+            a >> 5
+        } else if b == TWO_POW_8 {
+            a >> 8
+        } else if b == TWO_POW_16 {
+            a >> 16
+        } else if b == TWO_POW_24 {
+            a >> 24
+        } else if b == TWO_POW_64 {
+            a >> 64
+        } else if b == TWO_POW_96 {
+            a >> 96
+        } else if b == TWO_POW_224 {
+            a >> 224
+        } else if b == TWO_POW_248 {
+            a >> 248
+        } else {
+            a / b
+        }
+    } else {
+        U256::zero()
+    }
+}
+
+fn normal_div(a: U256, b: U256) -> U256 {
+    if !b.is_zero() {
+        a / b
+    } else {
+        U256::zero()
+    }
+}
+
+fn bench_u256_div(c: &mut Criterion) {
+    let mut group = c.benchmark_group("U256 Division Special Cases");
+    for i in [2u64, 256u64, 0x100000000000000u64].iter() {
+        group.bench_with_input(BenchmarkId::new("Common", i), i, |b, i| {
+            b.iter(|| normal_div(U256::from(10000), U256::from(*i)))
+        });
+        group.bench_with_input(BenchmarkId::new("Optimized", i), i, |b, i| {
+            b.iter(|| optimized_div(U256::from(10000), U256::from(*i)))
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("U256 Division Normal Cases");
+    for i in [3u64, 6u64].iter() {
+        group.bench_with_input(BenchmarkId::new("Common", i), i, |b, i| {
+            b.iter(|| normal_div(U256::from(10000), U256::from(*i)))
+        });
+        group.bench_with_input(BenchmarkId::new("Optimized", i), i, |b, i| {
+            b.iter(|| optimized_div(U256::from(10000), U256::from(*i)))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_u256_div);
+criterion_main!(benches);

--- a/crates/execution/vm-interpreter/src/interpreter/mod.rs
+++ b/crates/execution/vm-interpreter/src/interpreter/mod.rs
@@ -56,17 +56,6 @@ const GASOMETER_PROOF: &str = "If gasometer is None, Err is immediately returned
 
 type ProgramCounter = usize;
 
-const ONE: U256 = U256([1, 0, 0, 0]);
-const TWO: U256 = U256([2, 0, 0, 0]);
-const TWO_POW_5: U256 = U256([0x20, 0, 0, 0]);
-const TWO_POW_8: U256 = U256([0x100, 0, 0, 0]);
-const TWO_POW_16: U256 = U256([0x10000, 0, 0, 0]);
-const TWO_POW_24: U256 = U256([0x1000000, 0, 0, 0]);
-const TWO_POW_64: U256 = U256([0, 0x1, 0, 0]); // 0x1 00000000 00000000
-const TWO_POW_96: U256 = U256([0, 0x100000000, 0, 0]); //0x1 00000000 00000000 00000000
-const TWO_POW_224: U256 = U256([0, 0, 0, 0x100000000]); //0x1 00000000 00000000 00000000 00000000 00000000 00000000 00000000
-const TWO_POW_248: U256 = U256([0, 0, 0, 0x100000000000000]); //0x1 00000000 00000000 00000000 00000000 00000000 00000000 00000000 000000
-
 /// Maximal subroutine stack size as specified in
 /// https://eips.ethereum.org/EIPS/eip-2315.
 pub const MAX_SUB_STACK_SIZE: usize = 1023;
@@ -1322,48 +1311,8 @@ impl<Cost: CostType, const CANCUN: bool> Interpreter<Cost, CANCUN> {
             instructions::DIV => {
                 let a = self.stack.pop_back();
                 let b = self.stack.pop_back();
-                self.stack.push(
-                    if !b.is_zero() {
-                        // match b {
-                        //     ONE => a,
-                        //     TWO => a >> 1,
-                        //     TWO_POW_5 => a >> 5,
-                        //     TWO_POW_8 => a >> 8,
-                        //     TWO_POW_16 => a >> 16,
-                        //     TWO_POW_24 => a >> 24,
-                        //     TWO_POW_64 => a >> 64,
-                        //     TWO_POW_96 => a >> 96,
-                        //     TWO_POW_224 => a >> 224,
-                        //     TWO_POW_248 => a >> 248,
-                        //     _ => a / b,
-                        // }
-                        if b == ONE {
-                            a
-                        } else if b == TWO {
-                            a >> 1
-                        } else if b == TWO_POW_5 {
-                            a >> 5
-                        } else if b == TWO_POW_8 {
-                            a >> 8
-                        } else if b == TWO_POW_16 {
-                            a >> 16
-                        } else if b == TWO_POW_24 {
-                            a >> 24
-                        } else if b == TWO_POW_64 {
-                            a >> 64
-                        } else if b == TWO_POW_96 {
-                            a >> 96
-                        } else if b == TWO_POW_224 {
-                            a >> 224
-                        } else if b == TWO_POW_248 {
-                            a >> 248
-                        } else {
-                            a / b
-                        }
-                    } else {
-                        U256::zero()
-                    },
-                );
+                self.stack
+                    .push(if !b.is_zero() { a / b } else { U256::zero() });
             }
             instructions::MOD => {
                 let a = self.stack.pop_back();


### PR DESCRIPTION
Below is the bench result of u256 div:

This benchmark compares two implementations of the `U256` division operation:

1. **Common**: directly uses the built-in `U256` division.
2. **Optimized**: uses bitwise operations for a set of specific divisors (ten in total); for all other cases, it falls back to the standard `U256` division.

### Benchmark results (on my local machine):

1. For general divisors, the **Optimized** implementation is actually **40% slower** than the **Common** implementation.
2. For specific divisors with early-match conditions (e.g., `2`, `256`), the **Optimized** version performs up to **4x faster** than the **Common** version.
   However, for late-match cases such as `TWO_POW_248`, the Optimized version is still **slower** than the Common one.

### Conclusion:

Given the low probability of encountering these specific divisors in real-world scenarios, the **standard division implementation is overall faster** and more suitable.

```sh
     Running benches/u256.rs (target/release/deps/u256-f9b156515e931e82)
U256 Division Special Cases/Common/2
                        time:   [17.544 ns 17.574 ns 17.610 ns]
                        change: [−0.6382% −0.0209% +0.5046%] (p = 0.94 > 0.05)
                        No change in performance detected.
Found 21 outliers among 100 measurements (21.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  19 (19.00%) high severe
U256 Division Special Cases/Optimized/2
                        time:   [4.0172 ns 4.1765 ns 4.4112 ns]
                        change: [−1.2104% +1.1830% +4.5175%] (p = 0.49 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) high mild
  8 (8.00%) high severe
U256 Division Special Cases/Common/256
                        time:   [17.547 ns 17.993 ns 18.947 ns]
                        change: [+0.0890% +1.1660% +3.0384%] (p = 0.17 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe
U256 Division Special Cases/Optimized/256
                        time:   [4.2777 ns 4.4238 ns 4.6603 ns]
                        change: [+0.0718% +2.4526% +5.4810%] (p = 0.11 > 0.05)
                        No change in performance detected.
Found 16 outliers among 100 measurements (16.00%)
  7 (7.00%) high mild
  9 (9.00%) high severe
U256 Division Special Cases/Common/72057594037927936
                        time:   [3.3135 ns 3.3613 ns 3.4529 ns]
                        change: [+0.3336% +1.8456% +4.1620%] (p = 0.07 > 0.05)
                        No change in performance detected.
Found 16 outliers among 100 measurements (16.00%)
  5 (5.00%) high mild
  11 (11.00%) high severe
U256 Division Special Cases/Optimized/72057594037927936
                        time:   [6.1175 ns 6.1241 ns 6.1319 ns]
                        change: [−8.7028% −4.8431% −1.7582%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  9 (9.00%) high mild
  7 (7.00%) high severe

U256 Division Normal Cases/Common/3
                        time:   [17.646 ns 18.133 ns 18.876 ns]
                        change: [+0.3264% +1.5986% +3.7856%] (p = 0.04 < 0.05)
                        Change within noise threshold.
Found 16 outliers among 100 measurements (16.00%)
  4 (4.00%) high mild
  12 (12.00%) high severe
U256 Division Normal Cases/Optimized/3
                        time:   [24.920 ns 25.789 ns 26.944 ns]
                        change: [−0.0254% +1.8161% +4.0942%] (p = 0.06 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  10 (10.00%) high severe
U256 Division Normal Cases/Common/6
                        time:   [17.579 ns 17.615 ns 17.654 ns]
                        change: [+0.0715% +0.4856% +0.9559%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe
U256 Division Normal Cases/Optimized/6
                        time:   [24.819 ns 24.869 ns 24.932 ns]
                        change: [−0.5008% −0.2083% +0.0865%] (p = 0.18 > 0.05)
                        No change in performance detected.
Found 15 outliers among 100 measurements (15.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  10 (10.00%) high severe
```