### PR TITLE
Remove dead GovernanceRole and VMValidatorResult from PoS mempool

### DIFF
--- a/crates/cfxcore/core/src/pos/mempool/core_mempool/index.rs
+++ b/crates/cfxcore/core/src/pos/mempool/core_mempool/index.rs
@@ -10,9 +10,7 @@ use crate::pos::mempool::core_mempool::transaction::{
     MempoolTransaction, TimelineState,
 };
 use diem_crypto::HashValue;
-use diem_types::{
-    account_address::AccountAddress, transaction::GovernanceRole,
-};
+use diem_types::account_address::AccountAddress;
 use std::{
     cmp::Ordering,
     collections::{hash_map::Values, BTreeMap, BTreeSet, HashMap},
@@ -78,49 +76,6 @@ pub type TxnPointer = (AccountAddress, HashValue);
 impl From<&MempoolTransaction> for TxnPointer {
     fn from(transaction: &MempoolTransaction) -> Self {
         (transaction.get_sender(), transaction.get_hash())
-    }
-}
-
-#[derive(Eq, PartialEq, Clone, Debug, Hash)]
-#[allow(dead_code)]
-pub struct OrderedQueueKey {
-    pub gas_ranking_score: u64,
-    pub expiration_time: Duration,
-    pub address: AccountAddress,
-    pub hash: HashValue,
-    pub governance_role: GovernanceRole,
-}
-
-impl PartialOrd for OrderedQueueKey {
-    fn partial_cmp(&self, other: &OrderedQueueKey) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for OrderedQueueKey {
-    fn cmp(&self, other: &OrderedQueueKey) -> Ordering {
-        match self
-            .governance_role
-            .priority()
-            .cmp(&other.governance_role.priority())
-        {
-            Ordering::Equal => {}
-            ordering => return ordering,
-        }
-        match self.gas_ranking_score.cmp(&other.gas_ranking_score) {
-            Ordering::Equal => {}
-            ordering => return ordering,
-        }
-        match self.expiration_time.cmp(&other.expiration_time).reverse() {
-            Ordering::Equal => {}
-            ordering => return ordering,
-        }
-        match self.address.cmp(&other.address) {
-            Ordering::Equal => {}
-            ordering => return ordering,
-        }
-        // TODO(linxi): correct compare
-        self.hash.cmp(&other.hash).reverse()
     }
 }
 

--- a/crates/cfxcore/core/src/pos/mempool/core_mempool/mempool.rs
+++ b/crates/cfxcore/core/src/pos/mempool/core_mempool/mempool.rs
@@ -25,8 +25,8 @@ use diem_types::{
     mempool_status::MempoolStatus,
     term_state::PosState,
     transaction::{
-        authenticator::TransactionAuthenticator, GovernanceRole,
-        SignedTransaction, TransactionPayload,
+        authenticator::TransactionAuthenticator, SignedTransaction,
+        TransactionPayload,
     },
     validator_verifier::ValidatorVerifier,
 };
@@ -103,8 +103,7 @@ impl Mempool {
     /// Used to add a transaction to the Mempool.
     /// Performs basic validation: checks account's sequence number.
     pub(crate) fn add_txn(
-        &mut self, txn: SignedTransaction, ranking_score: u64,
-        timeline_state: TimelineState, governance_role: GovernanceRole,
+        &mut self, txn: SignedTransaction, timeline_state: TimelineState,
     ) -> MempoolStatus {
         diem_trace!(LogSchema::new(LogEntry::AddTxn)
             .txns(TxnsLog::new_txn(txn.sender(), txn.hash())),);
@@ -116,13 +115,8 @@ impl Mempool {
                 .insert((txn.sender(), txn.hash()), SystemTime::now());
         }
 
-        let txn_info = MempoolTransaction::new(
-            txn,
-            expiration_time,
-            ranking_score,
-            timeline_state,
-            governance_role,
-        );
+        let txn_info =
+            MempoolTransaction::new(txn, expiration_time, timeline_state);
 
         self.transactions.insert(txn_info)
     }
@@ -138,16 +132,8 @@ impl Mempool {
     ) -> Vec<SignedTransaction> {
         let mut block = vec![];
         let mut block_log = TxnsLog::new();
-        // Helper DS. Helps to mitigate scenarios where account submits several
-        // transactions with increasing gas price (e.g. user submits
-        // transactions with sequence number 1, 2 and gas_price 1, 10
-        // respectively) Later txn has higher gas price and will be
-        // observed first in priority index iterator, but can't be
-        // executed before first txn. Once observed, such txn will be saved in
-        // `skipped` DS and rechecked once it's ancestor becomes available
         let seen_size = seen.len();
         let mut txn_walked = 0usize;
-        // iterate all normal transaction
         for txn in self.transactions.iter() {
             txn_walked += 1;
             if seen.contains(&TxnPointer::from(txn)) {

--- a/crates/cfxcore/core/src/pos/mempool/core_mempool/transaction.rs
+++ b/crates/cfxcore/core/src/pos/mempool/core_mempool/transaction.rs
@@ -7,8 +7,7 @@
 
 use diem_crypto::HashValue;
 use diem_types::{
-    account_address::AccountAddress,
-    transaction::{GovernanceRole, SignedTransaction},
+    account_address::AccountAddress, transaction::SignedTransaction,
 };
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
@@ -19,22 +18,18 @@ pub struct MempoolTransaction {
     // System expiration time of the transaction. It should be removed from
     // mempool by that time.
     pub expiration_time: Duration,
-    pub ranking_score: u64,
     pub timeline_state: TimelineState,
-    pub governance_role: GovernanceRole,
 }
 
 impl MempoolTransaction {
     pub(crate) fn new(
-        txn: SignedTransaction, expiration_time: Duration, ranking_score: u64,
-        timeline_state: TimelineState, governance_role: GovernanceRole,
+        txn: SignedTransaction, expiration_time: Duration,
+        timeline_state: TimelineState,
     ) -> Self {
         Self {
             txn,
-            ranking_score,
             expiration_time,
             timeline_state,
-            governance_role,
         }
     }
 

--- a/crates/cfxcore/core/src/pos/mempool/core_mempool/transaction_store.rs
+++ b/crates/cfxcore/core/src/pos/mempool/core_mempool/transaction_store.rs
@@ -161,10 +161,8 @@ impl TransactionStore {
         );
     }
 
-    /// Handles transaction commit.
-    /// It includes deletion of all transactions with sequence number <=
-    /// `account_sequence_number` and potential promotion of sequential txns
-    /// to PriorityIndex/TimelineIndex.
+    /// Handles transaction commit: deletes the transaction and cleans up
+    /// its entries in the timeline and TTL indexes.
     pub(crate) fn commit_transaction(
         &mut self, _account: &AccountAddress, hash: HashValue,
     ) {

--- a/crates/cfxcore/core/src/pos/mempool/mod.rs
+++ b/crates/cfxcore/core/src/pos/mempool/mod.rs
@@ -28,39 +28,23 @@
 //! only transactions 2, 3 and 4 will be broadcast.
 //!
 //! Consensus pulls transactions from mempool rather than mempool pushing into
-//! consensus. This is done so that while consensus is not yet ready for
-//! transactions, we keep ordering based on gas and consensus can let
-//! transactions build up.  This allows for batching of transactions into a
-//! single consensus block as well as prioritizing by gas price. Mempool doesn't
-//! keep track of transactions that were sent to Consensus. On each get_block
-//! request, Consensus additionally sends a set of transactions that were pulled
-//! from Mempool so far but were not committed yet. This is done so Mempool can
-//! be agnostic about different Consensus proposal branches.  Once a transaction
-//! is fully executed and written to storage,  Consensus notifies Mempool about
-//! it which later drops it from its internal state.
+//! consensus. Mempool doesn't track which transactions have already been sent
+//! to Consensus; on each `get_block` request Consensus forwards a set of
+//! transactions that were pulled from Mempool but not yet committed, so
+//! Mempool can stay agnostic about Consensus proposal branches. Once a
+//! transaction is fully executed and written to storage, Consensus notifies
+//! Mempool and the transaction is dropped.
 //!
-//! **Internals**: Internally Mempool is modeled as `HashMap<AccountAddress,
-//! AccountTransactions>` with various indexes built on top of it. The main
-//! index `PriorityIndex` is an ordered queue of transactions that are “ready”
-//! to be included in next block(i.e. have sequence number sequential to current
-//! for account). This queue is ordered by gas price so that if a client is
-//! willing to pay more (than other clients) per unit of execution, then they
-//! can enter consensus earlier. Note that although global ordering is
-//! maintained by gas price, for a single account, transactions are ordered by
-//! sequence number.
+//! **Internals**: Mempool is modeled as
+//! `HashMap<AccountAddress, AccountTransactions>` plus a TTL index used only
+//! for expiration/GC. There is no priority ordering — the PoS mempool carries
+//! only PoS-specific transactions (Election, PivotDecision, BLS signatures),
+//! not user traffic, so gas-price ranking does not apply. `get_block` iterates
+//! accounts, returning sequence-number-ordered transactions per account while
+//! skipping those that Consensus has already seen.
 //!
-//! All transactions that are not ready to be included in the next block are
-//! part of separate `ParkingLotIndex`. They will be moved to the ordered queue
-//! once some event unblocks them. For example, Mempool has transaction with
-//! sequence number 4, while current sequence number for that account is 3. Such
-//! transaction is considered to be “non-ready”. Then callback from Consensus
-//! notifies that transaction was committed(i.e. transaction 3 was submitted to
-//! different node). Such event “unblocks” local transaction and txn4 will be
-//! moved to OrderedQueue.
-//!
-//! Mempool only holds a limited number of transactions to prevent OOMing the
-//! system. Additionally there's a limit of number of transactions per account
-//! to prevent different abuses/attacks
+//! Mempool caps both total transaction count and per-account count to bound
+//! memory use.
 //!
 //! Transactions in Mempool have two types of expirations: systemTTL and
 //! client-specified expiration. Once we hit either of those, the transaction is

--- a/crates/cfxcore/core/src/pos/mempool/shared_mempool/tasks.rs
+++ b/crates/cfxcore/core/src/pos/mempool/shared_mempool/tasks.rs
@@ -250,29 +250,20 @@ pub(crate) async fn process_incoming_transactions(
     {
         let mut mempool = smp.mempool.lock();
         for (idx, transaction) in transactions.into_iter().enumerate() {
-            if let Some(validation_result) = &validation_results[idx] {
-                match validation_result.status() {
-                    None => {
-                        let ranking_score = validation_result.score();
-                        let governance_role =
-                            validation_result.governance_role();
-                        let mempool_status = mempool.add_txn(
-                            transaction.clone(),
-                            ranking_score,
-                            timeline_state,
-                            governance_role,
-                        );
-                        statuses.push((transaction, (mempool_status, None)));
-                    }
-                    Some(validation_status) => {
-                        statuses.push((
-                            transaction.clone(),
-                            (
-                                MempoolStatus::new(MempoolStatusCode::VmError),
-                                Some(validation_status),
-                            ),
-                        ));
-                    }
+            match validation_results[idx] {
+                None => {
+                    let mempool_status =
+                        mempool.add_txn(transaction.clone(), timeline_state);
+                    statuses.push((transaction, (mempool_status, None)));
+                }
+                Some(validation_status) => {
+                    statuses.push((
+                        transaction,
+                        (
+                            MempoolStatus::new(MempoolStatusCode::VmError),
+                            Some(validation_status),
+                        ),
+                    ));
                 }
             }
         }

--- a/crates/cfxcore/core/src/pos/mempool/shared_mempool/transaction_validator.rs
+++ b/crates/cfxcore/core/src/pos/mempool/shared_mempool/transaction_validator.rs
@@ -1,8 +1,8 @@
 use diem_types::{
     term_state::PosState,
     transaction::{
-        authenticator::TransactionAuthenticator, GovernanceRole,
-        SignedTransaction, TransactionPayload, VMValidatorResult,
+        authenticator::TransactionAuthenticator, SignedTransaction,
+        TransactionPayload,
     },
 };
 use move_core_types::vm_status::DiscardedVMStatus;
@@ -13,11 +13,11 @@ pub struct TransactionValidator {}
 impl TransactionValidator {
     pub fn new() -> Self { Self {} }
 
-    // TODO: `score` and `governance_role` in `VMValidatorResult` are not
-    // needed now.
+    /// Returns `None` if the transaction is accepted, or a
+    /// `DiscardedVMStatus` describing why it should be rejected.
     pub fn validate_transaction(
         &self, tx: &SignedTransaction, pos_state: Arc<PosState>,
-    ) -> Option<VMValidatorResult> {
+    ) -> Option<DiscardedVMStatus> {
         // This check is cheaper than signature verification, so we do not
         // need to verify signatures for old transactions.
         let result = match tx.payload() {
@@ -30,33 +30,18 @@ impl TransactionValidator {
             _ => None,
         };
         if result.is_some() {
-            return Some(VMValidatorResult::new(
-                result,
-                0,
-                GovernanceRole::Validator,
-            ));
+            return result;
         }
 
         match tx.authenticator() {
             TransactionAuthenticator::BLS { .. } => {}
-            _ => {
-                return Some(VMValidatorResult::new(
-                    Some(DiscardedVMStatus::INVALID_SIGNATURE),
-                    0,
-                    GovernanceRole::Validator,
-                ));
-            }
+            _ => return Some(DiscardedVMStatus::INVALID_SIGNATURE),
         }
 
-        // check signature
         if tx.clone().check_signature().is_err() {
-            return Some(VMValidatorResult::new(
-                Some(DiscardedVMStatus::INVALID_SIGNATURE),
-                0,
-                GovernanceRole::Validator,
-            ));
+            return Some(DiscardedVMStatus::INVALID_SIGNATURE);
         }
 
-        Some(VMValidatorResult::new(result, 0, GovernanceRole::Validator))
+        None
     }
 }

--- a/crates/pos/types/types/src/transaction/mod.rs
+++ b/crates/pos/types/types/src/transaction/mod.rs
@@ -43,9 +43,7 @@ use crate::{
         ConsensusPrivateKey, ConsensusPublicKey, ConsensusSignature,
         ConsensusVRFProof, ConsensusVRFPublicKey, MultiConsensusSignature,
     },
-    vm_status::{
-        DiscardedVMStatus, KeptVMStatus, StatusCode, StatusType, VMStatus,
-    },
+    vm_status::{DiscardedVMStatus, KeptVMStatus, StatusCode, VMStatus},
 };
 
 pub mod authenticator;
@@ -633,95 +631,6 @@ impl From<VMStatus> for TransactionStatus {
             Err(code) => TransactionStatus::Discard(code),
         }
     }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub enum GovernanceRole {
-    DiemRoot,
-    TreasuryCompliance,
-    Validator,
-    ValidatorOperator,
-    DesignatedDealer,
-    NonGovernanceRole,
-}
-
-impl GovernanceRole {
-    pub fn from_role_id(role_id: u64) -> Self {
-        use GovernanceRole::*;
-        match role_id {
-            0 => DiemRoot,
-            1 => TreasuryCompliance,
-            2 => DesignatedDealer,
-            3 => Validator,
-            4 => ValidatorOperator,
-            _ => NonGovernanceRole,
-        }
-    }
-
-    /// The higher the number that is returned, the greater priority assigned to
-    /// a transaction sent from an account with that role in mempool. All
-    /// transactions sent from an account with role priority N are ranked
-    /// higher than all transactions sent from accounts with role priorities <
-    /// N. Transactions from accounts with equal priority are ranked base on
-    /// other characteristics (e.g., gas price).
-    pub fn priority(&self) -> u64 {
-        use GovernanceRole::*;
-        match self {
-            DiemRoot => 3,
-            TreasuryCompliance => 2,
-            Validator | ValidatorOperator | DesignatedDealer => 1,
-            NonGovernanceRole => 0,
-        }
-    }
-}
-
-/// The result of running the transaction through the VM validator.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct VMValidatorResult {
-    /// Result of the validation: `None` if the transaction was successfully
-    /// validated or `Some(DiscardedVMStatus)` if the transaction should be
-    /// discarded.
-    status: Option<DiscardedVMStatus>,
-
-    /// Score for ranking the transaction priority (e.g., based on the gas
-    /// price). Only used when the status is `None`. Higher values indicate
-    /// a higher priority.
-    score: u64,
-
-    /// The account role for the transaction sender, so that certain
-    /// governance transactions can be prioritized above normal transactions.
-    /// Only used when the status is `None`.
-    governance_role: GovernanceRole,
-}
-
-impl VMValidatorResult {
-    pub fn new(
-        vm_status: Option<DiscardedVMStatus>, score: u64,
-        governance_role: GovernanceRole,
-    ) -> Self {
-        debug_assert!(
-            match vm_status {
-                None => true,
-                Some(status) => {
-                    status.status_type() == StatusType::Unknown
-                        || status.status_type() == StatusType::Validation
-                }
-            },
-            "Unexpected discarded status: {:?}",
-            vm_status
-        );
-        Self {
-            status: vm_status,
-            score,
-            governance_role,
-        }
-    }
-
-    pub fn status(&self) -> Option<DiscardedVMStatus> { self.status }
-
-    pub fn score(&self) -> u64 { self.score }
-
-    pub fn governance_role(&self) -> GovernanceRole { self.governance_role }
 }
 
 /// The output of executing a transaction.


### PR DESCRIPTION
Drop Diem-inherited mempool priority plumbing that has been a no-op since Conflux-PoS launched.

`VMValidatorResult::score` is always 0 and `governance_role` is always `Validator`, so the priority-tier comparisons in `OrderedQueueKey::cmp` always fell through. `OrderedQueueKey` itself was `#[allow(dead_code)]`. The PoS mempool only carries validator-internal consensus messages, so gas-price ranking does not apply.

`TransactionValidator::validate_transaction` now returns `Option<DiscardedVMStatus>` directly, matching `PosState::validate_*_simple`. `Mempool::add_txn` shrinks to `(txn, timeline_state)`.

No DB or wire format impact.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3449)
<!-- Reviewable:end -->
