### PR TITLE
Fix the bug of using wrong ws_address to open rpc endpoints

### DIFF
--- a/crates/client/src/rpc/mod.rs
+++ b/crates/client/src/rpc/mod.rs
@@ -432,7 +432,7 @@ pub async fn launch_async_rpc_servers(
                     TransportRpcModuleConfig::set_http(apis.clone());
                 let server_config =
                     RpcServerConfig::http(ServerBuilder::default())
-                        .with_http_address(ws_config.address);
+                        .with_http_address(http_config.address);
                 (transport_rpc_module_config, server_config)
             }
             (false, true) => {


### PR DESCRIPTION
Fix the bug of using wrong address when only have http_port specified

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3304)
<!-- Reviewable:end -->
