### PR TITLE
chore: handle no log config

### DIFF
--- a/bins/conflux/src/main.rs
+++ b/bins/conflux/src/main.rs
@@ -191,8 +191,8 @@ fn setup_logger(conf: &Configuration) -> Result<(), String> {
         Some(ref log_conf) => {
             log4rs::init_file(log_conf, Default::default()).map_err(|e| {
                 format!(
-                    "failed to initialize log with log config file: {:?}",
-                    e
+                    "failed to initialize log with log config file '{}': {:?}; maybe you want 'run/log.yaml'?",
+                    log_conf, e
                 )
             })?;
         }


### PR DESCRIPTION
Original:
Error: "failed to initialize log with log config file: No such file or directory (os error 2)

Current:
Error: "failed to initialize log with log config file 'log.yaml': No such file or directory (os error 2); maybe you want 'run/log.yaml'?"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3360)
<!-- Reviewable:end -->
