### PR TITLE
sync: replace panic with None on missing parent in get_blame_states

### DIFF
--- a/crates/cfxcore/core/src/sync/message/snapshot_manifest_request.rs
+++ b/crates/cfxcore/core/src/sync/message/snapshot_manifest_request.rs
@@ -220,10 +220,6 @@ impl SnapshotManifestRequest {
         let mut blame_count = trusted_block.blame();
         let mut deferred_block_hash = block_hash;
         for _ in 0..DEFERRED_STATE_EPOCH_COUNT {
-            // A peer-supplied `trusted_blame_block` may sit in our DB while
-            // an ancestor within DEFERRED_STATE_EPOCH_COUNT is still missing
-            // (headers can land in DB before they become header-graph-ready).
-            // Bail out instead of panicking the IO worker thread.
             deferred_block_hash = *ctx
                 .manager
                 .graph
@@ -286,8 +282,6 @@ impl SnapshotManifestRequest {
                     break;
                 }
                 block_hash = *block.parent_hash();
-                // Same out-of-order persistence reason as the DEFERRED loop
-                // above: bail rather than panic.
                 deferred_block_hash = *ctx
                     .manager
                     .graph

--- a/crates/cfxcore/core/src/sync/message/snapshot_manifest_request.rs
+++ b/crates/cfxcore/core/src/sync/message/snapshot_manifest_request.rs
@@ -220,12 +220,15 @@ impl SnapshotManifestRequest {
         let mut blame_count = trusted_block.blame();
         let mut deferred_block_hash = block_hash;
         for _ in 0..DEFERRED_STATE_EPOCH_COUNT {
+            // A peer-supplied `trusted_blame_block` may sit in our DB while
+            // an ancestor within DEFERRED_STATE_EPOCH_COUNT is still missing
+            // (headers can land in DB before they become header-graph-ready).
+            // Bail out instead of panicking the IO worker thread.
             deferred_block_hash = *ctx
                 .manager
                 .graph
                 .data_man
-                .block_header_by_hash(&deferred_block_hash)
-                .expect("All headers exist")
+                .block_header_by_hash(&deferred_block_hash)?
                 .parent_hash();
         }
 
@@ -283,12 +286,13 @@ impl SnapshotManifestRequest {
                     break;
                 }
                 block_hash = *block.parent_hash();
+                // Same out-of-order persistence reason as the DEFERRED loop
+                // above: bail rather than panic.
                 deferred_block_hash = *ctx
                     .manager
                     .graph
                     .data_man
-                    .block_header_by_hash(&deferred_block_hash)
-                    .expect("All headers received")
+                    .block_header_by_hash(&deferred_block_hash)?
                     .parent_hash();
             } else {
                 warn!(


### PR DESCRIPTION
`get_blame_states` walks DEFERRED_STATE_EPOCH_COUNT parents from a peer-supplied `trusted_blame_block` using `.expect()`. The assumption that all five ancestors are always in the DB is wrong: `SynchronizationGraph::propagate_header_graph_status` persists a header to `BlockDataManager` even when it is not yet header-graph-ready (parent unknown), so a header can sit in the DB while its parent does not. The function already returns `Option`, and the sole caller wraps the result with `unwrap_or_default()`, so `?` is the contract-correct choice.

Bound on the previous behavior: panic kills only the SocketWorker thread handling the message (no `panic = "abort"`, no `catch_unwind` around `do_work`, panic hook only logs). Poisoning the four-thread SocketWorker pool degrades sync responsiveness without crashing the process; the offending header survives restart, so re-poisoning is automatic until the snapshot ages out.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3462)
<!-- Reviewable:end -->
