### PR TITLE
chore: update integration test dependency version

### DIFF
--- a/dev-support/requirements.txt
+++ b/dev-support/requirements.txt
@@ -19,7 +19,9 @@ bitarray==3.4.2
 certifi==2025.4.26
     # via requests
 cffi==1.17.1
-    # via coincurve
+    # via
+    #   coincurve
+    #   cryptography
 cfx-account==1.2.2
     # via
     #   conflux-rust-tests (pyproject.toml)
@@ -35,20 +37,23 @@ cfx-utils==1.1.0
     #   conflux-web3
 charset-normalizer==3.4.2
     # via requests
-ckzg==2.1.1
-    # via eth-account
+ckzg==2.1.5
+    # via
+    #   eth-account
+    #   ethereum-execution-spec-tests
 click==8.2.1
     # via ethereum-execution-spec-tests
 coincurve==20.0.0
     # via
     #   conflux-rust-tests (pyproject.toml)
-    #   ethereum-execution
     #   ethereum-execution-spec-tests
     #   ethereum-spec-evm-resolver
 colorlog==6.9.0
     # via ethereum-execution-spec-tests
 conflux-web3==1.4.4
     # via conflux-rust-tests (pyproject.toml)
+cryptography==45.0.7
+    # via ethereum-spec-evm-resolver
 cytoolz==1.0.1
     # via eth-utils
 eth-abi==5.2.0
@@ -94,21 +99,18 @@ eth-utils==5.3.0
     #   rlp
     #   trie
     #   web3
-ethereum-execution==1.17.0rc6.dev1
-    # via ethereum-execution-spec-tests
-ethereum-execution-spec-tests @ git+https://github.com/ethereum/execution-spec-tests.git@971214c0832f656b7250eb71cf0b7bcba96c3f49
+ethereum-execution-spec-tests @ git+https://github.com/ethereum/execution-spec-tests.git@fb4348d6707c6290e42042944e1d6d5637e91c9f
     # via conflux-rust-tests (pyproject.toml)
+ethereum-hive==0.1.0a2
+    # via ethereum-execution-spec-tests
 ethereum-rlp==0.1.3
-    # via
-    #   ethereum-execution
-    #   ethereum-execution-spec-tests
-ethereum-spec-evm-resolver @ git+https://github.com/petertdavies/ethereum-spec-evm-resolver.git@0e5609737ce4f86dc98cca1a5cf0eb64b8cddef2
+    # via ethereum-execution-spec-tests
+ethereum-spec-evm-resolver @ git+https://github.com/spencer-tb/ethereum-spec-evm-resolver@aec6a628b8d0f1c791a8378c5417a089566135ac
     # via
     #   conflux-rust-tests (pyproject.toml)
     #   ethereum-execution-spec-tests
 ethereum-types==0.2.3
     # via
-    #   ethereum-execution
     #   ethereum-execution-spec-tests
     #   ethereum-rlp
 execnet==2.1.1
@@ -135,8 +137,6 @@ hexbytes==1.3.1
     #   eth-rlp
     #   trie
     #   web3
-hive-py @ git+https://github.com/marioevz/hive.py@582703e2f94b4d5e61ae495d90d684852c87a580
-    # via ethereum-execution-spec-tests
 idna==3.10
     # via
     #   requests
@@ -164,6 +164,7 @@ numpy==2.3.0
 packaging==25.0
     # via
     #   pytest
+    #   pytest-rerunfailures
     #   solc-select
 parsimonious==0.10.0
     # via eth-abi
@@ -180,7 +181,6 @@ propcache==0.3.2
 py-ecc==8.0.0
     # via
     #   conflux-rust-tests (pyproject.toml)
-    #   ethereum-execution
     #   ethereum-spec-evm-resolver
 pycparser==2.22
     # via cffi
@@ -188,7 +188,6 @@ pycryptodome==3.23.0
     # via
     #   eth-hash
     #   eth-keyfile
-    #   ethereum-execution
     #   ethereum-spec-evm-resolver
     #   solc-select
 pydantic==2.11.5
@@ -216,6 +215,7 @@ pytest==8.4.0
     #   pytest-json-report
     #   pytest-metadata
     #   pytest-regex
+    #   pytest-rerunfailures
     #   pytest-xdist
 pytest-custom-report==1.0.1
     # via ethereum-execution-spec-tests
@@ -229,6 +229,8 @@ pytest-metadata==3.1.1
     #   pytest-html
     #   pytest-json-report
 pytest-regex==0.2.0
+    # via ethereum-execution-spec-tests
+pytest-rerunfailures==16.1
     # via ethereum-execution-spec-tests
 pytest-xdist==3.7.0
     # via
@@ -248,8 +250,9 @@ requests==2.32.4
     # via
     #   conflux-rust-tests (pyproject.toml)
     #   ethereum-execution-spec-tests
-    #   hive-py
+    #   ethereum-hive
     #   requests-unixsocket2
+    #   solc-select
     #   web3
 requests-unixsocket2==0.4.0
     # via
@@ -271,11 +274,11 @@ setuptools==80.9.0
     # via conflux-rust-tests (pyproject.toml)
 smmap==5.0.2
     # via gitdb
-solc-select==1.1.0
-    # via ethereum-execution-spec-tests
+solc-select==1.2.0
+    # via conflux-rust-tests (pyproject.toml)
 sortedcontainers==2.4.0
     # via trie
-tenacity==8.5.0
+tenacity==9.1.2
     # via ethereum-execution-spec-tests
 toolz==1.0.0
     # via cytoolz
@@ -295,7 +298,6 @@ typing-extensions==4.13.2
     #   cfx-utils
     #   conflux-web3
     #   eth-typing
-    #   ethereum-execution
     #   ethereum-execution-spec-tests
     #   ethereum-rlp
     #   ethereum-spec-evm-resolver

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "requests",
     "asyncio",
     "websockets>=15.0.1",
+    "solc-select==1.2.0",
     "pyyaml",
     "numpy",
     "pytest",
@@ -26,5 +27,4 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-ethereum-spec-evm-resolver = { git = "https://github.com/petertdavies/ethereum-spec-evm-resolver.git", rev = "0e5609737ce4f86dc98cca1a5cf0eb64b8cddef2" }
-ethereum-execution-spec-tests = { git = "https://github.com/ethereum/execution-spec-tests.git", rev = "971214c0832f656b7250eb71cf0b7bcba96c3f49" }
+ethereum-execution-spec-tests = { git = "https://github.com/ethereum/execution-spec-tests.git", rev = "fb4348d6707c6290e42042944e1d6d5637e91c9f" }


### PR DESCRIPTION
This pull request updates the `solc-select` version in order to avoid 403 forbidden issue: https://github.com/crytic/solc-select/issues/263

However, as a dependency (`hive.py `) of `ethereum-execution-spec-tests` is renamed, a uv resolve issue is raised to fobid `uv compile` issue. This pull request also pin `ethereum-execution-spec-tests` to latest version.

The `ethereum-spec-evm-resolver` source is removed as `ethereum-execution-spec-tests` already pins it to another source

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3378)
<!-- Reviewable:end -->
