### PR TITLE
fix: MptValue primitive decode panic issue

### DIFF
--- a/crates/primitives/src/storage.rs
+++ b/crates/primitives/src/storage.rs
@@ -141,7 +141,7 @@ impl Decodable for MptValue<H256> {
             0u8 => Ok(MptValue::None),
             1u8 => Ok(MptValue::TombStone),
             2u8 => Ok(MptValue::Some(rlp.val_at(1)?)),
-            n => panic!("Unexpected MptValue type in RLP: {}", n),
+            _ => Err(DecoderError::Custom("Unexpected MptValue type in RLP")),
         }
     }
 }
@@ -250,6 +250,15 @@ mod tests {
                 .concat()
         );
         assert_eq!(val, rlp::decode(&rlp::encode(&val)).unwrap());
+    }
+
+    #[test]
+    fn test_mpt_value_rlp_invalid_tag() {
+        let invalid = rlp::encode_list::<u8, _>(&[3]);
+        assert_eq!(
+            rlp::decode::<MptValue<MerkleHash>>(&invalid),
+            Err(rlp::DecoderError::Custom("Unexpected MptValue type in RLP"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
This issue can cause the light node to be attacked by malicious p2p messages, leading to a panic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3497)
<!-- Reviewable:end -->
