### PR TITLE
net: bound HELLO peer protocol list to fix O(n²) DoS

### DIFF
--- a/crates/network/src/session.rs
+++ b/crates/network/src/session.rs
@@ -23,6 +23,7 @@ use rlp::{Rlp, RlpStream};
 use serde::Deserialize;
 use serde_derive::Serialize;
 use std::{
+    collections::HashSet,
     convert::TryFrom,
     fmt,
     net::SocketAddr,
@@ -92,6 +93,9 @@ pub struct SessionDataWithDisconnectInfo {
 
 // id for Hello packet
 const PACKET_HELLO: u8 = 0x80;
+// A HELLO packet can be ~16MB; cap the advertised protocol count so a peer
+// can't pack it with millions of entries (real peers send a handful).
+const MAX_PEER_PROTOCOLS_IN_HELLO: usize = 64;
 // id for Disconnect packet
 const PACKET_DISCONNECT: u8 = 0x01;
 // id for protocol packet
@@ -426,19 +430,36 @@ impl Session {
             )));
         }
 
+        // `take(N + 1)` parses at most N+1 item headers (the rlp offset cache
+        // makes each O(1)), so an oversized list is rejected without walking
+        // it.
+        let peer_caps_count = rlp
+            .at(1)?
+            .iter()
+            .take(MAX_PEER_PROTOCOLS_IN_HELLO + 1)
+            .count();
+        if peer_caps_count > MAX_PEER_PROTOCOLS_IN_HELLO {
+            debug!(
+                "Too many protocols in hello: {}, remote = {}",
+                peer_caps_count, remote_network_id
+            );
+            return Err(self.send_disconnect(DisconnectReason::Custom(
+                "Invalid protocol list: too many protocols.".into(),
+            )));
+        }
+
         let mut peer_caps: Vec<ProtocolInfo> = rlp.list_at(1)?;
-        for i in 1..peer_caps.len() {
-            for j in 0..i {
-                if peer_caps[j].protocol == peer_caps[i].protocol {
-                    debug!(
-                        "Invalid protocol list from hello. Duplication: {:?},\
-                         remote = {}",
-                        peer_caps[i].protocol, remote_network_id
-                    );
-                    bail!(self.send_disconnect(DisconnectReason::Custom(
-                        "Invalid protocol list: duplication.".into()
-                    )))
-                }
+        let mut seen_protocols = HashSet::with_capacity(peer_caps.len());
+        for cap in &peer_caps {
+            if !seen_protocols.insert(cap.protocol) {
+                debug!(
+                    "Invalid protocol list from hello. Duplication: {:?}, \
+                     remote = {}",
+                    cap.protocol, remote_network_id
+                );
+                return Err(self.send_disconnect(DisconnectReason::Custom(
+                    "Invalid protocol list: duplication.".into(),
+                )));
             }
         }
 


### PR DESCRIPTION
A HELLO packet can be up to ~16 MB (the 3-byte length prefix in `connection.rs`), and `read_hello` runs inline on the single network event-loop thread. It decoded the peer-supplied `peer_caps` list with no length bound and then scanned it for duplicate protocols with an O(n²) nested loop, so one ~16 MB packet (~2.8 M entries) forces ~4×10¹² protocol comparisons — many minutes of 100%-CPU on the single poll thread — stalling all inbound P2P for the whole node. Smaller packets scale down quadratically but still cause severe stalls.

Bound the advertised protocol count before decoding — `iter().take(N + 1).count()` is constant-time thanks to the rlp offset cache — and reject peers exceeding it, then replace the O(n²) duplicate scan with an O(n) `HashSet`. Real peers advertise only a handful of protocols (`cfx`, `clp`, `hsb`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3539)
<!-- Reviewable:end -->
