### PR TITLE
fix: replace panic-prone UTF-8 and path conversions with safe variants

### DIFF
--- a/crates/cfx_store/src/accounts_dir/disk.rs
+++ b/crates/cfx_store/src/accounts_dir/disk.rs
@@ -227,18 +227,22 @@ where T: KeyFileManager
 
     /// all accounts found in keys directory
     fn files_content(&self) -> Result<HashMap<PathBuf, SafeAccount>, Error> {
-        // it's not done using one iterator cause
-        // there is an issue with rustc and it takes tooo much time to compile
+        // it's not done using one iterator because
+        // there is an issue with rustc and it takes too much time to compile
         let paths = self.files()?;
         Ok(paths
             .into_iter()
-            .filter_map(|path| {
-                let filename = Some(
-                    path.file_name()
-                        .and_then(|n| n.to_str())
-                        .expect("Keys have valid UTF8 names only.")
-                        .to_owned(),
-                );
+            .map(|path| {
+                let filename = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .ok_or_else(|| {
+                        Error::InvalidKeyFile(
+                            "Filename contains invalid UTF-8".into(),
+                        )
+                    })?
+                    .to_owned();
+                let filename = Some(filename);
                 fs::File::open(path.clone())
                     .map_err(Into::into)
                     .and_then(|file| self.key_manager.read(filename, file))
@@ -247,8 +251,8 @@ where T: KeyFileManager
                         err
                     })
                     .map(|account| (path, account))
-                    .ok()
             })
+            .filter_map(Result::ok)
             .collect())
     }
 

--- a/crates/dbs/storage/src/impls/storage_db/delta_db_manager_rocksdb.rs
+++ b/crates/dbs/storage/src/impls/storage_db/delta_db_manager_rocksdb.rs
@@ -57,7 +57,8 @@ impl DeltaDbManagerTrait for DeltaDbManagerRocksdb {
             Ok(KvdbRocksdb {
                 kvdb: Arc::new(Database::open(
                     &Self::ROCKSDB_CONFIG,
-                    path.to_str().unwrap(),
+                    path.to_str()
+                        .ok_or(Error::Msg("Invalid database path".into()))?,
                 )?),
                 col: 0,
             })

--- a/crates/dbs/storage/src/utils/tuple.rs
+++ b/crates/dbs/storage/src/utils/tuple.rs
@@ -484,13 +484,16 @@ mod test {
     }
     impl ElementToPrint for Vec<u8> {
         fn to_string(&self) -> String {
-            unsafe { std::str::from_utf8_unchecked(self.as_slice()) }
+            std::str::from_utf8(self.as_slice())
+                .expect("Vec<u8> should be valid utf8")
                 .to_string()
         }
     }
     impl ElementToPrint for Box<[u8]> {
         fn to_string(&self) -> String {
-            unsafe { std::str::from_utf8_unchecked(self.as_ref()) }.to_string()
+            std::str::from_utf8(self.as_ref())
+                .expect("Box<[u8]> should be valid utf8")
+                .to_string()
         }
     }
 

--- a/crates/execution/execute-helper/src/observer/exec_tracer/error_unwind.rs
+++ b/crates/execution/execute-helper/src/observer/exec_tracer/error_unwind.rs
@@ -100,10 +100,9 @@ impl ErrorUnwind {
                 "Vm reverted. {}",
                 string_revert_reason_decode(return_data)
             )),
-            Outcome::Fail => Some(
-                String::from_utf8(return_data.clone())
-                    .expect("Return data is encoded from valid utf-8 string"),
-            ),
+            Outcome::Fail => {
+                Some(String::from_utf8_lossy(return_data).into_owned())
+            }
         }
     }
 }

--- a/crates/pos/config/config/src/config/mod.rs
+++ b/crates/pos/config/config/src/config/mod.rs
@@ -92,11 +92,11 @@ impl NodeConfig {
 pub trait PersistableConfig: Serialize + DeserializeOwned {
     fn load_config<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
         let mut file = File::open(&path).map_err(|e| {
-            Error::IO(path.as_ref().to_str().unwrap().to_string(), e)
+            Error::IO(path.as_ref().to_string_lossy().to_string(), e)
         })?;
         let mut contents = String::new();
         file.read_to_string(&mut contents).map_err(|e| {
-            Error::IO(path.as_ref().to_str().unwrap().to_string(), e)
+            Error::IO(path.as_ref().to_string_lossy().to_string(), e)
         })?;
         Self::parse(&contents)
     }
@@ -105,16 +105,16 @@ pub trait PersistableConfig: Serialize + DeserializeOwned {
         let contents = yaml_serde::to_string(&self)
             .map_err(|e| {
                 Error::Yaml(
-                    output_file.as_ref().to_str().unwrap().to_string(),
+                    output_file.as_ref().to_string_lossy().to_string(),
                     e,
                 )
             })?
             .into_bytes();
         let mut file = File::create(output_file.as_ref()).map_err(|e| {
-            Error::IO(output_file.as_ref().to_str().unwrap().to_string(), e)
+            Error::IO(output_file.as_ref().to_string_lossy().to_string(), e)
         })?;
         file.write_all(&contents).map_err(|e| {
-            Error::IO(output_file.as_ref().to_str().unwrap().to_string(), e)
+            Error::IO(output_file.as_ref().to_string_lossy().to_string(), e)
         })?;
         Ok(())
     }


### PR DESCRIPTION
- accounts disk: propagate error on non-UTF8 key filenames instead of expect()
- delta_db_manager_rocksdb: return Err on non-UTF8 db path instead of unwrap()
- tuple test helpers: switch from_utf8_unchecked to checked from_utf8
- error_unwind: use from_utf8_lossy for revert return data instead of expect()
- pos config: use to_string_lossy for path display in IO/Yaml errors

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3488)
<!-- Reviewable:end -->
