### PR TITLE
Fix CIP-78 sponsor flags for reverted txs in cip78a→cip78b window

### DIFF
--- a/crates/execution/executor/src/executive/executed.rs
+++ b/crates/execution/executor/src/executive/executed.rs
@@ -181,7 +181,7 @@ impl Executed {
         };
 
         let mut gas_sponsor_paid = cost.gas_sponsored;
-        if !r.apply_state && !spec.cip78b {
+        if !r.apply_state && !spec.cip78a {
             gas_sponsor_paid = false;
             storage_sponsor_paid = false;
         }


### PR DESCRIPTION
## Summary

- Fix incorrect `gasCoveredBySponsor` / `storageCoveredBySponsor` receipt fields for reverted transactions during testnet replay in the cip78a→cip78b window (blocks 68845000–77340000)
- Change zeroing gate in `from_executive_return` from `!spec.cip78b` to `!spec.cip78a` to match the old consensus executor's behavior
- No effect on mainnet where `cip78a == cip78b` (both 92060600)

## Root Cause

Commit `9c59b40cb` ("Fix Inconsistency in Historical Replay Test Related to CIP-78") added `!spec.cip78b` zeroing to `from_executive_return`, modeled after the error-path methods. But `from_executive_return` follows a different path: the old consensus executor's `cip78a` override (introduced in `30969607b`) passed through real sponsor values for EVM reverts starting at cip78a, not cip78b. After executor decomposition (`67b97b3fe`), this cip78a behavior was preserved in `from_executive_return` but the zeroing gate should have used `!spec.cip78a`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3388)
<!-- Reviewable:end -->
