### PR TITLE
pos consensus: remove dormant Recovery state machine

### DIFF
--- a/crates/cfxcore/core/src/pos/consensus/block_storage/sync_manager.rs
+++ b/crates/cfxcore/core/src/pos/consensus/block_storage/sync_manager.rs
@@ -9,8 +9,6 @@ use crate::pos::consensus::{
     block_storage::{BlockReader, BlockStore},
     logging::{LogEvent, LogSchema},
     network::{ConsensusMsg, ConsensusNetworkSender},
-    persistent_liveness_storage::{PersistentLivenessStorage, RecoveryData},
-    state_replication::StateComputer,
 };
 use anyhow::{bail, format_err};
 use consensus_types::{
@@ -26,7 +24,7 @@ use diem_types::{
     ledger_info::LedgerInfoWithSignatures,
 };
 use rand::{prelude::*, rng};
-use std::{clone::Clone, sync::Arc, time::Duration};
+use std::{clone::Clone, time::Duration};
 
 pub const BLOCK_FETCH_BATCH_MAX_SIZE: u64 = 60;
 
@@ -184,51 +182,6 @@ impl BlockStore {
         }
 
         self.insert_single_quorum_cert(qc)
-    }
-
-    pub async fn fast_forward_sync<'a>(
-        highest_commit_cert: &'a QuorumCert, retriever: &'a mut BlockRetriever,
-        storage: Arc<dyn PersistentLivenessStorage>,
-        state_computer: Arc<dyn StateComputer>,
-    ) -> anyhow::Result<RecoveryData> {
-        diem_debug!(
-            LogSchema::new(LogEvent::StateSync)
-                .remote_peer(retriever.preferred_peer),
-            "Start state sync with peer to block: {}",
-            highest_commit_cert.commit_info(),
-        );
-
-        let blocks = retriever
-            .retrieve_block_for_qc(&highest_commit_cert, 3)
-            .await?;
-        assert_eq!(
-            blocks.last().expect("should have 3-chain").id(),
-            highest_commit_cert.commit_info().id(),
-        );
-        let mut quorum_certs = vec![];
-        quorum_certs.push(highest_commit_cert.clone());
-        quorum_certs.extend(
-            blocks
-                .iter()
-                .take(2)
-                .map(|block| block.quorum_cert().clone()),
-        );
-        for (i, block) in blocks.iter().enumerate() {
-            assert_eq!(block.id(), quorum_certs[i].certified_block().id());
-        }
-
-        // If a node restarts in the middle of state synchronization, it is
-        // going to try to catch up to the stored quorum certs as the
-        // new root.
-        storage.save_tree(blocks.clone(), quorum_certs.clone())?;
-        state_computer
-            .sync_to(highest_commit_cert.ledger_info().clone())
-            .await?;
-        let recovery_data = storage.start().expect_recovery_data(
-            "Failed to construct recovery data after fast forward sync",
-        );
-
-        Ok(recovery_data)
     }
 }
 

--- a/crates/cfxcore/core/src/pos/consensus/epoch_manager.rs
+++ b/crates/cfxcore/core/src/pos/consensus/epoch_manager.rs
@@ -22,12 +22,8 @@ use super::{
         ConsensusMsg, ConsensusNetworkSender, IncomingBlockRetrievalRequest,
         NetworkReceivers,
     },
-    persistent_liveness_storage::{
-        LedgerRecoveryData, PersistentLivenessStorage, RecoveryData,
-    },
-    round_manager::{
-        RecoveryManager, RoundManager, UnverifiedEvent, VerifiedEvent,
-    },
+    persistent_liveness_storage::{PersistentLivenessStorage, RecoveryData},
+    round_manager::{RoundManager, UnverifiedEvent, VerifiedEvent},
     state_replication::{StateComputer, TxnManager},
     util::time_service::TimeService,
 };
@@ -74,31 +70,6 @@ use std::{
     time::Duration,
 };
 
-/// RecoveryManager is used to process events in order to sync up with peer if
-/// we can't recover from local consensusdb RoundManager is used for normal
-/// event handling. We suppress clippy warning here because we expect most of
-/// the time we will have RoundManager
-#[allow(clippy::large_enum_variant)]
-pub enum RoundProcessor {
-    Recovery(RecoveryManager),
-    Normal(RoundManager),
-}
-
-#[allow(clippy::large_enum_variant)]
-pub enum LivenessStorageData {
-    RecoveryData(RecoveryData),
-    LedgerRecoveryData(LedgerRecoveryData),
-}
-
-impl LivenessStorageData {
-    pub fn expect_recovery_data(self, msg: &str) -> RecoveryData {
-        match self {
-            LivenessStorageData::RecoveryData(data) => data,
-            LivenessStorageData::LedgerRecoveryData(_) => panic!("{}", msg),
-        }
-    }
-}
-
 // Manager the components that shared across epoch and spawn per-epoch
 // RoundManager with epoch-specific input.
 pub struct EpochManager {
@@ -118,7 +89,7 @@ pub struct EpochManager {
     state_computer: Arc<dyn StateComputer>,
     storage: Arc<dyn PersistentLivenessStorage>,
     safety_rules: Arc<RwLock<SafetyRules>>,
-    processor: Option<RoundProcessor>,
+    processor: Option<RoundManager>,
     // Conflux PoW handler
     pow_handler: Arc<dyn PowInterface>,
     election_control: Arc<AtomicBool>,
@@ -197,14 +168,10 @@ impl EpochManager {
     }
 
     fn epoch_state(&self) -> &EpochState {
-        match self
-            .processor
+        self.processor
             .as_ref()
             .expect("EpochManager not started yet")
-        {
-            RoundProcessor::Normal(p) => p.epoch_state(),
-            RoundProcessor::Recovery(p) => p.epoch_state(),
-        }
+            .epoch_state()
     }
 
     fn epoch(&self) -> u64 { self.epoch_state().epoch }
@@ -350,36 +317,18 @@ impl EpochManager {
             "Received verified epoch change",
         );
 
-        // make sure storage is on this ledger_info too, it should be no-op if
-        // it's already committed
-        // self.state_computer
-        //     .sync_to(ledger_info.clone())
-        //     .await
-        //     .context(format!(
-        //         "[EpochManager] State sync to new epoch {}",
-        //         ledger_info
-        //     ))?;
         for ledger_info in proof.get_all_ledger_infos() {
-            match self.processor_mut() {
-                RoundProcessor::Recovery(_) => {
-                    bail!("start_new_epoch for Recovery processor");
-                }
-                RoundProcessor::Normal(p) => {
-                    if ledger_info.ledger_info().epoch()
-                        == p.epoch_state().epoch
-                    {
-                        p.sync_to_ledger_info(&ledger_info, peer_id).await?;
-                        let epoch_state = self.latest_epoch_state();
-                        self.start_processor_with_epoch_state(epoch_state)
-                            .await;
-                    } else {
-                        diem_error!(
-                            "Unexpected epoch change: me={} get={}",
-                            p.epoch_state().epoch,
-                            ledger_info.ledger_info().epoch()
-                        );
-                    }
-                }
+            let p = self.processor_mut();
+            if ledger_info.ledger_info().epoch() == p.epoch_state().epoch {
+                p.sync_to_ledger_info(&ledger_info, peer_id).await?;
+                let epoch_state = self.latest_epoch_state();
+                self.start_processor_with_epoch_state(epoch_state).await;
+            } else {
+                diem_error!(
+                    "Unexpected epoch change: me={} get={}",
+                    p.epoch_state().epoch,
+                    ledger_info.ledger_info().epoch()
+                );
             }
         }
 
@@ -488,33 +437,8 @@ impl EpochManager {
             Some(self.vrf_private_key.clone()),
         );
         processor.start(last_vote).await;
-        self.processor = Some(RoundProcessor::Normal(processor));
+        self.processor = Some(processor);
         diem_info!(epoch = epoch, "RoundManager started");
-    }
-
-    // Depending on what data we can extract from consensusdb, we may or may not
-    // have an event processor at startup. If we need to sync up with peers
-    // for blocks to construct a valid block store, which is required to
-    // construct an event processor, we will take care of the sync up here.
-    async fn start_recovery_manager(
-        &mut self, ledger_recovery_data: LedgerRecoveryData,
-        epoch_state: EpochState,
-    ) {
-        let epoch = epoch_state.epoch;
-        let network_sender = ConsensusNetworkSender::new(
-            self.author,
-            self.network_sender.clone(),
-            //self.self_sender.clone(),
-            epoch_state.verifier().clone(),
-        );
-        self.processor = Some(RoundProcessor::Recovery(RecoveryManager::new(
-            epoch_state,
-            network_sender,
-            self.storage.clone(),
-            self.state_computer.clone(),
-            ledger_recovery_data.commit_round(),
-        )));
-        diem_info!(epoch = epoch, "SyncProcessor started");
     }
 
     async fn start_processor_with_epoch_state(
@@ -524,15 +448,8 @@ impl EpochManager {
             "start_processor_with_epoch_state: epoch_state={:?}",
             epoch_state
         );
-        match self.storage.start() {
-            LivenessStorageData::RecoveryData(initial_data) => {
-                self.start_round_manager(initial_data, epoch_state).await
-            }
-            LivenessStorageData::LedgerRecoveryData(ledger_recovery_data) => {
-                self.start_recovery_manager(ledger_recovery_data, epoch_state)
-                    .await
-            }
-        }
+        let initial_data = self.storage.start();
+        self.start_round_manager(initial_data, epoch_state).await;
     }
 
     async fn process_message(
@@ -623,33 +540,15 @@ impl EpochManager {
     async fn process_event(
         &mut self, peer_id: AccountAddress, event: VerifiedEvent,
     ) -> anyhow::Result<()> {
-        match self.processor_mut() {
-            RoundProcessor::Recovery(p) => {
-                let recovery_data = match event {
-                    VerifiedEvent::ProposalMsg(proposal) => {
-                        p.process_proposal_msg(*proposal).await
-                    }
-                    VerifiedEvent::VoteMsg(vote) => {
-                        p.process_vote_msg(*vote).await
-                    }
-                    VerifiedEvent::SyncInfo(sync_info) => {
-                        p.sync_up(&sync_info, peer_id).await
-                    }
-                }?;
-                let epoch_state = p.epoch_state().clone();
-                diem_info!("Recovered from SyncProcessor");
-                self.start_round_manager(recovery_data, epoch_state).await;
-                Ok(())
+        let p = self.processor_mut();
+        match event {
+            VerifiedEvent::ProposalMsg(proposal) => {
+                p.process_proposal_msg(*proposal).await
             }
-            RoundProcessor::Normal(p) => match event {
-                VerifiedEvent::ProposalMsg(proposal) => {
-                    p.process_proposal_msg(*proposal).await
-                }
-                VerifiedEvent::VoteMsg(vote) => p.process_vote_msg(*vote).await,
-                VerifiedEvent::SyncInfo(sync_info) => {
-                    p.process_sync_info_msg(*sync_info, peer_id).await
-                }
-            },
+            VerifiedEvent::VoteMsg(vote) => p.process_vote_msg(*vote).await,
+            VerifiedEvent::SyncInfo(sync_info) => {
+                p.process_sync_info_msg(*sync_info, peer_id).await
+            }
         }
     }
 
@@ -661,10 +560,7 @@ impl EpochManager {
             Some(event) => event,
             None => return false,
         };
-        let processor = match self.processor_mut() {
-            RoundProcessor::Recovery(_) => return true,
-            RoundProcessor::Normal(p) => p,
-        };
+        let processor = self.processor_mut();
         match event {
             UnverifiedEvent::ProposalMsg(p) => {
                 processor.filter_proposal(p.as_ref())
@@ -674,7 +570,7 @@ impl EpochManager {
         }
     }
 
-    fn processor_mut(&mut self) -> &mut RoundProcessor {
+    fn processor_mut(&mut self) -> &mut RoundManager {
         self.processor
             .as_mut()
             .expect("[EpochManager] not started yet")
@@ -683,45 +579,31 @@ impl EpochManager {
     async fn process_block_retrieval(
         &mut self, request: IncomingBlockRetrievalRequest,
     ) -> anyhow::Result<()> {
-        match self.processor_mut() {
-            RoundProcessor::Normal(p) => {
-                p.process_block_retrieval(request).await
-            }
-            _ => bail!("[EpochManager] RoundManager not started yet"),
-        }
+        self.processor_mut().process_block_retrieval(request).await
     }
 
     async fn process_local_timeout(
         &mut self, epoch_round: (u64, Round),
     ) -> anyhow::Result<()> {
-        match self.processor_mut() {
-            RoundProcessor::Normal(p) => {
-                p.process_local_timeout(epoch_round).await
-            }
-            _ => unreachable!("RoundManager not started yet"),
-        }
+        self.processor_mut()
+            .process_local_timeout(epoch_round)
+            .await
     }
 
     async fn process_proposal_timeout(
         &mut self, epoch_round: (u64, Round),
     ) -> anyhow::Result<()> {
-        match self.processor_mut() {
-            RoundProcessor::Normal(p) => {
-                p.process_proposal_timeout(epoch_round).await
-            }
-            _ => unreachable!("RoundManager not started yet"),
-        }
+        self.processor_mut()
+            .process_proposal_timeout(epoch_round)
+            .await
     }
 
     async fn process_new_round_timeout(
         &mut self, epoch_round: (u64, Round),
     ) -> anyhow::Result<()> {
-        match self.processor_mut() {
-            RoundProcessor::Normal(p) => {
-                p.process_new_round_timeout(epoch_round).await
-            }
-            _ => unreachable!("RoundManager not started yet"),
-        }
+        self.processor_mut()
+            .process_new_round_timeout(epoch_round)
+            .await
     }
 
     pub async fn start(
@@ -760,12 +642,7 @@ impl EpochManager {
                     self.process_block_retrieval(block_retrieval).await
                 }
             };
-            let round_state =
-                if let RoundProcessor::Normal(p) = self.processor_mut() {
-                    Some(p.round_state())
-                } else {
-                    None
-                };
+            let round_state = self.processor.as_mut().map(|p| p.round_state());
             match result {
                 Ok(_) => diem_trace!(RoundStateLogSchema::new(round_state)),
                 Err(e) => {
@@ -792,32 +669,23 @@ impl EpochManager {
                 payload,
             } => self.force_propose(round, parent_id, payload).await,
             TestCommand::ProposalTimeOut => {
-                let round = match self.processor_mut() {
-                    RoundProcessor::Normal(p) => {
-                        (p.epoch_state().epoch, p.round_state().current_round())
-                    }
-                    _ => anyhow::bail!("RoundManager not started yet"),
-                };
+                let p = self.processor_mut();
+                let round =
+                    (p.epoch_state().epoch, p.round_state().current_round());
                 diem_debug!("TestCommand::ProposalTimeOut, round={:?}", round);
                 self.process_proposal_timeout(round).await
             }
             TestCommand::LocalTimeout => {
-                let round = match self.processor_mut() {
-                    RoundProcessor::Normal(p) => {
-                        (p.epoch_state().epoch, p.round_state().current_round())
-                    }
-                    _ => anyhow::bail!("RoundManager not started yet"),
-                };
+                let p = self.processor_mut();
+                let round =
+                    (p.epoch_state().epoch, p.round_state().current_round());
                 diem_debug!("TestCommand::LocalTimeout, round={:?}", round);
                 self.process_local_timeout(round).await
             }
             TestCommand::NewRoundTimeout => {
-                let round = match self.processor_mut() {
-                    RoundProcessor::Normal(p) => {
-                        (p.epoch_state().epoch, p.round_state().current_round())
-                    }
-                    _ => anyhow::bail!("RoundManager not started yet"),
-                };
+                let p = self.processor_mut();
+                let round =
+                    (p.epoch_state().epoch, p.round_state().current_round());
                 diem_debug!("TestCommand::NewRoundTimeout, round={:?}", round);
                 self.process_new_round_timeout(round).await
             }
@@ -834,13 +702,10 @@ impl EpochManager {
                 tx.send(final_serving_round)
                     .map_err(|e| anyhow!("send: err={:?}", e))
             }
-            TestCommand::GetChosenProposal(tx) => match self.processor_mut() {
-                RoundProcessor::Normal(p) => {
-                    let chosen = p.get_chosen_proposal()?;
-                    tx.send(chosen).map_err(|e| anyhow!("send: err={:?}", e))
-                }
-                _ => anyhow::bail!("RoundManager not started yet"),
-            },
+            TestCommand::GetChosenProposal(tx) => {
+                let chosen = self.processor_mut().get_chosen_proposal()?;
+                tx.send(chosen).map_err(|e| anyhow!("send: err={:?}", e))
+            }
             TestCommand::StartVoting((initialize, tx)) => {
                 let r = self.start_voting(initialize).await;
                 tx.send(r).map_err(|e| anyhow!("send: err={:?}", e))
@@ -862,12 +727,9 @@ impl EpochManager {
         diem_debug!("force_vote_proposal: {:?}", block_id);
         let bls_key = self.consensus_private_key.private_key();
         let author = self.author;
-        match self.processor_mut() {
-            RoundProcessor::Normal(p) => {
-                p.force_vote_proposal(block_id, author, &bls_key).await
-            }
-            _ => anyhow::bail!("RoundManager not started yet"),
-        }
+        self.processor_mut()
+            .force_vote_proposal(block_id, author, &bls_key)
+            .await
     }
 
     async fn force_propose(
@@ -875,40 +737,27 @@ impl EpochManager {
         payload: Vec<TransactionPayload>,
     ) -> anyhow::Result<()> {
         let bls_key = self.consensus_private_key.private_key();
-        match self.processor_mut() {
-            RoundProcessor::Normal(p) => {
-                p.force_propose(round, parent_block_id, payload, &bls_key)
-                    .await
-            }
-            _ => anyhow::bail!("RoundManager not started yet"),
-        }
+        self.processor_mut()
+            .force_propose(round, parent_block_id, payload, &bls_key)
+            .await
     }
 
     async fn force_sign_pivot_decision(
         &mut self, pivot_decision: PivotBlockDecision,
     ) -> anyhow::Result<()> {
-        match self.processor_mut() {
-            RoundProcessor::Normal(p) => {
-                p.force_sign_pivot_decision(pivot_decision).await
-            }
-            _ => anyhow::bail!("RoundManager not started yet"),
-        }
+        self.processor_mut()
+            .force_sign_pivot_decision(pivot_decision)
+            .await
     }
 
     async fn start_voting(&mut self, initialize: bool) -> anyhow::Result<()> {
-        match self.processor_mut() {
-            RoundProcessor::Normal(p) => p.start_voting(initialize)?,
-            _ => anyhow::bail!("RoundManager not started yet"),
-        };
+        self.processor_mut().start_voting(initialize)?;
         self.is_voting = true;
         Ok(())
     }
 
     async fn stop_voting(&mut self) -> anyhow::Result<()> {
-        match self.processor_mut() {
-            RoundProcessor::Normal(p) => p.stop_voting()?,
-            _ => anyhow::bail!("RoundManager not started yet"),
-        }
+        self.processor_mut().stop_voting()?;
         self.is_voting = false;
         Ok(())
     }

--- a/crates/cfxcore/core/src/pos/consensus/error.rs
+++ b/crates/cfxcore/core/src/pos/consensus/error.rs
@@ -16,19 +16,6 @@ pub struct DbError {
 
 #[derive(Debug, Error)]
 #[error(transparent)]
-pub struct StateSyncError {
-    #[from]
-    inner: anyhow::Error,
-}
-
-impl From<executor_types::Error> for StateSyncError {
-    fn from(e: executor_types::Error) -> Self {
-        StateSyncError { inner: e.into() }
-    }
-}
-
-#[derive(Debug, Error)]
-#[error(transparent)]
 pub struct MempoolError {
     #[from]
     inner: anyhow::Error,
@@ -45,12 +32,6 @@ pub fn error_kind(e: &anyhow::Error) -> &'static str {
     if e.downcast_ref::<executor_types::Error>().is_some() {
         return "Execution";
     }
-    if let Some(e) = e.downcast_ref::<StateSyncError>() {
-        if e.inner.downcast_ref::<executor_types::Error>().is_some() {
-            return "Execution";
-        }
-        return "StateSync";
-    }
     if e.downcast_ref::<MempoolError>().is_some() {
         return "Mempool";
     }
@@ -64,20 +45,4 @@ pub fn error_kind(e: &anyhow::Error) -> &'static str {
         return "VerifyError";
     }
     "InternalError"
-}
-
-#[cfg(test)]
-mod tests {
-    use super::super::error::{error_kind, StateSyncError};
-    use anyhow::Context;
-
-    #[test]
-    fn conversion_and_downcast() {
-        let error = executor_types::Error::InternalError {
-            error: "lalala".to_string(),
-        };
-        let typed_error: StateSyncError = error.into();
-        let upper: anyhow::Result<()> = Err(typed_error).context("Context!");
-        assert_eq!(error_kind(&upper.unwrap_err()), "Execution");
-    }
 }

--- a/crates/cfxcore/core/src/pos/consensus/logging.rs
+++ b/crates/cfxcore/core/src/pos/consensus/logging.rs
@@ -32,7 +32,6 @@ pub enum LogEvent {
     ReceiveSyncInfo,
     ReceiveVote,
     RetrieveBlock,
-    StateSync,
     SyncToPeer,
     Timeout,
     Vote,

--- a/crates/cfxcore/core/src/pos/consensus/persistent_liveness_storage.rs
+++ b/crates/cfxcore/core/src/pos/consensus/persistent_liveness_storage.rs
@@ -5,7 +5,7 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use super::{consensusdb::ConsensusDB, epoch_manager::LivenessStorageData};
+use super::consensusdb::ConsensusDB;
 use anyhow::{format_err, Context, Result};
 use consensus_types::{
     block::Block, db::LedgerBlockRW, quorum_cert::QuorumCert,
@@ -15,8 +15,7 @@ use diem_config::config::NodeConfig;
 use diem_crypto::HashValue;
 use diem_logger::prelude::*;
 use diem_types::{
-    block_info::{PivotBlockDecision, Round},
-    ledger_info::LedgerInfo,
+    block_info::PivotBlockDecision, ledger_info::LedgerInfo,
     transaction::Version,
 };
 use executor_types::ExecutedTrees;
@@ -40,8 +39,10 @@ pub trait PersistentLivenessStorage: Send + Sync {
     /// Persist consensus' state
     fn save_vote(&self, vote: &Vote) -> Result<()>;
 
-    /// Construct necessary data to start consensus.
-    fn start(&self) -> LivenessStorageData;
+    /// Construct necessary data to start consensus. Panics if the ConsensusDB
+    /// is missing the block referenced by the latest committed ledger info —
+    /// that combination is only reachable via on-disk corruption.
+    fn start(&self) -> RecoveryData;
 
     /// Persist the highest timeout certificate for improved liveness - proof
     /// for other replicas to jump to this round
@@ -64,78 +65,57 @@ pub trait PersistentLivenessStorage: Send + Sync {
 #[derive(Clone)]
 pub struct RootInfo(pub Block, pub QuorumCert, pub QuorumCert);
 
-/// LedgerRecoveryData is a subset of RecoveryData that we can get solely from
-/// ledger info.
-#[derive(Clone)]
-pub struct LedgerRecoveryData {
-    storage_ledger: LedgerInfo,
-}
+/// Finds the root (last committed block) from the ConsensusDB contents and the
+/// storage latest ledger info. For an end-of-epoch ledger info we synthesise a
+/// deterministic virtual genesis block so first-ever startups and epoch
+/// transitions can always resolve their root without waiting for peer data.
+fn find_root(
+    storage_ledger: &LedgerInfo, blocks: &mut Vec<Block>,
+    quorum_certs: &mut Vec<QuorumCert>,
+) -> Result<RootInfo> {
+    diem_info!(
+        "The last committed block id as recorded in storage: {}",
+        storage_ledger
+    );
 
-impl LedgerRecoveryData {
-    pub fn new(storage_ledger: LedgerInfo) -> Self {
-        LedgerRecoveryData { storage_ledger }
-    }
-
-    pub fn commit_round(&self) -> Round { self.storage_ledger.round() }
-
-    /// Finds the root (last committed block) and returns the root block, the QC
-    /// to the root block and the ledger info for the root block, return an
-    /// error if it can not be found.
-    ///
-    /// We guarantee that the block corresponding to the storage's latest ledger
-    /// info always exists.
-    fn find_root(
-        &self, blocks: &mut Vec<Block>, quorum_certs: &mut Vec<QuorumCert>,
-    ) -> Result<RootInfo> {
-        diem_info!(
-            "The last committed block id as recorded in storage: {}",
-            self.storage_ledger
+    let root_id = if storage_ledger.ends_epoch() {
+        let genesis =
+            Block::make_genesis_block_from_ledger_info(storage_ledger);
+        let genesis_qc = QuorumCert::certificate_for_genesis_from_ledger_info(
+            storage_ledger,
+            genesis.id(),
         );
+        let genesis_id = genesis.id();
+        blocks.push(genesis);
+        quorum_certs.push(genesis_qc);
+        genesis_id
+    } else {
+        storage_ledger.consensus_block_id()
+    };
 
-        // We start from the block that storage's latest ledger info, if storage
-        // has end-epoch LedgerInfo, we generate the virtual genesis
-        // block
-        let root_id = if self.storage_ledger.ends_epoch() {
-            let genesis = Block::make_genesis_block_from_ledger_info(
-                &self.storage_ledger,
-            );
-            let genesis_qc =
-                QuorumCert::certificate_for_genesis_from_ledger_info(
-                    &self.storage_ledger,
-                    genesis.id(),
-                );
-            let genesis_id = genesis.id();
-            blocks.push(genesis);
-            quorum_certs.push(genesis_qc);
-            genesis_id
-        } else {
-            self.storage_ledger.consensus_block_id()
-        };
+    // sort by (epoch, round) to guarantee the topological order of parent
+    // <- child
+    blocks.sort_by_key(|b| (b.epoch(), b.round()));
 
-        // sort by (epoch, round) to guarantee the topological order of parent
-        // <- child
-        blocks.sort_by_key(|b| (b.epoch(), b.round()));
+    let root_idx = blocks
+        .iter()
+        .position(|block| block.id() == root_id)
+        .ok_or_else(|| format_err!("unable to find root: {}", root_id))?;
+    let root_block = blocks.remove(root_idx);
+    let root_quorum_cert = quorum_certs
+        .iter()
+        .find(|qc| qc.certified_block().id() == root_block.id())
+        .ok_or_else(|| format_err!("No QC found for root: {}", root_id))?
+        .clone();
+    let root_ledger_info = quorum_certs
+        .iter()
+        .find(|qc| qc.commit_info().id() == root_block.id())
+        .ok_or_else(|| format_err!("No LI found for root: {}", root_id))?
+        .clone();
 
-        let root_idx = blocks
-            .iter()
-            .position(|block| block.id() == root_id)
-            .ok_or_else(|| format_err!("unable to find root: {}", root_id))?;
-        let root_block = blocks.remove(root_idx);
-        let root_quorum_cert = quorum_certs
-            .iter()
-            .find(|qc| qc.certified_block().id() == root_block.id())
-            .ok_or_else(|| format_err!("No QC found for root: {}", root_id))?
-            .clone();
-        let root_ledger_info = quorum_certs
-            .iter()
-            .find(|qc| qc.commit_info().id() == root_block.id())
-            .ok_or_else(|| format_err!("No LI found for root: {}", root_id))?
-            .clone();
+    diem_info!("Consensus root block is {}", root_block);
 
-        diem_info!("Consensus root block is {}", root_block);
-
-        Ok(RootInfo(root_block, root_quorum_cert, root_ledger_info))
-    }
+    Ok(RootInfo(root_block, root_quorum_cert, root_ledger_info))
 }
 
 pub struct RootMetadata {
@@ -192,19 +172,18 @@ pub struct RecoveryData {
 
 impl RecoveryData {
     pub fn new(
-        last_vote: Option<Vote>, ledger_recovery_data: LedgerRecoveryData,
+        last_vote: Option<Vote>, storage_ledger: &LedgerInfo,
         mut blocks: Vec<Block>, root_metadata: RootMetadata,
         mut quorum_certs: Vec<QuorumCert>,
         highest_timeout_certificate: Option<TimeoutCertificate>,
     ) -> Result<Self> {
-        let root = ledger_recovery_data
-            .find_root(&mut blocks, &mut quorum_certs)
+        let root = find_root(storage_ledger, &mut blocks, &mut quorum_certs)
             .with_context(|| {
                 // for better readability
                 quorum_certs.sort_by_key(|qc| qc.certified_block().round());
                 format!(
                     "\nRoot id: {}\nBlocks in db: {}\nQuorum Certs in db: {}\n",
-                    ledger_recovery_data.storage_ledger.consensus_block_id(),
+                    storage_ledger.consensus_block_id(),
                     blocks
                         .iter()
                         .map(|b| format!("\n\t{}", b))
@@ -323,7 +302,7 @@ impl PersistentLivenessStorage for StorageWriteProxy {
         Ok(self.db.save_vote(bcs::to_bytes(vote)?)?)
     }
 
-    fn start(&self) -> LivenessStorageData {
+    fn start(&self) -> RecoveryData {
         diem_info!("Start consensus recovery.");
         let raw_data = self
             .db
@@ -363,9 +342,8 @@ impl PersistentLivenessStorage for StorageWriteProxy {
             .expect("unable to read ledger info from storage")
             .expect("startup info is None");
         diem_debug!("startup_info={:?}", startup_info);
-        let ledger_recovery_data = LedgerRecoveryData::new(
-            startup_info.latest_ledger_info.ledger_info().clone(),
-        );
+        let storage_ledger =
+            startup_info.latest_ledger_info.ledger_info().clone();
         let frozen_root_hashes = startup_info
             .committed_tree_state
             .ledger_frozen_subtree_hashes
@@ -374,50 +352,44 @@ impl PersistentLivenessStorage for StorageWriteProxy {
             startup_info.committed_tree_state,
             startup_info.committed_pos_state,
         );
-        match RecoveryData::new(
+        let mut initial_data = RecoveryData::new(
             last_vote,
-            ledger_recovery_data.clone(),
+            &storage_ledger,
             blocks,
             RootMetadata::new(
                 root_executed_trees.txn_accumulator().num_leaves(),
                 root_executed_trees.state_id(),
                 frozen_root_hashes,
-                startup_info
-                    .latest_ledger_info
-                    .ledger_info()
-                    .pivot_decision()
-                    .cloned(),
+                storage_ledger.pivot_decision().cloned(),
             ),
             quorum_certs,
             highest_timeout_certificate,
-        ) {
-            Ok(mut initial_data) => {
-                (self as &dyn PersistentLivenessStorage)
-                    .prune_tree(initial_data.take_blocks_to_prune())
-                    .expect("unable to prune dangling blocks during restart");
-                if initial_data.last_vote.is_none() {
-                    self.db
-                        .delete_last_vote_msg()
-                        .expect("unable to cleanup last vote");
-                }
-                if initial_data.highest_timeout_certificate.is_none() {
-                    self.db
-                        .delete_highest_timeout_certificate()
-                        .expect("unable to cleanup highest timeout cert");
-                }
-                diem_info!(
-                    "Starting up the consensus state machine with recovery data - [last_vote {}], [highest timeout certificate: {}]",
-                    initial_data.last_vote.as_ref().map_or("None".to_string(), |v| v.to_string()),
-                    initial_data.highest_timeout_certificate.as_ref().map_or("None".to_string(), |v| v.to_string()),
-                );
+        )
+        .expect(
+            "ConsensusDB is missing the root block referenced by the latest \
+             committed ledger info — this indicates on-disk corruption",
+        );
 
-                LivenessStorageData::RecoveryData(initial_data)
-            }
-            Err(e) => {
-                diem_error!(error = ?e, "Failed to construct recovery data");
-                LivenessStorageData::LedgerRecoveryData(ledger_recovery_data)
-            }
+        (self as &dyn PersistentLivenessStorage)
+            .prune_tree(initial_data.take_blocks_to_prune())
+            .expect("unable to prune dangling blocks during restart");
+        if initial_data.last_vote.is_none() {
+            self.db
+                .delete_last_vote_msg()
+                .expect("unable to cleanup last vote");
         }
+        if initial_data.highest_timeout_certificate.is_none() {
+            self.db
+                .delete_highest_timeout_certificate()
+                .expect("unable to cleanup highest timeout cert");
+        }
+        diem_info!(
+            "Starting up the consensus state machine with recovery data - [last_vote {}], [highest timeout certificate: {}]",
+            initial_data.last_vote.as_ref().map_or("None".to_string(), |v| v.to_string()),
+            initial_data.highest_timeout_certificate.as_ref().map_or("None".to_string(), |v| v.to_string()),
+        );
+
+        initial_data
     }
 
     fn save_highest_timeout_cert(

--- a/crates/cfxcore/core/src/pos/consensus/round_manager.rs
+++ b/crates/cfxcore/core/src/pos/consensus/round_manager.rs
@@ -70,8 +70,7 @@ use super::{
         ConsensusMsg, ConsensusNetworkSender, IncomingBlockRetrievalRequest,
     },
     pending_votes::VoteReceptionResult,
-    persistent_liveness_storage::{PersistentLivenessStorage, RecoveryData},
-    state_replication::StateComputer,
+    persistent_liveness_storage::PersistentLivenessStorage,
 };
 
 #[derive(Serialize, Clone)]
@@ -130,77 +129,6 @@ pub enum VerifiedEvent {
 #[cfg(feature = "fuzzing")]
 #[path = "round_manager_fuzzing.rs"]
 pub mod round_manager_fuzzing;
-
-/// If the node can't recover corresponding blocks from local storage,
-/// RecoveryManager is responsible for processing the events carrying sync info
-/// and use the info to retrieve blocks from peers
-pub struct RecoveryManager {
-    epoch_state: EpochState,
-    network: ConsensusNetworkSender,
-    storage: Arc<dyn PersistentLivenessStorage>,
-    state_computer: Arc<dyn StateComputer>,
-    last_committed_round: Round,
-}
-
-impl RecoveryManager {
-    pub fn new(
-        epoch_state: EpochState, network: ConsensusNetworkSender,
-        storage: Arc<dyn PersistentLivenessStorage>,
-        state_computer: Arc<dyn StateComputer>, last_committed_round: Round,
-    ) -> Self {
-        RecoveryManager {
-            epoch_state,
-            network,
-            storage,
-            state_computer,
-            last_committed_round,
-        }
-    }
-
-    pub async fn process_proposal_msg(
-        &mut self, proposal_msg: ProposalMsg,
-    ) -> Result<RecoveryData> {
-        let author = proposal_msg.proposer();
-        let sync_info = proposal_msg.sync_info();
-        self.sync_up(&sync_info, author).await
-    }
-
-    pub async fn process_vote_msg(
-        &mut self, vote_msg: VoteMsg,
-    ) -> Result<RecoveryData> {
-        let author = vote_msg.vote().author();
-        let sync_info = vote_msg.sync_info();
-        self.sync_up(&sync_info, author).await
-    }
-
-    pub async fn sync_up(
-        &mut self, sync_info: &SyncInfo, peer: Author,
-    ) -> Result<RecoveryData> {
-        sync_info
-            .verify(&self.epoch_state.verifier())
-            .map_err(VerifyError::from)?;
-        ensure!(
-            sync_info.highest_round() > self.last_committed_round,
-            "[RecoveryManager] Received sync info has lower round number than committed block"
-        );
-        ensure!(
-            sync_info.epoch() == self.epoch_state.epoch,
-            "[RecoveryManager] Received sync info is in different epoch than committed block"
-        );
-        let mut retriever = BlockRetriever::new(self.network.clone(), peer);
-        let recovery_data = BlockStore::fast_forward_sync(
-            &sync_info.highest_commit_cert(),
-            &mut retriever,
-            self.storage.clone(),
-            self.state_computer.clone(),
-        )
-        .await?;
-
-        Ok(recovery_data)
-    }
-
-    pub fn epoch_state(&self) -> &EpochState { &self.epoch_state }
-}
 
 /// Consensus SMR is working in an event based fashion: RoundManager is
 /// responsible for processing the individual events (e.g., process_new_round,

--- a/crates/cfxcore/core/src/pos/consensus/state_computer.rs
+++ b/crates/cfxcore/core/src/pos/consensus/state_computer.rs
@@ -5,7 +5,7 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use super::{error::StateSyncError, state_replication::StateComputer};
+use super::state_replication::StateComputer;
 use crate::pos::mempool::{CommitNotification, CommittedTransaction};
 use anyhow::Result;
 use consensus_types::block::Block;
@@ -152,17 +152,6 @@ impl StateComputer for ExecutionProxy {
             .lock()
             .commit_blocks(block_ids, finality_proof)?;
         self.notify_mempool(committed_txns, timestamp).await;
-        Ok(())
-    }
-
-    /// No-op: state sync via chunk execution is not supported in
-    /// Conflux PoS.
-    async fn sync_to(
-        &self, _target: LedgerInfoWithSignatures,
-    ) -> Result<(), StateSyncError> {
-        fail_point!("consensus::sync_to", |_| {
-            Err(anyhow::anyhow!("Injected error in sync_to").into())
-        });
         Ok(())
     }
 }

--- a/crates/cfxcore/core/src/pos/consensus/state_replication.rs
+++ b/crates/cfxcore/core/src/pos/consensus/state_replication.rs
@@ -5,7 +5,7 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use super::error::{MempoolError, StateSyncError};
+use super::error::MempoolError;
 use anyhow::Result;
 use consensus_types::{block::Block, common::Payload};
 use diem_crypto::HashValue;
@@ -52,13 +52,4 @@ pub trait StateComputer: Send + Sync {
         &self, block_ids: Vec<HashValue>,
         finality_proof: LedgerInfoWithSignatures,
     ) -> Result<(), ExecutionError>;
-
-    /// Best effort state synchronization to the given target LedgerInfo.
-    /// In case of success (`Result::Ok`) the LI of storage is at the given
-    /// target. In case of failure (`Result::Error`) the LI of storage
-    /// remains unchanged, and the validator can assume there were no
-    /// modifications to the storage made.
-    async fn sync_to(
-        &self, target: LedgerInfoWithSignatures,
-    ) -> Result<(), StateSyncError>;
 }

--- a/crates/cfxcore/core/src/pos/consensus/test_utils/mock_state_computer.rs
+++ b/crates/cfxcore/core/src/pos/consensus/test_utils/mock_state_computer.rs
@@ -6,13 +6,11 @@
 // See http://www.gnu.org/licenses/
 
 use crate::pos::consensus::{
-    error::StateSyncError, state_replication::StateComputer,
-    test_utils::mock_storage::MockStorage,
+    state_replication::StateComputer, test_utils::mock_storage::MockStorage,
 };
 use anyhow::{format_err, Result};
 use consensus_types::{block::Block, common::Payload};
 use diem_crypto::{hash::ACCUMULATOR_PLACEHOLDER_HASH, HashValue};
-use diem_logger::prelude::*;
 use diem_types::ledger_info::LedgerInfoWithSignatures;
 use executor_types::{Error, StateComputeResult};
 use futures::channel::mpsc;
@@ -86,21 +84,6 @@ impl StateComputer for MockStateComputer {
         let _ = self.commit_callback.unbounded_send(commit);
         Ok(())
     }
-
-    async fn sync_to(
-        &self, commit: LedgerInfoWithSignatures,
-    ) -> Result<(), StateSyncError> {
-        diem_debug!(
-            "Fake sync to block id {}",
-            commit.ledger_info().consensus_block_id()
-        );
-        self.consensus_db
-            .commit_to_storage(commit.ledger_info().clone());
-        self.commit_callback
-            .unbounded_send(commit)
-            .expect("Fail to notify about sync");
-        Ok(())
-    }
 }
 
 pub struct EmptyStateComputer;
@@ -127,12 +110,6 @@ impl StateComputer for EmptyStateComputer {
     async fn commit(
         &self, _block_ids: Vec<HashValue>, _commit: LedgerInfoWithSignatures,
     ) -> Result<(), Error> {
-        Ok(())
-    }
-
-    async fn sync_to(
-        &self, _commit: LedgerInfoWithSignatures,
-    ) -> Result<(), StateSyncError> {
         Ok(())
     }
 }

--- a/crates/cfxcore/core/src/pos/consensus/test_utils/mock_storage.rs
+++ b/crates/cfxcore/core/src/pos/consensus/test_utils/mock_storage.rs
@@ -5,12 +5,8 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-use crate::pos::consensus::{
-    epoch_manager::LivenessStorageData,
-    persistent_liveness_storage::{
-        LedgerRecoveryData, PersistentLivenessStorage, RecoveryData,
-        RootMetadata,
-    },
+use crate::pos::consensus::persistent_liveness_storage::{
+    PersistentLivenessStorage, RecoveryData, RootMetadata,
 };
 use anyhow::Result;
 use consensus_types::{
@@ -99,12 +95,8 @@ impl MockStorage {
         &self.shared_storage.validator_set
     }
 
-    pub fn get_ledger_recovery_data(&self) -> LedgerRecoveryData {
-        LedgerRecoveryData::new(self.storage_ledger.lock().clone())
-    }
-
     pub fn try_start(&self) -> Result<RecoveryData> {
-        let ledger_recovery_data = self.get_ledger_recovery_data();
+        let storage_ledger = self.storage_ledger.lock().clone();
         let mut blocks: Vec<_> = self
             .shared_storage
             .block
@@ -124,7 +116,7 @@ impl MockStorage {
         blocks.sort_by_key(Block::round);
         RecoveryData::new(
             self.shared_storage.last_vote.lock().clone(),
-            ledger_recovery_data,
+            &storage_ledger,
             blocks,
             RootMetadata::new_empty(),
             quorum_certs,
@@ -146,10 +138,7 @@ impl MockStorage {
             Arc::new(MockSharedStorage::new(validator_set.clone()));
         let genesis_li = LedgerInfo::mock_genesis(Some(validator_set));
         let storage = Self::new_with_ledger_info(shared_storage, genesis_li);
-        let recovery_data = storage.start().expect_recovery_data(
-            "Mock storage should never fail constructing recovery data",
-        );
-
+        let recovery_data = storage.start();
         (recovery_data, Arc::new(storage))
     }
 }
@@ -202,15 +191,11 @@ impl PersistentLivenessStorage for MockStorage {
         Ok(())
     }
 
-    fn start(&self) -> LivenessStorageData {
-        match self.try_start() {
-            Ok(recovery_data) => {
-                LivenessStorageData::RecoveryData(recovery_data)
-            }
-            Err(_) => LivenessStorageData::LedgerRecoveryData(
-                self.get_ledger_recovery_data(),
-            ),
-        }
+    fn start(&self) -> RecoveryData {
+        self.try_start().expect(
+            "MockStorage failed to construct recovery data — this indicates \
+             an inconsistent test setup",
+        )
     }
 
     fn save_highest_timeout_cert(
@@ -235,9 +220,7 @@ impl EmptyStorage {
 
     pub fn start_for_testing() -> (RecoveryData, Arc<Self>) {
         let storage = Arc::new(EmptyStorage::new());
-        let recovery_data = storage.start().expect_recovery_data(
-            "Empty storage should never fail constructing recovery data",
-        );
+        let recovery_data = storage.start();
         (recovery_data, storage)
     }
 }
@@ -251,25 +234,16 @@ impl PersistentLivenessStorage for EmptyStorage {
 
     fn save_vote(&self, _: &Vote) -> Result<()> { Ok(()) }
 
-    fn start(&self) -> LivenessStorageData {
-        match RecoveryData::new(
+    fn start(&self) -> RecoveryData {
+        RecoveryData::new(
             None,
-            LedgerRecoveryData::new(LedgerInfo::mock_genesis(None)),
+            &LedgerInfo::mock_genesis(None),
             vec![],
             RootMetadata::new_empty(),
             vec![],
             None,
-        ) {
-            Ok(recovery_data) => {
-                LivenessStorageData::RecoveryData(recovery_data)
-            }
-            Err(e) => {
-                eprintln!("{}", e);
-                panic!(
-                    "Construct recovery data during genesis should never fail"
-                );
-            }
-        }
+        )
+        .expect("Construct recovery data during genesis should never fail")
     }
 
     fn save_highest_timeout_cert(&self, _: TimeoutCertificate) -> Result<()> {


### PR DESCRIPTION
`RoundProcessor::Recovery` + `RecoveryManager` + `LedgerRecoveryData` + `BlockStore::fast_forward_sync` exist to reconstruct consensus state when `RecoveryData::new` can't locate a root block matching the latest committed ledger info. That scenario has no remaining trigger:

- Fresh-genesis startup already goes to Normal. `maybe_bootstrap` writes a genesis `LedgerInfo` with `next_epoch_state = Some(...)`, so `find_root` takes its `ends_epoch()` branch and synthesises a virtual genesis block + QC from the ledger info alone.
- Normal running-node restarts also go to Normal. The write path is `save_tree(block+qc) → execute → commit(ledger) → prune`, and `prune_tree` preserves the root. On any clean crash/restart the root is in ConsensusDB and `find_root` resolves it directly.
- The residual "state-sync ran ahead of consensus" case from upstream Diem was neutralised in #3438 (`397cf34c`). `state_computer.sync_to` became a no-op, so `fast_forward_sync` can only write blocks to ConsensusDB — strictly weaker than Normal's sync path, which executes and commits.

What Recovery would technically still fire on is on-disk corruption where ConsensusDB is missing the block PosLedgerDB's latest ledger info points at. That combination isn't reachable through normal operation, and the `sync_to`-neutered recovery attempt couldn't repair the ledger even if we took it. A panic on that condition is strictly more diagnostic than silently stalling in Recovery.

Follow-on removals fall out once Recovery is gone: `StateComputer::sync_to` + `StateSyncError` + `LogEvent::StateSync` had no remaining callers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3457)
<!-- Reviewable:end -->
