### PR TITLE
chore: eSpace RPC block type reuse header definitions

### DIFF
--- a/crates/rpc/rpc-eth-types/src/block.rs
+++ b/crates/rpc/rpc-eth-types/src/block.rs
@@ -60,7 +60,7 @@ impl Serialize for BlockTransactions {
 #[serde(rename_all = "camelCase")]
 pub struct Block<H = Header> {
     /// Header of the block.
-    #[cfg_attr(feature = "serde", serde(flatten))]
+    #[serde(flatten)]
     pub header: H,
     /// Transactions
     pub transactions: BlockTransactions,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3366)
<!-- Reviewable:end -->
