### PR TITLE
chore: update dependencies in pyproject.toml and requirements.txt to …

### DIFF
--- a/dev-support/requirements.txt
+++ b/dev-support/requirements.txt
@@ -136,7 +136,9 @@ hexbytes==1.3.1
     #   trie
     #   web3
 hive-py @ git+https://github.com/marioevz/hive.py@582703e2f94b4d5e61ae495d90d684852c87a580
-    # via ethereum-execution-spec-tests
+    # via
+    #   --override (workspace)
+    #   ethereum-execution-spec-tests
 idna==3.10
     # via
     #   requests
@@ -250,6 +252,7 @@ requests==2.32.4
     #   ethereum-execution-spec-tests
     #   hive-py
     #   requests-unixsocket2
+    #   solc-select
     #   web3
 requests-unixsocket2==0.4.0
     # via
@@ -271,8 +274,10 @@ setuptools==80.9.0
     # via conflux-rust-tests (pyproject.toml)
 smmap==5.0.2
     # via gitdb
-solc-select==1.1.0
-    # via ethereum-execution-spec-tests
+solc-select==1.2.0
+    # via
+    #   conflux-rust-tests (pyproject.toml)
+    #   ethereum-execution-spec-tests
 sortedcontainers==2.4.0
     # via trie
 tenacity==8.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,12 @@ dependencies = [
     "setuptools", # setuptools is required as uv pip sync will remove packages not listed in the requirements.txt
     "ethereum-spec-evm-resolver",
     "ethereum-execution-spec-tests",
+    "solc-select==1.2.0",
 ]
+
+[tool.uv]
+# Force hive-py to a git rev where the package name was still "hive-py" (repo was later renamed to ethereum-hive)
+override-dependencies = ["hive-py @ git+https://github.com/marioevz/hive.py@582703e2f94b4d5e61ae495d90d684852c87a580"]
 
 [tool.uv.sources]
 ethereum-spec-evm-resolver = { git = "https://github.com/petertdavies/ethereum-spec-evm-resolver.git", rev = "0e5609737ce4f86dc98cca1a5cf0eb64b8cddef2" }


### PR DESCRIPTION
…include solc-select 1.2.0 and override hive-py to a specific git revision

This pull request updates the `solc-select` version in order to avoid 403 forbidden issue: https://github.com/crytic/solc-select/issues/263

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3379)
<!-- Reviewable:end -->
