### PR TITLE
pos mempool: drop dead expiration GC

### DIFF
--- a/crates/cfxcore/core/src/pos/consensus/state_computer.rs
+++ b/crates/cfxcore/core/src/pos/consensus/state_computer.rs
@@ -44,9 +44,7 @@ impl ExecutionProxy {
     }
 
     /// Notify mempool of committed transactions so it can prune them.
-    async fn notify_mempool(
-        &self, committed_txns: Vec<Transaction>, block_timestamp_usecs: u64,
-    ) {
+    async fn notify_mempool(&self, committed_txns: Vec<Transaction>) {
         let user_txns: Vec<CommittedTransaction> = committed_txns
             .iter()
             .filter_map(|txn| match txn {
@@ -67,7 +65,6 @@ impl ExecutionProxy {
         let (callback, cb_receiver) = oneshot::channel();
         let notification = CommitNotification {
             transactions: user_txns,
-            block_timestamp_usecs,
             callback,
         };
 
@@ -146,12 +143,11 @@ impl StateComputer for ExecutionProxy {
         &self, block_ids: Vec<HashValue>,
         finality_proof: LedgerInfoWithSignatures,
     ) -> Result<(), ExecutionError> {
-        let timestamp = finality_proof.ledger_info().timestamp_usecs();
         let committed_txns = self
             .executor
             .lock()
             .commit_blocks(block_ids, finality_proof)?;
-        self.notify_mempool(committed_txns, timestamp).await;
+        self.notify_mempool(committed_txns).await;
         Ok(())
     }
 

--- a/crates/cfxcore/core/src/pos/mempool/core_mempool/mempool.rs
+++ b/crates/cfxcore/core/src/pos/mempool/core_mempool/mempool.rs
@@ -196,14 +196,9 @@ impl Mempool {
         block
     }
 
-    /// Periodic core mempool garbage collection.
-    /// Removes all expired transactions.
+    /// Periodic core mempool garbage collection. Removes all expired
+    /// transactions by system TTL.
     pub(crate) fn gc(&mut self) { self.transactions.gc_by_system_ttl(); }
-
-    /// Garbage collection based on client-specified expiration time.
-    pub(crate) fn gc_by_expiration_time(&mut self, block_time: Duration) {
-        self.transactions.gc_by_expiration_time(block_time);
-    }
 
     /// Read `count` transactions from timeline since `timeline_id`.
     /// Returns block of transactions and new last_timeline_id.

--- a/crates/cfxcore/core/src/pos/mempool/core_mempool/transaction_store.rs
+++ b/crates/cfxcore/core/src/pos/mempool/core_mempool/transaction_store.rs
@@ -23,10 +23,7 @@ use diem_types::{
     mempool_status::{MempoolStatus, MempoolStatusCode},
     transaction::{SignedTransaction, TransactionPayload},
 };
-use std::{
-    collections::{hash_map::Values, HashMap, HashSet},
-    time::Duration,
-};
+use std::collections::{hash_map::Values, HashMap, HashSet};
 
 /// TransactionStore is in-memory storage for all transactions in mempool.
 pub struct TransactionStore {
@@ -35,24 +32,19 @@ pub struct TransactionStore {
     // pivot decision helper structure
     pivot_decisions: HashMap<HashValue, HashSet<(AccountAddress, HashValue)>>,
 
-    // TTLIndex based on client-specified expiration time
-    expiration_time_index: TTLIndex,
-    // TTLIndex based on system expiration time
-    // we keep it separate from `expiration_time_index` so Mempool can't be
-    // clogged  by old transactions even if it hasn't received commit
-    // callbacks for a while
+    // TTL keyed on `MempoolTransaction.expiration_time = add_time +
+    // system_transaction_timeout`. Every txn is evicted after the timeout,
+    // regardless of its payload — keeps old txns from clogging the mempool
+    // when commit callbacks are delayed.
     system_ttl_index: TTLIndex,
     timeline_index: TimelineIndex,
-
-    // configuration
-    _capacity: usize,
 }
 
 pub type PivotDecisionIter<'a> =
     Values<'a, HashValue, HashSet<(AccountAddress, HashValue)>>;
 
 impl TransactionStore {
-    pub(crate) fn new(config: &MempoolConfig) -> Self {
+    pub(crate) fn new(_config: &MempoolConfig) -> Self {
         Self {
             // main DS
             transactions: AccountTransactions::new(),
@@ -62,15 +54,7 @@ impl TransactionStore {
             system_ttl_index: TTLIndex::new(Box::new(
                 |t: &MempoolTransaction| t.expiration_time,
             )),
-            expiration_time_index: TTLIndex::new(Box::new(
-                |t: &MempoolTransaction| {
-                    Duration::from_secs(t.txn.expiration_timestamp_secs())
-                },
-            )),
             timeline_index: TimelineIndex::new(),
-
-            // configuration
-            _capacity: config.capacity,
         }
     }
 
@@ -110,12 +94,7 @@ impl TransactionStore {
         }
 
         self.timeline_index.insert(&mut txn);
-
-        // TODO(linxi): evict transaction when mempool is full
-
-        // insert into storage and other indexes
         self.system_ttl_index.insert(&txn);
-        self.expiration_time_index.insert(&txn);
 
         let payload = txn.txn.clone().into_raw_transaction().into_payload();
         if let TransactionPayload::PivotDecision(pivot_decision) = payload {
@@ -172,7 +151,6 @@ impl TransactionStore {
     /// Removes transaction from all indexes.
     fn index_remove(&mut self, txn: &MempoolTransaction) {
         self.system_ttl_index.remove(&txn);
-        self.expiration_time_index.remove(&txn);
         self.timeline_index.remove(&txn);
     }
 
@@ -206,34 +184,17 @@ impl TransactionStore {
             .collect()
     }
 
-    /// Garbage collect old transactions.
+    /// Garbage collect old transactions by system TTL.
     pub(crate) fn gc_by_system_ttl(&mut self) {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .expect("System time is before UNIX_EPOCH");
-        self.gc(now, true);
-    }
 
-    /// Garbage collect old transactions based on client-specified expiration
-    /// time.
-    pub(crate) fn gc_by_expiration_time(&mut self, block_time: Duration) {
-        self.gc(block_time, false);
-    }
-
-    fn gc(&mut self, now: Duration, by_system_ttl: bool) {
-        let (index, log_event) = if by_system_ttl {
-            (&mut self.system_ttl_index, LogEvent::SystemTTLExpiration)
-        } else {
-            (&mut self.expiration_time_index, LogEvent::ClientExpiration)
-        };
-
-        let mut gc_txns = index.gc(now);
-        // sort the expired txns by order of sequence number per account
+        let mut gc_txns = self.system_ttl_index.gc(now);
         gc_txns.sort_by_key(|key| (key.address, key.hash));
-        let mut gc_iter = gc_txns.iter().peekable();
 
         let mut gc_txns_log = TxnsLog::new();
-        while let Some(key) = gc_iter.next() {
+        for key in gc_txns.iter() {
             if let Some(txn) = self.transactions.remove(&key.hash) {
                 gc_txns_log.add(txn.get_sender(), txn.get_hash());
                 self.index_remove(&txn);
@@ -245,8 +206,11 @@ impl TransactionStore {
             }
         }
 
-        diem_debug!(LogSchema::event_log(LogEntry::GCRemoveTxns, log_event)
-            .txns(gc_txns_log));
+        diem_debug!(LogSchema::event_log(
+            LogEntry::GCRemoveTxns,
+            LogEvent::SystemTTLExpiration
+        )
+        .txns(gc_txns_log));
     }
 
     pub(crate) fn iter(&self) -> AccountTransactionIter<'_> {

--- a/crates/cfxcore/core/src/pos/mempool/logging.rs
+++ b/crates/cfxcore/core/src/pos/mempool/logging.rs
@@ -167,7 +167,6 @@ pub enum LogEvent {
 
     // garbage-collect txns events
     SystemTTLExpiration,
-    ClientExpiration,
 
     Success,
 }

--- a/crates/cfxcore/core/src/pos/mempool/shared_mempool/tasks.rs
+++ b/crates/cfxcore/core/src/pos/mempool/shared_mempool/tasks.rs
@@ -257,7 +257,7 @@ pub(crate) async fn process_committed_transactions(
         LogEvent::Received
     )
     .state_sync_msg(&req));
-    commit_txns(&mempool, req.transactions, req.block_timestamp_usecs).await;
+    commit_txns(&mempool, req.transactions).await;
     if req.callback.send(Ok(CommitResponse::success())).is_err() {
         diem_error!(LogSchema::event_log(
             LogEntry::StateSyncCommit,
@@ -289,14 +289,6 @@ pub(crate) async fn process_consensus_request(
     let mut txns;
     {
         let mut mempool = mempool.lock();
-        // gc before pulling block as extra protection against txns that
-        // may expire in consensus Note: this gc
-        // operation relies on the fact that consensus uses the system
-        // time to determine block timestamp
-        let curr_time = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("System time is before UNIX_EPOCH");
-        mempool.gc_by_expiration_time(curr_time);
         let block_size = cmp::max(max_block_size, 1);
         let pos_state = db
             .get_pos_state(&parent_block_id)
@@ -320,17 +312,10 @@ pub(crate) async fn process_consensus_request(
 
 async fn commit_txns(
     mempool: &Mutex<CoreMempool>, transactions: Vec<CommittedTransaction>,
-    block_timestamp_usecs: u64,
 ) {
     let mut pool = mempool.lock();
 
     for transaction in transactions {
         pool.remove_transaction(transaction.hash);
-    }
-
-    if block_timestamp_usecs > 0 {
-        pool.gc_by_expiration_time(Duration::from_micros(
-            block_timestamp_usecs,
-        ));
     }
 }

--- a/crates/cfxcore/core/src/pos/mempool/shared_mempool/types.rs
+++ b/crates/cfxcore/core/src/pos/mempool/shared_mempool/types.rs
@@ -157,12 +157,10 @@ pub struct ConsensusResponse {
     pub txns: Vec<SignedTransaction>,
 }
 
-/// Notification from state sync to mempool of commit event.
+/// Notification from consensus to mempool of commit event.
 /// This notifies mempool to remove committed txns.
 pub struct CommitNotification {
     pub transactions: Vec<CommittedTransaction>,
-    /// Timestamp of committed block.
-    pub block_timestamp_usecs: u64,
     pub callback: oneshot::Sender<Result<CommitResponse>>,
 }
 
@@ -172,11 +170,7 @@ impl fmt::Display for CommitNotification {
         for txn in self.transactions.iter() {
             txns += &format!("{} ", txn);
         }
-        write!(
-            f,
-            "CommitNotification [block_timestamp_usecs: {}, txns: {}]",
-            self.block_timestamp_usecs, txns
-        )
+        write!(f, "CommitNotification [txns: {}]", txns)
     }
 }
 

--- a/crates/pos/config/config/src/config/mempool_config.rs
+++ b/crates/pos/config/config/src/config/mempool_config.rs
@@ -10,7 +10,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct MempoolConfig {
-    pub capacity: usize,
     pub max_broadcasts_per_peer: usize,
     pub shared_mempool_ack_timeout_ms: u64,
     pub shared_mempool_backoff_interval_ms: u64,
@@ -31,7 +30,6 @@ impl Default for MempoolConfig {
             shared_mempool_max_concurrent_inbound_syncs: 2,
             // Allow for 1s latency with the default 500ms tick.
             max_broadcasts_per_peer: 2,
-            capacity: 100_000,
             system_transaction_timeout_secs: 600,
             system_transaction_gc_interval_ms: 60_000,
         }


### PR DESCRIPTION
Fee-free PoS has no price signal to evict stale txns; `gc_by_system_ttl` (600s) is the only live bound. This PR retires unused infrastructure.

> ⚠️ **Breaking config change.** `MempoolConfig.capacity` is removed. Operator yamls that set `mempool.capacity:` will fail to load under `deny_unknown_fields`. No in-tree config sets it.

**Cleanup.** `expiration_time_index` + `gc_by_expiration_time` (all PoS txns set `expiration_timestamp_secs = u64::MAX` — never evicted anything), plus the `CommitNotification.block_timestamp_usecs` plumbing through `ExecutionProxy::notify_mempool` / `process_consensus_request` that only fed this GC, and the `LogEvent::ClientExpiration` it logged. `MempoolConfig.capacity` had no remaining consumer (the `metrics_cache` ring buffer that used it was removed earlier in c3e460b0f); the unused `TransactionStore._capacity` field goes with it.

Scope reduced after review feedback: the per-sender cap and signer checks from the original draft need a redesign around an identity verifiable at admission. That work will land in a separate follow-up PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3456)
<!-- Reviewable:end -->