### PR TITLE
fix: use safe version rlp decode for VanillaTrieNode

### DIFF
--- a/crates/dbs/storage/src/impls/merkle_patricia_trie/trie_node.rs
+++ b/crates/dbs/storage/src/impls/merkle_patricia_trie/trie_node.rs
@@ -260,7 +260,7 @@ where ChildrenTableItem<NodeRefT>: DefaultChildrenItem<NodeRefT>
         }
 
         Ok(VanillaTrieNode::new(
-            MerkleHash::from_slice(rlp.val_at::<Vec<u8>>(0)?.as_slice()),
+            rlp.val_at::<MerkleHash>(0)?,
             rlp.val_at::<VanillaChildrenTable<NodeRefT>>(1)?,
             rlp.val_at::<Option<Vec<u8>>>(2)?
                 .map(|v| v.into_boxed_slice()),


### PR DESCRIPTION
MerkleHash::from_slice will panic if the input's length is not 32, so change to a safer version to decode it

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3535)
<!-- Reviewable:end -->
