### PR TITLE
chore: sign_with method check from is provided, if not will return error

### DIFF
--- a/crates/rpc/rpc-cfx-types/src/transaction_request.rs
+++ b/crates/rpc/rpc-cfx-types/src/transaction_request.rs
@@ -135,6 +135,7 @@ impl TransactionRequest {
         self, epoch_height: u64, chain_id: u32, password: Option<String>,
         accounts: Arc<AccountProvider>,
     ) -> Result<TransactionWithSignature, String> {
+        let from = self.from.clone().ok_or("should have from")?;
         let gas = self.gas.ok_or("should have gas")?;
         let nonce = self.nonce.ok_or("should have nonce")?;
         let transaction_type = self.transaction_type();
@@ -213,11 +214,7 @@ impl TransactionRequest {
         let tx = Transaction::Native(typed_native_tx);
         let password = password.map(Password::from);
         let sig = accounts
-            .sign(
-                self.from.unwrap().into(),
-                password,
-                tx.hash_for_compute_signature(),
-            )
+            .sign(from.into(), password, tx.hash_for_compute_signature())
             // TODO: sign error into secret store error codes.
             .map_err(|e| format!("failed to sign transaction: {:?}", e))?;
 


### PR DESCRIPTION
The `TransactionRequest.sign_with` method is executed by the internal methods `cfx_sendTransaction` and `cfx_signTransaction`. These two methods use the accounts stored in the node to sign the transaction, and therefore they require that `from` must be specified.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3542)
<!-- Reviewable:end -->
