### PR TITLE
fix(network): add simultaneous-dial tie-breaking in SessionManager

### DIFF
--- a/crates/network/src/service.rs
+++ b/crates/network/src/service.rs
@@ -1114,11 +1114,13 @@ impl NetworkServiceInner {
         }
 
         if let Some(token_to_disconnect) = token_to_disconnect {
+            // Sim-dial dedup, not a peer failure — `op = None`, no
+            // note_failure.
             self.kill_connection_by_token(
                 token_to_disconnect.0,
                 io,
                 true,
-                Some(UpdateNodeOperation::Failure),
+                None,
                 token_to_disconnect.1.as_str(), // reason
             );
         }

--- a/crates/network/src/service.rs
+++ b/crates/network/src/service.rs
@@ -1241,6 +1241,11 @@ impl NetworkServiceInner {
             if let Some(session) = self.sessions.get(token) {
                 let mut sess = session.write();
                 if !sess.expired() {
+                    // Removed before the disconnect packets (not just before
+                    // `set_expired`) to minimize the stale-entry window.
+                    if let Some(id) = sess.id() {
+                        self.sessions.remove_node_id_entry(id, token);
+                    }
                     if sess.is_ready() {
                         for (p, _) in self.handlers.read().iter() {
                             if sess.have_capability(*p) {
@@ -1314,6 +1319,9 @@ impl NetworkServiceInner {
         if let Some(session) = self.sessions.get_by_id(node_id) {
             let mut sess = session.write();
             if !sess.expired() {
+                // Removed before the disconnect packets (not just before
+                // `set_expired`) to minimize the stale-entry window.
+                self.sessions.remove_node_id_entry(node_id, sess.token());
                 if sess.is_ready() {
                     for (p, _) in self.handlers.read().iter() {
                         if sess.have_capability(*p) {

--- a/crates/network/src/service.rs
+++ b/crates/network/src/service.rs
@@ -596,6 +596,7 @@ impl NetworkServiceInner {
         };
 
         let nodes_path = config.config_path.clone();
+        let own_node_id = *keys.public();
 
         let mut inner = NetworkServiceInner {
             metadata: HostMetadata {
@@ -616,6 +617,7 @@ impl NetworkServiceInner {
                 FIRST_SESSION,
                 MAX_SESSIONS,
                 config.max_incoming_peers,
+                own_node_id,
                 &config.session_ip_limit_config,
                 Some(pos_pub_keys),
             ),

--- a/crates/network/src/session.rs
+++ b/crates/network/src/session.rs
@@ -27,6 +27,7 @@ use std::{
     fmt,
     net::SocketAddr,
     str,
+    sync::{Arc, OnceLock},
     time::{Duration, Instant},
 };
 
@@ -51,8 +52,10 @@ pub struct Session {
     sent_hello: Instant,
     /// Session ready flag that set after successful Hello packet received.
     had_hello: Option<Instant>,
-    /// Session is no longer active flag.
-    expired: Option<Instant>,
+    /// Set once when a kill path expires the session. `Arc<OnceLock>` so a
+    /// clone can live in `node_id_index` (see `IndexEntry`). The `Instant` is
+    /// diagnostic only — query liveness via `expired()`.
+    expired: Arc<OnceLock<Instant>>,
 
     // statistics for read/write
     last_read: Instant,
@@ -127,7 +130,7 @@ impl Session {
             state: State::Handshake(MovableWrapper::new(handshake)),
             sent_hello: Instant::now(),
             had_hello: None,
-            expired: None,
+            expired: Arc::new(OnceLock::new()),
             last_read: Instant::now(),
             last_write: (Instant::now(), WriteStatus::Complete),
             pos_public_key,
@@ -148,9 +151,18 @@ impl Session {
 
     pub fn is_ready(&self) -> bool { self.had_hello.is_some() }
 
-    pub fn expired(&self) -> bool { self.expired.is_some() }
+    pub fn expired(&self) -> bool { self.expired.get().is_some() }
 
-    pub fn set_expired(&mut self) { self.expired = Some(Instant::now()); }
+    /// Clone of the expired cell, for `SessionManager` to store in
+    /// `IndexEntry`.
+    pub fn expired_handle(&self) -> Arc<OnceLock<Instant>> {
+        self.expired.clone()
+    }
+
+    pub fn set_expired(&mut self) {
+        // Already-expired re-kills are benign: the first expiration wins.
+        let _ = self.expired.set(Instant::now());
+    }
 
     pub fn done(&self) -> bool {
         self.expired() && !self.connection().is_sending()
@@ -363,7 +375,7 @@ impl Session {
 
         let result = host
             .sessions
-            .update_ingress_node_id(token, &node_id)
+            .update_ingress_node_id(token, &node_id, self.expired.clone())
             .map_err(|reason| {
                 debug!(
                     "failed to update node id of ingress session, reason = {:?}, session = {:?}",
@@ -654,7 +666,7 @@ impl Session {
             node_id: self.metadata.id,
             address: self.address,
             connection: self.connection().details(),
-            status: if let Some(time) = self.expired {
+            status: if let Some(time) = self.expired.get() {
                 format!("expired ({:?})", time.elapsed())
             } else if let Some(time) = self.had_hello {
                 format!("communicating ({:?})", time.elapsed())
@@ -676,7 +688,7 @@ impl Session {
     /// heartbeat mechanism to exchange peer status. As a result, Inactive
     /// sessions (e.g. network issue) will be disconnected timely.
     pub fn check_timeout(&self) -> (bool, Option<UpdateNodeOperation>) {
-        if let Some(time) = self.expired {
+        if let Some(time) = self.expired.get() {
             // should disconnected timely once expired
             if time.elapsed() > Duration::from_secs(5) {
                 return (true, None);
@@ -695,7 +707,7 @@ impl Session {
 impl fmt::Debug for Session {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Session {{ token: {}, id: {:?}, originated: {}, address: {:?}, had_hello: {}, expired: {} }}",
-               self.token(), self.id(), self.metadata.originated, self.address, self.had_hello.is_some(), self.expired.is_some())
+               self.token(), self.id(), self.metadata.originated, self.address, self.had_hello.is_some(), self.expired())
     }
 }
 

--- a/crates/network/src/session.rs
+++ b/crates/network/src/session.rs
@@ -304,14 +304,6 @@ impl Session {
                 // For ingress session, update the node id in `SessionManager`
                 let token_to_disconnect = self.update_ingress_node_id(host)?;
 
-                let token_to_disconnect = match token_to_disconnect {
-                    Some(token) => Some((
-                        token,
-                        String::from("Remove old session from the same node"),
-                    )),
-                    None => None,
-                };
-
                 // Handle Hello packet to exchange protocols
                 let rlp = Rlp::new(&packet.data);
                 let pos_public_key = self.read_hello(&rlp, host)?;
@@ -348,10 +340,16 @@ impl Session {
         }
     }
 
-    /// Update node Id in `SessionManager` for ingress session.
+    /// Update node Id in `SessionManager` for ingress session and apply
+    /// the network-layer simultaneous-dial tie-breaker. Returns the
+    /// optional `(token, reason)` pair the caller should pass to
+    /// `kill_connection_by_token`, or `None` if no kill is needed. If
+    /// the tie-breaker decides this new ingress should lose, this
+    /// function sends a DISCONNECT to the remote and returns `Err` —
+    /// the caller's existing error path then kills our own session.
     fn update_ingress_node_id(
         &mut self, host: &NetworkServiceInner,
-    ) -> Result<Option<usize>, Error> {
+    ) -> Result<Option<(usize, String)>, Error> {
         // ignore egress session
         if self.metadata.originated {
             return Ok(None);
@@ -363,15 +361,39 @@ impl Session {
             .id
             .expect("should have node id after handshake");
 
-        host.sessions.update_ingress_node_id(token, &node_id)
+        let result = host
+            .sessions
+            .update_ingress_node_id(token, &node_id)
             .map_err(|reason| {
                 debug!(
                     "failed to update node id of ingress session, reason = {:?}, session = {:?}",
                     reason, self
                 );
-
                 self.send_disconnect(DisconnectReason::UpdateNodeIdFailed)
-            })
+            })?;
+
+        match result {
+            crate::session_manager::UpdateIngressResult::Inserted => Ok(None),
+            crate::session_manager::UpdateIngressResult::Replaced(old) => {
+                Ok(Some((
+                    old,
+                    String::from("Remove old session from the same node"),
+                )))
+            }
+            crate::session_manager::UpdateIngressResult::DropNew => {
+                // Lost the simultaneous-dial tie-breaker. Send a
+                // DISCONNECT to the remote and propagate as Err so the
+                // caller (`session_readable`) kills our own session via
+                // its standard error path.
+                debug!(
+                    "lost simultaneous-dial tie-break, dropping new ingress session = {:?}",
+                    self
+                );
+                Err(self.send_disconnect(DisconnectReason::Custom(
+                    "simultaneous dial: drop new connection".into(),
+                )))
+            }
+        }
     }
 
     /// Read Hello packet to exchange the supported protocols, and set the

--- a/crates/network/src/session.rs
+++ b/crates/network/src/session.rs
@@ -316,6 +316,17 @@ impl Session {
                 // For ingress session, update the node id in `SessionManager`
                 let token_to_disconnect = self.update_ingress_node_id(host)?;
 
+                // Dropped by the tie-break: stop before `Ready` so the loser
+                // never reaches `on_peer_connected`; the caller kills it.
+                if token_to_disconnect.as_ref().map(|(t, _)| *t)
+                    == Some(self.token())
+                {
+                    return Ok(SessionDataWithDisconnectInfo {
+                        session_data: SessionData::None,
+                        token_to_disconnect,
+                    });
+                }
+
                 // Handle Hello packet to exchange protocols
                 let rlp = Rlp::new(&packet.data);
                 let pos_public_key = self.read_hello(&rlp, host)?;
@@ -352,13 +363,9 @@ impl Session {
         }
     }
 
-    /// Update node Id in `SessionManager` for ingress session and apply
-    /// the network-layer simultaneous-dial tie-breaker. Returns the
-    /// optional `(token, reason)` pair the caller should pass to
-    /// `kill_connection_by_token`, or `None` if no kill is needed. If
-    /// the tie-breaker decides this new ingress should lose, this
-    /// function sends a DISCONNECT to the remote and returns `Err` —
-    /// the caller's existing error path then kills our own session.
+    /// Apply the simultaneous-dial tie-breaker for this ingress. Returns the
+    /// `(token, reason)` to kill — the old session if this ingress wins, our
+    /// own token if it loses — or `None` if no kill is needed.
     fn update_ingress_node_id(
         &mut self, host: &NetworkServiceInner,
     ) -> Result<Option<(usize, String)>, Error> {
@@ -393,16 +400,18 @@ impl Session {
                 )))
             }
             crate::session_manager::UpdateIngressResult::DropNew => {
-                // Lost the simultaneous-dial tie-breaker. Send a
-                // DISCONNECT to the remote and propagate as Err so the
-                // caller (`session_readable`) kills our own session via
-                // its standard error path.
+                // Lost the tie-break: tell the remote, then return our own
+                // token so the caller kills us via the non-failure path.
                 debug!(
                     "lost simultaneous-dial tie-break, dropping new ingress session = {:?}",
                     self
                 );
-                Err(self.send_disconnect(DisconnectReason::Custom(
+                let _ = self.send_disconnect(DisconnectReason::Custom(
                     "simultaneous dial: drop new connection".into(),
+                ));
+                Ok(Some((
+                    token,
+                    String::from("simultaneous dial: drop new connection"),
                 )))
             }
         }

--- a/crates/network/src/session.rs
+++ b/crates/network/src/session.rs
@@ -27,7 +27,6 @@ use std::{
     fmt,
     net::SocketAddr,
     str,
-    sync::{Arc, OnceLock},
     time::{Duration, Instant},
 };
 
@@ -52,10 +51,8 @@ pub struct Session {
     sent_hello: Instant,
     /// Session ready flag that set after successful Hello packet received.
     had_hello: Option<Instant>,
-    /// Set once when a kill path expires the session. `Arc<OnceLock>` so a
-    /// clone can live in `node_id_index` (see `IndexEntry`). The `Instant` is
-    /// diagnostic only — query liveness via `expired()`.
-    expired: Arc<OnceLock<Instant>>,
+    /// Set once when a kill path expires the session.
+    expired: Option<Instant>,
 
     // statistics for read/write
     last_read: Instant,
@@ -130,7 +127,7 @@ impl Session {
             state: State::Handshake(MovableWrapper::new(handshake)),
             sent_hello: Instant::now(),
             had_hello: None,
-            expired: Arc::new(OnceLock::new()),
+            expired: None,
             last_read: Instant::now(),
             last_write: (Instant::now(), WriteStatus::Complete),
             pos_public_key,
@@ -151,18 +148,9 @@ impl Session {
 
     pub fn is_ready(&self) -> bool { self.had_hello.is_some() }
 
-    pub fn expired(&self) -> bool { self.expired.get().is_some() }
+    pub fn expired(&self) -> bool { self.expired.is_some() }
 
-    /// Clone of the expired cell, for `SessionManager` to store in
-    /// `IndexEntry`.
-    pub fn expired_handle(&self) -> Arc<OnceLock<Instant>> {
-        self.expired.clone()
-    }
-
-    pub fn set_expired(&mut self) {
-        // Already-expired re-kills are benign: the first expiration wins.
-        let _ = self.expired.set(Instant::now());
-    }
+    pub fn set_expired(&mut self) { self.expired = Some(Instant::now()); }
 
     pub fn done(&self) -> bool {
         self.expired() && !self.connection().is_sending()
@@ -382,7 +370,7 @@ impl Session {
 
         let result = host
             .sessions
-            .update_ingress_node_id(token, &node_id, self.expired.clone())
+            .update_ingress_node_id(token, &node_id)
             .map_err(|reason| {
                 debug!(
                     "failed to update node id of ingress session, reason = {:?}, session = {:?}",
@@ -675,7 +663,7 @@ impl Session {
             node_id: self.metadata.id,
             address: self.address,
             connection: self.connection().details(),
-            status: if let Some(time) = self.expired.get() {
+            status: if let Some(time) = self.expired {
                 format!("expired ({:?})", time.elapsed())
             } else if let Some(time) = self.had_hello {
                 format!("communicating ({:?})", time.elapsed())
@@ -697,7 +685,7 @@ impl Session {
     /// heartbeat mechanism to exchange peer status. As a result, Inactive
     /// sessions (e.g. network issue) will be disconnected timely.
     pub fn check_timeout(&self) -> (bool, Option<UpdateNodeOperation>) {
-        if let Some(time) = self.expired.get() {
+        if let Some(time) = self.expired {
             // should disconnected timely once expired
             if time.elapsed() > Duration::from_secs(5) {
                 return (true, None);

--- a/crates/network/src/session_manager.rs
+++ b/crates/network/src/session_manager.rs
@@ -24,6 +24,63 @@ use std::{
     },
 };
 
+/// An entry in `SessionManager::node_id_index`. Tracks both the slab token
+/// of the session and whether that session is the local node's own outbound
+/// (`originated = true`) or an inbound from the remote (`originated = false`).
+///
+/// We store `originated` here — alongside the token — so that the
+/// simultaneous-dial tie-breaker in `update_ingress_node_id` can read it
+/// without acquiring the per-session `RwLock<Session>`. Acquiring that lock
+/// while holding `node_id_index.write()` would deadlock with any other
+/// thread that holds `Session::write()` and is itself trying to call
+/// `update_ingress_node_id` (which is a common case in the simultaneous-dial
+/// scenario the tie-breaker exists to fix).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct IndexEntry {
+    pub token: usize,
+    /// `true` if this session is our outbound to the remote (egress);
+    /// `false` if it is the remote's outbound to us (ingress).
+    pub originated: bool,
+}
+
+/// Outcome of `SessionManager::update_ingress_node_id`.
+#[derive(Debug)]
+pub enum UpdateIngressResult {
+    Inserted,
+    /// Caller should disconnect the old token.
+    Replaced(usize),
+    /// Caller should disconnect the new ingress it was about to
+    /// register — the existing entry won the simultaneous-dial tie-break.
+    DropNew,
+}
+
+/// Outcome of the simultaneous-dial tie-breaker for a (existing, new-ingress)
+/// pair sharing the same remote `NodeId`.
+#[derive(Debug, PartialEq, Eq)]
+pub enum SimDialOutcome {
+    KeepNew,
+    KeepExisting,
+}
+
+/// Deterministically resolve a simultaneous dial: keep the connection where
+/// the higher-`NodeId` peer is the dialer. Both sides compute the same
+/// comparison over the same two `NodeId`s and converge on the same surviving
+/// TCP connection.
+pub fn simultaneous_dial_outcome(
+    own_node_id: &NodeId, remote_node_id: &NodeId, existing_originated: bool,
+) -> SimDialOutcome {
+    if !existing_originated {
+        // Existing is also an ingress (an older inbound from the same peer):
+        // the fresher inbound replaces it.
+        return SimDialOutcome::KeepNew;
+    }
+    if own_node_id < remote_node_id {
+        SimDialOutcome::KeepNew
+    } else {
+        SimDialOutcome::KeepExisting
+    }
+}
+
 /// Session manager maintains all ingress and egress TCP connections in thread
 /// safe manner.
 ///
@@ -46,8 +103,15 @@ pub struct SessionManager {
     max_ingress_sessions: usize,
     cur_ingress_sessions: AtomicUsize,
 
-    /// session indices
-    node_id_index: RwLock<HashMap<NodeId, usize>>,
+    /// The local node's NodeId, used by `update_ingress_node_id` to
+    /// compute the simultaneous-dial tie-break.
+    own_node_id: NodeId,
+
+    /// session indices. Each entry stores the slab token plus whether
+    /// that session is egress (`originated = true`) or ingress
+    /// (`originated = false`); the latter is consulted by the
+    /// simultaneous-dial tie-breaker in `update_ingress_node_id`.
+    node_id_index: RwLock<HashMap<NodeId, IndexEntry>>,
     ip_limit: RwLock<Box<dyn SessionIpLimit>>,
     tag_index: RwLock<SessionTagIndex>,
     /// pos public key
@@ -59,7 +123,7 @@ impl SessionManager {
     /// Create a new instance.
     pub fn new(
         offset: usize, capacity: usize, max_ingress_sessions: usize,
-        ip_limit_config: &SessionIpLimitConfig,
+        own_node_id: NodeId, ip_limit_config: &SessionIpLimitConfig,
         self_pos_public_key: Option<(
             ConsensusPublicKey,
             ConsensusVRFPublicKey,
@@ -71,6 +135,7 @@ impl SessionManager {
             capacity,
             max_ingress_sessions,
             cur_ingress_sessions: AtomicUsize::new(0),
+            own_node_id,
             node_id_index: RwLock::new(HashMap::new()),
             ip_limit: RwLock::new(new_session_ip_limit(ip_limit_config)),
             tag_index: Default::default(),
@@ -89,8 +154,8 @@ impl SessionManager {
     /// Get the session of specified node id.
     pub fn get_by_id(&self, node_id: &NodeId) -> Option<Arc<RwLock<Session>>> {
         let sessions = self.sessions.read();
-        let idx = *self.node_id_index.read().get(node_id)?;
-        sessions.get(idx).cloned()
+        let entry = *self.node_id_index.read().get(node_id)?;
+        sessions.get(entry.token).cloned()
     }
 
     /// Get all the sessions in `SessionManager`.
@@ -142,7 +207,7 @@ impl SessionManager {
 
     /// Get the session index by node id.
     pub fn get_index_by_id(&self, id: &NodeId) -> Option<usize> {
-        self.node_id_index.read().get(id).cloned()
+        self.node_id_index.read().get(id).map(|entry| entry.token)
     }
 
     /// Check if the specified IP address is allowed to create a new session.
@@ -225,7 +290,14 @@ impl SessionManager {
 
         // update on creation succeeded
         if let Some(node_id) = id {
-            node_id_index.insert(node_id.clone(), index);
+            // egress: id is Some at construction
+            node_id_index.insert(
+                node_id.clone(),
+                IndexEntry {
+                    token: index,
+                    originated: true,
+                },
+            );
         }
 
         assert!(ip_limit.add(ip));
@@ -250,8 +322,8 @@ impl SessionManager {
             sessions.remove(session.token());
             if let Some(node_id) = session.id() {
                 let mut node_id_index = self.node_id_index.write();
-                if let Some(token) = node_id_index.get(node_id) {
-                    if *token == session.token() {
+                if let Some(entry) = node_id_index.get(node_id) {
+                    if entry.token == session.token() {
                         node_id_index.remove(node_id);
                     }
                 }
@@ -271,15 +343,23 @@ impl SessionManager {
         debug!("SessionManager.remove: leave");
     }
 
-    /// Update the node id index for ingress session.
-    /// Return error if the session index does not exist, or the node id already
-    /// in use by other session.
-    /// Return optional to-be-disconnected token if no error happens.
+    /// Update the node id index for an ingress session whose HELLO has
+    /// just been processed and the remote `node_id` is now known.
+    ///
+    /// Returns:
+    /// - `Err(_)` if the session at `idx` is no longer in the slab (the session
+    ///   was killed concurrently — caller should drop the new ingress).
+    /// - `Ok(Inserted)` — no prior entry for this `node_id`; the new ingress is
+    ///   now in the index.
+    /// - `Ok(Replaced(old_token))` — there was a prior entry; it has been
+    ///   replaced. Caller should disconnect `old_token`.
+    /// - `Ok(DropNew)` — there was a prior entry that won the simultaneous-dial
+    ///   tie-break; the index is unchanged. Caller should disconnect the new
+    ///   ingress (`idx`) it was about to register.
     pub fn update_ingress_node_id(
         &self, idx: usize, node_id: &NodeId,
-    ) -> Result<Option<usize>, String> {
+    ) -> Result<UpdateIngressResult, String> {
         debug!("SessionManager.update_ingress_node_id: enter");
-        let mut token_to_disconnect = None;
 
         let sessions = self.sessions.read();
         let mut node_id_index = self.node_id_index.write();
@@ -293,21 +373,42 @@ impl SessionManager {
             ));
         }
 
-        // ensure the node id is unique
-        if let Some(cur_idx) = node_id_index.get(node_id) {
-            debug!("SessionManager.update_ingress_node_id: leave on node_id already exists");
-            if *cur_idx != idx {
-                token_to_disconnect = Some(*cur_idx);
-            } else {
+        if let Some(existing) = node_id_index.get(node_id).copied() {
+            if existing.token == idx {
                 panic!("The same token already exists for the same node!!!");
             }
+            match simultaneous_dial_outcome(
+                &self.own_node_id,
+                node_id,
+                existing.originated,
+            ) {
+                SimDialOutcome::KeepNew => {
+                    node_id_index.insert(
+                        node_id.clone(),
+                        IndexEntry {
+                            token: idx,
+                            originated: false,
+                        },
+                    );
+                    debug!("SessionManager.update_ingress_node_id: leave (replaced)");
+                    Ok(UpdateIngressResult::Replaced(existing.token))
+                }
+                SimDialOutcome::KeepExisting => {
+                    debug!("SessionManager.update_ingress_node_id: leave (drop new — tie-break lost)");
+                    Ok(UpdateIngressResult::DropNew)
+                }
+            }
+        } else {
+            node_id_index.insert(
+                node_id.clone(),
+                IndexEntry {
+                    token: idx,
+                    originated: false,
+                },
+            );
+            debug!("SessionManager.update_ingress_node_id: leave (inserted)");
+            Ok(UpdateIngressResult::Inserted)
         }
-
-        node_id_index.insert(node_id.clone(), idx);
-
-        debug!("SessionManager.update_ingress_node_id: leave");
-
-        Ok(token_to_disconnect)
     }
 }
 
@@ -390,7 +491,38 @@ impl SessionTagIndex {
 
 #[cfg(test)]
 mod tests {
-    use crate::session_manager::SessionTagIndex;
+    use crate::{
+        node_table::NodeId,
+        session_manager::{
+            simultaneous_dial_outcome, SessionTagIndex, SimDialOutcome,
+        },
+    };
+
+    #[test]
+    fn simdial_two_nodes_converge_on_one_connection() {
+        // Both sides of a simultaneous dial compute the same comparison
+        // over the same two NodeIds and must converge on the same
+        // surviving TCP connection — exactly one side keeps its existing
+        // egress, the other side drops its own and accepts the new
+        // ingress. Run both views of the same (A, B) pair and assert the
+        // XOR property.
+        let a = NodeId::from_low_u64_be(1);
+        let b = NodeId::from_low_u64_be(2);
+
+        // A's view: existing = A's egress to B (originated=true)
+        let a_outcome = simultaneous_dial_outcome(&a, &b, true);
+        // B's view: existing = B's egress to A (originated=true)
+        let b_outcome = simultaneous_dial_outcome(&b, &a, true);
+
+        let a_keeps = matches!(a_outcome, SimDialOutcome::KeepExisting);
+        let b_keeps = matches!(b_outcome, SimDialOutcome::KeepExisting);
+        assert!(
+            a_keeps ^ b_keeps,
+            "exactly one side must keep its egress; got a={:?} b={:?}",
+            a_outcome,
+            b_outcome
+        );
+    }
 
     #[test]
     fn test_tag_index() {

--- a/crates/network/src/session_manager.rs
+++ b/crates/network/src/session_manager.rs
@@ -20,27 +20,32 @@ use std::{
     net::{IpAddr, SocketAddr},
     sync::{
         atomic::{AtomicUsize, Ordering},
-        Arc,
+        Arc, OnceLock,
     },
+    time::Instant,
 };
 
-/// An entry in `SessionManager::node_id_index`. Tracks both the slab token
-/// of the session and whether that session is the local node's own outbound
-/// (`originated = true`) or an inbound from the remote (`originated = false`).
+/// An entry in `SessionManager::node_id_index`: the session's slab token, its
+/// direction (`originated`), and a lock-free view of its expired flag.
 ///
-/// We store `originated` here — alongside the token — so that the
-/// simultaneous-dial tie-breaker in `update_ingress_node_id` can read it
-/// without acquiring the per-session `RwLock<Session>`. Acquiring that lock
-/// while holding `node_id_index.write()` would deadlock with any other
-/// thread that holds `Session::write()` and is itself trying to call
-/// `update_ingress_node_id` (which is a common case in the simultaneous-dial
-/// scenario the tie-breaker exists to fix).
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// `originated` and `expired` are cached here so the tie-breaker in
+/// `update_ingress_node_id` can read them without locking the `Session` —
+/// doing so while holding `node_id_index.write()` would deadlock the kill
+/// path. `expired` is the *same* `OnceLock` the `Session` holds, so it can't
+/// drift.
+#[derive(Clone, Debug)]
 pub struct IndexEntry {
     pub token: usize,
-    /// `true` if this session is our outbound to the remote (egress);
-    /// `false` if it is the remote's outbound to us (ingress).
+    /// `true` = our outbound (egress); `false` = remote's inbound (ingress).
     pub originated: bool,
+    /// Shares `Session::expired` — see the struct doc.
+    expired: Arc<OnceLock<Instant>>,
+}
+
+impl IndexEntry {
+    /// `true` once the pointed-at session is expired. The entry lingers in
+    /// `node_id_index` past expiry until `deregister_stream` removes it.
+    fn is_expired(&self) -> bool { self.expired.get().is_some() }
 }
 
 /// Outcome of `SessionManager::update_ingress_node_id`.
@@ -154,8 +159,8 @@ impl SessionManager {
     /// Get the session of specified node id.
     pub fn get_by_id(&self, node_id: &NodeId) -> Option<Arc<RwLock<Session>>> {
         let sessions = self.sessions.read();
-        let entry = *self.node_id_index.read().get(node_id)?;
-        sessions.get(entry.token).cloned()
+        let token = self.node_id_index.read().get(node_id)?.token;
+        sessions.get(token).cloned()
     }
 
     /// Get all the sessions in `SessionManager`.
@@ -269,7 +274,7 @@ impl SessionManager {
         }
         let entry = sessions.vacant_entry();
         let index = entry.key();
-        match Session::new(
+        let session = match Session::new(
             io,
             socket,
             address,
@@ -285,8 +290,10 @@ impl SessionManager {
                 );
                 return Err(format!("{:?}", e));
             }
-            Ok(session) => entry.insert(Arc::new(RwLock::new(session))),
+            Ok(session) => session,
         };
+        let expired = session.expired_handle();
+        entry.insert(Arc::new(RwLock::new(session)));
 
         // update on creation succeeded
         if let Some(node_id) = id {
@@ -296,6 +303,7 @@ impl SessionManager {
                 IndexEntry {
                     token: index,
                     originated: true,
+                    expired,
                 },
             );
         }
@@ -346,6 +354,9 @@ impl SessionManager {
     /// Update the node id index for an ingress session whose HELLO has
     /// just been processed and the remote `node_id` is now known.
     ///
+    /// `new_expired` is the new ingress's expired handle, passed in because the
+    /// caller already holds that `Session`'s write lock.
+    ///
     /// Returns:
     /// - `Err(_)` if the session at `idx` is no longer in the slab (the session
     ///   was killed concurrently — caller should drop the new ingress).
@@ -358,6 +369,7 @@ impl SessionManager {
     ///   ingress (`idx`) it was about to register.
     pub fn update_ingress_node_id(
         &self, idx: usize, node_id: &NodeId,
+        new_expired: Arc<OnceLock<Instant>>,
     ) -> Result<UpdateIngressResult, String> {
         debug!("SessionManager.update_ingress_node_id: enter");
 
@@ -373,23 +385,33 @@ impl SessionManager {
             ));
         }
 
-        if let Some(existing) = node_id_index.get(node_id).copied() {
+        let new_entry = IndexEntry {
+            token: idx,
+            originated: false,
+            expired: new_expired,
+        };
+
+        if let Some(existing) = node_id_index.get(node_id).cloned() {
             if existing.token == idx {
                 panic!("The same token already exists for the same node!!!");
             }
-            match simultaneous_dial_outcome(
-                &self.own_node_id,
-                node_id,
-                existing.originated,
-            ) {
+            // The existing entry may point at an already-expired session — its
+            // entry lingers until `deregister_stream`. Tie-breaking against a
+            // dying session could return `DropNew` and leave us with no
+            // connection, so treat an expired existing entry as a tie-break
+            // loss: the new ingress wins.
+            let outcome = if existing.is_expired() {
+                SimDialOutcome::KeepNew
+            } else {
+                simultaneous_dial_outcome(
+                    &self.own_node_id,
+                    node_id,
+                    existing.originated,
+                )
+            };
+            match outcome {
                 SimDialOutcome::KeepNew => {
-                    node_id_index.insert(
-                        node_id.clone(),
-                        IndexEntry {
-                            token: idx,
-                            originated: false,
-                        },
-                    );
+                    node_id_index.insert(node_id.clone(), new_entry);
                     debug!("SessionManager.update_ingress_node_id: leave (replaced)");
                     Ok(UpdateIngressResult::Replaced(existing.token))
                 }
@@ -399,13 +421,7 @@ impl SessionManager {
                 }
             }
         } else {
-            node_id_index.insert(
-                node_id.clone(),
-                IndexEntry {
-                    token: idx,
-                    originated: false,
-                },
-            );
+            node_id_index.insert(node_id.clone(), new_entry);
             debug!("SessionManager.update_ingress_node_id: leave (inserted)");
             Ok(UpdateIngressResult::Inserted)
         }

--- a/crates/network/src/session_manager.rs
+++ b/crates/network/src/session_manager.rs
@@ -25,13 +25,9 @@ use std::{
 };
 
 /// An entry in `SessionManager::node_id_index`: the session's slab token and
-/// its direction (`originated`).
-///
-/// `originated` is cached here so the simultaneous-dial tie-breaker in
-/// `update_ingress_node_id` can read it without locking the `Session`. Kill
-/// paths remove the entry (`remove_node_id_entry`) before marking the session
-/// expired, so a present entry is not left pointing at an already-expired
-/// session.
+/// its direction (`originated`). `originated` is cached here so the
+/// simultaneous-dial tie-breaker can read it without locking the `Session`.
+/// See `node_id_index` for the lifetime invariant.
 #[derive(Clone, Debug)]
 pub struct IndexEntry {
     pub token: usize,
@@ -103,10 +99,16 @@ pub struct SessionManager {
     /// compute the simultaneous-dial tie-break.
     own_node_id: NodeId,
 
-    /// session indices. Each entry stores the slab token plus whether
-    /// that session is egress (`originated = true`) or ingress
-    /// (`originated = false`); the latter is consulted by the
-    /// simultaneous-dial tie-breaker in `update_ingress_node_id`.
+    /// Reverse index from `NodeId` to slab token (plus direction). The
+    /// simultaneous-dial tie-breaker in `update_ingress_node_id` reads it
+    /// to detect and resolve duplicate sessions for the same peer.
+    ///
+    /// **Invariant:** `node_id_index` contains only sessions whose remote
+    /// node id is known and whose local session state is still active.
+    /// Sessions must be removed from this index (via `remove_node_id_entry`)
+    /// before their `Session::expired` state is set — otherwise the
+    /// tie-breaker could `DropNew` a fresh ingress in favour of an
+    /// already-dead session.
     node_id_index: RwLock<HashMap<NodeId, IndexEntry>>,
     ip_limit: RwLock<Box<dyn SessionIpLimit>>,
     tag_index: RwLock<SessionTagIndex>,

--- a/crates/network/src/session_manager.rs
+++ b/crates/network/src/session_manager.rs
@@ -86,6 +86,23 @@ pub fn simultaneous_dial_outcome(
     }
 }
 
+fn ingress_duplicate_outcome(
+    own_node_id: &NodeId, remote_node_id: &NodeId, existing: &IndexEntry,
+) -> SimDialOutcome {
+    // An expired existing entry is a session being torn down (its entry
+    // lingers until `deregister_stream`). Tie-breaking against it could
+    // `DropNew` and leave us with no connection, so it loses by default.
+    if existing.is_expired() {
+        SimDialOutcome::KeepNew
+    } else {
+        simultaneous_dial_outcome(
+            own_node_id,
+            remote_node_id,
+            existing.originated,
+        )
+    }
+}
+
 /// Session manager maintains all ingress and egress TCP connections in thread
 /// safe manner.
 ///
@@ -395,20 +412,11 @@ impl SessionManager {
             if existing.token == idx {
                 panic!("The same token already exists for the same node!!!");
             }
-            // The existing entry may point at an already-expired session — its
-            // entry lingers until `deregister_stream`. Tie-breaking against a
-            // dying session could return `DropNew` and leave us with no
-            // connection, so treat an expired existing entry as a tie-break
-            // loss: the new ingress wins.
-            let outcome = if existing.is_expired() {
-                SimDialOutcome::KeepNew
-            } else {
-                simultaneous_dial_outcome(
-                    &self.own_node_id,
-                    node_id,
-                    existing.originated,
-                )
-            };
+            let outcome = ingress_duplicate_outcome(
+                &self.own_node_id,
+                node_id,
+                &existing,
+            );
             match outcome {
                 SimDialOutcome::KeepNew => {
                     node_id_index.insert(node_id.clone(), new_entry);
@@ -510,8 +518,13 @@ mod tests {
     use crate::{
         node_table::NodeId,
         session_manager::{
-            simultaneous_dial_outcome, SessionTagIndex, SimDialOutcome,
+            ingress_duplicate_outcome, simultaneous_dial_outcome, IndexEntry,
+            SessionTagIndex, SimDialOutcome,
         },
+    };
+    use std::{
+        sync::{Arc, OnceLock},
+        time::Instant,
     };
 
     #[test]
@@ -537,6 +550,53 @@ mod tests {
             "exactly one side must keep its egress; got a={:?} b={:?}",
             a_outcome,
             b_outcome
+        );
+    }
+
+    #[test]
+    fn simdial_outcome_cases() {
+        let lo = NodeId::from_low_u64_be(1);
+        let hi = NodeId::from_low_u64_be(2);
+
+        // Ingress existing (originated = false): the fresher ingress wins.
+        assert_eq!(
+            simultaneous_dial_outcome(&lo, &hi, false),
+            SimDialOutcome::KeepNew
+        );
+        assert_eq!(
+            simultaneous_dial_outcome(&hi, &lo, false),
+            SimDialOutcome::KeepNew
+        );
+
+        // Egress existing: the connection from the higher-NodeId peer wins.
+        assert_eq!(
+            simultaneous_dial_outcome(&lo, &hi, true),
+            SimDialOutcome::KeepNew
+        );
+        assert_eq!(
+            simultaneous_dial_outcome(&hi, &lo, true),
+            SimDialOutcome::KeepExisting
+        );
+    }
+
+    #[test]
+    fn simdial_expired_existing_entry_keeps_new_ingress() {
+        let lo = NodeId::from_low_u64_be(1);
+        let hi = NodeId::from_low_u64_be(2);
+        let expired = Arc::new(OnceLock::new());
+        assert!(expired.set(Instant::now()).is_ok());
+        let existing = IndexEntry {
+            token: 1,
+            originated: true,
+            expired,
+        };
+
+        // Without the expired-entry guard, this ordering would keep the
+        // existing egress. Because that session is already expired, the new
+        // ingress must replace it instead.
+        assert_eq!(
+            ingress_duplicate_outcome(&hi, &lo, &existing),
+            SimDialOutcome::KeepNew
         );
     }
 

--- a/crates/network/src/session_manager.rs
+++ b/crates/network/src/session_manager.rs
@@ -20,32 +20,23 @@ use std::{
     net::{IpAddr, SocketAddr},
     sync::{
         atomic::{AtomicUsize, Ordering},
-        Arc, OnceLock,
+        Arc,
     },
-    time::Instant,
 };
 
-/// An entry in `SessionManager::node_id_index`: the session's slab token, its
-/// direction (`originated`), and a lock-free view of its expired flag.
+/// An entry in `SessionManager::node_id_index`: the session's slab token and
+/// its direction (`originated`).
 ///
-/// `originated` and `expired` are cached here so the tie-breaker in
-/// `update_ingress_node_id` can read them without locking the `Session` —
-/// doing so while holding `node_id_index.write()` would deadlock the kill
-/// path. `expired` is the *same* `OnceLock` the `Session` holds, so it can't
-/// drift.
+/// `originated` is cached here so the simultaneous-dial tie-breaker in
+/// `update_ingress_node_id` can read it without locking the `Session`. Kill
+/// paths remove the entry (`remove_node_id_entry`) before marking the session
+/// expired, so a present entry is not left pointing at an already-expired
+/// session.
 #[derive(Clone, Debug)]
 pub struct IndexEntry {
     pub token: usize,
     /// `true` = our outbound (egress); `false` = remote's inbound (ingress).
     pub originated: bool,
-    /// Shares `Session::expired` — see the struct doc.
-    expired: Arc<OnceLock<Instant>>,
-}
-
-impl IndexEntry {
-    /// `true` once the pointed-at session is expired. The entry lingers in
-    /// `node_id_index` past expiry until `deregister_stream` removes it.
-    fn is_expired(&self) -> bool { self.expired.get().is_some() }
 }
 
 /// Outcome of `SessionManager::update_ingress_node_id`.
@@ -83,23 +74,6 @@ pub fn simultaneous_dial_outcome(
         SimDialOutcome::KeepNew
     } else {
         SimDialOutcome::KeepExisting
-    }
-}
-
-fn ingress_duplicate_outcome(
-    own_node_id: &NodeId, remote_node_id: &NodeId, existing: &IndexEntry,
-) -> SimDialOutcome {
-    // An expired existing entry is a session being torn down (its entry
-    // lingers until `deregister_stream`). Tie-breaking against it could
-    // `DropNew` and leave us with no connection, so it loses by default.
-    if existing.is_expired() {
-        SimDialOutcome::KeepNew
-    } else {
-        simultaneous_dial_outcome(
-            own_node_id,
-            remote_node_id,
-            existing.originated,
-        )
     }
 }
 
@@ -309,7 +283,6 @@ impl SessionManager {
             }
             Ok(session) => session,
         };
-        let expired = session.expired_handle();
         entry.insert(Arc::new(RwLock::new(session)));
 
         // update on creation succeeded
@@ -320,7 +293,6 @@ impl SessionManager {
                 IndexEntry {
                     token: index,
                     originated: true,
-                    expired,
                 },
             );
         }
@@ -345,14 +317,7 @@ impl SessionManager {
         // TODO This check can be removed?
         if sessions.contains(session.token()) {
             sessions.remove(session.token());
-            if let Some(node_id) = session.id() {
-                let mut node_id_index = self.node_id_index.write();
-                if let Some(entry) = node_id_index.get(node_id) {
-                    if entry.token == session.token() {
-                        node_id_index.remove(node_id);
-                    }
-                }
-            }
+            // node_id_index was already cleared by `remove_node_id_entry`.
 
             assert!(self.ip_limit.write().remove(&session.address().ip()));
 
@@ -368,11 +333,19 @@ impl SessionManager {
         debug!("SessionManager.remove: leave");
     }
 
+    /// Drop the reverse-index entry for `node_id` if it still points at
+    /// `token`. Called early in a kill, before the session is marked expired.
+    pub fn remove_node_id_entry(&self, node_id: &NodeId, token: usize) {
+        let mut node_id_index = self.node_id_index.write();
+        if let Some(entry) = node_id_index.get(node_id) {
+            if entry.token == token {
+                node_id_index.remove(node_id);
+            }
+        }
+    }
+
     /// Update the node id index for an ingress session whose HELLO has
     /// just been processed and the remote `node_id` is now known.
-    ///
-    /// `new_expired` is the new ingress's expired handle, passed in because the
-    /// caller already holds that `Session`'s write lock.
     ///
     /// Returns:
     /// - `Err(_)` if the session at `idx` is no longer in the slab (the session
@@ -386,7 +359,6 @@ impl SessionManager {
     ///   ingress (`idx`) it was about to register.
     pub fn update_ingress_node_id(
         &self, idx: usize, node_id: &NodeId,
-        new_expired: Arc<OnceLock<Instant>>,
     ) -> Result<UpdateIngressResult, String> {
         debug!("SessionManager.update_ingress_node_id: enter");
 
@@ -405,17 +377,16 @@ impl SessionManager {
         let new_entry = IndexEntry {
             token: idx,
             originated: false,
-            expired: new_expired,
         };
 
         if let Some(existing) = node_id_index.get(node_id).cloned() {
             if existing.token == idx {
                 panic!("The same token already exists for the same node!!!");
             }
-            let outcome = ingress_duplicate_outcome(
+            let outcome = simultaneous_dial_outcome(
                 &self.own_node_id,
                 node_id,
-                &existing,
+                existing.originated,
             );
             match outcome {
                 SimDialOutcome::KeepNew => {
@@ -518,13 +489,8 @@ mod tests {
     use crate::{
         node_table::NodeId,
         session_manager::{
-            ingress_duplicate_outcome, simultaneous_dial_outcome, IndexEntry,
-            SessionTagIndex, SimDialOutcome,
+            simultaneous_dial_outcome, SessionTagIndex, SimDialOutcome,
         },
-    };
-    use std::{
-        sync::{Arc, OnceLock},
-        time::Instant,
     };
 
     #[test]
@@ -576,27 +542,6 @@ mod tests {
         assert_eq!(
             simultaneous_dial_outcome(&hi, &lo, true),
             SimDialOutcome::KeepExisting
-        );
-    }
-
-    #[test]
-    fn simdial_expired_existing_entry_keeps_new_ingress() {
-        let lo = NodeId::from_low_u64_be(1);
-        let hi = NodeId::from_low_u64_be(2);
-        let expired = Arc::new(OnceLock::new());
-        assert!(expired.set(Instant::now()).is_ok());
-        let existing = IndexEntry {
-            token: 1,
-            originated: true,
-            expired,
-        };
-
-        // Without the expired-entry guard, this ordering would keep the
-        // existing egress. Because that session is already expired, the new
-        // ingress must replace it instead.
-        assert_eq!(
-            ingress_duplicate_outcome(&hi, &lo, &existing),
-            SimDialOutcome::KeepNew
         );
     }
 

--- a/tests/network_tests/simultaneous_dial.py
+++ b/tests/network_tests/simultaneous_dial.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+Regression test for the network-layer simultaneous-dial bug.
+
+When two nodes simultaneously dial each other, each side's
+`SessionManager::update_ingress_node_id` sees the incoming ingress as a
+duplicate of its own outbound and unconditionally replaces the index
+entry, causing `kill_connection_by_token` to kill the egress and log
+"Remove old session from the same node". With the bug, both sides do
+this, so both TCP connections die.
+
+After the fix, the network layer runs a deterministic tie-break: only
+the loser side (smaller NodeId) kills its egress; the winner side
+returns `DropNew` and the new ingress is disconnected via a Custom
+disconnect — a different log path. So "Remove old session" kills only
+ever accumulate on one side of the pair.
+
+The test runs many disconnect/reconnect cycles on two pairs of nodes in
+parallel and asserts that, in each pair, "Remove old session" kills
+appear on at most one side. With the bug, both sides accumulate kills
+and the assertion trips.
+"""
+
+import os
+import sys
+import threading
+import time
+
+sys.path.insert(1, os.path.dirname(sys.path[0]))
+
+from test_framework.test_framework import ConfluxTestFramework
+from test_framework.util import disconnect_nodes, get_peer_addr, wait_until
+
+# Each "Remove old session from the same node" kill produces exactly one
+# log line matching this prefix (the actual kill_connection_by_token call).
+# A different log line ("set token_to_disconnect to Some(...)") also contains
+# the marker text — we use the more specific prefix to avoid double-counting.
+SIMDIAL_KILL_MARKER = (
+    'kill connection by token, deregister = true, '
+    'reason = "Remove old session from the same node"'
+)
+TRIALS = 100
+
+
+def count_pattern(node, pattern):
+    """Count occurrences of `pattern` in node's conflux.log."""
+    log_path = os.path.join(node.datadir, "conflux.log")
+    try:
+        with open(log_path, "r") as f:
+            return f.read().count(pattern)
+    except FileNotFoundError:
+        return 0
+
+
+class SimultaneousDialTest(ConfluxTestFramework):
+    def set_test_params(self):
+        # 4 nodes paired as (0, 1) and (2, 3). Both pairs run
+        # simultaneous-dial trials in parallel, doubling the rate at
+        # which the race condition is exercised.
+        self.num_nodes = 4
+        self.conf_parameters = {
+            "discovery_housekeeping_timeout_ms": "100",
+        }
+
+    def setup_network(self):
+        # Start the nodes isolated; the trigger function adds them as
+        # mutual trusted peers and lets housekeeping dial them.
+        self.setup_nodes()
+
+    def trigger_simultaneous_reconnect_pair(self, i, j):
+        """
+        Disconnect the pair, then re-add each side as trusted from both
+        nodes in parallel (via a Barrier) so the addNode RPCs land at
+        essentially the same instant. Each node's next housekeeping
+        cycle initiates an outbound against the freshly re-added trusted
+        entry, and the two outbounds frequently overlap — the
+        simultaneous-dial race window.
+        """
+        a, b = self.nodes[i], self.nodes[j]
+        try:
+            disconnect_nodes(self.nodes, i, j)
+        except Exception as e:
+            self.log.debug(f"disconnect_nodes({i}, {j}) failed: {e}")
+
+        barrier = threading.Barrier(2)
+
+        def add_a_to_b():
+            barrier.wait()
+            try:
+                b.test_addNode(a.key, get_peer_addr(a))
+            except Exception as e:
+                self.log.debug(f"add_a_to_b failed: {e}")
+
+        def add_b_to_a():
+            barrier.wait()
+            try:
+                a.test_addNode(b.key, get_peer_addr(b))
+            except Exception as e:
+                self.log.debug(f"add_b_to_a failed: {e}")
+
+        t1 = threading.Thread(target=add_b_to_a)
+        t2 = threading.Thread(target=add_a_to_b)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        try:
+            wait_until(
+                lambda: any(
+                    peer["nodeid"] == b.key
+                    for peer in a.test_getPeerInfo()
+                ),
+                timeout=5,
+            )
+        except Exception:
+            pass
+
+    def run_test(self):
+        # Run many disconnect/reconnect cycles on both pairs in parallel.
+        for trial in range(TRIALS):
+            if (trial + 1) % 10 == 0:
+                self.log.info(f"Trial {trial + 1}/{TRIALS}")
+            t_pair01 = threading.Thread(
+                target=self.trigger_simultaneous_reconnect_pair,
+                args=(0, 1),
+            )
+            t_pair23 = threading.Thread(
+                target=self.trigger_simultaneous_reconnect_pair,
+                args=(2, 3),
+            )
+            t_pair01.start()
+            t_pair23.start()
+            t_pair01.join()
+            t_pair23.join()
+            time.sleep(0.05)
+
+        # Allow any in-flight kills to flush to the log.
+        time.sleep(1.0)
+
+        kills = [count_pattern(n, SIMDIAL_KILL_MARKER) for n in self.nodes]
+        total = sum(kills)
+        self.log.info(
+            f"After {TRIALS} trials: kills per node = {kills}, total = {total}"
+        )
+
+        # Bug-detection assertion: with the bug, each successful
+        # simultaneous-dial race causes BOTH sides of the pair to kill
+        # their own egress (each side's update_ingress_node_id replaces
+        # the existing entry and returns the old token for
+        # kill_connection_by_token to log "Remove old session from the
+        # same node"). Over many trials, kills accumulate on both sides
+        # of each pair.
+        #
+        # With the fix, only the LOSER side of each pair (the one with
+        # the smaller NodeId) kills its egress; the WINNER side returns
+        # DropNew and the new ingress is disconnected via send_disconnect
+        # (a different log path). So in each pair, kills accumulate on
+        # exactly one side and the OTHER side has zero.
+        pair_01_bilateral = kills[0] > 0 and kills[1] > 0
+        pair_23_bilateral = kills[2] > 0 and kills[3] > 0
+        assert not (pair_01_bilateral or pair_23_bilateral), (
+            f"simultaneous-dial bug: 'Remove old session' kills observed "
+            f"on BOTH sides of a pair: kills={kills}. "
+            f"With the network-layer tie-breaking fix, only the loser side "
+            f"(smaller NodeId) of each pair should produce these kills."
+        )
+
+        # Sanity: at least one pair must have fired some races, otherwise
+        # the test isn't exercising the target code path.
+        assert total > 0, (
+            f"no simultaneous-dial events fired in {TRIALS} trials; "
+            f"the test isn't exercising the target code path"
+        )
+
+
+if __name__ == "__main__":
+    SimultaneousDialTest().main()


### PR DESCRIPTION
## Summary

When two nodes simultaneously dial each other, `SessionManager::update_ingress_node_id` had no tie-breaking: each side replaced its `node_id_index` entry and killed its own egress, so **both** TCP connections died.

This PR adds a deterministic tie-breaker: keep the connection initiated by the higher-`NodeId` peer. Both sides compute the same comparison and converge on the same surviving connection. The loser kills its own egress (existing `Replaced` path); the winner returns a new `DropNew` result and the new ingress is disconnected via `Custom("simultaneous dial: drop new connection")`.

The `originated` flag is stored alongside the slab token in a new `IndexEntry` struct so the tie-breaker can read it without acquiring the per-session `RwLock<Session>` — which would deadlock against any thread holding `Session::write()` and waiting for `node_id_index.write()`.

Follow-up to #3435, which fixes the complementary wrong-session-kill bug at the PoS protocol layer. Orthogonal, can be merged in either order.

## Test

`tests/network_tests/simultaneous_dial.py` — runs 100 simultaneous-dial trials across two node pairs and asserts that `"Remove old session from the same node"` kills appear on at most one side of each pair. Reliably fails on master, passes with this fix. Opt-in (named without `_test.py`, skipped by `test_all.py`); run directly when needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3436)
<!-- Reviewable:end -->
