### PR TITLE
fix: add fmt check, fix symlink bug, isolate tools workspaces

### DIFF
--- a/.claude/skills/test-sh-monitor/SKILL.md
+++ b/.claude/skills/test-sh-monitor/SKILL.md
@@ -189,8 +189,6 @@ On timer notification → run Step A → run Step B → repeat.
 ### Phase 2: cargo build consensus_bench
 - **Anchor:** `=== Phase 2/4: Building consensus_bench ===`
 - **Success anchor:** `=== Phase 2/4: Build succeeded ===`
-- **Special risk:** when the worktree is nested inside the parent repo, Cargo may walk up and resolve the wrong workspace
-- **Failure signal:** `error: current package believes it's in a workspace`
 
 ### Phase 3: test_all.py (integration tests) — requires active monitoring
 - **Anchor:** `=== Phase 3/4: Integration tests ===`

--- a/.claude/skills/test-sh-monitor/SKILL.md
+++ b/.claude/skills/test-sh-monitor/SKILL.md
@@ -31,7 +31,7 @@ Remember the chosen interval — it will be used in the monitoring loop in Step 
 
 ## Step 1: Pre-flight Checks
 
-Confirm these four items before launching to avoid discovering environment problems after a long wait:
+Confirm these five items before launching to avoid discovering environment problems after a long wait:
 
 ```bash
 # 1. uv is present
@@ -45,7 +45,12 @@ ls -la target 2>/dev/null || echo "target not present (OK, test.sh will handle)"
 
 # 4. venv (test.sh creates it automatically; this is just a sanity check)
 ls .venv 2>/dev/null && echo "venv exists" || echo "venv absent (test.sh will create it)"
+
+# 5. fmt check (fast — catches formatting issues before starting the long build)
+bash cargo_fmt.sh -- --check
 ```
+
+If fmt check fails, fix formatting before launching test.sh — there is no point waiting for a build that will eventually fail the same check.
 
 If submodules are missing:
 ```bash
@@ -59,16 +64,18 @@ git submodule update --init --recursive
 **Prefer `run_in_background: true`** so the framework owns the process and notifies you on exit, structurally eliminating zombie process issues:
 
 ```bash
-bash dev-support/test.sh > /tmp/test_run.log 2>&1
+bash -c 'set -o pipefail; bash dev-support/test.sh 2>&1 | tee /tmp/test_run.log'
 # (with run_in_background: true)
 ```
+
+> **Why pipe instead of `> file 2>&1`?** test.sh's check functions use `tee /dev/stderr` internally. When stderr is redirected to a regular file, `tee` opens `/dev/stderr` via `/proc/self/fd/2`, which creates a new file description starting at position 0 — overwriting earlier content (including phase anchors). With a pipe, there is no file position, so `tee /dev/stderr` appends correctly. `pipefail` ensures the exit code reflects test.sh, not tee.
 
 > **Why prefer run_in_background?** The framework-owned process is not a child of the current shell, so the framework reaps it — no need to handle zombies in the monitoring loop.
 
 If you must background it manually, **do not use `kill -0` as the loop condition** — it cannot distinguish a running process from a zombie (`kill -0` returns 0 for both). Use `ps -o stat=` instead:
 
 ```bash
-bash dev-support/test.sh > /tmp/test_run.log 2>&1 &
+bash -c 'set -o pipefail; bash dev-support/test.sh 2>&1 | tee /tmp/test_run.log' &
 PID=$!
 while [[ "$(ps -p $PID -o stat= 2>/dev/null)" =~ ^[^Z] ]]; do
     sleep 10
@@ -91,7 +98,7 @@ The core check logic is the same regardless of tool availability:
 PASSED=$(grep -c "✓" /tmp/test_run.log 2>/dev/null || echo 0)
 FAILED=$(grep -cE "[✖✗]" /tmp/test_run.log 2>/dev/null || echo 0)
 RUNNING=$(pgrep -f "bash dev-support/test.sh" > /dev/null 2>&1 && echo "RUNNING" || echo "STOPPED")
-PHASE=$(grep -oE "Phase [0-9]/[0-9]: [^=]+" /tmp/test_run.log 2>/dev/null | tail -1 || echo "unknown")
+PHASE=$(grep -oE "(Phase [0-9]/[0-9]: [^=]+|Fmt check( passed)?)" /tmp/test_run.log 2>/dev/null | tail -1 || echo "unknown")
 echo "[$(date '+%H:%M:%S')] $RUNNING phase=[$PHASE] passed=$PASSED failed=$FAILED"
 tail -3 /tmp/test_run.log
 ```
@@ -117,7 +124,7 @@ while true; do
   RUNNING=$(pgrep -f "bash dev-support/test.sh" > /dev/null 2>&1 && echo "yes" || echo "no")
   PASSED=$(grep -c "✓" /tmp/test_run.log 2>/dev/null || echo 0)
   FAILED=$(grep -cE "[✖✗]" /tmp/test_run.log 2>/dev/null || echo 0)
-  PHASE=$(grep -oE "Phase [0-9]/[0-9]: [^=]+" /tmp/test_run.log 2>/dev/null | tail -1)
+  PHASE=$(grep -oE "(Phase [0-9]/[0-9]: [^=]+|Fmt check( passed)?)" /tmp/test_run.log 2>/dev/null | tail -1)
 
   if [ "$PHASE" != "$PREV_PHASE" ]; then
     echo "[$(date '+%H:%M:%S')] $PHASE | passed=$PASSED failed=$FAILED"
@@ -149,7 +156,7 @@ Use the foreground Bash + background sleep alternating pattern:
 PASSED=$(grep -c "✓" /tmp/test_run.log 2>/dev/null || echo 0)
 FAILED=$(grep -cE "[✖✗]" /tmp/test_run.log 2>/dev/null || echo 0)
 RUNNING=$(pgrep -f "bash dev-support/test.sh" > /dev/null 2>&1 && echo "RUNNING" || echo "STOPPED")
-PHASE=$(grep -oE "Phase [0-9]/[0-9]: [^=]+" /tmp/test_run.log 2>/dev/null | tail -1 || echo "unknown")
+PHASE=$(grep -oE "(Phase [0-9]/[0-9]: [^=]+|Fmt check( passed)?)" /tmp/test_run.log 2>/dev/null | tail -1 || echo "unknown")
 echo "[$(date '+%H:%M:%S')] $RUNNING phase=[$PHASE] passed=$PASSED failed=$FAILED"
 tail -3 /tmp/test_run.log
 ```
@@ -165,7 +172,13 @@ On timer notification → run Step A → run Step B → repeat.
 
 ---
 
-## The Four Phases
+## Phases
+
+### Pre-check: Fmt
+- **Anchor:** `=== Fmt check ===`
+- **Success anchor:** `=== Fmt check passed ===`
+- **Behavior:** runs `cargo_fmt.sh -- --check` (nightly rustfmt across all workspaces). Fast (seconds). On failure, process exits immediately — no success anchor, no build phases.
+- **Note:** Step 1 pre-flight already runs this check independently. If you see fmt failure here, it means the pre-flight was skipped or code changed between pre-flight and launch.
 
 ### Phase 1: cargo build (main project)
 - **Anchor:** `=== Phase 1/4: Building main project ===`

--- a/.claude/skills/test-sh-monitor/SKILL.md
+++ b/.claude/skills/test-sh-monitor/SKILL.md
@@ -242,7 +242,7 @@ git submodule update --init --recursive
 ln -s /conflux-rust/build /home/ubuntu/worktrees/my-test/build
 
 # 4. Launch (run_in_background: true)
-bash dev-support/test.sh > /tmp/test_run.log 2>&1
+bash -c 'set -o pipefail; bash dev-support/test.sh 2>&1 | tee /tmp/test_run.log'
 ```
 
 ---

--- a/dev-support/test.sh
+++ b/dev-support/test.sh
@@ -17,9 +17,33 @@ export CARGO_TARGET_DIR=$ROOT_DIR/build
 export CONFLUX_BENCH=$CARGO_TARGET_DIR/release/consensus_bench
 export RUSTFLAGS="-g -D warnings"
 
+CHECK_FMT=0
 CHECK_BUILD=1
 CHECK_INT_TEST=2
 CHECK_PY_TEST=3
+
+function check_fmt {
+    local -n inner_result=$1
+
+    pushd $ROOT_DIR > /dev/null
+
+    local result
+
+    result=$(
+        $ROOT_DIR/cargo_fmt.sh -- --check | tee /dev/stderr
+    )
+
+    local exit_code=$?
+
+    popd > /dev/null
+
+    if [[ $exit_code -ne 0 ]]; then
+        result="Fmt check failed."$'\n'"$result"
+    else
+        result="Fmt check passed."
+    fi
+    inner_result=($exit_code "$result")
+}
 
 function check_build {
     local -n inner_result=$1
@@ -76,7 +100,7 @@ function check_integration_tests {
     local result
     result=$(
         # Make symbolic link for conflux binary to where integration test assumes its existence.
-        rm -f target; ln -s build target
+        rm -rf target; ln -s build target
         ./tests/test_all.py --max-workers $TEST_MAX_WORKERS --max-retries $TEST_MAX_RETRIES --max-nodes $TEST_MAX_NODES | tee /dev/stderr
     )
     local exit_code=$?
@@ -123,6 +147,11 @@ function save_test_result {
 
 echo -n "" > $ROOT_DIR/.phabricator-comment
 mkdir -p $ROOT_DIR/build
+
+# Fmt check
+echo "=== Fmt check ==="
+declare -a test_result; check_fmt test_result; save_test_result test_result $CHECK_FMT
+echo "=== Fmt check passed ==="
 
 # Phase 1: Build main project
 echo "=== Phase 1/4: Building main project ==="

--- a/tools/consensus_bench/Cargo.toml
+++ b/tools/consensus_bench/Cargo.toml
@@ -16,6 +16,8 @@ parking_lot = "0.12"
 log4rs = { version = "1.4.0", features = ["background_rotation", "gzip"] }
 log = "0.4"
 
+[workspace]
+
 [patch.crates-io]
 # use a forked version to fix a vulnerability(introduced by failure) in vrf-rs, can be removed after the upstream is fixed
 vrf = { git = "https://github.com/andrcmdr/vrf-rs.git", rev = "f7bdb21f7f5d1858a3bb0183f194440f9a4199b3" }

--- a/tools/evm-spec-tester/Cargo.toml
+++ b/tools/evm-spec-tester/Cargo.toml
@@ -36,6 +36,8 @@ clap-verbosity-flag = "3"
 [features]
 default = ["cfx-executor/align_evm", "cfx-statedb/testonly_code"]
 
+[workspace]
+
 [patch.crates-io]
 # use a forked version to fix a vulnerability(introduced by failure) in vrf-rs, can be removed after the upstream is fixed
 vrf = { git = "https://github.com/andrcmdr/vrf-rs.git", rev = "f7bdb21f7f5d1858a3bb0183f194440f9a4199b3" }


### PR DESCRIPTION
## Summary

This PR completes the remaining work from #3426 (after #3441 and #3442) and adds a fmt check phase to `test.sh`. The changes fall into two categories: fixes for existing bugs that surface in worktree environments, and a new fmt check that closes a gap in CI coverage.

## Symlink bug in `check_integration_tests`

Before running integration tests, `test.sh` replaces `target` with a symlink to `build/` so tests find the compiled binary. The original `rm -f target` cannot remove a real directory — the error is silently ignored, and `ln -s build target` creates a symlink *inside* the surviving directory rather than replacing it. Integration tests then run against a stale or missing binary. Changed to `rm -rf target`.

## Workspace isolation for `tools/*`

The main workspace declares `exclude = ["tools"]`, which works correctly in a normal checkout — Cargo walks up, sees the exclusion, and treats each `tools/*` package as standalone.

**The problem appears in nested worktrees.** When a worktree lives under the main repo (e.g. `/conflux-rust/.claude/worktrees/xxx/`), Cargo finds the worktree's workspace root first, sees the package is excluded, and continues walking upward — eventually reaching the main repo's workspace. At that level the package's relative path becomes `.claude/worktrees/.../tools/<pkg>`, which no longer matches `exclude = ["tools"]`. Cargo concludes the package is inside a workspace that doesn't claim it, and errors out.

Adding `[workspace]` to `consensus_bench/Cargo.toml` and `evm-spec-tester/Cargo.toml` makes each package its own workspace root, stopping the upward walk before it escapes the worktree.

## Fmt check in `test.sh`

The fmt check was previously assigned to Jenkins Master, which lacks the nightly toolchain — so it was effectively not running. Moving it into `test.sh` restores the CI gate on Worker where the toolchain is available, and benefits developers who use `test.sh` as a local pre-commit check.

The check runs before Phase 1 (build) with independent anchors (`=== Fmt check ===` / `=== Fmt check passed ===`) to avoid renumbering the existing four phases.

## SKILL.md monitoring updates

test.sh's check functions use `tee /dev/stderr` to echo captured output. When the log is collected via `> file 2>&1`, fd 2 points to a regular file, and `tee`'s `open("/proc/self/fd/2")` creates a new file description at position 0 — overwriting earlier log content including phase anchors. **The fix:** the launch command now pipes through `tee` (`2>&1 | tee file`), so fd 2 inside test.sh is a pipe. Pipes have no seek position, eliminating the overwrite.

The monitoring guide also picks up the new fmt phase: the detection regex recognizes fmt anchors, and a pre-flight fmt check is added so formatting issues surface before the long build. The Phase 2 workspace resolution warning is removed, as the `[workspace]` fix above eliminates the underlying risk.

## Test plan

Tested in a nested worktree at `/conflux-rust/.claude/worktrees/fix-remaining-3426/`.

**Workspace isolation:** `cargo_fmt.sh -- --check` hit the workspace resolution error on both `consensus_bench` and `evm-spec-tester` before the fix, and passed after.

**Fmt monitoring:** Launched test.sh via pipe with an artificially introduced fmt failure. The monitoring regex correctly detected `Fmt check` as the current phase and observed process exit before Phase 1. After reverting the failure, confirmed the phase transition from `Fmt check passed` to `Phase 1/4`.

**Not yet tested:** full end-to-end `test.sh` (build + integration + pytest) requires a clean build on Worker.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3443)
<!-- Reviewable:end -->
