### PR TITLE
chore: remove redundant identity map in list_geth_accounts

### DIFF
--- a/crates/accounts/src/lib.rs
+++ b/crates/accounts/src/lib.rs
@@ -605,7 +605,6 @@ impl AccountProvider {
         self.sstore
             .list_geth_accounts(testnet)
             .into_iter()
-            .map(|a| a)
             .collect()
     }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3409)
<!-- Reviewable:end -->
