### PR TITLE
Revert "espace rpc method eth_blockByNumber support pending tag"

### DIFF
--- a/changelogs/JSONRPC.md
+++ b/changelogs/JSONRPC.md
@@ -7,7 +7,6 @@
 ## v3.0.3
 
 1. Core Space `log` object add `blockTimestamp` field for method `cfx_getLogs` and `cfx_getFilterLogs`.
-2. eSpace `eth_getBlockByNumber` now support `pending` tag to get the pending block, which is actually the Conflux latest mined block.
 
 ## v3.0.2
 

--- a/crates/rpc/rpc-eth-types/src/block_number.rs
+++ b/crates/rpc/rpc-eth-types/src/block_number.rs
@@ -225,7 +225,7 @@ impl TryFrom<BlockId> for EpochNumber {
             BlockId::Num(num) => Ok(EpochNumber::Number(num)),
             BlockId::Latest => Ok(EpochNumber::LatestState),
             BlockId::Earliest => Ok(EpochNumber::Earliest),
-            BlockId::Pending => Ok(EpochNumber::LatestMined),
+            BlockId::Pending => Ok(EpochNumber::LatestState), /* TODO: LatestMined maybe is better or add a new Pending variant for EpochNumber */
             BlockId::Safe => Ok(EpochNumber::LatestConfirmed),
             BlockId::Finalized => Ok(EpochNumber::LatestFinalized),
             BlockId::Hash { .. } => Err(Error::InvalidParams(
@@ -249,7 +249,7 @@ impl From<BlockId> for BlockHashOrEpochNumber {
                 BlockHashOrEpochNumber::EpochNumber(EpochNumber::Earliest)
             }
             BlockId::Pending => {
-                BlockHashOrEpochNumber::EpochNumber(EpochNumber::LatestMined)
+                BlockHashOrEpochNumber::EpochNumber(EpochNumber::LatestState)
             }
             BlockId::Safe => BlockHashOrEpochNumber::EpochNumber(
                 EpochNumber::LatestConfirmed,

--- a/docs/rpc/readme.md
+++ b/docs/rpc/readme.md
@@ -1,5 +1,0 @@
-# eSpace RPC Documentation
-
-## eth_getBlockByNumber pending tag
-
-When the `eth_getBlockByNumber` method is called with the `pending` tag, the eSpace RPC node returns the current latest mined blocks. These blocks have already been included in the blockchain but have not yet been executed (due to a 5-epoch delay). For further details, please refer to [Conflux's Block Deferred Execution Mechanism.](https://doc.confluxnetwork.org/docs/core/core-space-basics/transactions/lifecycle#4-deferring-5-epochs---executed)


### PR DESCRIPTION
Reverts Conflux-Chain/conflux-rust#3368

Some ethereum tools will use pending tag to estimate gas, this pr will break them, so we revert it

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3385)
<!-- Reviewable:end -->
