### PR TITLE
op: eth_getBlockByNumber return null when parameter is bigger than latest block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,6 +1385,7 @@ dependencies = [
  "cfx-util-macros",
  "cfx-vm-types",
  "cfxcore",
+ "cfxcore-errors",
  "futures 0.3.30",
  "geth-tracer",
  "jsonrpc-core",
@@ -1733,6 +1734,7 @@ dependencies = [
  "cfx-types",
  "cfx-util-macros",
  "cfx-vm-types",
+ "cfxcore-errors",
  "cfxcore-pow",
  "cfxcore-types",
  "cfxkey",
@@ -1835,6 +1837,13 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tempfile",
+]
+
+[[package]]
+name = "cfxcore-errors"
+version = "3.0.0"
+dependencies = [
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -6605,6 +6614,7 @@ dependencies = [
  "cfx-bytes",
  "cfx-parameters",
  "cfx-types",
+ "cfxcore-errors",
  "cfxkey",
  "criterion",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ members = [
     "crates/config",
     "crates/cfxcore/types",
     "crates/cfxcore/pow",
+    "crates/cfxcore/errors",
 ]
 
 resolver = "2"
@@ -185,6 +186,7 @@ network = { path = "./crates/network" }
 cfxcore = { path = "./crates/cfxcore/core" }
 cfxcore-types = { path = "./crates/cfxcore/types" }
 cfxcore-pow = { path = "./crates/cfxcore/pow" }
+cfxcore-errors = { path = "./crates/cfxcore/errors" }
 cfx-parameters = { path = "./crates/parameters" }
 cfx-execute-helper = { path = "./crates/execution/execute-helper" }
 cfx-executor = { path = "./crates/execution/executor" }

--- a/changelogs/JSONRPC.md
+++ b/changelogs/JSONRPC.md
@@ -18,6 +18,7 @@ Misc changes:
    4. These trace methods now support `SelfDestruct(Suicide)` trace, to access historical selfdestruct transaction data, a resync of the data is required.
 4. eSpace now support geth style `txpool` namespace methods, including: `txpool_status`, `txpool_inspect`, `txpool_content`, `txpool_contentFrom`
 5. `eth_call`, `eth_estimateGas` add support for `stateoverride` feature.
+6. `eth_getBlockByNumber` will return `null` when block number is bigger than latest block, other than return error message.
 
 ## v2.4.1
 

--- a/crates/cfxcore/core/Cargo.toml
+++ b/crates/cfxcore/core/Cargo.toml
@@ -117,6 +117,7 @@ cfx-rpc-utils = { workspace = true }
 cfx-util-macros = { workspace = true }
 cfxcore-types = { workspace = true }
 cfxcore-pow = { workspace = true }
+cfxcore-errors = { workspace = true}
 
 [dev-dependencies]
 cfx-storage = { workspace = true, features = ["testonly_code"] }

--- a/crates/cfxcore/core/src/consensus/consensus_graph/mod.rs
+++ b/crates/cfxcore/core/src/consensus/consensus_graph/mod.rs
@@ -27,6 +27,7 @@ use crate::{
     verification::VerificationConfig,
     NodeType, Notifications,
 };
+pub use onchain_blocks_provider::EPOCH_NUMBER_TOO_LARGE_ERR_MESSAGE;
 
 use cfx_executor::spec::CommonParams;
 

--- a/crates/cfxcore/core/src/consensus/consensus_graph/mod.rs
+++ b/crates/cfxcore/core/src/consensus/consensus_graph/mod.rs
@@ -27,7 +27,6 @@ use crate::{
     verification::VerificationConfig,
     NodeType, Notifications,
 };
-pub use onchain_blocks_provider::EPOCH_NUMBER_TOO_LARGE_ERR_MESSAGE;
 
 use cfx_executor::spec::CommonParams;
 

--- a/crates/cfxcore/core/src/consensus/consensus_graph/onchain_blocks_provider.rs
+++ b/crates/cfxcore/core/src/consensus/consensus_graph/onchain_blocks_provider.rs
@@ -1,6 +1,7 @@
 use super::ConsensusGraph;
 
 use crate::errors::{invalid_params, Result as CoreResult};
+use cfxcore_errors::ProviderBlockError;
 
 use cfx_parameters::consensus::*;
 
@@ -8,9 +9,6 @@ use cfx_types::H256;
 
 use primitives::{compute_block_number, EpochNumber};
 use std::cmp::min;
-
-pub const EPOCH_NUMBER_TOO_LARGE_ERR_MESSAGE: &str =
-    "Invalid params: expected a numbers with less than largest epoch number.";
 
 impl ConsensusGraph {
     /// Returns the total number of blocks processed in consensus graph.
@@ -26,7 +24,7 @@ impl ConsensusGraph {
     /// Convert EpochNumber to height based on the current ConsensusGraph
     pub fn get_height_from_epoch_number(
         &self, epoch_number: EpochNumber,
-    ) -> Result<u64, String> {
+    ) -> Result<u64, ProviderBlockError> {
         Ok(match epoch_number {
             EpochNumber::Earliest => 0,
             EpochNumber::LatestCheckpoint => {
@@ -43,7 +41,7 @@ impl ConsensusGraph {
             EpochNumber::Number(num) => {
                 let epoch_num = num;
                 if epoch_num > self.inner.read_recursive().best_epoch_number() {
-                    return Err(EPOCH_NUMBER_TOO_LARGE_ERR_MESSAGE.to_owned());
+                    return Err(ProviderBlockError::EpochNumberTooLarge);
                 }
                 epoch_num
             }
@@ -64,7 +62,7 @@ impl ConsensusGraph {
 
     pub fn get_block_hashes_by_epoch(
         &self, epoch_number: EpochNumber,
-    ) -> Result<Vec<H256>, String> {
+    ) -> Result<Vec<H256>, ProviderBlockError> {
         self.get_height_from_epoch_number(epoch_number)
             .and_then(|height| {
                 self.inner.read_recursive().block_hashes_by_epoch(height)
@@ -73,7 +71,7 @@ impl ConsensusGraph {
 
     pub fn get_hash_from_epoch_number(
         &self, epoch_number: EpochNumber,
-    ) -> Result<H256, String> {
+    ) -> Result<H256, ProviderBlockError> {
         self.get_height_from_epoch_number(epoch_number)
             .and_then(|height| {
                 self.inner.read().get_pivot_hash_from_epoch_number(height)
@@ -82,7 +80,7 @@ impl ConsensusGraph {
 
     pub fn get_skipped_block_hashes_by_epoch(
         &self, epoch_number: EpochNumber,
-    ) -> Result<Vec<H256>, String> {
+    ) -> Result<Vec<H256>, ProviderBlockError> {
         self.get_height_from_epoch_number(epoch_number)
             .and_then(|height| {
                 self.inner

--- a/crates/cfxcore/core/src/consensus/consensus_graph/onchain_blocks_provider.rs
+++ b/crates/cfxcore/core/src/consensus/consensus_graph/onchain_blocks_provider.rs
@@ -9,6 +9,9 @@ use cfx_types::H256;
 use primitives::{compute_block_number, EpochNumber};
 use std::cmp::min;
 
+pub const EPOCH_NUMBER_TOO_LARGE_ERR_MESSAGE: &str =
+    "Invalid params: expected a numbers with less than largest epoch number.";
+
 impl ConsensusGraph {
     /// Returns the total number of blocks processed in consensus graph.
     ///
@@ -40,7 +43,7 @@ impl ConsensusGraph {
             EpochNumber::Number(num) => {
                 let epoch_num = num;
                 if epoch_num > self.inner.read_recursive().best_epoch_number() {
-                    return Err("Invalid params: expected a numbers with less than largest epoch number.".to_owned());
+                    return Err(EPOCH_NUMBER_TOO_LARGE_ERR_MESSAGE.to_owned());
                 }
                 epoch_num
             }

--- a/crates/cfxcore/core/src/consensus/consensus_graph/rpc_api/phantom_block_provider.rs
+++ b/crates/cfxcore/core/src/consensus/consensus_graph/rpc_api/phantom_block_provider.rs
@@ -4,6 +4,7 @@ use cfx_execute_helper::{
 };
 use cfx_rpc_cfx_types::PhantomBlock;
 use cfx_types::{Bloom, Space, H256, U256};
+use cfxcore_errors::ProviderBlockError;
 use primitives::{receipt::Receipt, EpochNumber, TransactionStatus};
 use std::sync::Arc;
 
@@ -12,7 +13,7 @@ use super::super::ConsensusGraph;
 impl ConsensusGraph {
     pub fn get_phantom_block_bloom_filter(
         &self, block_num: EpochNumber, pivot_assumption: H256,
-    ) -> Result<Option<Bloom>, String> {
+    ) -> Result<Option<Bloom>, ProviderBlockError> {
         let hashes = self.get_block_hashes_by_epoch(block_num)?;
 
         // sanity check: epoch is not empty
@@ -66,7 +67,7 @@ impl ConsensusGraph {
     pub fn get_phantom_block_pivot_by_number(
         &self, block_num: EpochNumber, pivot_assumption: Option<H256>,
         include_traces: bool,
-    ) -> Result<Option<PhantomBlock>, String> {
+    ) -> Result<Option<PhantomBlock>, ProviderBlockError> {
         self.get_phantom_block_by_number_inner(
             block_num,
             pivot_assumption,
@@ -78,7 +79,7 @@ impl ConsensusGraph {
     pub fn get_phantom_block_by_number(
         &self, block_num: EpochNumber, pivot_assumption: Option<H256>,
         include_traces: bool,
-    ) -> Result<Option<PhantomBlock>, String> {
+    ) -> Result<Option<PhantomBlock>, ProviderBlockError> {
         self.get_phantom_block_by_number_inner(
             block_num,
             pivot_assumption,
@@ -90,7 +91,7 @@ impl ConsensusGraph {
     fn get_phantom_block_by_number_inner(
         &self, block_num: EpochNumber, pivot_assumption: Option<H256>,
         include_traces: bool, only_pivot: bool,
-    ) -> Result<Option<PhantomBlock>, String> {
+    ) -> Result<Option<PhantomBlock>, ProviderBlockError> {
         let hashes = self.get_block_hashes_by_epoch(block_num)?;
 
         // special handling for genesis block
@@ -297,7 +298,7 @@ impl ConsensusGraph {
 
     pub fn get_phantom_block_by_hash(
         &self, hash: &H256, include_traces: bool,
-    ) -> Result<Option<PhantomBlock>, String> {
+    ) -> Result<Option<PhantomBlock>, ProviderBlockError> {
         let epoch_num = match self.get_block_epoch_number(hash) {
             None => return Ok(None),
             Some(n) => n,

--- a/crates/cfxcore/core/src/consensus/consensus_inner/mod.rs
+++ b/crates/cfxcore/core/src/consensus/consensus_inner/mod.rs
@@ -6,6 +6,7 @@ mod blame_verifier;
 pub mod confirmation_meter;
 pub mod consensus_executor;
 pub mod consensus_new_block_handler;
+use cfxcore_errors::ProviderBlockError;
 use cfxcore_pow as pow;
 
 use pow::{PowComputer, ProofOfWorkConfig};
@@ -2131,7 +2132,7 @@ impl ConsensusGraphInner {
     /// out of the current era.
     pub fn get_pivot_hash_from_epoch_number(
         &self, epoch_number: u64,
-    ) -> Result<EpochId, String> {
+    ) -> Result<EpochId, ProviderBlockError> {
         let height = epoch_number;
         if height >= self.cur_era_genesis_height {
             let pivot_index = (height - self.cur_era_genesis_height) as usize;
@@ -2161,7 +2162,7 @@ impl ConsensusGraphInner {
 
     pub fn block_hashes_by_epoch(
         &self, epoch_number: u64,
-    ) -> Result<Vec<H256>, String> {
+    ) -> Result<Vec<H256>, ProviderBlockError> {
         debug!(
             "block_hashes_by_epoch epoch_number={:?} pivot_chain.len={:?}",
             epoch_number,
@@ -2199,7 +2200,7 @@ impl ConsensusGraphInner {
 
     pub fn skipped_block_hashes_by_epoch(
         &self, epoch_number: u64,
-    ) -> Result<Vec<H256>, String> {
+    ) -> Result<Vec<H256>, ProviderBlockError> {
         debug!(
             "skipped_block_hashes_by_epoch epoch_number={:?} pivot_chain.len={:?}",
             epoch_number,
@@ -2351,11 +2352,11 @@ impl ConsensusGraphInner {
 
     pub fn check_block_pivot_assumption(
         &self, pivot_hash: &H256, epoch: u64,
-    ) -> Result<(), String> {
+    ) -> Result<(), ProviderBlockError> {
         let last_number = self.best_epoch_number();
         let hash = self.get_pivot_hash_from_epoch_number(epoch)?;
         if epoch > last_number || hash != *pivot_hash {
-            return Err("Error: pivot chain assumption failed".to_owned());
+            return Err("Error: pivot chain assumption failed".into());
         }
         Ok(())
     }
@@ -4143,6 +4144,7 @@ impl StateMaintenanceTrait for ConsensusGraphInner {
             self,
             epoch_number,
         )
+        .map_err(|e| e.to_string())
     }
 
     fn get_epoch_execution_commitment_with_db(

--- a/crates/cfxcore/core/src/consensus/mod.rs
+++ b/crates/cfxcore/core/src/consensus/mod.rs
@@ -22,7 +22,7 @@ pub use consensus_graph::{
     rpc_api::transaction_provider::{
         MaybeExecutedTxExtraInfo, TransactionInfo,
     },
-    ConsensusGraph, EPOCH_NUMBER_TOO_LARGE_ERR_MESSAGE,
+    ConsensusGraph,
 };
 pub use statistics::ConsensusGraphStatistics;
 

--- a/crates/cfxcore/core/src/consensus/mod.rs
+++ b/crates/cfxcore/core/src/consensus/mod.rs
@@ -22,7 +22,7 @@ pub use consensus_graph::{
     rpc_api::transaction_provider::{
         MaybeExecutedTxExtraInfo, TransactionInfo,
     },
-    ConsensusGraph,
+    ConsensusGraph, EPOCH_NUMBER_TOO_LARGE_ERR_MESSAGE,
 };
 pub use statistics::ConsensusGraphStatistics;
 

--- a/crates/cfxcore/core/src/errors.rs
+++ b/crates/cfxcore/core/src/errors.rs
@@ -6,6 +6,7 @@ use cfx_rpc_eth_types::Error as EthRpcError;
 pub use cfx_rpc_utils::error::error_codes::EXCEPTION_ERROR;
 use cfx_statedb::Error as StateDbError;
 use cfx_storage::Error as StorageError;
+use cfxcore_errors::ProviderBlockError;
 use jsonrpc_core::{futures::future, Error as JsonRpcError, ErrorCode};
 use jsonrpsee::types::ErrorObjectOwned;
 use primitives::{account::AccountError, filter::FilterError};
@@ -88,6 +89,10 @@ impl From<&str> for Error {
 
 impl From<String> for Error {
     fn from(s: String) -> Error { Error::Msg(s) }
+}
+
+impl From<ProviderBlockError> for Error {
+    fn from(e: ProviderBlockError) -> Error { Error::from(e.to_string()) }
 }
 
 impl From<EthRpcError> for Error {

--- a/crates/cfxcore/core/src/light_protocol/common/ledger_info.rs
+++ b/crates/cfxcore/core/src/light_protocol/common/ledger_info.rs
@@ -64,7 +64,10 @@ impl LedgerInfo {
     #[inline]
     fn pivot_hash_of(&self, height: u64) -> Result<H256, Error> {
         let epoch = EpochNumber::Number(height);
-        Ok(self.consensus.get_hash_from_epoch_number(epoch)?)
+        Ok(self
+            .consensus
+            .get_hash_from_epoch_number(epoch)
+            .map_err(|e| e.to_string())?)
     }
 
     /// Get header at `height` on the pivot chain, if it exists.
@@ -79,7 +82,10 @@ impl LedgerInfo {
     #[inline]
     pub fn block_hashes_in(&self, height: u64) -> Result<Vec<H256>, Error> {
         let epoch = EpochNumber::Number(height);
-        Ok(self.consensus.get_block_hashes_by_epoch(epoch)?)
+        Ok(self
+            .consensus
+            .get_block_hashes_by_epoch(epoch)
+            .map_err(|e| e.to_string())?)
     }
 
     /// Get the correct deferred state root of the block at `height` on the

--- a/crates/cfxcore/core/src/light_protocol/query_service.rs
+++ b/crates/cfxcore/core/src/light_protocol/query_service.rs
@@ -279,7 +279,10 @@ impl QueryService {
                 break;
             }
 
-            let mut epoch_hashes = inner.read().block_hashes_by_epoch(epoch)?;
+            let mut epoch_hashes = inner
+                .read()
+                .block_hashes_by_epoch(epoch)
+                .map_err(|e| e.to_string())?;
             epoch_hashes.reverse();
 
             let missing = GAS_PRICE_BLOCK_SAMPLE_SIZE - hashes.len();

--- a/crates/cfxcore/core/src/sync/synchronization_graph.rs
+++ b/crates/cfxcore/core/src/sync/synchronization_graph.rs
@@ -23,6 +23,7 @@ use unexpected::{Mismatch, OutOfBounds};
 
 use cfx_executor::machine::Machine;
 use cfx_types::{H256, U256};
+use cfxcore_errors::ProviderBlockError;
 use dag::{Graph, RichDAG, RichTreeGraph, TreeGraph, DAG};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use malloc_size_of_derive::MallocSizeOf as DeriveMallocSizeOf;
@@ -1876,7 +1877,7 @@ impl SynchronizationGraph {
 
     pub fn get_all_block_hashes_by_epoch(
         &self, epoch_number: u64,
-    ) -> Result<Vec<H256>, String> {
+    ) -> Result<Vec<H256>, ProviderBlockError> {
         let mut res = self.consensus.get_skipped_block_hashes_by_epoch(
             EpochNumber::Number(epoch_number.into()),
         )?;

--- a/crates/cfxcore/errors/Cargo.toml
+++ b/crates/cfxcore/errors/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "cfxcore-errors"
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+repository.workspace = true
+license-file.workspace = true
+edition.workspace = true
+
+[dependencies]
+thiserror = { workspace = true }

--- a/crates/cfxcore/errors/src/block.rs
+++ b/crates/cfxcore/errors/src/block.rs
@@ -1,0 +1,22 @@
+use thiserror::Error;
+
+/// Error type for block-related operations in the provider.
+#[derive(Error, Debug)]
+pub enum ProviderBlockError {
+    #[error("Invalid params: expected a numbers with less than largest epoch number.")]
+    EpochNumberTooLarge,
+    #[error("{0}")]
+    Common(String),
+}
+
+impl From<String> for ProviderBlockError {
+    fn from(err: String) -> Self { ProviderBlockError::Common(err) }
+}
+
+impl From<&str> for ProviderBlockError {
+    fn from(err: &str) -> Self { ProviderBlockError::Common(err.to_string()) }
+}
+
+impl From<ProviderBlockError> for String {
+    fn from(err: ProviderBlockError) -> Self { err.to_string() }
+}

--- a/crates/cfxcore/errors/src/lib.rs
+++ b/crates/cfxcore/errors/src/lib.rs
@@ -1,0 +1,3 @@
+mod block;
+
+pub use block::ProviderBlockError;

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -22,6 +22,7 @@ siphasher = { workspace = true }
 unexpected = { workspace = true }
 once_cell = { workspace = true }
 cfx-parameters = { workspace = true }
+cfxcore-errors = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/primitives/src/filter.rs
+++ b/crates/primitives/src/filter.rs
@@ -22,6 +22,7 @@
 
 use crate::{epoch::EpochNumber, log_entry::LogEntry};
 use cfx_types::{Address, Bloom, BloomInput, Space, H256};
+use cfxcore_errors::ProviderBlockError;
 use std::{
     error, fmt,
     ops::{Deref, DerefMut},
@@ -96,6 +97,20 @@ pub enum FilterError {
 
     /// Filter error with custom error message (e.g. timeout)
     Custom(String),
+}
+
+impl From<String> for FilterError {
+    fn from(s: String) -> Self { FilterError::Custom(s) }
+}
+
+impl From<&str> for FilterError {
+    fn from(s: &str) -> Self { FilterError::Custom(s.to_string()) }
+}
+
+impl From<ProviderBlockError> for FilterError {
+    fn from(err: ProviderBlockError) -> Self {
+        FilterError::from(err.to_string())
+    }
 }
 
 impl fmt::Display for FilterError {
@@ -325,8 +340,4 @@ impl LogFilterParams {
                     _ => true,
                 })
     }
-}
-
-impl From<String> for FilterError {
-    fn from(s: String) -> Self { FilterError::Custom(s) }
 }

--- a/crates/rpc/rpc-eth-impl/Cargo.toml
+++ b/crates/rpc/rpc-eth-impl/Cargo.toml
@@ -49,3 +49,4 @@ solidity-abi = { workspace = true }
 cfx-rpc-common-impl = { workspace = true }
 cfx-tasks = { workspace = true }
 cfx-parity-trace-types = { workspace = true }
+cfxcore-errors = { workspace = true }

--- a/crates/rpc/rpc-eth-impl/src/debug.rs
+++ b/crates/rpc/rpc-eth-impl/src/debug.rs
@@ -90,7 +90,7 @@ impl DebugApi {
         let epoch_block_hashes = self
             .consensus_graph()
             .get_block_hashes_by_epoch(EpochNumber::Number(epoch_num))
-            .map_err(|err| CoreError::Msg(err))?;
+            .map_err(|err| CoreError::Msg(err.into()))?;
         let epoch_id = epoch_block_hashes
             .last()
             .ok_or(CoreError::Msg("should have block hash".to_string()))?;

--- a/crates/rpc/rpc-eth-impl/src/helpers/eth_filter.rs
+++ b/crates/rpc/rpc-eth-impl/src/helpers/eth_filter.rs
@@ -390,6 +390,8 @@ impl BlockProvider for &EthFilterHelper {
     fn get_block_hashes_by_epoch(
         &self, epoch_number: EpochNumber,
     ) -> Result<Vec<H256>, String> {
-        self.consensus.get_block_hashes_by_epoch(epoch_number)
+        self.consensus
+            .get_block_hashes_by_epoch(epoch_number)
+            .map_err(|e| e.to_string())
     }
 }

--- a/crates/rpc/rpc-eth-impl/src/pubsub.rs
+++ b/crates/rpc/rpc-eth-impl/src/pubsub.rs
@@ -541,7 +541,9 @@ impl BlockProvider for &ChainDataProvider {
     fn get_block_hashes_by_epoch(
         &self, epoch_number: EpochNumber,
     ) -> Result<Vec<H256>, String> {
-        self.consensus.get_block_hashes_by_epoch(epoch_number)
+        self.consensus
+            .get_block_hashes_by_epoch(epoch_number)
+            .map_err(|e| e.to_string())
     }
 }
 

--- a/tools/consensus_bench/Cargo.lock
+++ b/tools/consensus_bench/Cargo.lock
@@ -1360,6 +1360,7 @@ dependencies = [
  "cfx-types",
  "cfx-util-macros",
  "cfx-vm-types",
+ "cfxcore-errors",
  "cfxcore-pow",
  "cfxcore-types",
  "cfxkey",
@@ -1445,6 +1446,13 @@ dependencies = [
  "toml 0.8.19",
  "treap-map",
  "unexpected",
+]
+
+[[package]]
+name = "cfxcore-errors"
+version = "3.0.0"
+dependencies = [
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -5029,6 +5037,7 @@ dependencies = [
  "cfx-bytes",
  "cfx-parameters",
  "cfx-types",
+ "cfxcore-errors",
  "cfxkey",
  "keccak-hash",
  "lazy_static",

--- a/tools/evm-spec-tester/Cargo.lock
+++ b/tools/evm-spec-tester/Cargo.lock
@@ -1210,6 +1210,7 @@ dependencies = [
  "cfx-util-macros",
  "cfx-vm-types",
  "cfxcore",
+ "cfxcore-errors",
  "futures 0.3.30",
  "geth-tracer",
  "jsonrpc-core",
@@ -1542,6 +1543,7 @@ dependencies = [
  "cfx-types",
  "cfx-util-macros",
  "cfx-vm-types",
+ "cfxcore-errors",
  "cfxcore-pow",
  "cfxcore-types",
  "cfxkey",
@@ -1627,6 +1629,13 @@ dependencies = [
  "toml 0.8.19",
  "treap-map",
  "unexpected",
+]
+
+[[package]]
+name = "cfxcore-errors"
+version = "3.0.0"
+dependencies = [
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -5533,6 +5542,7 @@ dependencies = [
  "cfx-bytes",
  "cfx-parameters",
  "cfx-types",
+ "cfxcore-errors",
  "cfxkey",
  "keccak-hash",
  "lazy_static",


### PR DESCRIPTION
To improve the compatibility of eSpace RPC method eth_getBlockByNumber, now will return null when the block number parameter is bigger than the latest block, other than return error message.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3295)
<!-- Reviewable:end -->
