### PR TITLE
 Fix BLS12-381 precompile activation and harden dev-support scripts

### DIFF
--- a/crates/execution/executor/src/builtin/mod.rs
+++ b/crates/execution/executor/src/builtin/mod.rs
@@ -57,6 +57,19 @@ pub(crate) use pricer::{
     AltBn128PairingPricer, Blake2FPricer, ConstPricer, Linear,
 };
 
+/// Determines when a built-in contract becomes active.
+pub enum ActivateAt {
+    /// Activates when the DAG block number reaches the given value.
+    ByBlockNumber(u64),
+    /// Activates when the pivot-chain epoch height reaches the given value.
+    ByEpochHeight(u64),
+}
+
+impl ActivateAt {
+    /// Shorthand for precompiles active from genesis (block 0).
+    pub const GENESIS: Self = Self::ByBlockNumber(0);
+}
+
 /// Pricing scheme, execution definition, and activation block for a built-in
 /// contract.
 ///
@@ -68,7 +81,7 @@ pub(crate) use pricer::{
 pub struct Builtin {
     price_plan: Box<dyn PricePlan>,
     native: Box<dyn Precompile>,
-    activate_at: u64,
+    activate_at: ActivateAt,
 }
 
 impl Builtin {
@@ -90,12 +103,19 @@ impl Builtin {
         self.native.execute(input, output)
     }
 
-    /// Whether the builtin is activated at the given cardinal number.
-    pub fn is_active(&self, at: u64) -> bool { at >= self.activate_at }
+    /// Whether the builtin is active at the given execution context.
+    /// `block_number` is the DAG block number; `epoch_height` is the pivot
+    /// chain height. Parameter order must match `Env`: (number, epoch_height).
+    pub fn is_active(&self, block_number: u64, epoch_height: u64) -> bool {
+        match self.activate_at {
+            ActivateAt::ByBlockNumber(n) => block_number >= n,
+            ActivateAt::ByEpochHeight(h) => epoch_height >= h,
+        }
+    }
 
     pub fn new(
         price_plan: Box<dyn PricePlan>, native: Box<dyn Precompile>,
-        activate_at: u64,
+        activate_at: ActivateAt,
     ) -> Builtin {
         Builtin {
             price_plan,
@@ -535,12 +555,14 @@ impl Precompile for KzgPointEval {
 mod tests {
     use super::{
         builtin_factory, modexp::modexp as me, price_plan::StaticPlan,
-        Blake2FPricer, Builtin, Linear, ModexpPricer,
+        ActivateAt, Blake2FPricer, Builtin, Linear, ModexpPricer,
     };
     use cfx_bytes::BytesRef;
     use cfx_types::U256;
     use num::{BigUint, One, Zero};
     use rustc_hex::FromHex;
+
+    const ALWAYS: ActivateAt = ActivateAt::GENESIS;
 
     #[test]
     fn modexp_func() {
@@ -730,7 +752,7 @@ mod tests {
         let f = Builtin {
             price_plan: Box::new(StaticPlan(ModexpPricer::new_byzantium(20))),
             native: builtin_factory("modexp"),
-            activate_at: 0,
+            activate_at: ALWAYS,
         };
 
         // test for potential gas cost multiplication overflow
@@ -855,7 +877,7 @@ mod tests {
         let f = Builtin {
             price_plan: Box::new(StaticPlan(Linear { base: 0, word: 0 })),
             native: builtin_factory("alt_bn128_add"),
-            activate_at: 0,
+            activate_at: ALWAYS,
         };
 
         // zero-points additions
@@ -924,7 +946,7 @@ mod tests {
         let f = Builtin {
             price_plan: Box::new(StaticPlan(Linear { base: 0, word: 0 })),
             native: builtin_factory("alt_bn128_mul"),
-            activate_at: 0,
+            activate_at: ALWAYS,
         };
 
         // zero-point multiplication
@@ -972,7 +994,7 @@ mod tests {
         Builtin {
             price_plan: Box::new(StaticPlan(Linear { base: 0, word: 0 })),
             native: builtin_factory("alt_bn128_pairing"),
-            activate_at: 0,
+            activate_at: ALWAYS,
         }
     }
 
@@ -1057,12 +1079,25 @@ mod tests {
         let b = Builtin {
             price_plan,
             native: builtin_factory("identity"),
-            activate_at: 100_000,
+            activate_at: ActivateAt::ByBlockNumber(100_000),
         };
 
-        assert!(!b.is_active(99_999));
-        assert!(b.is_active(100_000));
-        assert!(b.is_active(100_001));
+        // epoch_height=0: irrelevant for ByBlockNumber variant
+        assert!(!b.is_active(99_999, 0));
+        assert!(b.is_active(100_000, 0));
+        assert!(b.is_active(100_001, 0));
+
+        let price_plan = Box::new(StaticPlan(Linear { base: 10, word: 20 }));
+        let b_height = Builtin {
+            price_plan,
+            native: builtin_factory("identity"),
+            activate_at: ActivateAt::ByEpochHeight(100_000),
+        };
+
+        // block_number is irrelevant for ByEpochHeight variant
+        assert!(!b_height.is_active(u64::MAX, 99_999));
+        assert!(b_height.is_active(0, 100_000));
+        assert!(b_height.is_active(0, 100_001));
     }
 
     #[test]
@@ -1071,7 +1106,7 @@ mod tests {
         let b = Builtin {
             price_plan,
             native: builtin_factory("identity"),
-            activate_at: 1,
+            activate_at: ActivateAt::ByBlockNumber(1),
         };
 
         assert_eq!(b.cost_on_genesis(&[0; 0]), U256::from(10));
@@ -1090,7 +1125,7 @@ mod tests {
         Builtin {
             price_plan: Box::new(StaticPlan(Blake2FPricer::new(123))),
             native: builtin_factory("blake2_f"),
-            activate_at: 0,
+            activate_at: ALWAYS,
         }
     }
 

--- a/crates/execution/executor/src/context.rs
+++ b/crates/execution/executor/src/context.rs
@@ -571,7 +571,11 @@ impl<'a> ContextTrait for Context<'a> {
         if maybe_builtin
             && self
                 .machine
-                .builtin(&address_with_space, self.env.number)
+                .builtin(
+                    &address_with_space,
+                    self.env.number,
+                    self.env.epoch_height,
+                )
                 .is_some()
         {
             return true;

--- a/crates/execution/executor/src/machine/mod.rs
+++ b/crates/execution/executor/src/machine/mod.rs
@@ -7,11 +7,12 @@ mod vm_factory;
 use super::builtin::Builtin;
 use crate::{
     builtin::{
-        build_bls12_builtin_map, builtin_factory, AltBn128PairingPricer,
-        Blake2FPricer, IfPricer, Linear, ModexpPricer, StaticPlan,
+        build_bls12_builtin_map, builtin_factory, ActivateAt,
+        AltBn128PairingPricer, Blake2FPricer, IfPricer, Linear, ModexpPricer,
+        StaticPlan,
     },
     internal_contract::InternalContractMap,
-    spec::CommonParams,
+    spec::{CommonParams, TransitionsBlockNumber, TransitionsEpochHeight},
 };
 use cfx_types::{Address, AddressWithSpace, Space, H256};
 use cfx_vm_types::Spec;
@@ -20,6 +21,32 @@ use std::{collections::BTreeMap, sync::Arc};
 
 pub use vm_factory::VmFactory;
 pub type SpecCreationRules = dyn Fn(&mut Spec, BlockNumber) + Sync + Send;
+
+/// Extension trait for `TransitionsBlockNumber`: produces
+/// `ActivateAt::ByBlockNumber` via a field-selector closure. The closure
+/// type-checks against `&TransitionsBlockNumber`, so passing a field from
+/// `TransitionsEpochHeight` is a compile error.
+trait ActivateByNumbers {
+    fn activate_at(&self, f: impl Fn(&Self) -> u64) -> ActivateAt;
+}
+impl ActivateByNumbers for TransitionsBlockNumber {
+    fn activate_at(&self, f: impl Fn(&Self) -> u64) -> ActivateAt {
+        ActivateAt::ByBlockNumber(f(self))
+    }
+}
+
+/// Extension trait for `TransitionsEpochHeight`: produces
+/// `ActivateAt::ByEpochHeight` via a field-selector closure. The closure
+/// type-checks against `&TransitionsEpochHeight`, so passing a field from
+/// `TransitionsBlockNumber` is a compile error.
+trait ActivateByHeights {
+    fn activate_at(&self, f: impl Fn(&Self) -> u64) -> ActivateAt;
+}
+impl ActivateByHeights for TransitionsEpochHeight {
+    fn activate_at(&self, f: impl Fn(&Self) -> u64) -> ActivateAt {
+        ActivateAt::ByEpochHeight(f(self))
+    }
+}
 
 pub struct Machine {
     params: CommonParams,
@@ -64,13 +91,14 @@ impl Machine {
 
     pub fn builtin(
         &self, address: &AddressWithSpace, block_number: BlockNumber,
+        epoch_height: u64,
     ) -> Option<&Builtin> {
         let builtins = match address.space {
             Space::Native => &self.builtins,
             Space::Ethereum => &self.builtins_evm,
         };
         builtins.get(&address.address).and_then(|b| {
-            if b.is_active(block_number) {
+            if b.is_active(block_number, epoch_height) {
                 Some(b)
             } else {
                 None
@@ -130,7 +158,7 @@ fn new_builtin_map(
                 Space::Native => builtin_factory("ecrecover"),
                 Space::Ethereum => builtin_factory("ecrecover_evm"),
             },
-            0,
+            ActivateAt::GENESIS,
         ),
     );
     btree.insert(
@@ -138,7 +166,7 @@ fn new_builtin_map(
         Builtin::new(
             Box::new(StaticPlan(Linear::new(60, 12))),
             builtin_factory("sha256"),
-            0,
+            ActivateAt::GENESIS,
         ),
     );
     btree.insert(
@@ -146,7 +174,7 @@ fn new_builtin_map(
         Builtin::new(
             Box::new(StaticPlan(Linear::new(600, 120))),
             builtin_factory("ripemd160"),
-            0,
+            ActivateAt::GENESIS,
         ),
     );
     btree.insert(
@@ -154,7 +182,7 @@ fn new_builtin_map(
         Builtin::new(
             Box::new(StaticPlan(Linear::new(15, 3))),
             builtin_factory("identity"),
-            0,
+            ActivateAt::GENESIS,
         ),
     );
 
@@ -169,7 +197,7 @@ fn new_builtin_map(
         Builtin::new(
             Box::new(mod_exp_pricer),
             builtin_factory("modexp"),
-            params.transition_numbers.cip62,
+            params.transition_numbers.activate_at(|t| t.cip62),
         ),
     );
 
@@ -184,7 +212,7 @@ fn new_builtin_map(
         Builtin::new(
             Box::new(bn_add_pricer),
             builtin_factory("alt_bn128_add"),
-            params.transition_numbers.cip62,
+            params.transition_numbers.activate_at(|t| t.cip62),
         ),
     );
 
@@ -199,7 +227,7 @@ fn new_builtin_map(
         Builtin::new(
             Box::new(bn_mul_pricer),
             builtin_factory("alt_bn128_mul"),
-            params.transition_numbers.cip62,
+            params.transition_numbers.activate_at(|t| t.cip62),
         ),
     );
 
@@ -214,7 +242,7 @@ fn new_builtin_map(
         Builtin::new(
             Box::new(bn_pair_pricer),
             builtin_factory("alt_bn128_pairing"),
-            params.transition_numbers.cip62,
+            params.transition_numbers.activate_at(|t| t.cip62),
         ),
     );
     btree.insert(
@@ -222,7 +250,7 @@ fn new_builtin_map(
         Builtin::new(
             Box::new(StaticPlan(Blake2FPricer::new(1))),
             builtin_factory("blake2_f"),
-            params.transition_numbers.cip92,
+            params.transition_numbers.activate_at(|t| t.cip92),
         ),
     );
     btree.insert(
@@ -230,7 +258,7 @@ fn new_builtin_map(
         Builtin::new(
             Box::new(StaticPlan(Linear::new(50000, 0))),
             builtin_factory("kzg_point_eval"),
-            params.transition_numbers.cip144,
+            params.transition_numbers.activate_at(|t| t.cip144),
         ),
     );
     for (address, price_plan, bls12_impl) in build_bls12_builtin_map() {
@@ -239,7 +267,7 @@ fn new_builtin_map(
             Builtin::new(
                 price_plan,
                 bls12_impl,
-                params.transition_heights.eip2537,
+                params.transition_heights.activate_at(|t| t.eip2537),
             ),
         );
     }

--- a/crates/execution/executor/src/stack/executable.rs
+++ b/crates/execution/executor/src/stack/executable.rs
@@ -53,10 +53,11 @@ pub fn make_executable<'a>(
     let internal_contract_map = frame_local.machine.internal_contracts();
 
     // Builtin is located for both Conflux Space and EVM Space.
-    if let Some(builtin) = frame_local
-        .machine
-        .builtin(&code_address, frame_local.env.number)
-    {
+    if let Some(builtin) = frame_local.machine.builtin(
+        &code_address,
+        frame_local.env.number,
+        frame_local.env.epoch_height,
+    ) {
         trace!("CallBuiltin");
         return Box::new(BuiltinExec { builtin, params });
     }


### PR DESCRIPTION
## Background

Conflux's activation mechanism has gone through a gradual migration from *block-number-based* to *epoch-height-based* triggers.

In the early design, precompile and EVM feature activations all used DAG block numbers, mirroring the EVM `number` opcode exposed to contracts. Because smart contracts had no way to query epoch height, block number was the only on-chain signal available to them for detecting spec changes. Only consensus-layer features (which are invisible to contracts) used epoch heights.

Two developments shifted this design:

1. **eSpace became the primary execution environment.** With eSpace, a single block corresponds to an epoch in core space, which contains multiple DAG blocks; activating by block number means eSpace can change behaviour mid-epoch, which is semantically wrong for an EVM-compatible space.
2. **Core space gained epoch-height introspection** via the `ConfluxContext` internal contract, removing the original constraint that contracts could only observe block numbers.

As a result, newer features activate by epoch height. CIP-133 (Enhanced Block Hash Query) is the most illustrative case: it distinguishes core space (`cip133b`, block-number-triggered) from eSpace (`cip133e`, epoch-height-triggered). Going forward, all EVM-layer activations are expected to migrate to epoch height.

## The Bug (EIP-2537)

`eip2537` is declared in `TransitionsEpochHeight` — an epoch height value. However, before this fix, `Builtin::activate_at` was a plain `u64`, and `is_active` compared it against `env.number` (the DAG block number) regardless of what the stored value represented.

Because DAG block numbers grow approximately 2× faster than epoch heights, the BLS12-381 precompiles activated roughly 2× earlier than configured, meaning they would be available at an epoch that is far below the intended threshold.

## Fix

### Commit 1 — `fix(executor): correct BLS12-381 precompile activation to use epoch height`

**`ActivateAt` enum** (`builtin/mod.rs`)

Replace the bare `u64` field with a typed enum:

```rust
pub enum ActivateAt {
    ByBlockNumber(u64),
    ByEpochHeight(u64),
}
```

`is_active` now takes both `block_number` and `epoch_height` and dispatches on the variant, so the correct counter is always used.

**Extension traits** (`machine/mod.rs`)

Two private traits, `ActivateByNumbers` and `ActivateByHeights`, are implemented on `TransitionsBlockNumber` and `TransitionsEpochHeight` respectively. Each exposes an `activate_at(f)` method that accepts a field-selector closure typed against the concrete struct:

```rust
// OK — eip2537 exists in TransitionsEpochHeight
params.transition_heights.activate_at(|t| t.eip2537)

// Compile error — eip2537 does not exist in TransitionsBlockNumber
params.transition_numbers.activate_at(|t| t.eip2537)
```

This makes the category of bug impossible to reintroduce silently.

**Callsites** (`context.rs`, `stack/executable.rs`)

`Machine::builtin` now receives both `block_number` and `epoch_height`, both sourced from `env`, so the correct value reaches each `Builtin`.

### Commit 2 — ~~`fix: harden dev-support scripts and consensus_bench workspace isolation`~~

~~Four small fixes uncovered while running `test.sh` end-to-end in a worktree:~~

Removed, the first 2 issues have been resolved by PR #3442 , the CXXFLAGS issue have been resolved by PR #3441, the others is to be resolved by PR #3443. 

| File | Change |
|------|--------|
| `activate_new_venv.sh` | Guard `uv venv` with `[ ! -d .venv ]` so repeated runs do not recreate the virtualenv |
| `dep_pip3.sh` | Skip `pip install uv` when `uv` is already on `PATH`, avoiding PEP 668 errors on system Python |
| `test.sh` | Add `CXXFLAGS=-Wno-error=array-bounds` to suppress a C++ build failure on newer GCC; fix symlink bug: `rm -f target` silently fails when `target/` is a real directory, causing `ln -s build target` to create a dangling link inside the directory — changed to `rm -rf target` |
| `tools/consensus_bench/Cargo.toml` | Add `[workspace]` to make it a standalone workspace root, preventing Cargo from resolving upward to the parent repository's workspace when the worktree is nested inside it |

## Test Plan

Before merging the current branch into the production environment, restart tests must be conducted on both the mainnet and testnet! This is because the activation time of the relevant feature has actually been moved forward (earlier than originally planned). We want to verify that no calls were made to the relevant code paths during the period between the actual activation time and the originally expected activation time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3426)
<!-- Reviewable:end -->

Closes #3375