### PR TITLE
fix x86 macos build error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3620,8 +3620,7 @@ dependencies = [
 [[package]]
 name = "fs-swap"
 version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d47dad3685eceed8488986cad3d5027165ea5edb164331770e2059555f10a5"
+source = "git+https://github.com/Conflux-Chain/fs-swap?rev=72fed3585f430b1485e133d02b291d1976c58b06#72fed3585f430b1485e133d02b291d1976c58b06"
 dependencies = [
  "lazy_static",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -268,7 +268,7 @@ proc-macro-crate = "3"
 serde = { version = "1.0", features = [
     "derive",
     "alloc",
-    "rc"
+    "rc",
 ], default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde_derive = { version = "1.0", default-features = false }
@@ -388,7 +388,7 @@ vergen = "8.3.2"
 target_info = "0.1"
 bit-set = "0.4"
 typenum = "1.17.0"
-typemap = { package = "typemap-ors", version = "1.0"}
+typemap = { package = "typemap-ors", version = "1.0" }
 impl-trait-for-tuples = "0.2"
 impl-tools = "0.10"
 derive_more = { version = "2.0.1", features = ["full"] }
@@ -404,7 +404,7 @@ memoffset = "0.9"
 either = "1.15"
 fallible-iterator = "0.3"
 fs_extra = "1.1.0"
-fs-swap = "0.2.4"
+fs-swap = { git = "https://github.com/Conflux-Chain/fs-swap", rev = "72fed3585f430b1485e133d02b291d1976c58b06" }
 regex = "1.3.1"
 cfg-if = "1"
 unroll = "0.1.5"

--- a/tools/consensus_bench/Cargo.lock
+++ b/tools/consensus_bench/Cargo.lock
@@ -2737,8 +2737,7 @@ dependencies = [
 [[package]]
 name = "fs-swap"
 version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d47dad3685eceed8488986cad3d5027165ea5edb164331770e2059555f10a5"
+source = "git+https://github.com/Conflux-Chain/fs-swap?rev=72fed3585f430b1485e133d02b291d1976c58b06#72fed3585f430b1485e133d02b291d1976c58b06"
 dependencies = [
  "lazy_static",
  "libc",

--- a/tools/evm-spec-tester/Cargo.lock
+++ b/tools/evm-spec-tester/Cargo.lock
@@ -3014,8 +3014,7 @@ dependencies = [
 [[package]]
 name = "fs-swap"
 version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d47dad3685eceed8488986cad3d5027165ea5edb164331770e2059555f10a5"
+source = "git+https://github.com/Conflux-Chain/fs-swap?rev=72fed3585f430b1485e133d02b291d1976c58b06#72fed3585f430b1485e133d02b291d1976c58b06"
 dependencies = [
  "lazy_static",
  "libc",


### PR DESCRIPTION
On x86 macOS the `fs-swap` crate uses the "stdcall" calling convention for the `exchangedata` function. This causes a build failure with recent Rust versions(1.84+) as the unsupported_calling_conventions warning has been promoted to a hard error.

This PR replace fs-swap with fork version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3312)
<!-- Reviewable:end -->
