### PR TITLE
op: Optimize the to_event method to handle possible panics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ testdata/evm-spec-test/
 testdata/config.toml
 testdata/evm-spec-test.tar
 run/dev_metrics.toml
+.kilo

--- a/crates/pos/consensus/executor/src/vm.rs
+++ b/crates/pos/consensus/executor/src/vm.rs
@@ -160,7 +160,7 @@ impl ExecutableBuiltinTx for ElectionPayload {
                     VMStatus::Error(StatusCode::CFX_INVALID_TX)
                 })?;
         }
-        Ok(vec![self.to_event()])
+        Ok(vec![self.to_event()?])
     }
 }
 

--- a/crates/pos/types/types/src/transaction/mod.rs
+++ b/crates/pos/types/types/src/transaction/mod.rs
@@ -275,17 +275,20 @@ pub struct ElectionPayload {
 }
 
 impl ElectionPayload {
-    pub fn to_event(&self) -> ContractEvent {
+    pub fn to_event(&self) -> Result<ContractEvent, VMStatus> {
+        let vrf_hash = self
+            .vrf_proof
+            .to_hash()
+            .map_err(|_| VMStatus::Error(StatusCode::CFX_INVALID_TX))?;
         let event = ElectionEvent::new(
             self.public_key.clone(),
             self.vrf_public_key.clone(),
-            self.vrf_proof.to_hash().unwrap(),
+            vrf_hash,
             self.target_term,
         );
-        ContractEvent::new(
-            ElectionEvent::event_key(),
-            bcs::to_bytes(&event).unwrap(),
-        )
+        let bytes = bcs::to_bytes(&event)
+            .map_err(|_| VMStatus::Error(StatusCode::CFX_UNEXPECTED_TX))?;
+        Ok(ContractEvent::new(ElectionEvent::event_key(), bytes))
     }
 }
 


### PR DESCRIPTION
Malformed proofs can lead to panic when calling to_event, add checks for potentially failing operations, and return an error instead of panicking if they fail

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3537)
<!-- Reviewable:end -->
