### PR TITLE
pos mempool: close forgeable-sender DoS gap; bind sender to authenticator key

### DIFF
--- a/crates/cfxcore/core/src/pos/mempool/core_mempool/transaction_store.rs
+++ b/crates/cfxcore/core/src/pos/mempool/core_mempool/transaction_store.rs
@@ -32,16 +32,12 @@ pub struct TransactionStore {
     // pivot decision helper structure
     pivot_decisions: HashMap<HashValue, HashSet<(AccountAddress, HashValue)>>,
 
-    // TTL keyed on `MempoolTransaction.expiration_time = add_time +
-    // system_transaction_timeout`. Every txn is evicted after the timeout,
-    // regardless of its payload — keeps old txns from clogging the mempool
-    // when commit callbacks are delayed.
+    // Evicts txns after `system_transaction_timeout` so stalled commit
+    // callbacks cannot clog the mempool indefinitely.
     system_ttl_index: TTLIndex,
     timeline_index: TimelineIndex,
 
-    /// Per-sender live transaction count. Enforces `capacity_per_sender` so
-    /// a single Byzantine validator cannot flood the mempool with spam under
-    /// its own signing key.
+    // Caps live txns per sender to bound Byzantine-validator spam.
     per_sender_count: HashMap<AccountAddress, usize>,
     capacity_per_sender: usize,
 }
@@ -102,9 +98,9 @@ impl TransactionStore {
             return MempoolStatus::new(MempoolStatusCode::Accepted);
         }
 
-        let sender_count =
-            self.per_sender_count.get(&address).copied().unwrap_or(0);
-        if sender_count >= self.capacity_per_sender {
+        let sender_entry = self.per_sender_count.entry(address).or_insert(0);
+        if *sender_entry >= self.capacity_per_sender {
+            let sender_count = *sender_entry;
             diem_debug!(
                 sender = %address,
                 sender_count = sender_count,
@@ -117,6 +113,7 @@ impl TransactionStore {
                     address, sender_count, self.capacity_per_sender,
                 ));
         }
+        *sender_entry += 1;
 
         self.timeline_index.insert(&mut txn);
         self.system_ttl_index.insert(&txn);
@@ -137,7 +134,6 @@ impl TransactionStore {
         } else {
             self.transactions.insert(hash, txn, false);
         }
-        *self.per_sender_count.entry(address).or_insert(0) += 1;
         diem_debug!(
             LogSchema::new(LogEntry::AddTxn)
                 .txns(TxnsLog::new_txn(address, hash)),

--- a/crates/cfxcore/core/src/pos/mempool/core_mempool/transaction_store.rs
+++ b/crates/cfxcore/core/src/pos/mempool/core_mempool/transaction_store.rs
@@ -51,6 +51,10 @@ pub type PivotDecisionIter<'a> =
 
 impl TransactionStore {
     pub(crate) fn new(config: &MempoolConfig) -> Self {
+        assert!(
+            config.capacity_per_sender > 0,
+            "mempool.capacity_per_sender must be > 0",
+        );
         Self {
             // main DS
             transactions: AccountTransactions::new(),
@@ -184,6 +188,11 @@ impl TransactionStore {
         self.system_ttl_index.remove(&txn);
         self.timeline_index.remove(&txn);
         let sender = txn.get_sender();
+        debug_assert!(
+            self.per_sender_count.contains_key(&sender),
+            "per_sender_count missing entry for {} at index_remove",
+            sender,
+        );
         if let Some(count) = self.per_sender_count.get_mut(&sender) {
             *count -= 1;
             if *count == 0 {
@@ -367,5 +376,11 @@ mod tests {
 
         assert_eq!(store.insert(dup).code, MempoolStatusCode::Accepted);
         assert_eq!(store.per_sender_count[&sender], 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "mempool.capacity_per_sender must be > 0")]
+    fn capacity_per_sender_zero_panics_on_construction() {
+        let _ = store_with_cap(0);
     }
 }

--- a/crates/cfxcore/core/src/pos/mempool/core_mempool/transaction_store.rs
+++ b/crates/cfxcore/core/src/pos/mempool/core_mempool/transaction_store.rs
@@ -23,7 +23,10 @@ use diem_types::{
     mempool_status::{MempoolStatus, MempoolStatusCode},
     transaction::{SignedTransaction, TransactionPayload},
 };
-use std::collections::{hash_map::Values, HashMap, HashSet};
+use std::{
+    collections::{hash_map::Values, HashMap, HashSet},
+    time::Duration,
+};
 
 /// TransactionStore is in-memory storage for all transactions in mempool.
 pub struct TransactionStore {
@@ -38,6 +41,9 @@ pub struct TransactionStore {
     timeline_index: TimelineIndex,
 
     // Caps live txns per sender to bound Byzantine-validator spam.
+    // Invariant: incremented in `insert` and decremented in
+    // `index_remove`; every removal of `self.transactions` must route
+    // through `index_remove` to keep the count honest.
     per_sender_count: HashMap<AccountAddress, usize>,
     capacity_per_sender: usize,
 }
@@ -101,11 +107,17 @@ impl TransactionStore {
         let sender_entry = self.per_sender_count.entry(address).or_insert(0);
         if *sender_entry >= self.capacity_per_sender {
             let sender_count = *sender_entry;
-            diem_debug!(
-                sender = %address,
-                sender_count = sender_count,
-                cap = self.capacity_per_sender,
-                "mempool: per-sender capacity reached, rejecting txn",
+            // Surface at warn so operators see spam in default logs;
+            // rate-limited because a sustained attack can fire this on
+            // every gossip txn.
+            diem_sample!(
+                SampleRate::Duration(Duration::from_secs(60)),
+                diem_warn!(
+                    sender = %address,
+                    sender_count = sender_count,
+                    cap = self.capacity_per_sender,
+                    "mempool: per-sender capacity reached, rejecting txn",
+                )
             );
             return MempoolStatus::new(MempoolStatusCode::TooManyTransactions)
                 .with_message(format!(
@@ -271,6 +283,9 @@ mod tests {
         TransactionStore::new(&cfg)
     }
 
+    // Address is arbitrary; per_sender_count keys on the address only,
+    // so it doesn't need to match the BLS-derived NodeID for these
+    // bookkeeping tests.
     fn new_sender() -> (BLSPrivateKey, BLSPublicKey, AccountAddress) {
         let sk = BLSPrivateKey::generate_for_testing();
         let pk = sk.public_key();

--- a/crates/cfxcore/core/src/pos/mempool/core_mempool/transaction_store.rs
+++ b/crates/cfxcore/core/src/pos/mempool/core_mempool/transaction_store.rs
@@ -40,10 +40,8 @@ pub struct TransactionStore {
     system_ttl_index: TTLIndex,
     timeline_index: TimelineIndex,
 
-    // Caps live txns per sender to bound Byzantine-validator spam.
-    // Invariant: incremented in `insert` and decremented in
-    // `index_remove`; every removal of `self.transactions` must route
-    // through `index_remove` to keep the count honest.
+    // Per-sender cap against Byzantine spam. Invariant: every removal
+    // of `self.transactions` must route through `index_remove`.
     per_sender_count: HashMap<AccountAddress, usize>,
     capacity_per_sender: usize,
 }
@@ -107,9 +105,7 @@ impl TransactionStore {
         let sender_entry = self.per_sender_count.entry(address).or_insert(0);
         if *sender_entry >= self.capacity_per_sender {
             let sender_count = *sender_entry;
-            // Surface at warn so operators see spam in default logs;
-            // rate-limited because a sustained attack can fire this on
-            // every gossip txn.
+            // Rate-limited so a sustained attack doesn't flood logs.
             diem_sample!(
                 SampleRate::Duration(Duration::from_secs(60)),
                 diem_warn!(
@@ -283,9 +279,7 @@ mod tests {
         TransactionStore::new(&cfg)
     }
 
-    // Address is arbitrary; per_sender_count keys on the address only,
-    // so it doesn't need to match the BLS-derived NodeID for these
-    // bookkeeping tests.
+    // Address is arbitrary — `per_sender_count` keys on address only.
     fn new_sender() -> (BLSPrivateKey, BLSPublicKey, AccountAddress) {
         let sk = BLSPrivateKey::generate_for_testing();
         let pk = sk.public_key();

--- a/crates/cfxcore/core/src/pos/mempool/core_mempool/transaction_store.rs
+++ b/crates/cfxcore/core/src/pos/mempool/core_mempool/transaction_store.rs
@@ -250,3 +250,112 @@ impl TransactionStore {
         self.pivot_decisions.values()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use diem_crypto::{
+        bls::{BLSPrivateKey, BLSPublicKey},
+        PrivateKey, SigningKey, Uniform,
+    };
+    use diem_types::{
+        chain_id::ChainId,
+        transaction::{RawTransaction, RetirePayload, TransactionPayload},
+    };
+    use std::time::Duration;
+
+    fn store_with_cap(cap: usize) -> TransactionStore {
+        let mut cfg = MempoolConfig::default();
+        cfg.capacity_per_sender = cap;
+        TransactionStore::new(&cfg)
+    }
+
+    fn new_sender() -> (BLSPrivateKey, BLSPublicKey, AccountAddress) {
+        let sk = BLSPrivateKey::generate_for_testing();
+        let pk = sk.public_key();
+        (sk, pk, AccountAddress::random())
+    }
+
+    fn mk_txn(
+        sk: &BLSPrivateKey, pk: &BLSPublicKey, sender: AccountAddress,
+        nonce: u64,
+    ) -> MempoolTransaction {
+        let payload = TransactionPayload::Retire(RetirePayload {
+            node_id: sender,
+            votes: nonce,
+        });
+        let raw =
+            RawTransaction::new(sender, payload, u64::MAX, ChainId::test());
+        let sig = sk.sign(&raw);
+        MempoolTransaction::new(
+            SignedTransaction::new(raw, pk.clone(), sig),
+            Duration::from_secs(3600),
+            TimelineState::NotReady,
+        )
+    }
+
+    #[test]
+    fn per_sender_count_insert_and_commit_lifecycle() {
+        let mut store = store_with_cap(3);
+        let (sk, pk, sender) = new_sender();
+        assert!(!store.per_sender_count.contains_key(&sender));
+
+        let mut hashes = Vec::new();
+        for n in 0..3 {
+            let txn = mk_txn(&sk, &pk, sender, n);
+            hashes.push(txn.get_hash());
+            assert_eq!(store.insert(txn).code, MempoolStatusCode::Accepted);
+        }
+        assert_eq!(store.per_sender_count[&sender], 3);
+
+        for (i, h) in hashes.iter().enumerate() {
+            store.commit_transaction(*h);
+            let remaining = 3 - (i + 1);
+            if remaining == 0 {
+                assert!(!store.per_sender_count.contains_key(&sender));
+            } else {
+                assert_eq!(store.per_sender_count[&sender], remaining);
+            }
+        }
+    }
+
+    #[test]
+    fn per_sender_count_cap_rejects_without_growth() {
+        let mut store = store_with_cap(2);
+        let (sk, pk, sender) = new_sender();
+
+        for n in 0..2 {
+            assert_eq!(
+                store.insert(mk_txn(&sk, &pk, sender, n)).code,
+                MempoolStatusCode::Accepted
+            );
+        }
+        assert_eq!(store.per_sender_count[&sender], 2);
+
+        for n in 2..6 {
+            assert_eq!(
+                store.insert(mk_txn(&sk, &pk, sender, n)).code,
+                MempoolStatusCode::TooManyTransactions
+            );
+            assert_eq!(store.per_sender_count[&sender], 2);
+        }
+    }
+
+    #[test]
+    fn per_sender_count_duplicate_hash_no_double_count() {
+        let mut store = store_with_cap(8);
+        let (sk, pk, sender) = new_sender();
+        let txn = mk_txn(&sk, &pk, sender, 0);
+        let dup = MempoolTransaction::new(
+            txn.txn.clone(),
+            txn.expiration_time,
+            txn.timeline_state,
+        );
+
+        assert_eq!(store.insert(txn).code, MempoolStatusCode::Accepted);
+        assert_eq!(store.per_sender_count[&sender], 1);
+
+        assert_eq!(store.insert(dup).code, MempoolStatusCode::Accepted);
+        assert_eq!(store.per_sender_count[&sender], 1);
+    }
+}

--- a/crates/cfxcore/core/src/pos/mempool/core_mempool/transaction_store.rs
+++ b/crates/cfxcore/core/src/pos/mempool/core_mempool/transaction_store.rs
@@ -118,8 +118,9 @@ impl TransactionStore {
         self.timeline_index.insert(&mut txn);
         self.system_ttl_index.insert(&txn);
 
-        let payload = txn.txn.clone().into_raw_transaction().into_payload();
-        if let TransactionPayload::PivotDecision(pivot_decision) = payload {
+        if let TransactionPayload::PivotDecision(pivot_decision) =
+            txn.txn.payload()
+        {
             let pivot_decision_hash = pivot_decision.hash();
             self.pivot_decisions
                 .entry(pivot_decision_hash)

--- a/crates/cfxcore/core/src/pos/mempool/core_mempool/transaction_store.rs
+++ b/crates/cfxcore/core/src/pos/mempool/core_mempool/transaction_store.rs
@@ -38,13 +38,19 @@ pub struct TransactionStore {
     // when commit callbacks are delayed.
     system_ttl_index: TTLIndex,
     timeline_index: TimelineIndex,
+
+    /// Per-sender live transaction count. Enforces `capacity_per_sender` so
+    /// a single Byzantine validator cannot flood the mempool with spam under
+    /// its own signing key.
+    per_sender_count: HashMap<AccountAddress, usize>,
+    capacity_per_sender: usize,
 }
 
 pub type PivotDecisionIter<'a> =
     Values<'a, HashValue, HashSet<(AccountAddress, HashValue)>>;
 
 impl TransactionStore {
-    pub(crate) fn new(_config: &MempoolConfig) -> Self {
+    pub(crate) fn new(config: &MempoolConfig) -> Self {
         Self {
             // main DS
             transactions: AccountTransactions::new(),
@@ -55,6 +61,9 @@ impl TransactionStore {
                 |t: &MempoolTransaction| t.expiration_time,
             )),
             timeline_index: TimelineIndex::new(),
+
+            per_sender_count: HashMap::new(),
+            capacity_per_sender: config.capacity_per_sender,
         }
     }
 
@@ -93,6 +102,22 @@ impl TransactionStore {
             return MempoolStatus::new(MempoolStatusCode::Accepted);
         }
 
+        let sender_count =
+            self.per_sender_count.get(&address).copied().unwrap_or(0);
+        if sender_count >= self.capacity_per_sender {
+            diem_debug!(
+                sender = %address,
+                sender_count = sender_count,
+                cap = self.capacity_per_sender,
+                "mempool: per-sender capacity reached, rejecting txn",
+            );
+            return MempoolStatus::new(MempoolStatusCode::TooManyTransactions)
+                .with_message(format!(
+                    "sender {} already has {} transactions (cap {})",
+                    address, sender_count, self.capacity_per_sender,
+                ));
+        }
+
         self.timeline_index.insert(&mut txn);
         self.system_ttl_index.insert(&txn);
 
@@ -112,6 +137,7 @@ impl TransactionStore {
         } else {
             self.transactions.insert(hash, txn, false);
         }
+        *self.per_sender_count.entry(address).or_insert(0) += 1;
         diem_debug!(
             LogSchema::new(LogEntry::AddTxn)
                 .txns(TxnsLog::new_txn(address, hash)),
@@ -152,6 +178,13 @@ impl TransactionStore {
     fn index_remove(&mut self, txn: &MempoolTransaction) {
         self.system_ttl_index.remove(&txn);
         self.timeline_index.remove(&txn);
+        let sender = txn.get_sender();
+        if let Some(count) = self.per_sender_count.get_mut(&sender) {
+            *count -= 1;
+            if *count == 0 {
+                self.per_sender_count.remove(&sender);
+            }
+        }
     }
 
     /// Read `count` transactions from timeline since `timeline_id`.

--- a/crates/cfxcore/core/src/pos/mempool/shared_mempool/tasks.rs
+++ b/crates/cfxcore/core/src/pos/mempool/shared_mempool/tasks.rs
@@ -136,28 +136,12 @@ pub(crate) async fn process_transaction_broadcast(
 fn gen_ack_response(
     request_id: Vec<u8>, results: Vec<SubmissionStatusBundle>, peer: &NodeId,
 ) -> MempoolSyncMsg {
-    let mut backoff = false;
-    let mut retry = false;
-    for (_, (mempool_status, _)) in results.into_iter() {
-        match mempool_status.code {
-            // Global pressure: ask the peer to back off broadcasts *and*
-            // retry this txn later.
-            MempoolStatusCode::MempoolIsFull => {
-                backoff = true;
-                retry = true;
-            }
-            // Per-sender cap hit: retry so the txn can land once a TTL GC
-            // sweep or commit frees a slot; no broad broadcast backoff.
-            MempoolStatusCode::TooManyTransactions => {
-                retry = true;
-            }
-            _ => {}
-        }
-
-        if backoff && retry {
-            break;
-        }
-    }
+    // There is no global-capacity cap, so `MempoolIsFull` is unreachable
+    // and the wire-level `backoff` signal is always off. Retry is driven
+    // purely by the per-sender cap: a GC sweep or commit will free a slot.
+    let retry = results.iter().any(|(_, (status, _))| {
+        matches!(status.code, MempoolStatusCode::TooManyTransactions)
+    });
 
     diem_trace!(
         "request[{:?}] from peer[{:?}] retry[{:?}]",
@@ -169,7 +153,7 @@ fn gen_ack_response(
     MempoolSyncMsg::BroadcastTransactionsResponse {
         request_id,
         retry,
-        backoff,
+        backoff: false,
     }
 }
 

--- a/crates/cfxcore/core/src/pos/mempool/shared_mempool/tasks.rs
+++ b/crates/cfxcore/core/src/pos/mempool/shared_mempool/tasks.rs
@@ -136,9 +136,9 @@ pub(crate) async fn process_transaction_broadcast(
 fn gen_ack_response(
     request_id: Vec<u8>, results: Vec<SubmissionStatusBundle>, peer: &NodeId,
 ) -> MempoolSyncMsg {
-    // There is no global-capacity cap, so `MempoolIsFull` is unreachable
-    // and the wire-level `backoff` signal is always off. Retry is driven
-    // purely by the per-sender cap: a GC sweep or commit will free a slot.
+    // No global-capacity cap, so `MempoolIsFull` is unreachable and
+    // `backoff` stays off. Retry fires on the per-sender cap; GC or
+    // commit frees a slot.
     let retry = results.iter().any(|(_, (status, _))| {
         matches!(status.code, MempoolStatusCode::TooManyTransactions)
     });

--- a/crates/cfxcore/core/src/pos/mempool/shared_mempool/tasks.rs
+++ b/crates/cfxcore/core/src/pos/mempool/shared_mempool/tasks.rs
@@ -138,13 +138,20 @@ fn gen_ack_response(
 ) -> MempoolSyncMsg {
     let mut backoff = false;
     let mut retry = false;
-    for r in results.into_iter() {
-        let submission_status = r.1;
-        if submission_status.0.code == MempoolStatusCode::MempoolIsFull {
-            backoff = true;
-        }
-        if is_txn_retryable(submission_status) {
-            retry = true;
+    for (_, (mempool_status, _)) in results.into_iter() {
+        match mempool_status.code {
+            // Global pressure: ask the peer to back off broadcasts *and*
+            // retry this txn later.
+            MempoolStatusCode::MempoolIsFull => {
+                backoff = true;
+                retry = true;
+            }
+            // Per-sender cap hit: retry so the txn can land once a TTL GC
+            // sweep or commit frees a slot; no broad broadcast backoff.
+            MempoolStatusCode::TooManyTransactions => {
+                retry = true;
+            }
+            _ => {}
         }
 
         if backoff && retry {
@@ -164,10 +171,6 @@ fn gen_ack_response(
         retry,
         backoff,
     }
-}
-
-fn is_txn_retryable(result: SubmissionStatus) -> bool {
-    result.0.code == MempoolStatusCode::MempoolIsFull
 }
 
 /// Submits a list of SignedTransaction to the local mempool

--- a/crates/cfxcore/core/src/pos/mempool/shared_mempool/tasks.rs
+++ b/crates/cfxcore/core/src/pos/mempool/shared_mempool/tasks.rs
@@ -136,9 +136,8 @@ pub(crate) async fn process_transaction_broadcast(
 fn gen_ack_response(
     request_id: Vec<u8>, results: Vec<SubmissionStatusBundle>, peer: &NodeId,
 ) -> MempoolSyncMsg {
-    // No global-capacity cap, so `MempoolIsFull` is unreachable and
-    // `backoff` stays off. Retry fires on the per-sender cap; GC or
-    // commit frees a slot.
+    // No global cap (`MempoolIsFull` is unreachable), so `backoff`
+    // stays off. Retry on the per-sender cap; GC or commit frees a slot.
     let retry = results.iter().any(|(_, (status, _))| {
         matches!(status.code, MempoolStatusCode::TooManyTransactions)
     });

--- a/crates/cfxcore/core/src/pos/mempool/shared_mempool/transaction_validator.rs
+++ b/crates/cfxcore/core/src/pos/mempool/shared_mempool/transaction_validator.rs
@@ -65,9 +65,7 @@ impl TransactionValidator {
             return result;
         }
 
-        // Cheaper checks ran first; only verify the signature once the
-        // payload + sender + auth pubkey have all passed.
-        if tx.clone().check_signature().is_err() {
+        if tx.verify_signature().is_err() {
             return Some(DiscardedVMStatus::INVALID_SIGNATURE);
         }
 

--- a/crates/cfxcore/core/src/pos/mempool/shared_mempool/transaction_validator.rs
+++ b/crates/cfxcore/core/src/pos/mempool/shared_mempool/transaction_validator.rs
@@ -18,17 +18,46 @@ impl TransactionValidator {
     pub fn validate_transaction(
         &self, tx: &SignedTransaction, pos_state: Arc<PosState>,
     ) -> Option<DiscardedVMStatus> {
-        // This check is cheaper than signature verification, so we do not
-        // need to verify signatures for old transactions.
+        // Authenticator must be BLS — the per-type checks below assume a
+        // BLS public key is available to bind against `node_map`. Doing
+        // this first also avoids paying for payload lookups on
+        // malformed inputs. `tx.authenticator()` returns by value (it
+        // clones internally), so hold onto the binding for the lifetime
+        // of `auth_pk`.
+        let authenticator = tx.authenticator();
+        let auth_pk = match &authenticator {
+            TransactionAuthenticator::BLS { public_key, .. } => public_key,
+            _ => return Some(DiscardedVMStatus::INVALID_SIGNATURE),
+        };
+
+        // Reject payload types that never legitimately enter via mempool
+        // gossip. Register/Retire/UpdateVotingPower are proposer-built
+        // from PoW staking events (see
+        // `proposal_generator::generate_proposal` →
+        // `RawTransaction::from_staking_event`) and pushed straight into
+        // the block payload, so any copy seen on the gossip path is
+        // adversarial. Admitting them would let a peer seed the
+        // mempool with non-matching staking events that a proposer
+        // could then pull into a doomed block.
         let sender = tx.sender();
         let result = match tx.payload() {
-            TransactionPayload::Election(election_payload) => {
-                pos_state.validate_election_simple(&sender, election_payload)
-            }
+            TransactionPayload::Election(election_payload) => pos_state
+                .validate_election_simple(&sender, auth_pk, election_payload),
             TransactionPayload::PivotDecision(pivot_decision) => pos_state
-                .validate_pivot_decision_simple(&sender, pivot_decision),
+                .validate_pivot_decision_simple(
+                    &sender,
+                    auth_pk,
+                    pivot_decision,
+                ),
             TransactionPayload::Dispute(_) => {
-                pos_state.validate_dispute_simple(&sender)
+                pos_state.validate_dispute_simple(&sender, auth_pk)
+            }
+            TransactionPayload::Register(_)
+            | TransactionPayload::Retire(_)
+            | TransactionPayload::UpdateVotingPower(_) => {
+                return Some(
+                    DiscardedVMStatus::PAYLOAD_NOT_ALLOWED_VIA_MEMPOOL,
+                );
             }
             _ => None,
         };
@@ -36,11 +65,8 @@ impl TransactionValidator {
             return result;
         }
 
-        match tx.authenticator() {
-            TransactionAuthenticator::BLS { .. } => {}
-            _ => return Some(DiscardedVMStatus::INVALID_SIGNATURE),
-        }
-
+        // Cheaper checks ran first; only verify the signature once the
+        // payload + sender + auth pubkey have all passed.
         if tx.clone().check_signature().is_err() {
             return Some(DiscardedVMStatus::INVALID_SIGNATURE);
         }

--- a/crates/cfxcore/core/src/pos/mempool/shared_mempool/transaction_validator.rs
+++ b/crates/cfxcore/core/src/pos/mempool/shared_mempool/transaction_validator.rs
@@ -20,12 +20,15 @@ impl TransactionValidator {
     ) -> Option<DiscardedVMStatus> {
         // This check is cheaper than signature verification, so we do not
         // need to verify signatures for old transactions.
+        let sender = tx.sender();
         let result = match tx.payload() {
             TransactionPayload::Election(election_payload) => {
-                pos_state.validate_election_simple(election_payload)
+                pos_state.validate_election_simple(&sender, election_payload)
             }
-            TransactionPayload::PivotDecision(pivot_decision) => {
-                pos_state.validate_pivot_decision_simple(pivot_decision)
+            TransactionPayload::PivotDecision(pivot_decision) => pos_state
+                .validate_pivot_decision_simple(&sender, pivot_decision),
+            TransactionPayload::Dispute(_) => {
+                pos_state.validate_dispute_simple(&sender)
             }
             _ => None,
         };

--- a/crates/cfxcore/core/src/pos/mempool/shared_mempool/transaction_validator.rs
+++ b/crates/cfxcore/core/src/pos/mempool/shared_mempool/transaction_validator.rs
@@ -18,27 +18,12 @@ impl TransactionValidator {
     pub fn validate_transaction(
         &self, tx: &SignedTransaction, pos_state: Arc<PosState>,
     ) -> Option<DiscardedVMStatus> {
-        // Authenticator must be BLS — the per-type checks below assume a
-        // BLS public key is available to bind against `node_map`. Doing
-        // this first also avoids paying for payload lookups on
-        // malformed inputs. `tx.authenticator()` returns by value (it
-        // clones internally), so hold onto the binding for the lifetime
-        // of `auth_pk`.
         let authenticator = tx.authenticator();
         let auth_pk = match &authenticator {
             TransactionAuthenticator::BLS { public_key, .. } => public_key,
             _ => return Some(DiscardedVMStatus::INVALID_SIGNATURE),
         };
 
-        // Reject payload types that never legitimately enter via mempool
-        // gossip. Register/Retire/UpdateVotingPower are proposer-built
-        // from PoW staking events (see
-        // `proposal_generator::generate_proposal` →
-        // `RawTransaction::from_staking_event`) and pushed straight into
-        // the block payload, so any copy seen on the gossip path is
-        // adversarial. Admitting them would let a peer seed the
-        // mempool with non-matching staking events that a proposer
-        // could then pull into a doomed block.
         let sender = tx.sender();
         let result = match tx.payload() {
             TransactionPayload::Election(election_payload) => pos_state

--- a/crates/pos/config/config/src/config/mempool_config.rs
+++ b/crates/pos/config/config/src/config/mempool_config.rs
@@ -10,8 +10,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct MempoolConfig {
-    /// Maximum transactions a single sender can hold in the mempool.
-    /// Bounds Byzantine-validator memory footprint.
     pub capacity_per_sender: usize,
     pub max_broadcasts_per_peer: usize,
     pub shared_mempool_ack_timeout_ms: u64,
@@ -33,11 +31,9 @@ impl Default for MempoolConfig {
             shared_mempool_max_concurrent_inbound_syncs: 2,
             // Allow for 1s latency with the default 500ms tick.
             max_broadcasts_per_peer: 2,
-            // Conflux-PoS legitimate per-validator traffic over one
-            // `system_transaction_timeout_secs` window is ~30-50 txns
-            // (one pivot decision per block, rare elections/disputes).
-            // 128 leaves ~3x burst headroom without allowing meaningful
-            // Byzantine spam.
+            // Legitimate per-validator traffic is ~30-50 txns per
+            // `system_transaction_timeout_secs` window; 128 gives ~3x
+            // burst headroom.
             capacity_per_sender: 128,
             system_transaction_timeout_secs: 600,
             system_transaction_gc_interval_ms: 60_000,

--- a/crates/pos/config/config/src/config/mempool_config.rs
+++ b/crates/pos/config/config/src/config/mempool_config.rs
@@ -10,6 +10,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct MempoolConfig {
+    /// Maximum transactions a single sender can hold in the mempool.
+    /// Bounds Byzantine-validator memory footprint.
+    pub capacity_per_sender: usize,
     pub max_broadcasts_per_peer: usize,
     pub shared_mempool_ack_timeout_ms: u64,
     pub shared_mempool_backoff_interval_ms: u64,
@@ -30,6 +33,12 @@ impl Default for MempoolConfig {
             shared_mempool_max_concurrent_inbound_syncs: 2,
             // Allow for 1s latency with the default 500ms tick.
             max_broadcasts_per_peer: 2,
+            // Conflux-PoS legitimate per-validator traffic over one
+            // `system_transaction_timeout_secs` window is ~30-50 txns
+            // (one pivot decision per block, rare elections/disputes).
+            // 128 leaves ~3x burst headroom without allowing meaningful
+            // Byzantine spam.
+            capacity_per_sender: 128,
             system_transaction_timeout_secs: 600,
             system_transaction_gc_interval_ms: 60_000,
         }

--- a/crates/pos/config/config/src/config/mempool_config.rs
+++ b/crates/pos/config/config/src/config/mempool_config.rs
@@ -31,9 +31,7 @@ impl Default for MempoolConfig {
             shared_mempool_max_concurrent_inbound_syncs: 2,
             // Allow for 1s latency with the default 500ms tick.
             max_broadcasts_per_peer: 2,
-            // Legitimate per-validator traffic is ~30-50 txns per
-            // `system_transaction_timeout_secs` window; 128 gives ~3x
-            // burst headroom.
+            // ~3x burst headroom over legitimate per-validator traffic.
             capacity_per_sender: 128,
             system_transaction_timeout_secs: 600,
             system_transaction_gc_interval_ms: 60_000,

--- a/crates/pos/types/move-core-types/src/vm_status.rs
+++ b/crates/pos/types/move-core-types/src/vm_status.rs
@@ -208,6 +208,14 @@ pub enum StatusCode {
     PIVOT_DECISION_HEIGHT_TOO_OLD = 33,
     PIVOT_DECISION_SENDER_NOT_REGISTERED = 34,
     DISPUTE_SENDER_NOT_REGISTERED = 35,
+    // The submitter's authenticator BLS public key does not match the
+    // one registered in `node_map` for `tx.sender()`. This is the bind
+    // that makes `tx.sender()` a non-forgeable identity at admission.
+    AUTHENTICATOR_KEY_MISMATCH = 36,
+    // Payload type that never legitimately enters via mempool gossip
+    // (Register / Retire / UpdateVotingPower — proposer-built from PoW
+    // staking events and pushed directly into block payloads).
+    PAYLOAD_NOT_ALLOWED_VIA_MEMPOOL = 37,
 
     // Runtime Errors: 4000-4999
     EXECUTED = 4001,

--- a/crates/pos/types/move-core-types/src/vm_status.rs
+++ b/crates/pos/types/move-core-types/src/vm_status.rs
@@ -208,13 +208,7 @@ pub enum StatusCode {
     PIVOT_DECISION_HEIGHT_TOO_OLD = 33,
     PIVOT_DECISION_SENDER_NOT_REGISTERED = 34,
     DISPUTE_SENDER_NOT_REGISTERED = 35,
-    // The submitter's authenticator BLS public key does not match the
-    // one registered in `node_map` for `tx.sender()`. This is the bind
-    // that makes `tx.sender()` a non-forgeable identity at admission.
     AUTHENTICATOR_KEY_MISMATCH = 36,
-    // Payload type that never legitimately enters via mempool gossip
-    // (Register / Retire / UpdateVotingPower — proposer-built from PoW
-    // staking events and pushed directly into block payloads).
     PAYLOAD_NOT_ALLOWED_VIA_MEMPOOL = 37,
 
     // Runtime Errors: 4000-4999

--- a/crates/pos/types/move-core-types/src/vm_status.rs
+++ b/crates/pos/types/move-core-types/src/vm_status.rs
@@ -202,9 +202,12 @@ pub enum StatusCode {
     // The pos transaction does not pass validation based on pos state
     CFX_INVALID_TX = 28,
     ELECTION_NON_EXISTENT_NODE = 29,
+    ELECTION_SIGNER_MISMATCH = 30,
     ELECTION_TARGET_TERM_NOT_OPEN = 31,
     ELECTION_WITHOUT_VOTES = 32,
     PIVOT_DECISION_HEIGHT_TOO_OLD = 33,
+    PIVOT_DECISION_SENDER_NOT_REGISTERED = 34,
+    DISPUTE_SENDER_NOT_REGISTERED = 35,
 
     // Runtime Errors: 4000-4999
     EXECUTED = 4001,

--- a/crates/pos/types/types/src/term_state.rs
+++ b/crates/pos/types/types/src/term_state.rs
@@ -1425,14 +1425,18 @@ mod tests {
     //! `tx.sender()` a non-forgeable identity at mempool admission.
 
     use super::*;
-    use crate::block_info::PivotBlockDecision;
+    use crate::{
+        block_info::PivotBlockDecision, transaction::ElectionPayload,
+        validator_config::ConsensusVRFProof,
+    };
     use diem_crypto::{
-        bls::BLSPrivateKey, ec_vrf::EcVrfPrivateKey, PrivateKey, Uniform,
+        bls::BLSPrivateKey,
+        ec_vrf::{EcVrfPrivateKey, EcVrfProof},
+        PrivateKey, Uniform,
     };
     use rand::{rngs::StdRng, SeedableRng};
 
     struct Keys {
-        bls_sk: BLSPrivateKey,
         bls_pk: ConsensusPublicKey,
         vrf_pk: ConsensusVRFPublicKey,
         addr: AccountAddress,
@@ -1446,11 +1450,15 @@ mod tests {
         let vrf_pk = vrf_sk.public_key();
         let node_id = NodeID::new(bls_pk.clone(), vrf_pk.clone());
         Keys {
-            bls_sk,
             bls_pk,
             vrf_pk,
             addr: node_id.addr,
         }
+    }
+
+    // simple-validation doesn't verify the VRF proof, so any bytes work.
+    fn dummy_vrf_proof() -> ConsensusVRFProof {
+        EcVrfProof::try_from(&[][..]).unwrap()
     }
 
     fn state_with_node(k: &Keys) -> PosState {
@@ -1519,8 +1527,6 @@ mod tests {
             ),
             None,
         );
-        // sanity: keep the keypair owner alive — silences unused warning.
-        let _ = alice.bls_sk;
     }
 
     #[test]
@@ -1556,7 +1562,36 @@ mod tests {
             state.validate_dispute_simple(&alice.addr, &alice.bls_pk),
             None,
         );
-        let _ = alice.bls_sk;
+    }
+
+    fn election_payload_for(k: &Keys) -> ElectionPayload {
+        ElectionPayload {
+            public_key: k.bls_pk.clone(),
+            vrf_public_key: k.vrf_pk.clone(),
+            target_term: 1,
+            vrf_proof: dummy_vrf_proof(),
+        }
+    }
+
+    #[test]
+    fn election_rejects_signer_mismatch() {
+        let alice = keys_from_seed(1);
+        let mallory = keys_from_seed(2);
+        let state = state_with_node(&alice);
+
+        // Payload claims alice's keys but `tx.sender` is mallory's
+        // address. The payload-identity check fires before the
+        // node_map lookup, so this rejects regardless of whether
+        // mallory is registered.
+        let payload = election_payload_for(&alice);
+        assert_eq!(
+            state.validate_election_simple(
+                &mallory.addr,
+                &mallory.bls_pk,
+                &payload
+            ),
+            Some(DiscardedVMStatus::ELECTION_SIGNER_MISMATCH),
+        );
     }
 
     #[test]
@@ -1565,20 +1600,15 @@ mod tests {
         let mallory = keys_from_seed(2);
         let state = state_with_node(&alice);
 
-        // Attacker constructs a payload claiming alice's keys, sets
-        // sender = alice.addr (so the payload-pk-derived addr check
-        // passes), but signs with mallory's BLS key.
-        // We can't easily construct an ElectionPayload without a real
-        // VRF proof; instead, test the auth-key binding via the helper
-        // that `validate_election_simple` uses.
+        // Sender = alice.addr (so the payload-pk-derived addr check
+        // passes), but the authenticator pubkey is mallory's.
+        let payload = election_payload_for(&alice);
         assert_eq!(
-            state
-                .check_sender_owns_auth_key(
-                    &alice.addr,
-                    &mallory.bls_pk,
-                    DiscardedVMStatus::ELECTION_NON_EXISTENT_NODE,
-                )
-                .err(),
+            state.validate_election_simple(
+                &alice.addr,
+                &mallory.bls_pk,
+                &payload
+            ),
             Some(DiscardedVMStatus::AUTHENTICATOR_KEY_MISMATCH),
         );
     }

--- a/crates/pos/types/types/src/term_state.rs
+++ b/crates/pos/types/types/src/term_state.rs
@@ -629,12 +629,9 @@ impl PosState {
 
 /// Read-only functions use in `TransactionValidator`
 impl PosState {
-    /// Look up the registered BLS public key for `sender` and verify it
-    /// matches `auth_pk`. This is what makes `tx.sender()` a non-forgeable
-    /// identity at admission: `raw_txn.sender` is otherwise a free-form
-    /// field, but pairing it with the authenticator pubkey + node_map
-    /// constrains it to a slot the submitter actually controls. Returns
-    /// the `NodeData` so callers can reuse the borrow.
+    /// Binds `sender` to a slot the submitter actually controls by
+    /// requiring `node_map[sender].public_key == auth_pk`. Returns the
+    /// `NodeData` so callers can reuse the borrow.
     fn check_sender_owns_auth_key(
         &self, sender: &AccountAddress, auth_pk: &ConsensusPublicKey,
         not_registered: DiscardedVMStatus,
@@ -659,11 +656,9 @@ impl PosState {
             node_id.addr,
             election_tx.target_term
         );
-        // sender must be the addr derived from the payload's declared
-        // keys, AND the submitter must hold the BLS private key
-        // registered at that addr. Together these mean a forged sender
-        // gets rejected, and a registered submitter cannot impersonate
-        // another node's slot by stuffing someone else's payload keys.
+        // Sender must match the addr derived from the payload's
+        // declared keys, so a registered submitter can't stuff another
+        // node's payload keys.
         if *sender != node_id.addr {
             return Some(DiscardedVMStatus::ELECTION_SIGNER_MISMATCH);
         }
@@ -703,14 +698,9 @@ impl PosState {
         &self, sender: &AccountAddress, auth_pk: &ConsensusPublicKey,
         pivot_decision_tx: &PivotBlockDecision,
     ) -> Option<DiscardedVMStatus> {
-        // Registered-node check (not active-committee): mempool gossip
-        // is the sole propagation path for individual PivotDecision
-        // signatures (one per validator per round). A committee check
-        // would drop newly-joined members' signatures at every term
-        // boundary until lagged receivers catch up. PoS collateral at
-        // registration keeps fresh-keypair spam infeasible, and the
-        // auth-key binding below ensures `sender` actually controls the
-        // BLS private key registered for this slot.
+        // node_map (not active-committee): PivotDecision is gossiped
+        // per round and committee gating would drop newly-joined
+        // members at every term boundary.
         if let Err(err) = self.check_sender_owns_auth_key(
             sender,
             auth_pk,
@@ -1420,10 +1410,6 @@ impl DisputeEvent {
 
 #[cfg(test)]
 mod tests {
-    //! Admission tests for `validate_*_simple`. These cover the
-    //! authenticator-pubkey ↔ `node_map` binding that makes
-    //! `tx.sender()` a non-forgeable identity at mempool admission.
-
     use super::*;
     use crate::{
         block_info::PivotBlockDecision, transaction::ElectionPayload,
@@ -1491,7 +1477,6 @@ mod tests {
 
     #[test]
     fn pivot_decision_rejects_auth_key_mismatch() {
-        // Attacker claims sender = alice but signs with mallory's key.
         let alice = keys_from_seed(1);
         let mallory = keys_from_seed(2);
         let state = state_with_node(&alice);
@@ -1579,10 +1564,6 @@ mod tests {
         let mallory = keys_from_seed(2);
         let state = state_with_node(&alice);
 
-        // Payload claims alice's keys but `tx.sender` is mallory's
-        // address. The payload-identity check fires before the
-        // node_map lookup, so this rejects regardless of whether
-        // mallory is registered.
         let payload = election_payload_for(&alice);
         assert_eq!(
             state.validate_election_simple(
@@ -1600,8 +1581,6 @@ mod tests {
         let mallory = keys_from_seed(2);
         let state = state_with_node(&alice);
 
-        // Sender = alice.addr (so the payload-pk-derived addr check
-        // passes), but the authenticator pubkey is mallory's.
         let payload = election_payload_for(&alice);
         assert_eq!(
             state.validate_election_simple(
@@ -1619,8 +1598,6 @@ mod tests {
         let mallory = keys_from_seed(2);
         let state = state_with_node(&alice);
 
-        // Custom not_registered code (use ELECTION_NON_EXISTENT_NODE
-        // here to exercise the parameterized return).
         assert_eq!(
             state
                 .check_sender_owns_auth_key(

--- a/crates/pos/types/types/src/term_state.rs
+++ b/crates/pos/types/types/src/term_state.rs
@@ -641,10 +641,8 @@ impl PosState {
             node_id.addr,
             election_tx.target_term
         );
-        // The outer tx signer must match the identity derived from the
-        // payload keys — otherwise an attacker with any fresh outer
-        // keypair could wrap an existing node's payload and burn a
-        // `capacity_per_sender` slot per attacker-sender.
+        // Guard against a fresh outer keypair wrapping a legit payload to
+        // bypass the per-sender cap.
         if *sender != node_id.addr {
             return Some(DiscardedVMStatus::ELECTION_SIGNER_MISMATCH);
         }
@@ -681,19 +679,14 @@ impl PosState {
     pub fn validate_pivot_decision_simple(
         &self, sender: &AccountAddress, pivot_decision_tx: &PivotBlockDecision,
     ) -> Option<DiscardedVMStatus> {
-        // Registered-node check (not active-committee). Committee check
-        // would be tighter but drops signatures from newly-joined
-        // committee members at every term boundary — each validator
-        // broadcasts a signed PivotDecision every round via mempool, and
-        // mempool gossip is the only propagation path for individual
-        // signatures, so receiver-lag rejections reduce the aggregated
-        // multi-sig threshold. Registered-node gating still requires
-        // paying PoS collateral, which makes fresh-keypair spam
-        // economically infeasible.
-        //
-        // TODO: revisit once production lag/latency data is available —
-        // if term-boundary windows prove small, tightening to active
-        // committee is worth the stricter DoS bound.
+        // Registered-node check, not active-committee: mempool gossip is
+        // the sole propagation path for individual PivotDecision
+        // signatures (one per validator per round), and a committee
+        // check would drop newly-joined members' signatures at every
+        // term boundary until lagged receivers catch up. PoS collateral
+        // at registration keeps fresh-keypair spam infeasible.
+        // TODO: tighten to active committee if production lag data
+        // shows term-boundary windows are small enough to tolerate.
         if !self.node_map.contains_key(sender) {
             return Some(
                 DiscardedVMStatus::PIVOT_DECISION_SENDER_NOT_REGISTERED,
@@ -708,10 +701,9 @@ impl PosState {
     pub fn validate_dispute_simple(
         &self, sender: &AccountAddress,
     ) -> Option<DiscardedVMStatus> {
-        // See `validate_pivot_decision_simple` for the rationale behind
-        // registered-node gating (vs active-committee) — same
-        // term-boundary concern applies here. Full payload verification
-        // (verify_dispute) runs at execute time.
+        // Registered-node gating, same rationale as
+        // `validate_pivot_decision_simple`; `verify_dispute` runs at
+        // execute time.
         if !self.node_map.contains_key(sender) {
             return Some(DiscardedVMStatus::DISPUTE_SENDER_NOT_REGISTERED);
         }

--- a/crates/pos/types/types/src/term_state.rs
+++ b/crates/pos/types/types/src/term_state.rs
@@ -630,7 +630,7 @@ impl PosState {
 /// Read-only functions use in `TransactionValidator`
 impl PosState {
     pub fn validate_election_simple(
-        &self, election_tx: &ElectionPayload,
+        &self, sender: &AccountAddress, election_tx: &ElectionPayload,
     ) -> Option<DiscardedVMStatus> {
         let node_id = NodeID::new(
             election_tx.public_key.clone(),
@@ -641,6 +641,13 @@ impl PosState {
             node_id.addr,
             election_tx.target_term
         );
+        // The outer tx signer must match the identity derived from the
+        // payload keys — otherwise an attacker with any fresh outer
+        // keypair could wrap an existing node's payload and burn a
+        // `capacity_per_sender` slot per attacker-sender.
+        if *sender != node_id.addr {
+            return Some(DiscardedVMStatus::ELECTION_SIGNER_MISMATCH);
+        }
         let node = match self.node_map.get(&node_id.addr) {
             Some(node) => node,
             None => {
@@ -672,10 +679,41 @@ impl PosState {
     }
 
     pub fn validate_pivot_decision_simple(
-        &self, pivot_decision_tx: &PivotBlockDecision,
+        &self, sender: &AccountAddress, pivot_decision_tx: &PivotBlockDecision,
     ) -> Option<DiscardedVMStatus> {
+        // Registered-node check (not active-committee). Committee check
+        // would be tighter but drops signatures from newly-joined
+        // committee members at every term boundary — each validator
+        // broadcasts a signed PivotDecision every round via mempool, and
+        // mempool gossip is the only propagation path for individual
+        // signatures, so receiver-lag rejections reduce the aggregated
+        // multi-sig threshold. Registered-node gating still requires
+        // paying PoS collateral, which makes fresh-keypair spam
+        // economically infeasible.
+        //
+        // TODO: revisit once production lag/latency data is available —
+        // if term-boundary windows prove small, tightening to active
+        // committee is worth the stricter DoS bound.
+        if !self.node_map.contains_key(sender) {
+            return Some(
+                DiscardedVMStatus::PIVOT_DECISION_SENDER_NOT_REGISTERED,
+            );
+        }
         if pivot_decision_tx.height <= self.pivot_decision.height {
             return Some(DiscardedVMStatus::PIVOT_DECISION_HEIGHT_TOO_OLD);
+        }
+        None
+    }
+
+    pub fn validate_dispute_simple(
+        &self, sender: &AccountAddress,
+    ) -> Option<DiscardedVMStatus> {
+        // See `validate_pivot_decision_simple` for the rationale behind
+        // registered-node gating (vs active-committee) — same
+        // term-boundary concern applies here. Full payload verification
+        // (verify_dispute) runs at execute time.
+        if !self.node_map.contains_key(sender) {
+            return Some(DiscardedVMStatus::DISPUTE_SENDER_NOT_REGISTERED);
         }
         None
     }

--- a/crates/pos/types/types/src/term_state.rs
+++ b/crates/pos/types/types/src/term_state.rs
@@ -109,6 +109,8 @@ pub struct NodeData {
 
 impl NodeData {
     pub fn lock_status(&self) -> &NodeLockStatus { &self.lock_status }
+
+    pub fn public_key(&self) -> &ConsensusPublicKey { &self.public_key }
 }
 
 /// A node becomes its voting power number of ElectionNodes for election.
@@ -629,8 +631,28 @@ impl PosState {
 
 /// Read-only functions use in `TransactionValidator`
 impl PosState {
+    /// Look up the registered BLS public key for `addr` and verify it
+    /// matches `auth_pk`. This is what makes `tx.sender()` a non-forgeable
+    /// identity at admission: `raw_txn.sender` is otherwise a free-form
+    /// field, but pairing it with the authenticator pubkey + node_map
+    /// constrains it to a slot the submitter actually controls.
+    fn check_sender_owns_auth_key(
+        &self, sender: &AccountAddress, auth_pk: &ConsensusPublicKey,
+        not_registered: DiscardedVMStatus,
+    ) -> Option<DiscardedVMStatus> {
+        let node = match self.node_map.get(sender) {
+            Some(node) => node,
+            None => return Some(not_registered),
+        };
+        if node.public_key() != auth_pk {
+            return Some(DiscardedVMStatus::AUTHENTICATOR_KEY_MISMATCH);
+        }
+        None
+    }
+
     pub fn validate_election_simple(
-        &self, sender: &AccountAddress, election_tx: &ElectionPayload,
+        &self, sender: &AccountAddress, auth_pk: &ConsensusPublicKey,
+        election_tx: &ElectionPayload,
     ) -> Option<DiscardedVMStatus> {
         let node_id = NodeID::new(
             election_tx.public_key.clone(),
@@ -641,17 +663,24 @@ impl PosState {
             node_id.addr,
             election_tx.target_term
         );
-        // Guard against a fresh outer keypair wrapping a legit payload to
-        // bypass the per-sender cap.
+        // sender must be the addr derived from the payload's declared
+        // keys, AND the submitter must hold the BLS private key
+        // registered at that addr. Together these mean a forged sender
+        // gets rejected, and a registered submitter cannot impersonate
+        // another node's slot by stuffing someone else's payload keys.
         if *sender != node_id.addr {
             return Some(DiscardedVMStatus::ELECTION_SIGNER_MISMATCH);
         }
-        let node = match self.node_map.get(&node_id.addr) {
-            Some(node) => node,
-            None => {
-                return Some(DiscardedVMStatus::ELECTION_NON_EXISTENT_NODE);
-            }
-        };
+        if let Some(err) = self.check_sender_owns_auth_key(
+            sender,
+            auth_pk,
+            DiscardedVMStatus::ELECTION_NON_EXISTENT_NODE,
+        ) {
+            return Some(err);
+        }
+        // Safe to unwrap: check_sender_owns_auth_key returned None, so
+        // the entry exists.
+        let node = self.node_map.get(&node_id.addr).unwrap();
 
         let target_view = match POS_STATE_CONFIG
             .get_starting_view_for_term(election_tx.target_term)
@@ -677,20 +706,23 @@ impl PosState {
     }
 
     pub fn validate_pivot_decision_simple(
-        &self, sender: &AccountAddress, pivot_decision_tx: &PivotBlockDecision,
+        &self, sender: &AccountAddress, auth_pk: &ConsensusPublicKey,
+        pivot_decision_tx: &PivotBlockDecision,
     ) -> Option<DiscardedVMStatus> {
-        // Registered-node check, not active-committee: mempool gossip is
-        // the sole propagation path for individual PivotDecision
-        // signatures (one per validator per round), and a committee
-        // check would drop newly-joined members' signatures at every
-        // term boundary until lagged receivers catch up. PoS collateral
-        // at registration keeps fresh-keypair spam infeasible.
-        // TODO: tighten to active committee if production lag data
-        // shows term-boundary windows are small enough to tolerate.
-        if !self.node_map.contains_key(sender) {
-            return Some(
-                DiscardedVMStatus::PIVOT_DECISION_SENDER_NOT_REGISTERED,
-            );
+        // Registered-node check (not active-committee): mempool gossip
+        // is the sole propagation path for individual PivotDecision
+        // signatures (one per validator per round). A committee check
+        // would drop newly-joined members' signatures at every term
+        // boundary until lagged receivers catch up. PoS collateral at
+        // registration keeps fresh-keypair spam infeasible, and the
+        // auth-key binding below ensures `sender` actually controls the
+        // BLS private key registered for this slot.
+        if let Some(err) = self.check_sender_owns_auth_key(
+            sender,
+            auth_pk,
+            DiscardedVMStatus::PIVOT_DECISION_SENDER_NOT_REGISTERED,
+        ) {
+            return Some(err);
         }
         if pivot_decision_tx.height <= self.pivot_decision.height {
             return Some(DiscardedVMStatus::PIVOT_DECISION_HEIGHT_TOO_OLD);
@@ -699,15 +731,14 @@ impl PosState {
     }
 
     pub fn validate_dispute_simple(
-        &self, sender: &AccountAddress,
+        &self, sender: &AccountAddress, auth_pk: &ConsensusPublicKey,
     ) -> Option<DiscardedVMStatus> {
-        // Registered-node gating, same rationale as
-        // `validate_pivot_decision_simple`; `verify_dispute` runs at
-        // execute time.
-        if !self.node_map.contains_key(sender) {
-            return Some(DiscardedVMStatus::DISPUTE_SENDER_NOT_REGISTERED);
-        }
-        None
+        // Registered-node gating; `verify_dispute` runs at execute time.
+        self.check_sender_owns_auth_key(
+            sender,
+            auth_pk,
+            DiscardedVMStatus::DISPUTE_SENDER_NOT_REGISTERED,
+        )
     }
 }
 
@@ -1389,5 +1420,202 @@ impl DisputeEvent {
 
     pub fn from_bytes(bytes: &[u8]) -> anyhow::Result<Self> {
         bcs::from_bytes(bytes).map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Admission tests for `validate_*_simple`. These cover the
+    //! authenticator-pubkey ↔ `node_map` binding that makes
+    //! `tx.sender()` a non-forgeable identity at mempool admission.
+
+    use super::*;
+    use crate::block_info::PivotBlockDecision;
+    use diem_crypto::{
+        bls::BLSPrivateKey, ec_vrf::EcVrfPrivateKey, PrivateKey, Uniform,
+    };
+    use rand::{rngs::StdRng, SeedableRng};
+
+    struct Keys {
+        bls_sk: BLSPrivateKey,
+        bls_pk: ConsensusPublicKey,
+        vrf_pk: ConsensusVRFPublicKey,
+        addr: AccountAddress,
+    }
+
+    fn keys_from_seed(seed: u64) -> Keys {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let bls_sk = BLSPrivateKey::generate(&mut rng);
+        let bls_pk = bls_sk.public_key();
+        let vrf_sk = EcVrfPrivateKey::generate(&mut rng);
+        let vrf_pk = vrf_sk.public_key();
+        let node_id = NodeID::new(bls_pk.clone(), vrf_pk.clone());
+        Keys {
+            bls_sk,
+            bls_pk,
+            vrf_pk,
+            addr: node_id.addr,
+        }
+    }
+
+    fn state_with_node(k: &Keys) -> PosState {
+        let mut state = PosState::new_empty();
+        state
+            .register_node(NodeID::new(k.bls_pk.clone(), k.vrf_pk.clone()))
+            .expect("register_node");
+        state
+    }
+
+    #[test]
+    fn pivot_decision_rejects_unregistered_sender() {
+        let alice = keys_from_seed(1);
+        let mallory = keys_from_seed(2);
+        let state = state_with_node(&alice);
+
+        let tx = PivotBlockDecision {
+            block_hash: Default::default(),
+            height: 1,
+        };
+        assert_eq!(
+            state.validate_pivot_decision_simple(
+                &mallory.addr,
+                &mallory.bls_pk,
+                &tx
+            ),
+            Some(DiscardedVMStatus::PIVOT_DECISION_SENDER_NOT_REGISTERED),
+        );
+    }
+
+    #[test]
+    fn pivot_decision_rejects_auth_key_mismatch() {
+        // Attacker claims sender = alice but signs with mallory's key.
+        let alice = keys_from_seed(1);
+        let mallory = keys_from_seed(2);
+        let state = state_with_node(&alice);
+
+        let tx = PivotBlockDecision {
+            block_hash: Default::default(),
+            height: 1,
+        };
+        assert_eq!(
+            state.validate_pivot_decision_simple(
+                &alice.addr,
+                &mallory.bls_pk,
+                &tx
+            ),
+            Some(DiscardedVMStatus::AUTHENTICATOR_KEY_MISMATCH),
+        );
+    }
+
+    #[test]
+    fn pivot_decision_accepts_legitimate_self_signed() {
+        let alice = keys_from_seed(1);
+        let state = state_with_node(&alice);
+
+        let tx = PivotBlockDecision {
+            block_hash: Default::default(),
+            height: 1,
+        };
+        assert_eq!(
+            state.validate_pivot_decision_simple(
+                &alice.addr,
+                &alice.bls_pk,
+                &tx
+            ),
+            None,
+        );
+        // sanity: keep the keypair owner alive — silences unused warning.
+        let _ = alice.bls_sk;
+    }
+
+    #[test]
+    fn dispute_rejects_unregistered_sender() {
+        let alice = keys_from_seed(1);
+        let mallory = keys_from_seed(2);
+        let state = state_with_node(&alice);
+
+        assert_eq!(
+            state.validate_dispute_simple(&mallory.addr, &mallory.bls_pk),
+            Some(DiscardedVMStatus::DISPUTE_SENDER_NOT_REGISTERED),
+        );
+    }
+
+    #[test]
+    fn dispute_rejects_auth_key_mismatch() {
+        let alice = keys_from_seed(1);
+        let mallory = keys_from_seed(2);
+        let state = state_with_node(&alice);
+
+        assert_eq!(
+            state.validate_dispute_simple(&alice.addr, &mallory.bls_pk),
+            Some(DiscardedVMStatus::AUTHENTICATOR_KEY_MISMATCH),
+        );
+    }
+
+    #[test]
+    fn dispute_accepts_legitimate_self_signed() {
+        let alice = keys_from_seed(1);
+        let state = state_with_node(&alice);
+
+        assert_eq!(
+            state.validate_dispute_simple(&alice.addr, &alice.bls_pk),
+            None,
+        );
+        let _ = alice.bls_sk;
+    }
+
+    #[test]
+    fn election_rejects_auth_key_mismatch() {
+        let alice = keys_from_seed(1);
+        let mallory = keys_from_seed(2);
+        let state = state_with_node(&alice);
+
+        // Attacker constructs a payload claiming alice's keys, sets
+        // sender = alice.addr (so the payload-pk-derived addr check
+        // passes), but signs with mallory's BLS key.
+        // We can't easily construct an ElectionPayload without a real
+        // VRF proof; instead, test the auth-key binding via the helper
+        // that `validate_election_simple` uses.
+        assert_eq!(
+            state.check_sender_owns_auth_key(
+                &alice.addr,
+                &mallory.bls_pk,
+                DiscardedVMStatus::ELECTION_NON_EXISTENT_NODE,
+            ),
+            Some(DiscardedVMStatus::AUTHENTICATOR_KEY_MISMATCH),
+        );
+    }
+
+    #[test]
+    fn check_sender_owns_auth_key_unregistered() {
+        let alice = keys_from_seed(1);
+        let mallory = keys_from_seed(2);
+        let state = state_with_node(&alice);
+
+        // Custom not_registered code (use ELECTION_NON_EXISTENT_NODE
+        // here to exercise the parameterized return).
+        assert_eq!(
+            state.check_sender_owns_auth_key(
+                &mallory.addr,
+                &mallory.bls_pk,
+                DiscardedVMStatus::ELECTION_NON_EXISTENT_NODE,
+            ),
+            Some(DiscardedVMStatus::ELECTION_NON_EXISTENT_NODE),
+        );
+    }
+
+    #[test]
+    fn check_sender_owns_auth_key_accepts_matching() {
+        let alice = keys_from_seed(1);
+        let state = state_with_node(&alice);
+
+        assert_eq!(
+            state.check_sender_owns_auth_key(
+                &alice.addr,
+                &alice.bls_pk,
+                DiscardedVMStatus::ELECTION_NON_EXISTENT_NODE,
+            ),
+            None,
+        );
     }
 }

--- a/crates/pos/types/types/src/term_state.rs
+++ b/crates/pos/types/types/src/term_state.rs
@@ -109,8 +109,6 @@ pub struct NodeData {
 
 impl NodeData {
     pub fn lock_status(&self) -> &NodeLockStatus { &self.lock_status }
-
-    pub fn public_key(&self) -> &ConsensusPublicKey { &self.public_key }
 }
 
 /// A node becomes its voting power number of ElectionNodes for election.
@@ -631,23 +629,21 @@ impl PosState {
 
 /// Read-only functions use in `TransactionValidator`
 impl PosState {
-    /// Look up the registered BLS public key for `addr` and verify it
+    /// Look up the registered BLS public key for `sender` and verify it
     /// matches `auth_pk`. This is what makes `tx.sender()` a non-forgeable
     /// identity at admission: `raw_txn.sender` is otherwise a free-form
     /// field, but pairing it with the authenticator pubkey + node_map
-    /// constrains it to a slot the submitter actually controls.
+    /// constrains it to a slot the submitter actually controls. Returns
+    /// the `NodeData` so callers can reuse the borrow.
     fn check_sender_owns_auth_key(
         &self, sender: &AccountAddress, auth_pk: &ConsensusPublicKey,
         not_registered: DiscardedVMStatus,
-    ) -> Option<DiscardedVMStatus> {
-        let node = match self.node_map.get(sender) {
-            Some(node) => node,
-            None => return Some(not_registered),
-        };
-        if node.public_key() != auth_pk {
-            return Some(DiscardedVMStatus::AUTHENTICATOR_KEY_MISMATCH);
+    ) -> Result<&NodeData, DiscardedVMStatus> {
+        let node = self.account_node_data(*sender).ok_or(not_registered)?;
+        if &node.public_key != auth_pk {
+            return Err(DiscardedVMStatus::AUTHENTICATOR_KEY_MISMATCH);
         }
-        None
+        Ok(node)
     }
 
     pub fn validate_election_simple(
@@ -671,16 +667,14 @@ impl PosState {
         if *sender != node_id.addr {
             return Some(DiscardedVMStatus::ELECTION_SIGNER_MISMATCH);
         }
-        if let Some(err) = self.check_sender_owns_auth_key(
+        let node = match self.check_sender_owns_auth_key(
             sender,
             auth_pk,
             DiscardedVMStatus::ELECTION_NON_EXISTENT_NODE,
         ) {
-            return Some(err);
-        }
-        // Safe to unwrap: check_sender_owns_auth_key returned None, so
-        // the entry exists.
-        let node = self.node_map.get(&node_id.addr).unwrap();
+            Ok(node) => node,
+            Err(err) => return Some(err),
+        };
 
         let target_view = match POS_STATE_CONFIG
             .get_starting_view_for_term(election_tx.target_term)
@@ -717,7 +711,7 @@ impl PosState {
         // registration keeps fresh-keypair spam infeasible, and the
         // auth-key binding below ensures `sender` actually controls the
         // BLS private key registered for this slot.
-        if let Some(err) = self.check_sender_owns_auth_key(
+        if let Err(err) = self.check_sender_owns_auth_key(
             sender,
             auth_pk,
             DiscardedVMStatus::PIVOT_DECISION_SENDER_NOT_REGISTERED,
@@ -739,6 +733,7 @@ impl PosState {
             auth_pk,
             DiscardedVMStatus::DISPUTE_SENDER_NOT_REGISTERED,
         )
+        .err()
     }
 }
 
@@ -1577,11 +1572,13 @@ mod tests {
         // VRF proof; instead, test the auth-key binding via the helper
         // that `validate_election_simple` uses.
         assert_eq!(
-            state.check_sender_owns_auth_key(
-                &alice.addr,
-                &mallory.bls_pk,
-                DiscardedVMStatus::ELECTION_NON_EXISTENT_NODE,
-            ),
+            state
+                .check_sender_owns_auth_key(
+                    &alice.addr,
+                    &mallory.bls_pk,
+                    DiscardedVMStatus::ELECTION_NON_EXISTENT_NODE,
+                )
+                .err(),
             Some(DiscardedVMStatus::AUTHENTICATOR_KEY_MISMATCH),
         );
     }
@@ -1595,11 +1592,13 @@ mod tests {
         // Custom not_registered code (use ELECTION_NON_EXISTENT_NODE
         // here to exercise the parameterized return).
         assert_eq!(
-            state.check_sender_owns_auth_key(
-                &mallory.addr,
-                &mallory.bls_pk,
-                DiscardedVMStatus::ELECTION_NON_EXISTENT_NODE,
-            ),
+            state
+                .check_sender_owns_auth_key(
+                    &mallory.addr,
+                    &mallory.bls_pk,
+                    DiscardedVMStatus::ELECTION_NON_EXISTENT_NODE,
+                )
+                .err(),
             Some(DiscardedVMStatus::ELECTION_NON_EXISTENT_NODE),
         );
     }
@@ -1609,13 +1608,12 @@ mod tests {
         let alice = keys_from_seed(1);
         let state = state_with_node(&alice);
 
-        assert_eq!(
-            state.check_sender_owns_auth_key(
+        assert!(state
+            .check_sender_owns_auth_key(
                 &alice.addr,
                 &alice.bls_pk,
                 DiscardedVMStatus::ELECTION_NON_EXISTENT_NODE,
-            ),
-            None,
-        );
+            )
+            .is_ok());
     }
 }

--- a/crates/pos/types/types/src/transaction/mod.rs
+++ b/crates/pos/types/types/src/transaction/mod.rs
@@ -496,15 +496,22 @@ impl SignedTransaction {
             .len()
     }
 
-    /// Checks that the signature of given transaction. Returns
-    /// `Ok(SignatureCheckedTransaction)` if the signature is valid.
-    pub fn check_signature(self) -> Result<SignatureCheckedTransaction> {
+    /// Verifies the authenticator's signature against the appropriate
+    /// signed message without consuming `self`. Returns `Ok(())` on a
+    /// valid signature.
+    pub fn verify_signature(&self) -> Result<()> {
         match self.payload() {
             TransactionPayload::PivotDecision(pivot_decision) => {
-                self.authenticator.verify(pivot_decision)?
+                self.authenticator.verify(pivot_decision)
             }
-            _ => self.authenticator.verify(&self.raw_txn)?,
+            _ => self.authenticator.verify(&self.raw_txn),
         }
+    }
+
+    /// Same as `verify_signature`, but consumes `self` and returns a
+    /// `SignatureCheckedTransaction` newtype that proves the check ran.
+    pub fn check_signature(self) -> Result<SignatureCheckedTransaction> {
+        self.verify_signature()?;
         Ok(SignatureCheckedTransaction(self))
     }
 }


### PR DESCRIPTION
Follow-up to ChenxingLi's #3456 review on the forgeable-sender gap.

Three admission-time changes, ordered cheapest-first ahead of signature verification:

1. **Per-sender capacity cap** (`MempoolConfig.capacity_per_sender`, default 128) on `tx.sender()`.

2. **Payload allowlist.** Reject `Register` / `Retire` / `UpdateVotingPower` from the gossip path — these are proposer-built from PoW staking events and never legitimately enter via mempool.

3. **Authenticator-pubkey binding.** Require `node_map[tx.sender()].public_key == auth_pk` for Election / PivotDecision / Dispute, so `tx.sender()` is constrained to a slot the submitter holds the BLS private key for. Election additionally requires `tx.sender() == NodeID(payload.pubkey, payload.vrf_pubkey).addr`. With this in place, the cap from (1) bounds a real identity.

`node_map` (registered nodes) rather than active-committee — PivotDecision relies on mempool gossip as the sole propagation path for individual-validator signatures, and committee gating would drop newly-joined members at every term boundary. Worth revisiting once production lag data is available.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3493)
<!-- Reviewable:end -->
