### PR TITLE
pos: lock out-queue stake on dispute for fully-retired nodes

### DIFF
--- a/crates/config/src/configuration.rs
+++ b/crates/config/src/configuration.rs
@@ -401,6 +401,7 @@ build_config! {
         (pos_cip156_transition_view, (u64), u64::MAX)
         // 6 months with 30s rounds
         (pos_cip156_dispute_locked_views, (u64), 6 * 30 * 24 * 60 * 2)
+        (pos_fix_cip156_transition_view, (u64), u64::MAX)
         (dev_pos_private_key_encryption_password, (Option<String>), None)
         (pos_started_as_voter, (bool), true)
 
@@ -1336,6 +1337,7 @@ impl Configuration {
             self.raw_conf.pos_cip136_round_per_term,
             self.raw_conf.pos_cip156_transition_view,
             self.raw_conf.pos_cip156_dispute_locked_views,
+            self.raw_conf.pos_fix_cip156_transition_view,
         )
     }
 

--- a/crates/pos/types/types/src/term_state/lock_status.rs
+++ b/crates/pos/types/types/src/term_state/lock_status.rs
@@ -113,6 +113,8 @@ impl StatusList {
 
     pub fn len(&self) -> usize { self.inner.len() }
 
+    pub fn is_empty(&self) -> bool { self.inner.is_empty() }
+
     pub fn iter(&self) -> Iter<'_, StatusItem> { self.inner.iter() }
 }
 
@@ -283,7 +285,7 @@ impl NodeLockStatus {
                 // (stake only in out_queue) escaped the lock before the fix.
                 let relock = self.available_votes > 0
                     || (POS_STATE_CONFIG.dispute_lock_includes_out_queue(view)
-                        && self.out_queue.len() > 0);
+                        && !self.out_queue.is_empty());
                 if relock {
                     // We will lock all votes in `in_queue`, `locked`, and
                     // `out_queue`.

--- a/crates/pos/types/types/src/term_state/lock_status.rs
+++ b/crates/pos/types/types/src/term_state/lock_status.rs
@@ -279,7 +279,12 @@ impl NodeLockStatus {
         match POS_STATE_CONFIG.dispute_locked_views(view) {
             None => self.exempt_from_forfeit = Some(self.unlocked),
             Some(dispute_locked_views) => {
-                if self.available_votes > 0 {
+                // available_votes excludes out_queue, so a fully-retired node
+                // (stake only in out_queue) escaped the lock before the fix.
+                let relock = self.available_votes > 0
+                    || (POS_STATE_CONFIG.dispute_lock_includes_out_queue(view)
+                        && self.out_queue.len() > 0);
+                if relock {
                     // We will lock all votes in `in_queue`, `locked`, and
                     // `out_queue`.
                     let mut to_lock_votes = self.available_votes;

--- a/crates/pos/types/types/src/term_state/pos_state_config.rs
+++ b/crates/pos/types/types/src/term_state/pos_state_config.rs
@@ -28,6 +28,9 @@ pub struct PosStateConfig {
 
     cip156_transition_view: u64,
     cip156_dispute_locked_views: u64,
+    // After this view, a dispute also relocks a fully-retired node's
+    // out_queue.
+    fix_cip156_transition_view: u64,
 
     nonce_limit_transition_view: u64,
     max_nonce_per_account: u64,
@@ -52,6 +55,7 @@ pub trait PosStateConfigTrait {
     // Returning None means the stake should be forfeited instead of being
     // locked.
     fn dispute_locked_views(&self, view: u64) -> Option<u64>;
+    fn dispute_lock_includes_out_queue(&self, view: u64) -> bool;
 }
 
 impl PosStateConfig {
@@ -63,7 +67,7 @@ impl PosStateConfig {
         max_nonce_per_account: u64, cip136_transition_view: u64,
         cip136_in_queue_locked_views: u64, cip136_out_queue_locked_views: u64,
         cip136_round_per_term: u64, cip156_transition_view: u64,
-        cip156_dispute_locked_views: u64,
+        cip156_dispute_locked_views: u64, fix_cip156_transition_view: u64,
     ) -> Self {
         Self {
             round_per_term,
@@ -80,6 +84,7 @@ impl PosStateConfig {
             cip136_round_per_term,
             cip156_transition_view,
             cip156_dispute_locked_views,
+            fix_cip156_transition_view,
             nonce_limit_transition_view,
             max_nonce_per_account,
         }
@@ -208,6 +213,10 @@ impl PosStateConfigTrait for OnceCell<PosStateConfig> {
             Some(conf.cip156_dispute_locked_views)
         }
     }
+
+    fn dispute_lock_includes_out_queue(&self, view: u64) -> bool {
+        view >= self.get().unwrap().fix_cip156_transition_view
+    }
 }
 
 pub static POS_STATE_CONFIG: OnceCell<PosStateConfig> = OnceCell::new();
@@ -229,6 +238,7 @@ impl Default for PosStateConfig {
             cip136_round_per_term: ROUND_PER_TERM,
             cip156_transition_view: u64::MAX,
             cip156_dispute_locked_views: u64::MAX,
+            fix_cip156_transition_view: u64::MAX,
             nonce_limit_transition_view: u64::MAX,
             max_nonce_per_account: u64::MAX,
         }


### PR DESCRIPTION
## Summary

CIP-156 changed the PoS dispute penalty from permanently forfeiting stake to locking it for `dispute_locked_views`. `NodeLockStatus::forfeit` gates that relock on `available_votes > 0`, but `available_votes` counts only `in_queue + locked`, not `out_queue`. A validator that has retired all of its available votes — stake sitting only in `out_queue`, so `available_votes == 0` — is therefore not relocked when disputed, and recovers its stake on the normal out-queue schedule instead of being locked for `dispute_locked_views`. A Byzantine validator can exploit this by self-retiring after equivocating, defeating the dispute time-lock deterrent. (Under CIP-156 the penalty is a lock rather than a burn, so this weakens the deterrent rather than enabling fund loss, and cannot split consensus since all nodes apply the same rule.)

Relocking the out-queue mutates the per-block `PosState`, so changing this behavior is a consensus-rule change. It is gated behind a new `pos_fix_cip156_transition_view`, defaulting to `u64::MAX`.

Related: #3513 — another consensus-rule PoS fix slated for the same next PoS hardfork.

## Follow-up

No unit test is included here. The `NodeLockStatus` methods (including `forfeit`) read the chain config from a process-global singleton (`POS_STATE_CONFIG`), so a unit test can't supply its own config without mutating shared global state. A follow-up PR will refactor these methods to take the config as an explicit parameter, making them unit-testable in isolation; the regression test for this fix will be added there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3524)
<!-- Reviewable:end -->
