### PR TITLE
fix: manifest panic on empty chunk_boundaries

### DIFF
--- a/crates/cfxcore/core/src/sync/state/storage.rs
+++ b/crates/cfxcore/core/src/sync/state/storage.rs
@@ -180,10 +180,11 @@ impl RangedManifest {
             ));
         }
         if let Some(next) = &self.next {
-            if next != self.chunk_boundaries.last().unwrap() {
-                bail!(Error::InvalidSnapshotManifest(
+            match self.chunk_boundaries.last() {
+                Some(last) if next == last => (),
+                _ => bail!(Error::InvalidSnapshotManifest(
                     "next does not match last boundary".into(),
-                ));
+                )),
             }
         }
 


### PR DESCRIPTION
Replace unwrap() with match to avoid panic when validating a manifest whose next is set but chunk_boundaries is empty.

The bad data can be sent by malicious remote peer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3503)
<!-- Reviewable:end -->
