### PR TITLE
fix: SnapshotKeptToProvideSyncStatus rlp decode UB issue

### DIFF
--- a/crates/dbs/storage/src/storage_db/snapshot_db.rs
+++ b/crates/dbs/storage/src/storage_db/snapshot_db.rs
@@ -22,7 +22,14 @@ impl Encodable for SnapshotKeptToProvideSyncStatus {
 
 impl Decodable for SnapshotKeptToProvideSyncStatus {
     fn decode(rlp: &Rlp) -> std::result::Result<Self, DecoderError> {
-        Ok(unsafe { std::mem::transmute(rlp.as_val::<u8>()?) })
+        match rlp.as_val::<u8>()? {
+            0 => Ok(Self::No),
+            1 => Ok(Self::InfoOnly),
+            2 => Ok(Self::InfoAndSnapshot),
+            _ => Err(DecoderError::Custom(
+                "invalid SnapshotKeptToProvideSyncStatus",
+            )),
+        }
     }
 }
 


### PR DESCRIPTION
Malicious node p2p messages may cause UB behavior in SnapshotKeptToProvideSyncStatus

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3530)
<!-- Reviewable:end -->
