### PR TITLE
Fix Deploy Docs workflow nightly toolchain version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
           CMAKE_POLICY_VERSION_MINIMUM: 3.5
           RUSTDOCFLAGS: "--enable-index-page -Z unstable-options"
         run: |
-          rustup default nightly-2025-02-01 && cargo +nightly-2025-02-01 doc --no-deps
+          rustup default nightly-2025-10-01 && cargo +nightly-2025-10-01 doc --no-deps
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
## Summary
- Update nightly toolchain in docs workflow from `nightly-2025-02-01` (rustc 1.86) to `nightly-2025-10-01` to fix build failures caused by dependencies requiring rustc 1.88+

## Test plan
- [ ] Verify the Deploy Docs workflow passes after merging to master

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3391)
<!-- Reviewable:end -->
