### PR TITLE
security: bump rustls-webpki to 0.103.13 (RUSTSEC-2026-0104)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8191,9 +8191,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/tools/evm-spec-tester/Cargo.lock
+++ b/tools/evm-spec-tester/Cargo.lock
@@ -6887,9 +6887,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

RUSTSEC-2026-0104 (published 2026-04-22) reports a reachable panic in `rustls-webpki`'s CRL parsing (`BorrowedCertRevocationList::from_der` / `OwnedCertRevocationList::from_der`) triggered by an empty `BIT STRING` in the `onlySomeReasons` field of an `IssuingDistributionPoint` extension. The panic fires before CRL signature verification, so an attacker-controlled CRL can crash the parser.

Conflux does not configure CRL verification on any rustls client, so the vulnerable path is not reached in practice. Even so, the patched release (0.103.13) is a SemVer-compatible bump, so take it to clear the advisory cleanly rather than carrying an ignore in `deny.toml`.

Both `Cargo.lock` and `tools/evm-spec-tester/Cargo.lock` pick up the new version; `tools/consensus_bench/Cargo.lock` does not depend on `rustls-webpki`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3453)
<!-- Reviewable:end -->
