### PR TITLE
pos: remove dead reject-transaction plumbing

### DIFF
--- a/crates/cfxcore/core/src/pos/consensus/epoch_manager.rs
+++ b/crates/cfxcore/core/src/pos/consensus/epoch_manager.rs
@@ -464,7 +464,6 @@ impl EpochManager {
             proposal_generator,
             self.safety_rules.clone(),
             network_sender,
-            self.txn_manager.clone(),
             self.storage.clone(),
             self.config.sync_only,
             self.tx_sender.clone(),

--- a/crates/cfxcore/core/src/pos/consensus/round_manager.rs
+++ b/crates/cfxcore/core/src/pos/consensus/round_manager.rs
@@ -72,7 +72,7 @@ use super::{
     },
     pending_votes::VoteReceptionResult,
     persistent_liveness_storage::{PersistentLivenessStorage, RecoveryData},
-    state_replication::{StateComputer, TxnManager},
+    state_replication::StateComputer,
 };
 
 #[derive(Serialize, Clone)]
@@ -217,7 +217,6 @@ pub struct RoundManager {
     proposal_generator: Option<ProposalGenerator>,
     safety_rules: Arc<RwLock<SafetyRules>>,
     network: ConsensusNetworkSender,
-    txn_manager: Arc<dyn TxnManager>,
     storage: Arc<dyn PersistentLivenessStorage>,
     sync_only: bool,
     tx_sender: mpsc::Sender<(
@@ -239,7 +238,7 @@ impl RoundManager {
         proposer_election: Box<dyn ProposerElection + Send + Sync>,
         proposal_generator: Option<ProposalGenerator>,
         safety_rules: Arc<RwLock<SafetyRules>>,
-        network: ConsensusNetworkSender, txn_manager: Arc<dyn TxnManager>,
+        network: ConsensusNetworkSender,
         storage: Arc<dyn PersistentLivenessStorage>, sync_only: bool,
         tx_sender: mpsc::Sender<(
             SignedTransaction,
@@ -257,7 +256,6 @@ impl RoundManager {
             proposal_generator,
             is_voting,
             safety_rules,
-            txn_manager,
             network,
             storage,
             sync_only,
@@ -956,17 +954,6 @@ impl RoundManager {
             .block_store
             .execute_and_insert_block(proposed_block, false, false)
             .context("[RoundManager] Failed to execute_and_insert the block")?;
-        // notify mempool about failed txn
-        let compute_result = executed_block.compute_result();
-        if let Err(e) = self
-            .txn_manager
-            .notify(executed_block.block(), compute_result)
-            .await
-        {
-            diem_error!(
-                error = ?e, "[RoundManager] Failed to notify mempool of rejected txns",
-            );
-        }
 
         // Short circuit if already voted.
         ensure!(

--- a/crates/cfxcore/core/src/pos/consensus/round_manager_fuzzing.rs
+++ b/crates/cfxcore/core/src/pos/consensus/round_manager_fuzzing.rs
@@ -157,7 +157,7 @@ fn create_node_for_fuzzing() -> RoundManager {
     let proposal_generator = ProposalGenerator::new(
         signer.author(),
         block_store.clone(),
-        Arc::new(MockTransactionManager::new(None)),
+        Arc::new(MockTransactionManager),
         time_service,
         1,
     );
@@ -179,7 +179,7 @@ fn create_node_for_fuzzing() -> RoundManager {
         proposal_generator,
         safety_rules,
         network,
-        Arc::new(MockTransactionManager::new(None)),
+        Arc::new(MockTransactionManager),
         storage,
         false,
     )

--- a/crates/cfxcore/core/src/pos/consensus/state_replication.rs
+++ b/crates/cfxcore/core/src/pos/consensus/state_replication.rs
@@ -26,12 +26,6 @@ pub trait TxnManager: Send + Sync {
         &self, max_size: u64, exclude: Vec<&Payload>, hash: HashValue,
         validators: ValidatorVerifier,
     ) -> Result<Payload, MempoolError>;
-
-    /// Notifies TxnManager about the executed result of the block,
-    /// which includes the specifics of what transactions succeeded and failed.
-    async fn notify(
-        &self, block: &Block, compute_result: &StateComputeResult,
-    ) -> Result<(), MempoolError>;
 }
 
 /// While Consensus is managing proposed blocks, `StateComputer` is managing the

--- a/crates/cfxcore/core/src/pos/consensus/test_utils/mock_txn_manager.rs
+++ b/crates/cfxcore/core/src/pos/consensus/test_utils/mock_txn_manager.rs
@@ -5,101 +5,26 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use crate::pos::{
-    consensus::{
-        error::MempoolError, state_replication::TxnManager,
-        txn_manager::MempoolProxy,
-    },
-    mempool::ConsensusRequest,
+use crate::pos::consensus::{
+    error::MempoolError, state_replication::TxnManager,
 };
 use anyhow::Result;
 use consensus_types::{
-    block::{block_test_utils::random_payload, Block},
-    common::Payload,
+    block::block_test_utils::random_payload, common::Payload,
 };
 use diem_crypto::HashValue;
-use diem_types::{
-    transaction::TransactionStatus,
-    validator_verifier::ValidatorVerifier,
-    vm_status::{KeptVMStatus, StatusCode},
-};
-use executor_types::StateComputeResult;
-use futures::channel::mpsc;
-use rand::Rng;
+use diem_types::validator_verifier::ValidatorVerifier;
 
-#[derive(Clone)]
-pub struct MockTransactionManager {
-    rejected_txns: Payload,
-    // used non-mocked TxnManager to test interaction with shared mempool
-    mempool_proxy: Option<MempoolProxy>,
-}
-
-impl MockTransactionManager {
-    #[allow(unused)]
-    pub fn new(
-        consensus_to_mempool_sender: Option<mpsc::Sender<ConsensusRequest>>,
-    ) -> Self {
-        let mempool_proxy =
-            consensus_to_mempool_sender.map(|s| MempoolProxy::new(s, 1, 1));
-        Self {
-            rejected_txns: vec![],
-            mempool_proxy,
-        }
-    }
-}
-
-// mock transaction status on the fly
-fn mock_transaction_status(count: usize) -> Vec<TransactionStatus> {
-    let mut statuses = vec![];
-    // generate count + 1 status to mock the block metadata txn in mempool proxy
-    for _ in 0..=count {
-        let random_status = match rand::rng().random_range(0..1000) {
-            0 => TransactionStatus::Discard(
-                StatusCode::UNKNOWN_VALIDATION_STATUS,
-            ),
-            _ => TransactionStatus::Keep(KeptVMStatus::Executed),
-        };
-        statuses.push(random_status);
-    }
-    statuses
-}
+#[derive(Clone, Default)]
+pub struct MockTransactionManager;
 
 #[async_trait::async_trait]
 impl TxnManager for MockTransactionManager {
-    /// The returned future is fulfilled with the vector of SignedTransactions
     async fn pull_txns(
         &self, _max_size: u64, _exclude_txns: Vec<&Payload>, _hash: HashValue,
         _validators: ValidatorVerifier,
     ) -> Result<Payload, MempoolError> {
         // generate 1k txn is too slow with coverage instrumentation
         Ok(random_payload(10))
-    }
-
-    async fn notify(
-        &self, block: &Block, compute_results: &StateComputeResult,
-    ) -> Result<(), MempoolError> {
-        if self.mempool_proxy.is_some() {
-            let mock_compute_result = StateComputeResult::new(
-                compute_results.root_hash(),
-                compute_results.frozen_subtree_roots().clone(),
-                compute_results.num_leaves(),
-                compute_results.parent_frozen_subtree_roots().clone(),
-                compute_results.parent_num_leaves(),
-                compute_results.epoch_state().clone(),
-                mock_transaction_status(
-                    block.payload().map_or(0, |txns| txns.len()),
-                ),
-                compute_results.transaction_info_hashes().clone(),
-                None,
-            );
-            assert!(self
-                .mempool_proxy
-                .as_ref()
-                .unwrap()
-                .notify(&block, &mock_compute_result)
-                .await
-                .is_ok());
-        }
-        Ok(())
     }
 }

--- a/crates/cfxcore/core/src/pos/consensus/txn_manager.rs
+++ b/crates/cfxcore/core/src/pos/consensus/txn_manager.rs
@@ -5,17 +5,14 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use crate::pos::mempool::{
-    ConsensusRequest, ConsensusResponse, TransactionExclusion,
-};
+use crate::pos::mempool::{ConsensusRequest, TransactionExclusion};
 
 use super::{error::MempoolError, state_replication::TxnManager};
 use anyhow::Result;
-use consensus_types::{block::Block, common::Payload};
+use consensus_types::common::Payload;
 use diem_crypto::HashValue;
 use diem_logger::prelude::*;
 use diem_types::validator_verifier::ValidatorVerifier;
-use executor_types::StateComputeResult;
 use fail::fail_point;
 use futures::channel::{mpsc, oneshot};
 use std::time::Duration;
@@ -54,13 +51,13 @@ impl MempoolProxy {
         parent_block_id: HashValue, validators: ValidatorVerifier,
     ) -> Result<Payload, MempoolError> {
         let (callback, callback_rcv) = oneshot::channel();
-        let req = ConsensusRequest::GetBlockRequest(
-            max_size,
-            exclude_txns.clone(),
+        let req = ConsensusRequest {
+            max_block_size: max_size,
+            exclude_txns,
             parent_block_id,
             validators,
             callback,
-        );
+        };
         // send to shared mempool
         self.consensus_to_mempool_sender
             .clone()
@@ -78,13 +75,9 @@ impl MempoolProxy {
             )
             .into()),
             Ok(resp) => {
-                match resp.map_err(|e| anyhow::anyhow!("{:?}", e))?? {
-                    ConsensusResponse::GetBlockResponse(txns) => Ok(txns),
-                    _ => Err(anyhow::anyhow!(
-                        "[consensus] did not receive expected GetBlockResponse"
-                    )
-                    .into()),
-                }
+                let response =
+                    resp.map_err(|e| anyhow::anyhow!("{:?}", e))??;
+                Ok(response.txns)
             }
         }
     }
@@ -133,13 +126,5 @@ impl TxnManager for MempoolProxy {
             "Pull txn from mempool"
         );
         Ok(txns)
-    }
-
-    // TODO: reject txns. Conflux-PoS never populates the reject list
-    // today, so `notify` is a no-op.
-    async fn notify(
-        &self, _block: &Block, _compute_results: &StateComputeResult,
-    ) -> Result<(), MempoolError> {
-        Ok(())
     }
 }

--- a/crates/cfxcore/core/src/pos/mempool/core_mempool/index.rs
+++ b/crates/cfxcore/core/src/pos/mempool/core_mempool/index.rs
@@ -65,10 +65,6 @@ impl AccountTransactions {
     pub(crate) fn iter(&self) -> AccountTransactionIter<'_> {
         self.normal_transaction.values()
     }
-
-    pub(crate) fn iter_pivot_decision(&self) -> AccountTransactionIter<'_> {
-        self.pivot_decision_transaction.values()
-    }
 }
 
 pub type TxnPointer = (AccountAddress, HashValue);

--- a/crates/cfxcore/core/src/pos/mempool/core_mempool/mempool.rs
+++ b/crates/cfxcore/core/src/pos/mempool/core_mempool/mempool.rs
@@ -49,19 +49,8 @@ impl Mempool {
     }
 
     /// This function will be called once the transaction has been stored.
-    pub(crate) fn remove_transaction(
-        &mut self, sender: &AccountAddress, hash: HashValue, is_rejected: bool,
-    ) {
-        diem_trace!(
-            LogSchema::new(LogEntry::RemoveTxn)
-                .txns(TxnsLog::new_txn(*sender, hash)),
-            is_rejected = is_rejected
-        );
-        if is_rejected {
-            self.transactions.reject_transaction(&sender, hash);
-        } else {
-            self.transactions.commit_transaction(&sender, hash);
-        }
+    pub(crate) fn remove_transaction(&mut self, hash: HashValue) {
+        self.transactions.commit_transaction(hash);
     }
 
     /// Used to add a transaction to the Mempool.

--- a/crates/cfxcore/core/src/pos/mempool/core_mempool/transaction_store.rs
+++ b/crates/cfxcore/core/src/pos/mempool/core_mempool/transaction_store.rs
@@ -145,9 +145,7 @@ impl TransactionStore {
 
     /// Handles transaction commit: deletes the transaction and cleans up
     /// its entries in the timeline and TTL indexes.
-    pub(crate) fn commit_transaction(
-        &mut self, _account: &AccountAddress, hash: HashValue,
-    ) {
+    pub(crate) fn commit_transaction(&mut self, hash: HashValue) {
         let mut txns_log = TxnsLog::new();
         if let Some(transaction) = self.transactions.remove(&hash) {
             txns_log.add(transaction.get_sender(), transaction.get_hash());
@@ -169,31 +167,6 @@ impl TransactionStore {
             }
         }
         diem_debug!(LogSchema::new(LogEntry::CleanCommittedTxn).txns(txns_log));
-    }
-
-    pub(crate) fn reject_transaction(
-        &mut self, account: &AccountAddress, _hash: HashValue,
-    ) {
-        let mut txns_log = TxnsLog::new();
-        let mut hashes = Vec::new();
-        for txn in self.transactions.iter() {
-            if txn.get_sender() == *account {
-                txns_log.add(txn.get_sender(), txn.get_hash());
-                hashes.push(txn.get_hash());
-            }
-        }
-        for txn in self.transactions.iter_pivot_decision() {
-            if txn.get_sender() == *account {
-                txns_log.add(txn.get_sender(), txn.get_hash());
-                hashes.push(txn.get_hash());
-            }
-        }
-        for hash in hashes {
-            if let Some(txn) = self.transactions.remove(&hash) {
-                self.index_remove(&txn);
-            }
-        }
-        diem_debug!(LogSchema::new(LogEntry::CleanRejectedTxn).txns(txns_log));
     }
 
     /// Removes transaction from all indexes.

--- a/crates/cfxcore/core/src/pos/mempool/logging.rs
+++ b/crates/cfxcore/core/src/pos/mempool/logging.rs
@@ -142,7 +142,6 @@ pub enum LogEntry {
     MempoolFullEvictedTxn,
     GCRemoveTxns,
     CleanCommittedTxn,
-    CleanRejectedTxn,
     ProcessReadyTxns,
     DBError,
     UpstreamNetwork,

--- a/crates/cfxcore/core/src/pos/mempool/shared_mempool/tasks.rs
+++ b/crates/cfxcore/core/src/pos/mempool/shared_mempool/tasks.rs
@@ -257,8 +257,7 @@ pub(crate) async fn process_committed_transactions(
         LogEvent::Received
     )
     .state_sync_msg(&req));
-    commit_txns(&mempool, req.transactions, req.block_timestamp_usecs, false)
-        .await;
+    commit_txns(&mempool, req.transactions, req.block_timestamp_usecs).await;
     if req.callback.send(Ok(CommitResponse::success())).is_err() {
         diem_error!(LogSchema::event_log(
             LogEntry::StateSyncCommit,
@@ -276,48 +275,39 @@ pub(crate) async fn process_consensus_request(
             .consensus_msg(&req)
     );
 
-    let (resp, callback) = match req {
-        ConsensusRequest::GetBlockRequest(
-            max_block_size,
-            transactions,
-            parent_block_id,
+    let ConsensusRequest {
+        max_block_size,
+        exclude_txns,
+        parent_block_id,
+        validators,
+        callback,
+    } = req;
+    let exclude_transactions: HashSet<TxnPointer> = exclude_txns
+        .iter()
+        .map(|txn| (txn.sender, txn.hash))
+        .collect();
+    let mut txns;
+    {
+        let mut mempool = mempool.lock();
+        // gc before pulling block as extra protection against txns that
+        // may expire in consensus Note: this gc
+        // operation relies on the fact that consensus uses the system
+        // time to determine block timestamp
+        let curr_time = diem_infallible::duration_since_epoch();
+        mempool.gc_by_expiration_time(curr_time);
+        let block_size = cmp::max(max_block_size, 1);
+        let pos_state = db
+            .get_pos_state(&parent_block_id)
+            .expect("pos_state should exist");
+        txns = mempool.get_block(
+            block_size,
+            exclude_transactions,
+            &pos_state,
             validators,
-            callback,
-        ) => {
-            let exclude_transactions: HashSet<TxnPointer> = transactions
-                .iter()
-                .map(|txn| (txn.sender, txn.hash))
-                .collect();
-            let mut txns;
-            {
-                let mut mempool = mempool.lock();
-                // gc before pulling block as extra protection against txns that
-                // may expire in consensus Note: this gc
-                // operation relies on the fact that consensus uses the system
-                // time to determine block timestamp
-                let curr_time = diem_infallible::duration_since_epoch();
-                mempool.gc_by_expiration_time(curr_time);
-                let block_size = cmp::max(max_block_size, 1);
-                let pos_state = db
-                    .get_pos_state(&parent_block_id)
-                    .expect("pos_state should exist");
-                txns = mempool.get_block(
-                    block_size,
-                    exclude_transactions,
-                    &pos_state,
-                    validators,
-                );
-            }
-            let pulled_block =
-                txns.drain(..).map(SignedTransaction::into).collect();
-
-            (ConsensusResponse::GetBlockResponse(pulled_block), callback)
-        }
-        ConsensusRequest::RejectNotification(transactions, callback) => {
-            commit_txns(mempool, transactions, 0, true).await;
-            (ConsensusResponse::CommitResponse(), callback)
-        }
-    };
+        );
+    }
+    let pulled_block = txns.drain(..).map(SignedTransaction::into).collect();
+    let resp = ConsensusResponse { txns: pulled_block };
     if callback.send(Ok(resp)).is_err() {
         diem_error!(LogSchema::event_log(
             LogEntry::Consensus,
@@ -328,16 +318,12 @@ pub(crate) async fn process_consensus_request(
 
 async fn commit_txns(
     mempool: &Mutex<CoreMempool>, transactions: Vec<CommittedTransaction>,
-    block_timestamp_usecs: u64, is_rejected: bool,
+    block_timestamp_usecs: u64,
 ) {
     let mut pool = mempool.lock();
 
     for transaction in transactions {
-        pool.remove_transaction(
-            &transaction.sender,
-            transaction.hash,
-            is_rejected,
-        );
+        pool.remove_transaction(transaction.hash);
     }
 
     if block_timestamp_usecs > 0 {

--- a/crates/cfxcore/core/src/pos/mempool/shared_mempool/types.rs
+++ b/crates/cfxcore/core/src/pos/mempool/shared_mempool/types.rs
@@ -129,63 +129,32 @@ impl Future for ScheduledBroadcast {
     }
 }
 
-/// Message sent from consensus to mempool.
-pub enum ConsensusRequest {
-    /// Request to pull block to submit to consensus.
-    GetBlockRequest(
-        // max block size
-        u64,
-        // transactions to exclude from requested block
-        Vec<TransactionExclusion>,
-        // parent block id
-        HashValue,
-        // current validators
-        ValidatorVerifier,
-        oneshot::Sender<Result<ConsensusResponse>>,
-    ),
-    /// Notifications about *rejected* committed txns.
-    RejectNotification(
-        Vec<CommittedTransaction>,
-        oneshot::Sender<Result<ConsensusResponse>>,
-    ),
+/// Consensus asking mempool to pull a block to submit to consensus.
+pub struct ConsensusRequest {
+    pub max_block_size: u64,
+    pub exclude_txns: Vec<TransactionExclusion>,
+    pub parent_block_id: HashValue,
+    pub validators: ValidatorVerifier,
+    pub callback: oneshot::Sender<Result<ConsensusResponse>>,
 }
 
 impl fmt::Display for ConsensusRequest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let payload = match self {
-            ConsensusRequest::GetBlockRequest(
-                block_size,
-                excluded_txns,
-                parent_block_id,
-                _,
-                _,
-            ) => {
-                let mut txns_str = "".to_string();
-                for tx in excluded_txns.iter() {
-                    txns_str += &format!("{} ", tx);
-                }
-                format!(
-                    "GetBlockRequest [block_size: {}, excluded_txns: {}, parent_block_id: {}]",
-                    block_size, txns_str, parent_block_id
-                )
-            }
-            ConsensusRequest::RejectNotification(rejected_txns, _) => {
-                let mut txns_str = "".to_string();
-                for tx in rejected_txns.iter() {
-                    txns_str += &format!("{} ", tx);
-                }
-                format!("RejectNotification [rejected_txns: {}]", txns_str)
-            }
-        };
-        write!(f, "{}", payload)
+        let mut txns_str = "".to_string();
+        for tx in self.exclude_txns.iter() {
+            txns_str += &format!("{} ", tx);
+        }
+        write!(
+            f,
+            "GetBlockRequest [block_size: {}, excluded_txns: {}, parent_block_id: {}]",
+            self.max_block_size, txns_str, self.parent_block_id
+        )
     }
 }
 
-/// Response sent from mempool to consensus.
-pub enum ConsensusResponse {
-    /// Block to submit to consensus
-    GetBlockResponse(Vec<SignedTransaction>),
-    CommitResponse(),
+/// Block of transactions returned from mempool to consensus.
+pub struct ConsensusResponse {
+    pub txns: Vec<SignedTransaction>,
 }
 
 /// Notification from state sync to mempool of commit event.


### PR DESCRIPTION
Conflux-PoS never populates the post-execution reject list. `TxnManager::notify` is wired into `round_manager` but `MempoolProxy::notify` is a no-op, so `ConsensusRequest::RejectNotification` is never produced and `TransactionStore::reject_transaction` is unreachable.

Delete the whole chain from the `notify` hook down through the mempool's reject path, plus the parameters and fields that only existed to carry it. With one variant each, `ConsensusRequest` and `ConsensusResponse` collapse to structs.

Commit-based pruning via `CommitNotification` is unchanged; `gc_by_system_ttl` still handles expiration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3454)
<!-- Reviewable:end -->
