### PR TITLE
chore: update linux ulimit number

### DIFF
--- a/run/hydra.toml
+++ b/run/hydra.toml
@@ -594,3 +594,5 @@ hydra_transition_number = 92060600
 hydra_transition_height = 36935000
 cip43_init_end_number = 92751800
 pos_reference_enable_height = 37400000
+
+use_isolated_db_for_mpt_table = true

--- a/run/start.sh
+++ b/run/start.sh
@@ -1,3 +1,3 @@
-ulimit -n 10000
+ulimit -n 65535
 export RUST_BACKTRACE=1
 ./conflux --config hydra.toml 2> stderr.txt


### PR DESCRIPTION
Recently, some partners have found that the limit of 10,000 is not enough when setting up new nodes using snapshot data, so the limit has been increased.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3425)
<!-- Reviewable:end -->
