### PR TITLE
pos: read mempool pos_state fresh per batch instead of caching

### DIFF
--- a/crates/cfxcore/core/src/pos/mempool/shared_mempool/coordinator.rs
+++ b/crates/cfxcore/core/src/pos/mempool/shared_mempool/coordinator.rs
@@ -69,7 +69,7 @@ pub(crate) async fn coordinator(
                 tasks::process_consensus_request(smp.db_with_cache.clone(), &smp.mempool, msg).await;
             }
             msg = commit_notifications.select_next_some() => {
-                handle_commit_notification(&mut smp, msg);
+                handle_commit_notification(&smp, msg);
             }
             (peer, backoff) = scheduled_broadcasts.select_next_some() => {
                 // diem_debug!("scheduled_broadcasts");
@@ -119,10 +119,7 @@ async fn handle_client_event(
         .await;
 }
 
-fn handle_commit_notification(
-    smp: &mut SharedMempool, msg: CommitNotification,
-) {
-    smp.update_pos_state();
+fn handle_commit_notification(smp: &SharedMempool, msg: CommitNotification) {
     tokio::spawn(tasks::process_committed_transactions(
         smp.mempool.clone(),
         msg,

--- a/crates/cfxcore/core/src/pos/mempool/shared_mempool/runtime.rs
+++ b/crates/cfxcore/core/src/pos/mempool/shared_mempool/runtime.rs
@@ -62,7 +62,6 @@ pub(crate) fn start_shared_mempool(
         validator,
         peer_manager,
         subscribers,
-        commited_pos_state: db_with_cache.db.reader.get_latest_pos_state(),
     };
 
     executor.spawn(coordinator(

--- a/crates/cfxcore/core/src/pos/mempool/shared_mempool/tasks.rs
+++ b/crates/cfxcore/core/src/pos/mempool/shared_mempool/tasks.rs
@@ -173,13 +173,10 @@ pub(crate) async fn process_incoming_transactions(
             .filter(|tx| mempool.transactions.get(&tx.hash()).is_none())
             .collect()
     };
+    let pos_state = smp.db_with_cache.db.reader.get_latest_pos_state();
     let validation_results = transactions
         .par_iter()
-        .map(|t| {
-            smp.validator
-                .read()
-                .validate_transaction(&t, smp.commited_pos_state.clone())
-        })
+        .map(|t| smp.validator.read().validate_transaction(&t, &pos_state))
         .collect::<Vec<_>>();
 
     {

--- a/crates/cfxcore/core/src/pos/mempool/shared_mempool/transaction_validator.rs
+++ b/crates/cfxcore/core/src/pos/mempool/shared_mempool/transaction_validator.rs
@@ -6,7 +6,6 @@ use diem_types::{
     },
 };
 use move_core_types::vm_status::DiscardedVMStatus;
-use std::sync::Arc;
 
 pub struct TransactionValidator {}
 
@@ -16,7 +15,7 @@ impl TransactionValidator {
     /// Returns `None` if the transaction is accepted, or a
     /// `DiscardedVMStatus` describing why it should be rejected.
     pub fn validate_transaction(
-        &self, tx: &SignedTransaction, pos_state: Arc<PosState>,
+        &self, tx: &SignedTransaction, pos_state: &PosState,
     ) -> Option<DiscardedVMStatus> {
         let authenticator = tx.authenticator();
         let auth_pk = match &authenticator {

--- a/crates/cfxcore/core/src/pos/mempool/shared_mempool/types.rs
+++ b/crates/cfxcore/core/src/pos/mempool/shared_mempool/types.rs
@@ -23,8 +23,8 @@ use diem_config::config::MempoolConfig;
 use diem_crypto::HashValue;
 use diem_types::{
     account_address::AccountAddress, mempool_status::MempoolStatus,
-    term_state::PosState, transaction::SignedTransaction,
-    validator_verifier::ValidatorVerifier, vm_status::DiscardedVMStatus,
+    transaction::SignedTransaction, validator_verifier::ValidatorVerifier,
+    vm_status::DiscardedVMStatus,
 };
 use futures::{
     channel::{
@@ -49,14 +49,6 @@ pub(crate) struct SharedMempool {
     pub validator: Arc<RwLock<TransactionValidator>>,
     pub peer_manager: Arc<PeerManager>,
     pub subscribers: Vec<UnboundedSender<SharedMempoolNotification>>,
-    pub commited_pos_state: Arc<PosState>,
-}
-
-impl SharedMempool {
-    pub(crate) fn update_pos_state(&mut self) {
-        self.commited_pos_state =
-            self.db_with_cache.db.reader.get_latest_pos_state();
-    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]


### PR DESCRIPTION
## Summary

`SharedMempool` cached `commited_pos_state` and refreshed it as a side effect of `handle_commit_notification`. The coupling broke whenever `ExecutionProxy::notify_mempool` skipped the notification on empty user-txn lists (reconfiguration-suffix blocks, quiet rounds): PoS state advanced in the DB while the cache went stale, so valid Election/PivotDecision txns prevalidated against the old view — rejected as `ELECTION_TARGET_TERM_NOT_OPEN`, or stale ones admitted — until the next non-empty commit.

Drop the cache. `LedgerStore::get_latest_pos_state` is an `ArcSwap::load` — lock-free `Arc` clone — so reading once per batch costs the same as cloning the cached field and is always fresh.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3522)
<!-- Reviewable:end -->
