### PR TITLE
op: add pre validate for ElectionPayload.vrf_proof

### DIFF
--- a/crates/pos/consensus/executor/src/vm.rs
+++ b/crates/pos/consensus/executor/src/vm.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use consensus_types::{block::Block, vote::Vote};
+use diem_crypto::VRFProof;
 use diem_logger::{error as diem_error, prelude::*};
 use diem_state_view::StateView;
 use diem_types::{
@@ -160,6 +161,10 @@ impl ExecutableBuiltinTx for ElectionPayload {
                     VMStatus::Error(StatusCode::CFX_INVALID_TX)
                 })?;
         }
+        self.vrf_proof.to_hash().map_err(|e| {
+            diem_error!("election tx vrf proof to_hash error: {:?}", e);
+            VMStatus::Error(StatusCode::CFX_INVALID_TX)
+        })?;
         Ok(vec![self.to_event()])
     }
 }


### PR DESCRIPTION
Under extreme circumstances, `self.vrf_proof.to_hash()` may return an error, and calling `unwrap()` directly would cause a panic. Therefore, a pre-check has been added.

```rust
pub fn to_event(&self) -> ContractEvent {
      let event = ElectionEvent::new(
          self.public_key.clone(),
          self.vrf_public_key.clone(),
          self.vrf_proof.to_hash().unwrap(),
          self.target_term,
      );
      ContractEvent::new(
          ElectionEvent::event_key(),
          bcs::to_bytes(&event).unwrap(),
      )
  }
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3536)
<!-- Reviewable:end -->
