### PR TITLE
chore: remove mem::uninitialized() from the delta-MPT cache/heap

### DIFF
--- a/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/lru.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/lru.rs
@@ -164,13 +164,11 @@ impl<PosT: PrimitiveNum, CacheIndexT: CacheIndexTrait> CacheAlgorithm
             // Set new head.
             let new_head = self.size;
             self.head = new_head;
-            unsafe {
-                CacheAlgoDataAdapter::new_mut_most_recently_accessed(
-                    cache_store_util,
-                    cache_index,
-                )
-                .set_most_recently_accessed();
-            }
+            CacheAlgoDataAdapter::new_mut_most_recently_accessed(
+                cache_store_util,
+                cache_index,
+            )
+            .set_most_recently_accessed();
             self.recent.push(DoubleLinkListNode {
                 next: old_head,
                 cache_index,

--- a/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/mod.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/mod.rs
@@ -102,26 +102,28 @@ where CacheStoreUtilT::CacheAlgoData: CacheAlgoDataTrait
         }
     }
 
-    #[allow(deprecated)]
-    unsafe fn new_mut(
+    fn new_mut(
         util: &mut CacheStoreUtilT, index: CacheIndexT,
     ) -> CacheAlgoDataSetter<'_, CacheStoreUtilT, CacheIndexT> {
+        // `algo_data` is a write-only placeholder: every caller overwrites it
+        // via `placement_new_*` before the `Drop` flush, so its initial value
+        // never affects the result. `Default` avoids `mem::uninitialized()` UB.
         CacheAlgoDataSetter {
             cache_store_util: util,
             element_index: index,
-            algo_data: mem::uninitialized(),
+            algo_data: Default::default(),
         }
     }
 
-    #[allow(deprecated)]
-    unsafe fn new_mut_most_recently_accessed(
+    fn new_mut_most_recently_accessed(
         util: &mut CacheStoreUtilT, index: CacheIndexT,
     ) -> CacheAlgoDataSetterMostRecentlyAccessed<'_, CacheStoreUtilT, CacheIndexT>
     {
+        // See `new_mut`: write-only placeholder, overwritten before flush.
         CacheAlgoDataSetterMostRecentlyAccessed {
             cache_store_util: util,
             element_index: index,
-            algo_data: mem::uninitialized(),
+            algo_data: Default::default(),
         }
     }
 }
@@ -344,7 +346,6 @@ use malloc_size_of::MallocSizeOf;
 use std::{
     fmt::{Debug, Display},
     marker::PhantomData,
-    mem,
     ops::{
         Add, AddAssign, Deref, DerefMut, Div, DivAssign, Mul, Sub, SubAssign,
     },

--- a/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/recent_lfu.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/recent_lfu.rs
@@ -173,15 +173,10 @@ impl<
     fn set_removed(
         &mut self, value: &mut RecentLFUMetadata<PosT, CacheIndexT>,
     ) {
-        unsafe {
-            // There is no need to update lru cache_index because heap removal
-            // always happens after frequency_lru removal.
-            CacheAlgoDataAdapter::new_mut(
-                self.cache_store_util,
-                value.cache_index,
-            )
+        // There is no need to update lru cache_index because heap removal
+        // always happens after frequency_lru removal.
+        CacheAlgoDataAdapter::new_mut(self.cache_store_util, value.cache_index)
             .placement_new_evicted();
-        }
     }
 
     fn get_key_for_comparison<'x>(

--- a/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/removable_heap.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/removable_heap.rs
@@ -5,11 +5,7 @@
 use super::{super::super::super::errors::*, MyInto, PrimitiveNum};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use std::{
-    cmp::Ordering,
-    marker::PhantomData,
-    mem::{self, MaybeUninit},
-    ptr,
-    vec::Vec,
+    cmp::Ordering, marker::PhantomData, mem::MaybeUninit, ptr, vec::Vec,
 };
 
 // To make it easy for any value type to implement HeapValueUtil.
@@ -50,11 +46,11 @@ impl<ValueType, PosT: PrimitiveNum>
     TrivialValueWithHeapHandle<ValueType, PosT>
 {
     // Used in tests.
-    #[allow(dead_code, deprecated)]
+    #[allow(dead_code)]
     pub fn new(value: ValueType) -> Self {
         Self {
             value,
-            handle: unsafe { mem::uninitialized() },
+            handle: HeapHandle::default(),
         }
     }
 
@@ -523,7 +519,7 @@ impl<PosT: PrimitiveNum, ValueType> RemovableHeap<PosT, ValueType> {
     }
 
     // Used in tests and by a currently unused class.
-    #[allow(dead_code, deprecated)]
+    #[allow(dead_code)]
     pub fn insert<ValueUtilT: HeapValueUtil<ValueType, PosT>>(
         &mut self, value: ValueType, value_util: &mut ValueUtilT,
     ) -> Result<PosT> {
@@ -531,8 +527,11 @@ impl<PosT: PrimitiveNum, ValueType> RemovableHeap<PosT, ValueType> {
             return Err(Error::OutOfCapacity.into());
         }
 
-        let mut hole: Hole<ValueType> = unsafe { mem::uninitialized() };
-        hole.value = value;
+        // `pointer_pos` stays uninit until `insert_with_hole_unchecked` writes
+        // it; `value` is moved in directly (the old `mem::uninitialized()` +
+        // assignment dropped an uninitialized `value`, UB if `ValueType:
+        // Drop`).
+        let hole = Hole::new_uninit_pointer(value);
 
         let pos = unsafe { self.insert_with_hole_unchecked(hole, value_util) };
 


### PR DESCRIPTION
## Summary

Removes the last four `mem::uninitialized()` calls in the repo (delta-MPT cache/heap), which were retained under a scoped `#[allow(deprecated)]` in #3526, and drops those allows.

In the production cache setters the `algo_data` field is a write-only placeholder: every one of the 10 callers overwrites the sole field (via `placement_new_*`) before the `Drop` flush reads it, so the initial value is never observed. `CacheAlgoData` is `Copy + Default`, so `Default::default()` is a defined, behavior-equivalent initializer.

The two test-only `removable_heap.rs` sites use `HeapHandle::default()` and the existing `Hole::new_uninit_pointer(value)` helper (which also avoids the old `hole.value = value` assignment that dropped an uninitialized `value`).

With `mem::uninitialized()` gone, those two setters no longer do anything unsafe, so this also drops their now-redundant `unsafe fn` markers (annotation-only, no codegen change). No `#[allow(deprecated)]` remains in the crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3527)
<!-- Reviewable:end -->
