### PR TITLE
fix: the issue where phantom tx trace recover fails when cip90 is not effective

### DIFF
--- a/crates/cfxcore/core/src/consensus/consensus_graph/rpc_api/phantom_block_provider.rs
+++ b/crates/cfxcore/core/src/consensus/consensus_graph/rpc_api/phantom_block_provider.rs
@@ -249,6 +249,23 @@ impl ConsensusGraph {
                             continue;
                         }
 
+                        // if cip90 is not enabled, there will be no phantom
+                        // txs, so we can skip the recovery process
+                        let block_number = self
+                            .get_block_number(&b.hash())?
+                            .ok_or(
+                            "block_number not found when recover phantom block",
+                        )?;
+                        let epoch_number = pivot.block_header.height();
+                        let spec = self.params.spec(block_number, epoch_number);
+
+                        let cip90_enabled = epoch_number
+                            >= self.params.transition_heights.cip90a;
+
+                        if !(cip90_enabled && spec.cip90) {
+                            continue;
+                        }
+
                         let (phantom_txs, _) = build_bloom_and_recover_phantom(
                             &block_receipts[id].logs[..],
                             tx.hash(),

--- a/crates/cfxcore/core/src/consensus/consensus_graph/rpc_api/phantom_block_provider.rs
+++ b/crates/cfxcore/core/src/consensus/consensus_graph/rpc_api/phantom_block_provider.rs
@@ -206,6 +206,12 @@ impl ConsensusGraph {
 
             let evm_chain_id = self.best_chain_id().in_evm_space();
 
+            let block_number = self
+                .get_block_number(&b.hash())?
+                .ok_or("block_number not found when recover phantom block")?;
+            let epoch_number = pivot.block_header.height();
+            let spec = self.params.spec(block_number, epoch_number);
+
             for (id, tx) in b.transactions.iter().enumerate() {
                 match tx.space() {
                     Space::Ethereum => {
@@ -251,18 +257,7 @@ impl ConsensusGraph {
 
                         // if cip90 is not enabled, there will be no phantom
                         // txs, so we can skip the recovery process
-                        let block_number = self
-                            .get_block_number(&b.hash())?
-                            .ok_or(
-                            "block_number not found when recover phantom block",
-                        )?;
-                        let epoch_number = pivot.block_header.height();
-                        let spec = self.params.spec(block_number, epoch_number);
-
-                        let cip90_enabled = epoch_number
-                            >= self.params.transition_heights.cip90a;
-
-                        if !(cip90_enabled && spec.cip90) {
+                        if !spec.cip90 {
                             continue;
                         }
 


### PR DESCRIPTION
If cip90 is not effective, but the cross space internal contract is called, this transaction will be successfully executed, but it is essentially a regular transfer. Therefore, performing a phantom trace recover operation on this transaction will fail.

Therefore, an additional check for whether cip90 is effective is added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3431)
<!-- Reviewable:end -->
