### PR TITLE
fix(sync): keep block inflight cleanup on malformed blocktxn response

### DIFF
--- a/crates/cfxcore/core/src/sync/message/get_block_txn_response.rs
+++ b/crates/cfxcore/core/src/sync/message/get_block_txn_response.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use cfx_types::H256;
 use metrics::MeterTimer;
-use primitives::{Block, TransactionWithSignature};
+use primitives::{Block, BlockHeader, TransactionWithSignature};
 use rlp_derive::{RlpDecodable, RlpEncodable};
 use std::collections::HashSet;
 
@@ -33,103 +33,62 @@ impl Handleable for GetBlockTxnResponse {
         let resp_hash = self.block_hash;
         let req = ctx.match_request(self.request_id)?;
         let delay = req.delay;
+        // `?` here is safe: downcast_ref calls resend_request_to_another_peer
+        // on failure, whose Request::on_removed handles inflight cleanup.
         let req = req.downcast_ref::<GetBlockTxn>(
             ctx.io,
             &ctx.manager.request_manager,
         )?;
 
-        let mut request_from_same_peer = false;
-        // There can be at most one success block in this set.
-        let mut received_blocks = HashSet::new();
-        if resp_hash != req.block_hash {
-            warn!("Response blocktxn is not the requested block, req={:?}, resp={:?}", req.block_hash, resp_hash);
+        // Errors found after match_request consumed the inflight request are
+        // carried in `outcome` so blocks_received can run before Err
+        // propagates, otherwise the inflight key would leak and sync would
+        // stall on this block.
+        let outcome: Result<HandleOutcome, Error> = if resp_hash
+            != req.block_hash
+        {
+            // get_block_txn.rs returns block_hash=H256::default() when the
+            // requested block isn't available locally - that is the
+            // protocol's "I don't have it" signal from an honest peer. Only
+            // a non-zero mismatch is suspicious enough to warn; both retry
+            // via another peer without demoting.
+            if resp_hash == H256::default() {
+                debug!(
+                    "Peer {} does not have block {}",
+                    ctx.node_id, req.block_hash
+                );
+            } else {
+                warn!(
+                    "Response blocktxn is not the requested block, \
+                     req={:?}, resp={:?}",
+                    req.block_hash, resp_hash
+                );
+            }
+            Ok(HandleOutcome::RetryAnotherPeer)
         } else if ctx.manager.graph.contains_block(&resp_hash) {
             debug!(
                 "Get blocktxn, but full block already received, hash={}",
                 resp_hash
             );
-            received_blocks.insert(resp_hash);
+            Ok(HandleOutcome::Received)
         } else if let Some(header) =
             ctx.manager.graph.block_header_by_hash(&resp_hash)
         {
             debug!("Process blocktxn hash={:?}", resp_hash);
-
-            let signed_txns = ctx
-                .manager
-                .graph
-                .data_man
-                .recover_unsigned_tx_with_order(&self.block_txn)?;
-            match ctx.manager.graph.data_man.compact_block_by_hash(&resp_hash) {
-                Some(cmpct) => {
-                    // FIXME: Invalid blocktxn responses after match_request
-                    // must still clean up block inflight
-                    // state and resend the request. Otherwise the
-                    // corresponding request will never be satisfied.
-                    let trans = fill_missing_slots(
-                        cmpct.reconstructed_txns,
-                        &signed_txns,
-                    )
-                    .ok_or(Error::UnexpectedResponse)?;
-                    // FIXME Should check if hash matches
-                    let block = Block::new(header, trans);
-                    debug!(
-                        "transaction received by block: ratio={:?}",
-                        self.block_txn.len() as f64
-                            / block.transactions.len() as f64
-                    );
-                    debug!(
-                        "new block received: block_header={:?}, tx_count={}, block_size={}",
-                        block.block_header,
-                        block.transactions.len(),
-                        block.size(),
-                    );
-                    let insert_result = ctx.manager.graph.insert_block(
-                        block, true,  // need_to_verify
-                        true,  // persistent
-                        false, // recover_from_db
-                    );
-
-                    if !insert_result.request_again() {
-                        received_blocks.insert(resp_hash);
-                    }
-                    if insert_result.is_valid() {
-                        //insert signed transaction to tx pool
-                        let (signed_txns, _) = ctx
-                            .manager
-                            .graph
-                            .consensus
-                            .tx_pool()
-                            .insert_new_signed_transactions(signed_txns);
-                        // a transaction from compact block should be
-                        // added to received pool
-                        ctx.manager
-                            .request_manager
-                            .append_received_transactions(signed_txns);
-                    }
-                    if insert_result.should_relay()
-                        && !ctx.manager.catch_up_mode()
-                    {
-                        ctx.manager.relay_blocks(ctx.io, vec![resp_hash]).ok();
-                    }
-                    if insert_result.request_again() {
-                        request_from_same_peer = true;
-                    }
-                }
-                None => {
-                    warn!(
-                        "Get blocktxn, but misses compact block, hash={}",
-                        resp_hash
-                    );
-                }
-            }
+            process_blocktxn(ctx, header, resp_hash, self.block_txn)
         } else {
             warn!("Get blocktxn, but header not received, hash={}", resp_hash);
-        }
+            Ok(HandleOutcome::RetryAnotherPeer)
+        };
 
-        let peer = if request_from_same_peer {
-            Some(ctx.node_id.clone())
-        } else {
-            None
+        let (received_blocks, peer) = match &outcome {
+            Ok(HandleOutcome::Received) => {
+                (std::iter::once(resp_hash).collect(), None)
+            }
+            Ok(HandleOutcome::RetrySamePeer) => {
+                (HashSet::new(), Some(ctx.node_id.clone()))
+            }
+            _ => (HashSet::new(), None),
         };
         ctx.manager.blocks_received(
             ctx.io,
@@ -140,7 +99,115 @@ impl Handleable for GetBlockTxnResponse {
             delay,
             None, /* preferred_node_type_for_block_request */
         );
-        Ok(())
+        outcome.map(|_| ())
+    }
+}
+
+enum HandleOutcome {
+    /// Block inserted; mark resp_hash in received_blocks. No retry.
+    Received,
+    /// Insert succeeded but insert_result.request_again() — retry from the
+    /// same peer.
+    RetrySamePeer,
+    /// Nothing inserted; retry via PeerFilter (different peer). Used when
+    /// the peer is not at fault (our header expired, our compact block was
+    /// evicted).
+    RetryAnotherPeer,
+}
+
+fn process_blocktxn(
+    ctx: &Context, header: BlockHeader, resp_hash: H256,
+    block_txn: Vec<TransactionWithSignature>,
+) -> Result<HandleOutcome, Error> {
+    let cmpct =
+        match ctx.manager.graph.data_man.compact_block_by_hash(&resp_hash) {
+            Some(c) => c,
+            None => {
+                warn!(
+                    "Get blocktxn, but misses compact block, hash={}",
+                    resp_hash
+                );
+                return Ok(HandleOutcome::RetryAnotherPeer);
+            }
+        };
+
+    let signed_txns = match ctx
+        .manager
+        .graph
+        .data_man
+        .recover_unsigned_tx_with_order(&block_txn)
+    {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(
+                "Peer {} sent GetBlockTxnResponse with unrecoverable \
+                 transactions for block {}: {}",
+                ctx.node_id, resp_hash, e
+            );
+            return Err(Error::InvalidGetBlockTxn(format!(
+                "transaction signature recovery failed: {}",
+                e
+            )));
+        }
+    };
+
+    let block_txn_len = block_txn.len();
+    let trans = match fill_missing_slots(cmpct.reconstructed_txns, &signed_txns)
+    {
+        Some(t) => t,
+        None => {
+            warn!(
+                "Peer {} sent GetBlockTxnResponse for block {} with {} txs, \
+                 which does not match the compact block's missing-slot count",
+                ctx.node_id, resp_hash, block_txn_len,
+            );
+            return Err(Error::InvalidGetBlockTxn(
+                "block_txn count does not match missing transactions".into(),
+            ));
+        }
+    };
+
+    // transactions_root mismatch is caught by insert_block's
+    // verify_block_integrity.
+    let block = Block::new(header, trans);
+    debug!(
+        "transaction received by block: ratio={:?}",
+        block_txn_len as f64 / block.transactions.len() as f64
+    );
+    debug!(
+        "new block received: block_header={:?}, tx_count={}, block_size={}",
+        block.block_header,
+        block.transactions.len(),
+        block.size(),
+    );
+    let insert_result = ctx.manager.graph.insert_block(
+        block, true,  // need_to_verify
+        true,  // persistent
+        false, // recover_from_db
+    );
+
+    if insert_result.is_valid() {
+        //insert signed transaction to tx pool
+        let (signed_txns, _) = ctx
+            .manager
+            .graph
+            .consensus
+            .tx_pool()
+            .insert_new_signed_transactions(signed_txns);
+        // a transaction from compact block should be
+        // added to received pool
+        ctx.manager
+            .request_manager
+            .append_received_transactions(signed_txns);
+    }
+    if insert_result.should_relay() && !ctx.manager.catch_up_mode() {
+        ctx.manager.relay_blocks(ctx.io, vec![resp_hash]).ok();
+    }
+
+    if insert_result.request_again() {
+        Ok(HandleOutcome::RetrySamePeer)
+    } else {
+        Ok(HandleOutcome::Received)
     }
 }
 


### PR DESCRIPTION
Follow-up to #3509, addressing its "Future Work: GetBlockTxnResponse State-Machine Gap".

After match_request consumed the inflight request, `recover_unsigned_tx_with_order?` and `fill_missing_slots`'s length-mismatch path each early-returned via `?` and skipped the trailing blocks_received cleanup. The block stayed in the inflight set, stalling sync until the request timed out.

Both paths now route through a single `Result<HandleOutcome, Error>` so blocks_received runs unconditionally, and the original error is returned afterwards so the peer is still demoted.

The recover failure is wrapped in `Error::InvalidGetBlockTxn` rather than propagated as `Error::Decoder`. Both peer-malformed-data paths now produce uniform Demotion.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3512)
<!-- Reviewable:end -->
