### PR TITLE
Reduce write lock holding time

### DIFF
--- a/crates/cfxcore/core/src/sync/synchronization_graph.rs
+++ b/crates/cfxcore/core/src/sync/synchronization_graph.rs
@@ -7,7 +7,7 @@ use std::{
     collections::{BinaryHeap, HashMap, HashSet, VecDeque},
     mem, panic,
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
     },
     thread,
@@ -992,10 +992,12 @@ struct ConsensusWorkerHandle {
     /// Channel + subscription ID for unsubscribe-based shutdown.
     new_block_hashes: Arc<Channel<H256>>,
     worker_subscription_id: u64,
+    stop_requested: Arc<AtomicBool>,
 }
 
 impl ConsensusWorkerHandle {
     fn stop(&self) {
+        self.stop_requested.store(true, Ordering::SeqCst);
         self.new_block_hashes
             .unsubscribe(self.worker_subscription_id);
         if let Some(handle) = self.thread.lock().take() {
@@ -1088,6 +1090,8 @@ impl SynchronizationGraph {
         let worker_data_man = data_man.clone();
         let worker_consensus = consensus.clone();
         let worker_unprocessed_count = consensus_unprocessed_count.clone();
+        let worker_stop_requested = Arc::new(AtomicBool::new(false));
+        let worker_stop_requested_for_thread = worker_stop_requested.clone();
 
         // It receives `BLOCK_GRAPH_READY` blocks in order and handles them in
         // `ConsensusGraph`
@@ -1106,6 +1110,12 @@ impl SynchronizationGraph {
                 let mut pos_started = false;
 
                 'outer: loop {
+                    if worker_stop_requested_for_thread
+                        .load(Ordering::SeqCst)
+                    {
+                        break;
+                    }
+
                     // Only block when we have processed all received blocks.
                     let mut blocking = priority_queue.is_empty();
                     'inner: loop {
@@ -1123,7 +1133,11 @@ impl SynchronizationGraph {
 
                         match maybe_item {
                             // FIXME: We need to investigate why duplicate hash may send to the consensus worker
-                            Ok(hash) => if !reverse_map.contains_key(&hash) {
+                            Ok(hash) => if worker_stop_requested_for_thread
+                                .load(Ordering::SeqCst)
+                            {
+                                break 'outer;
+                            } else if !reverse_map.contains_key(&hash) {
                                 debug!("Worker thread receive: block = {}", hash);
                                 let header = worker_data_man.block_header_by_hash(&hash).expect("Header must exist before sending to the consensus worker!");
 
@@ -1168,6 +1182,9 @@ impl SynchronizationGraph {
                             Err(TryRecvError::Disconnected) => break 'outer,
                         }
                     }
+                    if worker_stop_requested_for_thread.load(Ordering::SeqCst) {
+                        break 'outer;
+                    }
                     if let Some((_, hash)) = priority_queue.pop() {
                         CONSENSUS_WORKER_QUEUE.dequeue(1);
                         let successors = reverse_map.remove(&hash).unwrap();
@@ -1195,6 +1212,7 @@ impl SynchronizationGraph {
             thread: Mutex::new(Some(handle)),
             new_block_hashes: notifications.new_block_hashes.clone(),
             worker_subscription_id,
+            stop_requested: worker_stop_requested,
         };
 
         let sync_graph = SynchronizationGraph {

--- a/crates/cfxcore/core/src/sync/synchronization_graph.rs
+++ b/crates/cfxcore/core/src/sync/synchronization_graph.rs
@@ -1803,6 +1803,18 @@ impl SynchronizationGraph {
 
         debug!("insert_block {:?}", hash);
 
+        // This verification only depends on the block payload and current
+        // chain id. Running it before taking the sync-graph write lock reduces
+        // lock hold time for large blocks with many transactions.
+        let basic_verify_result = if need_to_verify {
+            Some(self.verification_config.verify_sync_graph_block_basic(
+                &block,
+                self.consensus.best_chain_id(),
+            ))
+        } else {
+            None
+        };
+
         let inner = &mut *self.inner.write();
 
         let contains_block =
@@ -1828,14 +1840,9 @@ impl SynchronizationGraph {
 
         debug_assert!(hash == inner.arena[me].block_header.hash());
         debug_assert!(!inner.arena[me].block_ready);
-        inner.arena[me].block_ready = true;
 
-        if need_to_verify {
-            let r = self.verification_config.verify_sync_graph_block_basic(
-                &block,
-                self.consensus.best_chain_id(),
-            );
-            match r {
+        if let Some(result) = basic_verify_result {
+            match result {
                 Err(Error::Block(BlockError::InvalidTransactionsRoot(e))) => {
                     warn!("BlockTransactionRoot not match! inserted_block={:?} err={:?}", block, e);
                     // If the transaction root does not match, it might be
@@ -1845,7 +1852,6 @@ impl SynchronizationGraph {
                     // adversaries. In either case, we should request the block
                     // again, and the received block body is
                     // discarded.
-                    inner.arena[me].block_ready = false;
                     return BlockInsertionResult::RequestAgain;
                 }
                 Err(e) => {
@@ -1858,6 +1864,8 @@ impl SynchronizationGraph {
                 _ => {}
             };
         }
+
+        inner.arena[me].block_ready = true;
 
         let block = Arc::new(block);
         if inner.arena[me].graph_status != BLOCK_INVALID {

--- a/crates/network/src/session_manager.rs
+++ b/crates/network/src/session_manager.rs
@@ -90,7 +90,12 @@ impl SessionManager {
     pub fn get_by_id(&self, node_id: &NodeId) -> Option<Arc<RwLock<Session>>> {
         let sessions = self.sessions.read();
         let idx = *self.node_id_index.read().get(node_id)?;
-        sessions.get(idx).cloned()
+        let session = sessions.get(idx)?.clone();
+        if session.read().expired() {
+            None
+        } else {
+            Some(session)
+        }
     }
 
     /// Get all the sessions in `SessionManager`.
@@ -137,7 +142,7 @@ impl SessionManager {
 
     /// Check the session existence for the specified node id.
     pub fn contains_node(&self, id: &NodeId) -> bool {
-        self.node_id_index.read().contains_key(id)
+        self.get_by_id(id).is_some()
     }
 
     /// Get the session index by node id.
@@ -177,14 +182,25 @@ impl SessionManager {
 
         // ensure the node id is unique if specified.
         if let Some(node_id) = id {
-            if node_id_index.contains_key(node_id) {
-                debug!(
-                    "SessionManager.create: leave on node_id already exists"
-                );
-                return Err(format!(
-                    "session already exists, nodeId = {:?}",
-                    node_id
-                ));
+            if let Some(cur_idx) = node_id_index.get(node_id).cloned() {
+                // Stream deregistration is asynchronous, so a recently
+                // disconnected session can leave a stale NodeId index behind
+                // briefly even though the session is already expired.
+                let is_stale = sessions
+                    .get(cur_idx)
+                    .map(|session| session.read().expired())
+                    .unwrap_or(true);
+                if is_stale {
+                    node_id_index.remove(node_id);
+                } else {
+                    debug!(
+                        "SessionManager.create: leave on node_id already exists"
+                    );
+                    return Err(format!(
+                        "session already exists, nodeId = {:?}",
+                        node_id
+                    ));
+                }
             }
         }
 

--- a/tests/evm_full_history_state_test.py
+++ b/tests/evm_full_history_state_test.py
@@ -43,7 +43,7 @@ class EvmFullHistoryStateTest(ConfluxTestFramework):
         client = RpcClient(self.nodes[0])
         client.generate_empty_blocks(500)
         # This should not raise error if the state is available.
-        assert_raises_rpc_error(None, None, client.call, "0x0000000000000000000000000000000000000000", "0x00", None, "0x33")
+        client.call("0x0000000000000000000000000000000000000000", "0x00", None, "0x33")
         self.nodes[0].eth_call({"to": "0x0000000000000000000000000000000000000000", "data": "0x00"}, "0x33")
         assert_raises_rpc_error(None, None, self.nodes[0].eth_call, {"to": "0x0000000000000000000000000000000000000000", "data": "0x00"}, "0x31")
 


### PR DESCRIPTION
Detected some bottlenecks in massive tests. This is a possible simple way to improve.
For large blocks, `verify_sync_graph_block_basic` could cost much time while holding the lock `let inner = &mut *self.inner.write();`

Possible major bottlenecks on large incoming blocks:
1. Lock competition through `insert_block` -> `set_graph_ready` until consensus graph sync
2. The waiting of `self.inner.write()` outside `Consensus::on_new_block(...)`
3. `new_block_hashes` channel invocation delay, in `CONSENSUS_WORKER_QUEUE.enqueue(1)` and `new_block_hashes.send(h)`.
4.  `enqueue_epoch -> execution worker`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3447)
<!-- Reviewable:end -->
