### PR TITLE
fix: optimize unsafe code in get_epoch_id_at_height

### DIFF
--- a/crates/dbs/storage/src/storage_db/snapshot_db.rs
+++ b/crates/dbs/storage/src/storage_db/snapshot_db.rs
@@ -96,11 +96,10 @@ impl SnapshotInfo {
         } else if height > self.height {
             None
         } else {
-            unsafe {
-                Some(self.pivot_chain_parts.get_unchecked(
-                    (height - self.parent_snapshot_height - 1) as usize,
-                ))
-            }
+            let index =
+                usize::try_from(height - self.parent_snapshot_height - 1)
+                    .ok()?;
+            self.pivot_chain_parts.get(index)
         }
     }
 }


### PR DESCRIPTION
A maliciously crafted P2P message can cause `self.height - parent_snapshot_height != pivot_chain_parts.len()`, leading to a panic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3532)
<!-- Reviewable:end -->
