### PR TITLE
chore: change block_number in eSpace RPC types from U256 to U64

### DIFF
--- a/crates/rpc/rpc-cfx-types/src/fee_history.rs
+++ b/crates/rpc/rpc-cfx-types/src/fee_history.rs
@@ -1,4 +1,4 @@
-use cfx_types::U256;
+use cfx_types::{U256, U64};
 use serde::Serialize;
 use std::collections::VecDeque;
 
@@ -6,7 +6,7 @@ use std::collections::VecDeque;
 #[serde(rename_all = "camelCase")]
 pub struct CfxFeeHistory {
     /// Oldest epoch
-    oldest_epoch: U256,
+    oldest_epoch: U64,
     /// An array of pivot block base fees per gas. This includes one block
     /// earlier than the oldest block. Zeroes are returned for pre-EIP-1559
     /// blocks.
@@ -21,7 +21,7 @@ pub struct CfxFeeHistory {
 
 impl CfxFeeHistory {
     pub fn new(
-        oldest_epoch: U256, base_fee_per_gas: VecDeque<U256>,
+        oldest_epoch: U64, base_fee_per_gas: VecDeque<U256>,
         gas_used_ratio: VecDeque<f64>, reward: VecDeque<Vec<U256>>,
     ) -> Self {
         CfxFeeHistory {

--- a/crates/rpc/rpc-eth-impl/src/eth.rs
+++ b/crates/rpc/rpc-eth-impl/src/eth.rs
@@ -191,7 +191,7 @@ impl EthApi {
         let transaction_hash = tx.hash();
         let transaction_index: U256 = idx.into();
         let block_hash = b.pivot_header.hash();
-        let block_height: U256 = b.pivot_header.height().into();
+        let block_height: U64 = b.pivot_header.height().into();
 
         let logs: Vec<_> = receipt
             .logs
@@ -346,9 +346,9 @@ impl EthApi {
     pub fn sync_status(&self) -> SyncStatus {
         if self.sync.catch_up_mode() {
             SyncStatus::Info(SyncInfo {
-                starting_block: U256::from(self.consensus.block_count()),
-                current_block: U256::from(self.consensus.block_count()),
-                highest_block: U256::from(
+                starting_block: U64::from(self.consensus.block_count()),
+                current_block: U64::from(self.consensus.block_count()),
+                highest_block: U64::from(
                     self.sync.get_synchronization_graph().block_count(),
                 ),
                 warp_chunks_amount: None,

--- a/crates/rpc/rpc-eth-types/src/block.rs
+++ b/crates/rpc/rpc-eth-types/src/block.rs
@@ -21,7 +21,7 @@
 use crate::{Bytes, Transaction};
 use cfx_rpc_cfx_types::PhantomBlock;
 use cfx_types::{
-    hexstr_to_h256, Address, Bloom as H2048, Space, H160, H256, H64, U256,
+    hexstr_to_h256, Address, Bloom as H2048, Space, H160, H256, H64, U256, U64,
 };
 use primitives::receipt::EVM_SPACE_SUCCESS;
 use serde::{Deserialize, Serialize, Serializer};
@@ -90,7 +90,7 @@ pub struct Header {
     /// Transactions receipts root hash
     pub receipts_root: H256,
     /// Block number
-    pub number: U256,
+    pub number: U64,
     /// Gas Used
     pub gas_used: U256,
     /// Gas Limit
@@ -271,7 +271,7 @@ pub struct BlockOverrides {
         skip_serializing_if = "Option::is_none",
         alias = "blockNumber"
     )]
-    pub number: Option<U256>,
+    pub number: Option<U64>,
     /// Overrides the difficulty of the block.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub difficulty: Option<U256>,
@@ -323,7 +323,7 @@ pub struct BlockOverrides {
 mod tests {
     use super::{Block, BlockTransactions, Header};
     use crate::Bytes;
-    use cfx_types::{Bloom as H2048, H160, H256, H64, U256};
+    use cfx_types::{Bloom as H2048, H160, H256, H64, U256, U64};
 
     #[test]
     fn test_serialize_block() {
@@ -337,7 +337,7 @@ mod tests {
                 state_root: H256::default(),
                 transactions_root: H256::default(),
                 receipts_root: H256::default(),
-                number: U256::default(),
+                number: U64::default(),
                 gas_used: U256::default(),
                 gas_limit: U256::default(),
                 espace_gas_limit: U256::default(),

--- a/crates/rpc/rpc-eth-types/src/fee_history.rs
+++ b/crates/rpc/rpc-eth-types/src/fee_history.rs
@@ -6,14 +6,14 @@ use cfx_parameters::block::{
     espace_block_gas_limit_of_enabled_block,
 };
 use cfx_rpc_cfx_types::{CfxFeeHistory, FeeHistoryCacheEntry};
-use cfx_types::{Space, SpaceMap, U256};
+use cfx_types::{Space, SpaceMap, U256, U64};
 use primitives::{transaction::SignedTransaction, BlockHeader};
 
 #[derive(Serialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct FeeHistory {
     /// Oldest Block
-    oldest_block: U256,
+    oldest_block: U64,
     /// An array of block base fees per gas. This includes one block earlier
     /// than the oldest block. Zeroes are returned for pre-EIP-1559 blocks.
     base_fee_per_gas: VecDeque<U256>,

--- a/crates/rpc/rpc-eth-types/src/log.rs
+++ b/crates/rpc/rpc-eth-types/src/log.rs
@@ -37,7 +37,7 @@ pub struct Log {
     /// Block Hash
     pub block_hash: H256,
     /// Block Number
-    pub block_number: U256,
+    pub block_number: U64,
     /// Transaction Hash
     pub transaction_hash: H256,
     /// Transaction Index

--- a/crates/rpc/rpc-eth-types/src/receipt.rs
+++ b/crates/rpc/rpc-eth-types/src/receipt.rs
@@ -39,7 +39,7 @@ pub struct Receipt {
     /// Recipient
     pub to: Option<H160>,
     /// Block number
-    pub block_number: U256,
+    pub block_number: U64,
     /// Cumulative gas used
     pub cumulative_gas_used: U256,
     /// Gas used

--- a/crates/rpc/rpc-eth-types/src/sync.rs
+++ b/crates/rpc/rpc-eth-types/src/sync.rs
@@ -18,7 +18,7 @@
 // You should have received a copy of the GNU General Public License
 // along with OpenEthereum.  If not, see <http://www.gnu.org/licenses/>.
 
-use cfx_types::U256;
+use cfx_types::{U256, U64};
 use serde::{Serialize, Serializer};
 
 /// Sync info
@@ -26,11 +26,11 @@ use serde::{Serialize, Serializer};
 #[serde(rename_all = "camelCase")]
 pub struct SyncInfo {
     /// Starting block
-    pub starting_block: U256,
+    pub starting_block: U64,
     /// Current block
-    pub current_block: U256,
+    pub current_block: U64,
     /// Highest block seen so far
-    pub highest_block: U256,
+    pub highest_block: U64,
     /// Warp sync snapshot chunks total.
     pub warp_chunks_amount: Option<U256>,
     /// Warp sync snpashot chunks processed.

--- a/crates/rpc/rpc-eth-types/src/transaction.rs
+++ b/crates/rpc/rpc-eth-types/src/transaction.rs
@@ -42,7 +42,7 @@ pub struct Transaction {
     /// Block hash
     pub block_hash: Option<H256>,
     /// Block number
-    pub block_number: Option<U256>,
+    pub block_number: Option<U64>,
     /// Transaction Index
     pub transaction_index: Option<U256>,
     /// Sender
@@ -99,7 +99,7 @@ impl Transaction {
     /// Convert `SignedTransaction` into RPC Transaction.
     pub fn from_signed(
         t: &SignedTransaction,
-        block_info: (Option<H256>, Option<U256>, Option<U256>),
+        block_info: (Option<H256>, Option<U64>, Option<U256>),
         exec_info: (Option<U64>, Option<H160>),
     ) -> Transaction {
         let signature = t.signature();


### PR DESCRIPTION
The main purpose of this PR is to address a potential panic in the `apply_env_overrides` method.

```rust
if let Some(number) = block_override.number {
    env.number = number.as_u64();
}
```
The original type of `block_override.number` was `U256`, now it has been changed to `U64`. Using `U64` to represent block height is entirely sufficient in blockchain applications, and most Ethereum implementations also use `U64`.

To maintain consistency, this PR uniformly changes all fields representing block numbers in RPC types to the `U64` type.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3521)
<!-- Reviewable:end -->
