### PR TITLE
Update lz4-sys to fix CVE-2021-3520

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5785,7 +5785,7 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=b84f1c0f549059602c1d51d87d2c1b01e931e5fd#b84f1c0f549059602c1d51d87d2c1b01e931e5fd"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=d0cd089bc092ec77b65a5262d453848f57abe3c3#d0cd089bc092ec77b65a5262d453848f57abe3c3"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -5802,7 +5802,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=b84f1c0f549059602c1d51d87d2c1b01e931e5fd#b84f1c0f549059602c1d51d87d2c1b01e931e5fd"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=d0cd089bc092ec77b65a5262d453848f57abe3c3#d0cd089bc092ec77b65a5262d453848f57abe3c3"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -5967,8 +5967,9 @@ checksum = "ab44e08e5b5110188be64dc8f0865635206ad7386fe672903bef195df3cc8960"
 
 [[package]]
 name = "lz4-sys"
-version = "1.8.3"
-source = "git+https://github.com/busyjay/lz4-rs.git?branch=adjust-build#5a8afe4010c67899fc7af876a58d67fd6269bf81"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
 dependencies = [
  "cc",
  "libc",
@@ -8139,7 +8140,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=b84f1c0f549059602c1d51d87d2c1b01e931e5fd#b84f1c0f549059602c1d51d87d2c1b01e931e5fd"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=d0cd089bc092ec77b65a5262d453848f57abe3c3#d0cd089bc092ec77b65a5262d453848f57abe3c3"
 dependencies = [
  "libc",
  "librocksdb_sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -468,7 +468,7 @@ sqlite3-sys = "0.12"
 kvdb = "0.13"
 influx_db_client = "0.5.1"
 # conflux forked crates
-rocksdb = { git = "https://github.com/Conflux-Chain/rust-rocksdb.git", rev = "b84f1c0f549059602c1d51d87d2c1b01e931e5fd" }
+rocksdb = { git = "https://github.com/Conflux-Chain/rust-rocksdb.git", rev = "d0cd089bc092ec77b65a5262d453848f57abe3c3" }
 
 [patch.crates-io]
 # use a forked version to fix a vulnerability(introduced by failure) in vrf-rs, can be removed after the upstream is fixed

--- a/deny.toml
+++ b/deny.toml
@@ -277,8 +277,6 @@ allow-git = [
     "https://github.com/paritytech/rust-secp256k1.git",
     "https://github.com/paritytech/rust-ctrlc.git",
 
-    # librocksdb_sys -> lz4-sys
-    "https://github.com/busyjay/lz4-rs.git?branch=adjust-build",
     # librocksdb_sys -> snappy-sys
     "https://github.com/busyjay/rust-snappy.git?branch=static-link",
 

--- a/tools/consensus_bench/Cargo.lock
+++ b/tools/consensus_bench/Cargo.lock
@@ -4410,7 +4410,7 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=b84f1c0f549059602c1d51d87d2c1b01e931e5fd#b84f1c0f549059602c1d51d87d2c1b01e931e5fd"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=d0cd089bc092ec77b65a5262d453848f57abe3c3#d0cd089bc092ec77b65a5262d453848f57abe3c3"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -4427,7 +4427,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=b84f1c0f549059602c1d51d87d2c1b01e931e5fd#b84f1c0f549059602c1d51d87d2c1b01e931e5fd"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=d0cd089bc092ec77b65a5262d453848f57abe3c3#d0cd089bc092ec77b65a5262d453848f57abe3c3"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -4560,8 +4560,9 @@ checksum = "ab44e08e5b5110188be64dc8f0865635206ad7386fe672903bef195df3cc8960"
 
 [[package]]
 name = "lz4-sys"
-version = "1.8.3"
-source = "git+https://github.com/busyjay/lz4-rs.git?branch=adjust-build#5a8afe4010c67899fc7af876a58d67fd6269bf81"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
 dependencies = [
  "cc",
  "libc",
@@ -6220,7 +6221,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=b84f1c0f549059602c1d51d87d2c1b01e931e5fd#b84f1c0f549059602c1d51d87d2c1b01e931e5fd"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=d0cd089bc092ec77b65a5262d453848f57abe3c3#d0cd089bc092ec77b65a5262d453848f57abe3c3"
 dependencies = [
  "libc",
  "librocksdb_sys",

--- a/tools/evm-spec-tester/Cargo.lock
+++ b/tools/evm-spec-tester/Cargo.lock
@@ -4984,7 +4984,7 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=b84f1c0f549059602c1d51d87d2c1b01e931e5fd#b84f1c0f549059602c1d51d87d2c1b01e931e5fd"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=d0cd089bc092ec77b65a5262d453848f57abe3c3#d0cd089bc092ec77b65a5262d453848f57abe3c3"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -5001,7 +5001,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=b84f1c0f549059602c1d51d87d2c1b01e931e5fd#b84f1c0f549059602c1d51d87d2c1b01e931e5fd"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=d0cd089bc092ec77b65a5262d453848f57abe3c3#d0cd089bc092ec77b65a5262d453848f57abe3c3"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -5134,8 +5134,9 @@ checksum = "ab44e08e5b5110188be64dc8f0865635206ad7386fe672903bef195df3cc8960"
 
 [[package]]
 name = "lz4-sys"
-version = "1.8.3"
-source = "git+https://github.com/busyjay/lz4-rs.git?branch=adjust-build#5a8afe4010c67899fc7af876a58d67fd6269bf81"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
 dependencies = [
  "cc",
  "libc",
@@ -6845,7 +6846,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=b84f1c0f549059602c1d51d87d2c1b01e931e5fd#b84f1c0f549059602c1d51d87d2c1b01e931e5fd"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=d0cd089bc092ec77b65a5262d453848f57abe3c3#d0cd089bc092ec77b65a5262d453848f57abe3c3"
 dependencies = [
  "libc",
  "librocksdb_sys",


### PR DESCRIPTION
## Summary

- Update rust-rocksdb rev to use crates.io `lz4-sys` 1.11 instead of the `busyjay/lz4-rs` fork (1.8.3)
- The fork was created in 2017 to add header copying and `cargo:root` output for RocksDB integration — upstream `lz4-sys` now includes this natively
- Remove the busyjay/lz4-rs allow-git entry from `deny.toml`

Fixes https://github.com/Conflux-Chain/conflux-rust/security/dependabot/160 (GHSA-9q5j-jm53-v7vr)

## Test plan

- [x] Verified lz4 compression format is backward-compatible (no data migration needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3430)
<!-- Reviewable:end -->
