### PR TITLE
chore: migrate storage/network off deprecated rand 0.9 / std APIs

### DIFF
--- a/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/mod.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/mod.rs
@@ -102,6 +102,7 @@ where CacheStoreUtilT::CacheAlgoData: CacheAlgoDataTrait
         }
     }
 
+    #[allow(deprecated)]
     unsafe fn new_mut(
         util: &mut CacheStoreUtilT, index: CacheIndexT,
     ) -> CacheAlgoDataSetter<'_, CacheStoreUtilT, CacheIndexT> {
@@ -112,6 +113,7 @@ where CacheStoreUtilT::CacheAlgoData: CacheAlgoDataTrait
         }
     }
 
+    #[allow(deprecated)]
     unsafe fn new_mut_most_recently_accessed(
         util: &mut CacheStoreUtilT, index: CacheIndexT,
     ) -> CacheAlgoDataSetterMostRecentlyAccessed<'_, CacheStoreUtilT, CacheIndexT>

--- a/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/recent_lfu.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/recent_lfu.rs
@@ -101,7 +101,7 @@ impl<PosT: PrimitiveNum, CacheIndexT: CacheIndexTrait>
     fn init_visit_counter_random_bits<RngT: Rng>(
         rng: &mut RngT,
     ) -> FrequencyType {
-        RANDOM_BITS & rng.gen::<FrequencyType>()
+        RANDOM_BITS & rng.random::<FrequencyType>()
     }
 
     fn inc_visit_counter<RngT: Rng>(&mut self, _rng: &mut RngT) {

--- a/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/removable_heap.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/removable_heap.rs
@@ -50,7 +50,7 @@ impl<ValueType, PosT: PrimitiveNum>
     TrivialValueWithHeapHandle<ValueType, PosT>
 {
     // Used in tests.
-    #[allow(dead_code)]
+    #[allow(dead_code, deprecated)]
     pub fn new(value: ValueType) -> Self {
         Self {
             value,
@@ -523,7 +523,7 @@ impl<PosT: PrimitiveNum, ValueType> RemovableHeap<PosT, ValueType> {
     }
 
     // Used in tests and by a currently unused class.
-    #[allow(dead_code)]
+    #[allow(dead_code, deprecated)]
     pub fn insert<ValueUtilT: HeapValueUtil<ValueType, PosT>>(
         &mut self, value: ValueType, value_util: &mut ValueUtilT,
     ) -> Result<PosT> {

--- a/crates/dbs/storage/src/lib.rs
+++ b/crates/dbs/storage/src/lib.rs
@@ -4,7 +4,6 @@
 
 // TODO: check them again and reason about the safety of each usage.
 #![allow(clippy::mut_from_ref)]
-#![allow(deprecated)]
 
 #[macro_use]
 extern crate cfx_util_macros;

--- a/crates/dbs/storage/src/tests/mod.rs
+++ b/crates/dbs/storage/src/tests/mod.rs
@@ -199,7 +199,7 @@ fn generate_keys(number_of_keys: usize) -> Vec<Vec<u8>> {
     let mut keys_num: Vec<u64> = Default::default();
 
     for _i in 0..number_of_keys {
-        keys_num.push(rng.gen());
+        keys_num.push(rng.random());
     }
 
     keys_num.sort();
@@ -221,7 +221,7 @@ fn generate_keys(number_of_keys: usize) -> Vec<Vec<u8>> {
 fn generate_account_keys(number_of_keys: usize) -> Vec<Vec<u8>> {
     let mut rng = get_rng_for_test();
     (0..number_of_keys)
-        .map(|_| rng.gen::<[u8; 20]>().to_vec())
+        .map(|_| rng.random::<[u8; 20]>().to_vec())
         .collect()
 }
 

--- a/crates/dbs/storage/src/tests/proofs.rs
+++ b/crates/dbs/storage/src/tests/proofs.rs
@@ -40,7 +40,7 @@ fn generate_random_state(
 
     let mut keys: Vec<Vec<u8>> = generate_account_keys(TEST_NUMBER_OF_KEYS)
         .into_iter()
-        .filter(|_| rng.gen_bool(0.2))
+        .filter(|_| rng.random_bool(0.2))
         .collect();
 
     // insert 0th, 1st, 2nd, 3rd 1/7 portions into state-0
@@ -228,7 +228,7 @@ fn select_keys(
 ) -> Vec<Vec<u8>> {
     existing_keys
         .iter()
-        .filter(|_| rng.gen_bool(0.1))
+        .filter(|_| rng.random_bool(0.1))
         .cloned()
         .collect()
 }
@@ -238,7 +238,7 @@ fn generate_nonexistent_keys(
 ) -> Vec<Vec<u8>> {
     generate_account_keys(TEST_NUMBER_OF_KEYS)
         .into_iter()
-        .filter(|_| rng.gen_bool(0.1)) // use fewer keys for now so that tests won't run forever
+        .filter(|_| rng.random_bool(0.1)) // use fewer keys for now so that tests won't run forever
         .filter(|k| !existing_keys.contains(k))
         .collect()
 }
@@ -247,7 +247,7 @@ fn get_invalid_hash(rng: &mut ChaChaRng, hash: H256) -> H256 {
     let mut new_hash = hash;
 
     while new_hash == hash {
-        new_hash.as_bytes_mut()[rng.random_range(0..32)] = rng.gen::<u8>();
+        new_hash.as_bytes_mut()[rng.random_range(0..32)] = rng.random::<u8>();
     }
 
     new_hash
@@ -260,7 +260,7 @@ fn get_invalid_maybe_hash(
     let mut new_maybe_hash = maybe_hash.map(|h| get_invalid_hash(rng, h));
 
     // randomly change Some(_) to None
-    if rng.gen_bool(0.1) {
+    if rng.random_bool(0.1) {
         new_maybe_hash = None;
     }
 

--- a/crates/dbs/storage/src/tests/sharded_iter_merger.rs
+++ b/crates/dbs/storage/src/tests/sharded_iter_merger.rs
@@ -61,7 +61,7 @@ fn test_sharded_iter_merger() -> Result<()> {
     let total_keys: usize = shard_sizes.iter().sum();
     let mut sorted = vec![];
     while sorted.len() != total_keys {
-        let number_key = rng.gen();
+        let number_key = rng.random();
         let shard_id = number_key_to_shard_id(number_key, num_shards);
         if shards[shard_id].len() != shard_sizes[shard_id] {
             sorted.push((number_key, ()));

--- a/crates/dbs/storage/src/tests/snapshot.rs
+++ b/crates/dbs/storage/src/tests/snapshot.rs
@@ -293,7 +293,7 @@ fn test_merkle_root() {
     for _i in 0..5 {
         let keys: Vec<Vec<u8>> = generate_keys(TEST_NUMBER_OF_KEYS)
             .iter()
-            .filter(|_| rng.gen_bool(0.1))
+            .filter(|_| rng.random_bool(0.1))
             .cloned()
             .collect();
         let mpt_kv_iter = DumpedMptKvIterator {
@@ -309,7 +309,7 @@ fn test_delete_all() {
     let mut rng = get_rng_for_test();
     let keys: Vec<Vec<u8>> = generate_keys(TEST_NUMBER_OF_KEYS)
         .iter()
-        .filter(|_| rng.gen_bool(0.5))
+        .filter(|_| rng.random_bool(0.5))
         .cloned()
         .collect();
     let mpt_kv_iter = DumpedMptKvIterator {

--- a/crates/dbs/storage/src/tests/snapshot/slicer.rs
+++ b/crates/dbs/storage/src/tests/snapshot/slicer.rs
@@ -28,7 +28,7 @@ fn test_slicing_position() {
     let mut rng = get_rng_for_test();
     let mut keys: Vec<Vec<u8>> = generate_keys(TEST_NUMBER_OF_KEYS)
         .iter()
-        .filter(|_| rng.gen_bool(0.5))
+        .filter(|_| rng.random_bool(0.5))
         .cloned()
         .collect();
     keys.sort();

--- a/crates/dbs/storage/src/tests/snapshot/verifier.rs
+++ b/crates/dbs/storage/src/tests/snapshot/verifier.rs
@@ -84,7 +84,7 @@ fn test_slice_verifier() {
     let mut rng = get_rng_for_test();
     let mut keys: Vec<Vec<u8>> = generate_keys(TEST_NUMBER_OF_KEYS)
         .iter()
-        .filter(|_| rng.gen_bool(0.5))
+        .filter(|_| rng.random_bool(0.5))
         .cloned()
         .collect();
     keys.sort();
@@ -649,7 +649,7 @@ fn test_full_sync_verifier() {
     let mut rng = get_rng_for_test();
     let mut keys: Vec<Vec<u8>> = generate_keys(TEST_NUMBER_OF_KEYS)
         .iter()
-        .filter(|_| rng.gen_bool(0.5))
+        .filter(|_| rng.random_bool(0.5))
         .cloned()
         .collect();
     keys.sort();

--- a/crates/dbs/storage/src/tests/state.rs
+++ b/crates/dbs/storage/src/tests/state.rs
@@ -31,7 +31,7 @@ fn test_set_get() {
     let mut state = state_manager.get_state_for_genesis_write();
     let mut keys: Vec<Vec<u8>> = generate_keys(TEST_NUMBER_OF_KEYS)
         .iter()
-        .filter(|_| rng.gen_bool(0.5))
+        .filter(|_| rng.random_bool(0.5))
         .cloned()
         .collect();
 
@@ -573,7 +573,7 @@ fn test_set_order() {
     let state_manager = new_state_manager_for_unit_test();
     let keys: Vec<Vec<u8>> = generate_keys(500000)
         .iter()
-        .filter(|_| rng.gen_bool(0.5))
+        .filter(|_| rng.random_bool(0.5))
         .cloned()
         .collect();
 
@@ -639,7 +639,7 @@ fn test_set_order_concurrent() {
     let keys = Arc::new(
         generate_keys(TEST_NUMBER_OF_KEYS / 10)
             .iter()
-            .filter(|_| rng.gen_bool(0.5))
+            .filter(|_| rng.random_bool(0.5))
             .cloned()
             .collect::<Vec<_>>(),
     );
@@ -696,7 +696,7 @@ fn test_set_order_concurrent() {
     };
     let mut threads = Vec::with_capacity(thread_count);
     for thread_id in 0..thread_count {
-        thread::sleep_ms(30);
+        thread::sleep(Duration::from_millis(30));
         let keys = keys.clone();
         let state_manager = state_manager.clone();
         let merkle_1 = merkle_1.clone();

--- a/crates/network/src/ip/bucket.rs
+++ b/crates/network/src/ip/bucket.rs
@@ -3,7 +3,7 @@ use crate::{
     node_database::NodeDatabase,
     node_table::{NodeContact, NodeId},
 };
-use rand::{prelude::ThreadRng, thread_rng, Rng};
+use rand::{prelude::ThreadRng, Rng};
 use std::time::Duration;
 
 /// NodeBucket is used to manage the nodes that grouped by subnet,
@@ -62,7 +62,7 @@ impl NodeBucket {
             }
         }
 
-        let mut rng = thread_rng();
+        let mut rng = rand::rng();
 
         // evict out-of-date node with high priority
         if !long_time_nodes.is_empty() {
@@ -83,7 +83,6 @@ impl NodeBucket {
 #[cfg(test)]
 mod tests {
     use super::{NodeBucket, NodeId};
-    use rand::thread_rng;
 
     #[test]
     fn test_add_remove() {
@@ -119,7 +118,7 @@ mod tests {
     #[test]
     fn test_sample() {
         let mut bucket = NodeBucket::default();
-        let mut rng = thread_rng();
+        let mut rng = rand::rng();
 
         // sample None if bucket is empty
         assert_eq!(bucket.sample(&mut rng), None);

--- a/crates/network/src/ip/node_limit.rs
+++ b/crates/network/src/ip/node_limit.rs
@@ -3,7 +3,6 @@ use crate::{
     node_database::NodeDatabase,
     node_table::NodeId,
 };
-use rand::thread_rng;
 use std::{
     collections::{HashMap, HashSet},
     net::IpAddr,
@@ -136,7 +135,7 @@ impl NodeIpLimit {
             return sampled;
         }
 
-        let mut rng = thread_rng();
+        let mut rng = rand::rng();
 
         for _ in 0..n {
             if let Some(bucket) = self.trusted_buckets.sample(&mut rng) {

--- a/crates/network/src/ip/node_tag_index.rs
+++ b/crates/network/src/ip/node_tag_index.rs
@@ -10,7 +10,6 @@ use crate::{
     node_table::{NodeId, NodeTable},
     Node,
 };
-use rand::thread_rng;
 use std::collections::{HashMap, HashSet};
 
 /// Tag based node index, so as to filter nodes by tag in node database.
@@ -84,7 +83,7 @@ impl NodeTagIndex {
     ) -> Option<HashSet<NodeId>> {
         let buckets = self.items.get(key)?.get(value)?;
 
-        let mut rng = thread_rng();
+        let mut rng = rand::rng();
         let mut sampled = HashSet::new();
 
         for _ in 0..count {

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -2,7 +2,6 @@
 // Conflux is free software and distributed under GNU General Public License.
 // See http://www.gnu.org/licenses/
 
-#![allow(deprecated)]
 use cfxkey as keylib;
 use io as iolib;
 use keccak_hash as hash;

--- a/crates/network/src/node_table.rs
+++ b/crates/network/src/node_table.rs
@@ -447,7 +447,7 @@ impl NodeTable {
     ) -> Vec<NodeEntry> {
         let mut nodes: Vec<NodeEntry> = Vec::new();
         for _i in 0..count {
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
             let node_rep_idx = rng.random_range(0..NODE_REPUTATION_LEVEL_COUNT);
             let node_rep = NodeReputation::iter().nth(node_rep_idx).unwrap();
             let node_rep_vec = &self.node_reputation_table[node_rep];
@@ -476,7 +476,7 @@ impl NodeTable {
         &self, count: u32, _filter: &IpFilter,
     ) -> HashSet<NodeId> {
         let mut node_id_set: HashSet<NodeId> = HashSet::new();
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         for _i in 0..count {
             let node_rep_idx = rng.random_range(0..NODE_REPUTATION_LEVEL_COUNT);
             let node_rep = NodeReputation::iter().nth(node_rep_idx).unwrap();
@@ -656,7 +656,7 @@ impl NodeTable {
             a.time().cmp(&b.time())
         });
 
-        unknown.shuffle(&mut rand::thread_rng());
+        unknown.shuffle(&mut rand::rng());
 
         success.append(&mut unknown);
         success.append(&mut failures);


### PR DESCRIPTION
## Summary

Both crates are already on workspace `rand 0.9` but carried crate-wide `#![allow(deprecated)]` masking rand-0.9 method renames. This migrates the call sites and removes the blanket suppressions.

- **network**: `thread_rng()` → `rand::rng()` everywhere; crate-wide allow removed entirely.
- **storage**: `gen`/`gen_bool`/`gen::<T>` → `random`/`random_bool`/`random::<T>` and `thread::sleep_ms` → `sleep(Duration)` (almost all in tests, plus one real site in `recent_lfu.rs`).

The storage blanket allow becomes a per-function `#[allow(deprecated)]` on the four remaining `mem::uninitialized()` sites in the delta-MPT cache/heap, so any new deprecated use in the crate now fails the build. Migrating those four (UB-delicate unsafe code) is left as separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3526)
<!-- Reviewable:end -->
