### PR TITLE
Update rust-rocksdb to fix GCC 13+ release build failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5709,7 +5709,7 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=d0cd089bc092ec77b65a5262d453848f57abe3c3#d0cd089bc092ec77b65a5262d453848f57abe3c3"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=672b02bc21874a5e91705f3642dac3614a7a8f9e#672b02bc21874a5e91705f3642dac3614a7a8f9e"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -5726,7 +5726,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=d0cd089bc092ec77b65a5262d453848f57abe3c3#d0cd089bc092ec77b65a5262d453848f57abe3c3"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=672b02bc21874a5e91705f3642dac3614a7a8f9e#672b02bc21874a5e91705f3642dac3614a7a8f9e"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -8029,7 +8029,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=d0cd089bc092ec77b65a5262d453848f57abe3c3#d0cd089bc092ec77b65a5262d453848f57abe3c3"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=672b02bc21874a5e91705f3642dac3614a7a8f9e#672b02bc21874a5e91705f3642dac3614a7a8f9e"
 dependencies = [
  "libc",
  "librocksdb_sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -461,7 +461,7 @@ sqlite3-sys = "0.12"
 kvdb = "0.13"
 influx_db_client = "0.5.1"
 # conflux forked crates
-rocksdb = { git = "https://github.com/Conflux-Chain/rust-rocksdb.git", rev = "d0cd089bc092ec77b65a5262d453848f57abe3c3" }
+rocksdb = { git = "https://github.com/Conflux-Chain/rust-rocksdb.git", rev = "672b02bc21874a5e91705f3642dac3614a7a8f9e" }
 
 [patch.crates-io]
 # use a forked version to fix a vulnerability(introduced by failure) in vrf-rs, can be removed after the upstream is fixed

--- a/docs/build-from-source.md
+++ b/docs/build-from-source.md
@@ -122,11 +122,6 @@ Note: when compiling a crate and you receive errors, it is in most cases due to 
 ```shell
 cargo clean && cargo update
 ```
-When compiling on Linux, by default `cc` is linked to `gcc`. You may need to export the `CC` environment variable to point to `clang`:
-
-```shell
-CC=clang CXX=clang++ cargo build --release
-```
 
 To start running a Conflux full node, you can follow the instructions at [Running Conflux Full Node](https://doc.confluxnetwork.org/docs/general/run-a-node/).
 

--- a/tools/consensus_bench/Cargo.lock
+++ b/tools/consensus_bench/Cargo.lock
@@ -4335,7 +4335,7 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=d0cd089bc092ec77b65a5262d453848f57abe3c3#d0cd089bc092ec77b65a5262d453848f57abe3c3"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=672b02bc21874a5e91705f3642dac3614a7a8f9e#672b02bc21874a5e91705f3642dac3614a7a8f9e"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -4352,7 +4352,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=d0cd089bc092ec77b65a5262d453848f57abe3c3#d0cd089bc092ec77b65a5262d453848f57abe3c3"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=672b02bc21874a5e91705f3642dac3614a7a8f9e#672b02bc21874a5e91705f3642dac3614a7a8f9e"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -6111,7 +6111,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=d0cd089bc092ec77b65a5262d453848f57abe3c3#d0cd089bc092ec77b65a5262d453848f57abe3c3"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=672b02bc21874a5e91705f3642dac3614a7a8f9e#672b02bc21874a5e91705f3642dac3614a7a8f9e"
 dependencies = [
  "libc",
  "librocksdb_sys",

--- a/tools/evm-spec-tester/Cargo.lock
+++ b/tools/evm-spec-tester/Cargo.lock
@@ -4909,7 +4909,7 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=d0cd089bc092ec77b65a5262d453848f57abe3c3#d0cd089bc092ec77b65a5262d453848f57abe3c3"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=672b02bc21874a5e91705f3642dac3614a7a8f9e#672b02bc21874a5e91705f3642dac3614a7a8f9e"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -4926,7 +4926,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=d0cd089bc092ec77b65a5262d453848f57abe3c3#d0cd089bc092ec77b65a5262d453848f57abe3c3"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=672b02bc21874a5e91705f3642dac3614a7a8f9e#672b02bc21874a5e91705f3642dac3614a7a8f9e"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -6736,7 +6736,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=d0cd089bc092ec77b65a5262d453848f57abe3c3#d0cd089bc092ec77b65a5262d453848f57abe3c3"
+source = "git+https://github.com/Conflux-Chain/rust-rocksdb.git?rev=672b02bc21874a5e91705f3642dac3614a7a8f9e#672b02bc21874a5e91705f3642dac3614a7a8f9e"
 dependencies = [
  "libc",
  "librocksdb_sys",


### PR DESCRIPTION
## Background

PR #3236 added a build guide (`docs/build-from-source.md`) recommending `CC=clang CXX=clang++` as a workaround for GCC build failures on Linux. However, RocksDB's build system assumes GCC as the primary non-MSVC compiler (`CMakeLists.txt`: `else() # assume GCC`), and major downstream consumers (Fedora, Ceph, CockroachDB, Pika) all build with GCC. Rather than requiring users to switch compilers, this PR fixes the underlying GCC compatibility issue and removes the clang workaround from the build guide.

## Problem

Building conflux-rust in release mode with GCC 13+ (default on Ubuntu 24.04+, Fedora 38+, Debian 12+) fails with `-Werror=array-bounds` in Titan's `db_impl.cc`. Debug builds are unaffected because `-O0` does not trigger GCC's deep bounds analysis. CI (which uses clang-18) is also unaffected.

## Root Cause

Titan's `db_impl.cc` calls `RecordTick()`, which accesses `statistics_impl.h`'s tickers array. GCC 13+ under `-O2+` performs deeper static analysis and raises a false-positive `-Warray-bounds` on this access. Combined with RocksDB's `FAIL_ON_WARNINGS=ON` (which adds `-Werror`), the warning becomes a fatal error.

The initial investigation attributed the issue to RocksDB's `InlineSkipList` negative-index pattern, but targeted builds confirmed that only Titan's code path triggers the warning — RocksDB's own sources compile cleanly with GCC 13.

## Why standalone rust-rocksdb doesn't reproduce the failure

The `cc` crate changed the semantics of `warnings(false)` between versions:

- cc 1.2.22: "don't add any warning flag" — no effect on downstream CMake flags
- cc 1.2.60+: actively injects `-w` (suppress all warnings)

The `cmake` crate calls `cc::Build::warnings(false)` for compiler detection, then leaks `cc::Tool::args()` into `CMAKE_CXX_FLAGS`. Since `-w` always beats `-Werror` regardless of flag ordering, the leaked `-w` accidentally masks the issue.

- conflux-rust resolves to cmake 0.1.49 + cc 1.2.22 → no `-w` leak → failure
- Standalone rust-rocksdb resolves to cmake 0.1.58 + cc 1.2.60 → `-w` leak → masked

## Decision

Three options were considered:

1. **`-DFAIL_ON_WARNINGS=OFF`**: too broad — silences all `-Werror`, may hide real warnings
2. **Rely on cc 1.2.60's `-w` leak**: depends on an accidental side effect in a third-party crate that may be fixed at any time
3. **`cfg.cxxflag("-Wno-error=array-bounds")`**: targeted — only demotes this specific false positive from error to warning ✓

Option 3 was chosen, matching how CockroachDB handles the same GCC 13 issue.

## Scope

[The fix](https://github.com/Conflux-Chain/rust-rocksdb/commit/672b02bc21874a5e91705f3642dac3614a7a8f9e) is applied only to `libtitan_sys/build.rs`. RocksDB's own sources do not trigger `-Warray-bounds` with GCC 13 — only Titan's `db_impl.cc` → `statistics_impl.h` code path does.

## Verification

| Scenario | Result |
|----------|--------|
| No fix, release build (GCC 13) | ✗ `-Werror=array-bounds` in libtitan_sys |
| With fix, release build (GCC 13) | ✓ Clean build |
| With fix, debug build (GCC 13) | ✓ Unaffected (never triggered) |
| End-to-end conflux-rust `cargo build --release` | ✓ Clean build |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3441)
<!-- Reviewable:end -->
