### PR TITLE
fix: remove peer from stratum worker pool if send message failed(aka, disconnected)

### DIFF
--- a/crates/stratum/src/lib.rs
+++ b/crates/stratum/src/lib.rs
@@ -226,8 +226,11 @@ impl StratumImpl {
                         debug!(target: "stratum", "Worker no longer connected: {} addr {}", &worker_id, &addr);
                         hup_peers.insert(**addr);
                     }
-                    Err(e) => {
+                    Err(PushMessageError::Send(e)) => {
                         warn!(target: "stratum", "Unexpected transport error: {:?}", e);
+                        if e.is_disconnected() {
+                            hup_peers.insert(**addr);
+                        }
                     }
                     Ok(_) => {}
                 }


### PR DESCRIPTION
One of our pow miner account this issue, when one worker is disconnected, we should remove it from worker pool, to avoid this

<img width="1273" height="36" alt="22" src="https://github.com/user-attachments/assets/7611c58d-26c9-4ac1-9447-8c990c367b93" />

![conflux_v3](https://github.com/user-attachments/assets/2180acc2-bbbf-4101-9624-46ba73daebcf)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3307)
<!-- Reviewable:end -->
