### PR TITLE
RPC type BlockNumber optimize

### DIFF
--- a/crates/rpc/rpc-eth-api/src/debug.rs
+++ b/crates/rpc/rpc-eth-api/src/debug.rs
@@ -2,7 +2,7 @@ use alloy_rpc_types_trace::geth::{
     GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace,
     TraceResult,
 };
-use cfx_rpc_eth_types::{BlockNumber, TransactionRequest};
+use cfx_rpc_eth_types::{BlockId, TransactionRequest};
 use cfx_types::H256;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
@@ -28,12 +28,12 @@ pub trait DebugApi {
 
     #[method(name = "traceBlockByNumber")]
     async fn debug_trace_block_by_number(
-        &self, block: BlockNumber, opts: Option<GethDebugTracingOptions>,
+        &self, block: BlockId, opts: Option<GethDebugTracingOptions>,
     ) -> RpcResult<Vec<TraceResult>>;
 
     #[method(name = "traceCall")]
     async fn debug_trace_call(
-        &self, request: TransactionRequest, block_number: Option<BlockNumber>,
+        &self, request: TransactionRequest, block_number: Option<BlockId>,
         opts: Option<GethDebugTracingCallOptions>,
     ) -> RpcResult<GethTrace>;
 }

--- a/crates/rpc/rpc-eth-api/src/eth.rs
+++ b/crates/rpc/rpc-eth-api/src/eth.rs
@@ -1,9 +1,8 @@
 use cfx_rpc_eth_types::{
-    AccessListResult, AccountPendingTransactions, Block,
-    BlockNumber as BlockId, BlockOverrides, Bundle, EthCallResponse,
-    EthRpcLogFilter as Filter, FeeHistory, Header, Log, Receipt,
-    RpcStateOverride, SimulatePayload, SimulatedBlock, StateContext,
-    SyncStatus, Transaction, TransactionRequest,
+    AccessListResult, AccountPendingTransactions, Block, BlockId,
+    BlockOverrides, Bundle, EthCallResponse, EthRpcLogFilter as Filter,
+    FeeHistory, Header, Log, Receipt, RpcStateOverride, SimulatePayload,
+    SimulatedBlock, StateContext, SyncStatus, Transaction, TransactionRequest,
 };
 use cfx_rpc_primitives::{Bytes, Index};
 use cfx_types::{Address, H256, H64, U256, U64};

--- a/crates/rpc/rpc-eth-api/src/parity.rs
+++ b/crates/rpc/rpc-eth-api/src/parity.rs
@@ -1,4 +1,4 @@
-use cfx_rpc_eth_types::{BlockNumber as BlockId, Receipt};
+use cfx_rpc_eth_types::{BlockId, Receipt};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 #[rpc(server, namespace = "parity")]

--- a/crates/rpc/rpc-eth-api/src/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/trace.rs
@@ -1,5 +1,5 @@
 use cfx_rpc_eth_types::{
-    BlockNumber, Index, LocalizedSetAuthTrace, LocalizedTrace, TraceFilter,
+    BlockId, Index, LocalizedSetAuthTrace, LocalizedTrace, TraceFilter,
 };
 use cfx_types::H256;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
@@ -9,13 +9,13 @@ pub trait TraceApi {
     /// Returns all traces produced at the given block.
     #[method(name = "block")]
     async fn block_traces(
-        &self, block_number: BlockNumber,
+        &self, block_number: BlockId,
     ) -> RpcResult<Option<Vec<LocalizedTrace>>>;
 
     /// Returns all set auth traces produced at the given block.
     #[method(name = "blockSetAuth")]
     async fn block_set_auth_traces(
-        &self, block_number: BlockNumber,
+        &self, block_number: BlockId,
     ) -> RpcResult<Option<Vec<LocalizedSetAuthTrace>>>;
 
     /// Returns all traces matching the provided filter.

--- a/crates/rpc/rpc-eth-impl/src/eth.rs
+++ b/crates/rpc/rpc-eth-impl/src/eth.rs
@@ -11,10 +11,10 @@ use cfx_rpc_cfx_types::{
 use cfx_rpc_eth_api::EthApiServer;
 use cfx_rpc_eth_types::{
     AccessListResult, AccountOverride, AccountPendingTransactions, Block,
-    BlockNumber as BlockId, BlockOverrides, Bundle, Error, EthCallResponse,
-    EthRpcLogFilter, EthRpcLogFilter as Filter, EvmOverrides, FeeHistory,
-    Header, Log, Receipt, RpcStateOverride, SimulatePayload, SimulatedBlock,
-    StateContext, SyncInfo, SyncStatus, Transaction, TransactionRequest,
+    BlockId, BlockOverrides, Bundle, Error, EthCallResponse, EthRpcLogFilter,
+    EthRpcLogFilter as Filter, EvmOverrides, FeeHistory, Header, Log, Receipt,
+    RpcStateOverride, SimulatePayload, SimulatedBlock, StateContext, SyncInfo,
+    SyncStatus, Transaction, TransactionRequest,
 };
 use cfx_rpc_primitives::{Bytes, Index, U64 as HexU64};
 use cfx_rpc_utils::{

--- a/crates/rpc/rpc-eth-impl/src/filter.rs
+++ b/crates/rpc/rpc-eth-impl/src/filter.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use cfx_rpc_eth_api::EthFilterApiServer;
 use cfx_rpc_eth_types::{
-    BlockNumber, EthRpcLogFilter as Filter, FilterChanges, Log,
+    BlockId, EthRpcLogFilter as Filter, FilterChanges, Log,
 };
 use cfx_rpc_utils::error::jsonrpsee_error_helpers::{
     invalid_request_msg, jsonrpc_error_to_error_object_owned,
@@ -52,7 +52,7 @@ impl EthFilterApiServer for EthFilterApi {
         let mut polls = self.inner.polls().lock();
         let epoch_number = self.inner.best_executed_epoch_number();
 
-        if filter.to_block == Some(BlockNumber::Pending) {
+        if filter.to_block == Some(BlockId::Pending) {
             bail!(invalid_request_msg(
                 "Filter logs from pending blocks is not supported"
             ))

--- a/crates/rpc/rpc-eth-impl/src/parity.rs
+++ b/crates/rpc/rpc-eth-impl/src/parity.rs
@@ -1,7 +1,7 @@
 use crate::EthApi;
 use async_trait::async_trait;
 use cfx_rpc_eth_api::ParityApiServer;
-use cfx_rpc_eth_types::{BlockNumber as BlockId, Receipt};
+use cfx_rpc_eth_types::{BlockId, Receipt};
 use jsonrpsee::core::RpcResult;
 
 pub struct ParityApi {

--- a/crates/rpc/rpc-eth-impl/src/trace.rs
+++ b/crates/rpc/rpc-eth-impl/src/trace.rs
@@ -10,7 +10,7 @@ use cfx_rpc_common_impl::trace::{
 use cfx_rpc_eth_api::TraceApiServer;
 use cfx_rpc_eth_types::{
     trace::{LocalizedSetAuthTrace, LocalizedTrace as EthLocalizedTrace},
-    BlockNumber, Index, LocalizedTrace, TraceFilter,
+    BlockId, Index, LocalizedTrace, TraceFilter,
 };
 use cfx_types::H256;
 use cfx_util_macros::unwrap_option_or_return_result_none as unwrap_or_return;
@@ -30,10 +30,10 @@ impl TraceApi {
     }
 
     pub fn get_block(
-        &self, block_number: BlockNumber,
+        &self, block_number: BlockId,
     ) -> CoreResult<Option<PhantomBlock>> {
         let phantom_block = match block_number {
-            BlockNumber::Hash { hash, .. } => self
+            BlockId::Hash { hash, .. } => self
                 .trace_handler
                 .consensus_graph()
                 .get_phantom_block_by_hash(
@@ -56,7 +56,7 @@ impl TraceApi {
     }
 
     pub fn block_traces(
-        &self, block_number: BlockNumber,
+        &self, block_number: BlockId,
     ) -> CoreResult<Option<Vec<LocalizedTrace>>> {
         let phantom_block = self.get_block(block_number)?;
 
@@ -86,7 +86,7 @@ impl TraceApi {
     }
 
     pub fn block_set_auth_traces(
-        &self, block_number: BlockNumber,
+        &self, block_number: BlockId,
     ) -> CoreResult<Option<Vec<LocalizedSetAuthTrace>>> {
         let phantom_block = self.get_block(block_number)?;
 
@@ -202,7 +202,7 @@ impl TraceApi {
 #[async_trait::async_trait]
 impl TraceApiServer for TraceApi {
     async fn block_traces(
-        &self, block_number: BlockNumber,
+        &self, block_number: BlockId,
     ) -> RpcResult<Option<Vec<LocalizedTrace>>> {
         self.block_traces(block_number).map_err(|err| err.into())
     }
@@ -220,7 +220,7 @@ impl TraceApiServer for TraceApi {
     }
 
     async fn block_set_auth_traces(
-        &self, block_number: BlockNumber,
+        &self, block_number: BlockId,
     ) -> RpcResult<Option<Vec<LocalizedSetAuthTrace>>> {
         self.block_set_auth_traces(block_number)
             .map_err(|err| err.into())

--- a/crates/rpc/rpc-eth-types/src/call.rs
+++ b/crates/rpc/rpc-eth-types/src/call.rs
@@ -1,4 +1,4 @@
-use crate::{BlockNumber as BlockId, BlockOverrides, TransactionRequest};
+use crate::{BlockId, BlockOverrides, TransactionRequest};
 use cfx_bytes::Bytes;
 
 /// Bundle of transactions

--- a/crates/rpc/rpc-eth-types/src/filter.rs
+++ b/crates/rpc/rpc-eth-types/src/filter.rs
@@ -18,7 +18,7 @@
 // You should have received a copy of the GNU General Public License
 // along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{BlockNumber, Error as SelfError, Log};
+use crate::{BlockId, Error as SelfError, Log};
 use cfx_rpc_cfx_types::traits::BlockProvider;
 use cfx_rpc_primitives::VariadicValue;
 use cfx_types::{Space, H160, H256};
@@ -41,9 +41,9 @@ pub type Topic = VariadicValue<H256>;
 #[serde(rename_all = "camelCase")]
 pub struct EthRpcLogFilter {
     /// From Block
-    pub from_block: Option<BlockNumber>,
+    pub from_block: Option<BlockId>,
     /// To Block
-    pub to_block: Option<BlockNumber>,
+    pub to_block: Option<BlockId>,
     /// Block hash
     pub block_hash: Option<H256>,
     /// Address

--- a/crates/rpc/rpc-eth-types/src/lib.rs
+++ b/crates/rpc/rpc-eth-types/src/lib.rs
@@ -21,7 +21,7 @@ mod tx_pool;
 pub use access_list::*;
 pub use authorization::{Authorization, SignedAuthorization};
 pub use block::{Block, BlockOverrides, Header};
-pub use block_number::BlockNumber;
+pub use block_number::BlockId;
 pub use call::*;
 pub use cfx_rpc_primitives::{Bytes, Index, U64};
 pub use errors::Error;

--- a/crates/rpc/rpc-eth-types/src/trace_filter.rs
+++ b/crates/rpc/rpc-eth-types/src/trace_filter.rs
@@ -16,7 +16,7 @@
 
 //! Trace filter deserialization.
 
-use crate::BlockNumber;
+use crate::BlockId;
 use cfx_parity_trace_types::TraceFilter as PrimitiveTraceFilter;
 use cfx_types::{Space, H160};
 use jsonrpc_core::Error as RpcError;
@@ -30,9 +30,9 @@ use std::convert::TryInto;
 #[serde(rename_all = "camelCase")]
 pub struct TraceFilter {
     /// From block
-    pub from_block: Option<BlockNumber>,
+    pub from_block: Option<BlockId>,
     /// To block
-    pub to_block: Option<BlockNumber>,
+    pub to_block: Option<BlockId>,
     /// From address
     pub from_address: Option<Vec<H160>>,
     /// To address

--- a/deny.toml
+++ b/deny.toml
@@ -88,6 +88,7 @@ ignore = [
     "RUSTSEC-2021-0059", # aesni unmaintained
     "RUSTSEC-2021-0060", # aes-soft unmaintained
     "RUSTSEC-2021-0061", # aes-ctr unmaintained
+    "RUSTSEC-2025-0056", # adler is unmaintained, use adler2 instead
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
1. Rename to BlockId which is more precise, because this type can not only present a block number but also block hash
2. BlockId now can support deserialize block hash like this

```
["0x218d08d99974c571b5578bbf3270a9a778905e18398f55168c66abd6e5deb954"]
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3328)
<!-- Reviewable:end -->
