### PR TITLE
Update rust-rocksdb to fix build with clang 21+ (Xcode 16+)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5910,7 +5910,7 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=f42a47efa918ebccf1f49076c96051af67d9893f#f42a47efa918ebccf1f49076c96051af67d9893f"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=b84f1c0f549059602c1d51d87d2c1b01e931e5fd#b84f1c0f549059602c1d51d87d2c1b01e931e5fd"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -5927,7 +5927,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=f42a47efa918ebccf1f49076c96051af67d9893f#f42a47efa918ebccf1f49076c96051af67d9893f"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=b84f1c0f549059602c1d51d87d2c1b01e931e5fd#b84f1c0f549059602c1d51d87d2c1b01e931e5fd"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -8312,7 +8312,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=f42a47efa918ebccf1f49076c96051af67d9893f#f42a47efa918ebccf1f49076c96051af67d9893f"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=b84f1c0f549059602c1d51d87d2c1b01e931e5fd#b84f1c0f549059602c1d51d87d2c1b01e931e5fd"
 dependencies = [
  "libc",
  "librocksdb_sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -476,7 +476,7 @@ sqlite3-sys = "0.12"
 kvdb = "0.13"
 influx_db_client = "0.5.1"
 # conflux forked crates
-rocksdb = { git = "https://github.com/Conflux-Chain/rust-rocksdb.git", rev = "f42a47efa918ebccf1f49076c96051af67d9893f" }
+rocksdb = { git = "https://github.com/Conflux-Chain/rust-rocksdb.git", rev = "b84f1c0f549059602c1d51d87d2c1b01e931e5fd" }
 
 [patch.crates-io]
 # use a forked version to fix a vulnerability(introduced by failure) in vrf-rs, can be removed after the upstream is fixed

--- a/tools/consensus_bench/Cargo.lock
+++ b/tools/consensus_bench/Cargo.lock
@@ -2666,17 +2666,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "diem-github-client"
-version = "0.1.0"
-dependencies = [
- "proxy",
- "serde",
- "serde_json",
- "thiserror 1.0.63",
- "ureq",
-]
-
-[[package]]
 name = "diem-global-constants"
 version = "0.1.0"
 
@@ -2789,13 +2778,11 @@ dependencies = [
  "bcs",
  "chrono",
  "diem-crypto",
- "diem-github-client",
  "diem-infallible",
  "diem-logger",
  "diem-temppath",
  "diem-time-service",
  "diem-types",
- "diem-vault-client",
  "enum_dispatch",
  "rand 0.8.5",
  "serde",
@@ -2853,22 +2840,6 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.63",
  "tiny-keccak 2.0.2",
-]
-
-[[package]]
-name = "diem-vault-client"
-version = "0.1.0"
-dependencies = [
- "base64 0.13.1",
- "chrono",
- "diem-crypto",
- "diem-types",
- "native-tls",
- "once_cell",
- "serde",
- "serde_json",
- "thiserror 1.0.63",
- "ureq",
 ]
 
 [[package]]
@@ -4586,7 +4557,7 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=f42a47efa918ebccf1f49076c96051af67d9893f#f42a47efa918ebccf1f49076c96051af67d9893f"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=b84f1c0f549059602c1d51d87d2c1b01e931e5fd#b84f1c0f549059602c1d51d87d2c1b01e931e5fd"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -4603,7 +4574,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=f42a47efa918ebccf1f49076c96051af67d9893f#f42a47efa918ebccf1f49076c96051af67d9893f"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=b84f1c0f549059602c1d51d87d2c1b01e931e5fd#b84f1c0f549059602c1d51d87d2c1b01e931e5fd"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -5881,13 +5852,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proxy"
-version = "0.1.0"
-dependencies = [
- "ipnet",
-]
-
-[[package]]
 name = "qstring"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6450,7 +6414,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=f42a47efa918ebccf1f49076c96051af67d9893f#f42a47efa918ebccf1f49076c96051af67d9893f"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=b84f1c0f549059602c1d51d87d2c1b01e931e5fd#b84f1c0f549059602c1d51d87d2c1b01e931e5fd"
 dependencies = [
  "libc",
  "librocksdb_sys",
@@ -6609,7 +6573,6 @@ dependencies = [
  "diem-secure-storage",
  "diem-temppath",
  "diem-types",
- "diem-vault-client",
  "log",
  "once_cell",
  "rand 0.8.5",

--- a/tools/evm-spec-tester/Cargo.lock
+++ b/tools/evm-spec-tester/Cargo.lock
@@ -2867,17 +2867,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "diem-github-client"
-version = "0.1.0"
-dependencies = [
- "proxy",
- "serde",
- "serde_json",
- "thiserror 1.0.63",
- "ureq",
-]
-
-[[package]]
 name = "diem-global-constants"
 version = "0.1.0"
 
@@ -2990,13 +2979,11 @@ dependencies = [
  "bcs",
  "chrono",
  "diem-crypto",
- "diem-github-client",
  "diem-infallible",
  "diem-logger",
  "diem-temppath",
  "diem-time-service",
  "diem-types",
- "diem-vault-client",
  "enum_dispatch",
  "rand 0.8.5",
  "serde",
@@ -3054,22 +3041,6 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.63",
  "tiny-keccak 2.0.2",
-]
-
-[[package]]
-name = "diem-vault-client"
-version = "0.1.0"
-dependencies = [
- "base64 0.13.1",
- "chrono",
- "diem-crypto",
- "diem-types",
- "native-tls",
- "once_cell",
- "serde",
- "serde_json",
- "thiserror 1.0.63",
- "ureq",
 ]
 
 [[package]]
@@ -5071,7 +5042,7 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=f42a47efa918ebccf1f49076c96051af67d9893f#f42a47efa918ebccf1f49076c96051af67d9893f"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=b84f1c0f549059602c1d51d87d2c1b01e931e5fd#b84f1c0f549059602c1d51d87d2c1b01e931e5fd"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -5088,7 +5059,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=f42a47efa918ebccf1f49076c96051af67d9893f#f42a47efa918ebccf1f49076c96051af67d9893f"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=b84f1c0f549059602c1d51d87d2c1b01e931e5fd#b84f1c0f549059602c1d51d87d2c1b01e931e5fd"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -6395,13 +6366,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proxy"
-version = "0.1.0"
-dependencies = [
- "ipnet",
-]
-
-[[package]]
 name = "qstring"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6975,7 +6939,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=f42a47efa918ebccf1f49076c96051af67d9893f#f42a47efa918ebccf1f49076c96051af67d9893f"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=b84f1c0f549059602c1d51d87d2c1b01e931e5fd#b84f1c0f549059602c1d51d87d2c1b01e931e5fd"
 dependencies = [
  "libc",
  "librocksdb_sys",
@@ -7214,7 +7178,6 @@ dependencies = [
  "diem-secure-storage",
  "diem-temppath",
  "diem-types",
- "diem-vault-client",
  "log",
  "once_cell",
  "rand 0.8.5",


### PR DESCRIPTION
## Summary

Xcode 16+ ships clang 21 which introduces two new warnings that break the RocksDB/Titan C++ build under `-Werror`:

- **`-Wunnecessary-virtual-specifier`**: flags `virtual` methods in `final` classes (e.g. `InternalKeyComparator` in RocksDB headers). This is a style warning with no semantic effect — suppressing it is safe.
- **`-Wdangling-assignment-gsl`**: caught a real latent bug in `titan/src/version_edit.cc` where `s.ToString().c_str()` assigned a pointer from a temporary `std::string` (dangling after end of statement). Fixed by holding the string in a local variable.

## Changes

This PR bumps the `rust-rocksdb` rev to pick up fixes in the submodule chain:

- [Conflux-Chain/titan@0cfd672](https://github.com/Conflux-Chain/titan/commit/0cfd672) — suppress `-Wunnecessary-virtual-specifier`, fix dangling pointer in `version_edit.cc`
- [Conflux-Chain/rocksdb@0e5b299](https://github.com/Conflux-Chain/rocksdb/commit/0e5b299) — suppress `-Wunnecessary-virtual-specifier`
- [Conflux-Chain/rust-rocksdb@b84f1c0](https://github.com/Conflux-Chain/rust-rocksdb/commit/b84f1c0) — update submodule pointers

## Test plan

- [x] `cargo build --release` succeeds on macOS with Xcode 16+ (clang 21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3422)
<!-- Reviewable:end -->
