### PR TITLE
chore: add doc comment and tests about solidity abi-decode for uintN

### DIFF
--- a/crates/execution/solidity-abi/src/basic.rs
+++ b/crates/execution/solidity-abi/src/basic.rs
@@ -82,6 +82,45 @@ macro_rules! impl_abi_variable_for_primitive {
             const BASIC_TYPE: bool = true;
             const STATIC_LENGTH: Option<usize> = Some(32);
 
+            /// Decode a fixed-size unsigned integer from a 32-byte ABI word.
+            ///
+            /// ⚠️ **Non-strict decoding (intentional, consensus-critical).**
+            ///
+            /// This implementation only validates that the input word is
+            /// exactly 32 bytes long and then takes the low `BITS/8` bytes
+            /// of the word. The high-order bytes (bytes `0..32 - BYTES`)
+            /// are **silently ignored**, even when they are non-zero.
+            ///
+            /// This deviates from the Solidity / EVM ABI dispatcher
+            /// semantics, which require `value < 2^N` for any `uintN`
+            /// (`N < 256`) parameter and revert otherwise. As a result the
+            /// same calldata can be interpreted differently by a Solidity
+            /// contract and by a Conflux Core-space built-in function:
+            ///   - a Solidity contract would revert on a non-zero high
+            ///     word,
+            ///   - a Conflux built-in will accept the call and observe the
+            ///     truncated low-byte value.
+            ///
+            /// **Why we keep this behavior.** Tightening the check is a
+            /// consensus-level change: historical on-chain transactions
+            /// may have relied on (or accidentally produced) non-canonical
+            /// calldata with non-zero high bytes for built-in functions,
+            /// and rejecting them now would cause a hard fork. Any future
+            /// alignment with Solidity semantics must be gated by a
+            /// `Spec`-controlled transition (e.g. a CIP) rather than an
+            /// in-place fix here.
+            ///
+            /// **Caller obligations.** Because this layer does **not**
+            /// enforce the `uintN` upper bound, every built-in function
+            /// that accepts a sub-256-bit integer through this trait MUST
+            /// perform its own range / overflow checks (e.g. via
+            /// `checked_add`, `U256` widening, or explicit upper bounds)
+            /// and MUST NOT assume the value has been clamped by the ABI
+            /// decoder. Reviewers adding new built-in functions should
+            /// treat the ABI-level type as advisory only.
+            ///
+            /// See `tests_basic::test_*_truncates_high_bytes` for the
+            /// behavior that this contract pins down.
             fn from_abi(data: &[u8]) -> Result<Self, ABIDecodeError> {
                 const BYTES: usize = ($ty::BITS/8) as usize;
                 abi_require(data.len() == 32, "Invalid call data length")?;
@@ -216,5 +255,132 @@ mod tests_basic {
         let input = [128];
         let u = U8::from_be_bytes(input);
         assert_eq!(u.to_be_bytes(), input);
+    }
+
+    // -------------------------------------------------------------------
+    // Pin-down tests for the non-strict `uintN` decoding behavior in
+    // `impl_abi_variable_for_primitive!`.
+    //
+    // These tests intentionally lock in the *current* "silently take the
+    // low BYTES bytes" semantics. The behavior is consensus-critical:
+    // changing it would alter how historical calldata to built-in
+    // contracts decodes and would require a Spec-gated transition (CIP).
+    //
+    // If a future change "fixes" `from_abi` to reject non-zero high bytes
+    // without a hard-fork gate, these tests should fail and force the
+    // change to go through the proper consensus-upgrade path. See the
+    // doc-comment on `from_abi` above for the full rationale.
+    // -------------------------------------------------------------------
+
+    /// Build a 32-byte ABI word whose low `n` bytes hold the big-endian
+    /// representation of `low` and whose high `32 - n` bytes are filled
+    /// with `high_fill`.
+    fn make_word_with_high_fill(low: &[u8], high_fill: u8) -> [u8; 32] {
+        assert!(low.len() <= 32, "low slice must fit in a 32-byte ABI word");
+        let mut word = [high_fill; 32];
+        let start = 32 - low.len();
+        word[start..].copy_from_slice(low);
+        word
+    }
+
+    #[test]
+    fn test_u8_truncates_high_bytes() {
+        // The local `U8` newtype also flows through the
+        // `impl_abi_variable_for_primitive!` macro and therefore inherits
+        // the same low-byte truncation. Lock this in so a future
+        // "fix" cannot quietly tighten U8 decoding.
+        let word = make_word_with_high_fill(&[0xAB], 0xFF);
+        let decoded = U8::from_abi(&word).unwrap();
+        assert_eq!(decoded.to_be_bytes(), [0xAB]);
+    }
+
+    #[test]
+    fn test_u16_truncates_high_bytes() {
+        // Low 2 bytes encode 0x1234; the remaining 30 high bytes are
+        // 0xFF. A Solidity uint16 dispatcher would revert; we instead
+        // silently keep only the low 2 bytes.
+        let word = make_word_with_high_fill(&0x1234u16.to_be_bytes(), 0xFF);
+        let decoded = u16::from_abi(&word).unwrap();
+        assert_eq!(decoded, 0x1234u16);
+    }
+
+    #[test]
+    fn test_u32_truncates_high_bytes() {
+        let word = make_word_with_high_fill(&0xDEADBEEFu32.to_be_bytes(), 0xAA);
+        let decoded = u32::from_abi(&word).unwrap();
+        assert_eq!(decoded, 0xDEADBEEFu32);
+    }
+
+    #[test]
+    fn test_u64_truncates_high_bytes() {
+        let word = make_word_with_high_fill(
+            &0x0123_4567_89AB_CDEFu64.to_be_bytes(),
+            0x01,
+        );
+        let decoded = u64::from_abi(&word).unwrap();
+        assert_eq!(decoded, 0x0123_4567_89AB_CDEFu64);
+    }
+
+    #[test]
+    fn test_u128_truncates_high_bytes() {
+        let low: u128 = 0x0011_2233_4455_6677_8899_AABB_CCDD_EEFFu128;
+        let word = make_word_with_high_fill(&low.to_be_bytes(), 0x77);
+        let decoded = u128::from_abi(&word).unwrap();
+        assert_eq!(decoded, low);
+    }
+
+    #[test]
+    fn test_uintn_accepts_max_low_with_dirty_high_bits() {
+        // u64::MAX in the low 8 bytes plus arbitrary garbage in the
+        // high 24 bytes should still decode to u64::MAX, not error.
+        let word = make_word_with_high_fill(&u64::MAX.to_be_bytes(), 0x5A);
+        let decoded = u64::from_abi(&word).unwrap();
+        assert_eq!(decoded, u64::MAX);
+    }
+
+    #[test]
+    fn test_uintn_decoding_is_non_canonical() {
+        // Two distinct 32-byte words that differ only in their high
+        // (ignored) bytes must decode to the same u32. This documents
+        // that built-in calldata is *not* canonical at the ABI layer.
+        let value: u32 = 0xCAFEBABE;
+        let word_clean = make_word_with_high_fill(&value.to_be_bytes(), 0x00);
+        let word_dirty = make_word_with_high_fill(&value.to_be_bytes(), 0xFF);
+        assert_ne!(word_clean, word_dirty);
+        assert_eq!(
+            u32::from_abi(&word_clean).unwrap(),
+            u32::from_abi(&word_dirty).unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_uintn_rejects_wrong_word_length() {
+        // The length check is the only validation `from_abi` performs;
+        // make sure it still fires for non-32-byte inputs.
+        assert!(u16::from_abi(&[0u8; 31]).is_err());
+        assert!(u32::from_abi(&[0u8; 33]).is_err());
+        assert!(u64::from_abi(&[]).is_err());
+        assert!(u128::from_abi(&[0u8; 16]).is_err());
+    }
+
+    #[test]
+    fn test_uintn_roundtrip_zero_high_bytes() {
+        // Encoding via `to_abi` always zero-pads the high bytes; the
+        // round trip through `from_abi` must be the identity.
+        let cases_u16: &[u16] = &[0, 1, 0x1234, u16::MAX];
+        for &v in cases_u16 {
+            let bytes = v.to_abi().to_vec();
+            assert_eq!(bytes.len(), 32);
+            assert!(bytes[..30].iter().all(|&b| b == 0));
+            assert_eq!(u16::from_abi(&bytes).unwrap(), v);
+        }
+
+        let cases_u64: &[u64] = &[0, 1, 0x0123_4567_89AB_CDEF, u64::MAX];
+        for &v in cases_u64 {
+            let bytes = v.to_abi().to_vec();
+            assert_eq!(bytes.len(), 32);
+            assert!(bytes[..24].iter().all(|&b| b == 0));
+            assert_eq!(u64::from_abi(&bytes).unwrap(), v);
+        }
     }
 }

--- a/crates/execution/solidity-abi/src/basic.rs
+++ b/crates/execution/solidity-abi/src/basic.rs
@@ -86,41 +86,22 @@ macro_rules! impl_abi_variable_for_primitive {
             ///
             /// ⚠️ **Non-strict decoding (intentional, consensus-critical).**
             ///
-            /// This implementation only validates that the input word is
-            /// exactly 32 bytes long and then takes the low `BITS/8` bytes
-            /// of the word. The high-order bytes (bytes `0..32 - BYTES`)
-            /// are **silently ignored**, even when they are non-zero.
+            /// Only validates the 32-byte length and takes the low `BITS/8` bytes;
+            /// high-order bytes are **silently ignored even if non-zero**.
             ///
-            /// This deviates from the Solidity / EVM ABI dispatcher
-            /// semantics, which require `value < 2^N` for any `uintN`
-            /// (`N < 256`) parameter and revert otherwise. As a result the
-            /// same calldata can be interpreted differently by a Solidity
-            /// contract and by a Conflux Core-space built-in function:
-            ///   - a Solidity contract would revert on a non-zero high
-            ///     word,
-            ///   - a Conflux built-in will accept the call and observe the
-            ///     truncated low-byte value.
+            /// This deviates from Solidity/EVM ABI semantics, which require
+            /// `value < 2^N` for `uintN` (`N < 256`) and revert otherwise. The same
+            /// calldata may therefore be interpreted differently:
+            ///   - Solidity: reverts on non-zero high bytes.
+            ///   - Conflux built-in: accepts the call with the truncated low value.
             ///
-            /// **Why we keep this behavior.** Tightening the check is a
-            /// consensus-level change: historical on-chain transactions
-            /// may have relied on (or accidentally produced) non-canonical
-            /// calldata with non-zero high bytes for built-in functions,
-            /// and rejecting them now would cause a hard fork. Any future
-            /// alignment with Solidity semantics must be gated by a
-            /// `Spec`-controlled transition (e.g. a CIP) rather than an
-            /// in-place fix here.
+            /// **Caller obligations.** Built-in functions taking sub-256-bit integers
+            /// via this trait MUST perform their own range/overflow checks
+            /// (`checked_add`, `U256` widening, explicit bounds, etc.) and MUST NOT
+            /// assume the decoder has clamped the value. Treat the ABI-level type as
+            /// advisory only.
             ///
-            /// **Caller obligations.** Because this layer does **not**
-            /// enforce the `uintN` upper bound, every built-in function
-            /// that accepts a sub-256-bit integer through this trait MUST
-            /// perform its own range / overflow checks (e.g. via
-            /// `checked_add`, `U256` widening, or explicit upper bounds)
-            /// and MUST NOT assume the value has been clamped by the ABI
-            /// decoder. Reviewers adding new built-in functions should
-            /// treat the ABI-level type as advisory only.
-            ///
-            /// See `tests_basic::test_*_truncates_high_bytes` for the
-            /// behavior that this contract pins down.
+            /// See `tests_basic::test_*_truncates_high_bytes` for pinned behavior.
             fn from_abi(data: &[u8]) -> Result<Self, ABIDecodeError> {
                 const BYTES: usize = ($ty::BITS/8) as usize;
                 abi_require(data.len() == 32, "Invalid call data length")?;


### PR DESCRIPTION
The current `solidity-abi` implementation for decoding `uintN` types deviates from the standard Solidity behavior in how it handles high-order bits. In the standard implementation, the high-order bits are required to be zero, otherwise the decoding reverts. However, the current implementation does not perform this check.

This PR adds explanatory comments and introduces unit tests.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3516)
<!-- Reviewable:end -->
