### PR TITLE
chore: fix tx pool uint256 overflow issue caused by unchecked tx.value

### DIFF
--- a/crates/cfxcore/core/src/transaction_pool/transaction_pool_inner.rs
+++ b/crates/cfxcore/core/src/transaction_pool/transaction_pool_inner.rs
@@ -1029,18 +1029,24 @@ impl TransactionPoolInner {
             );
             match transaction.unsigned {
                 Transaction::Native(ref utx) => {
-                    need_balance += utx.value().clone();
+                    need_balance =
+                        need_balance.saturating_add(utx.value().clone());
                     if sponsored_gas == U256::from(0) {
-                        need_balance += estimate_gas_fee;
+                        need_balance =
+                            need_balance.saturating_add(estimate_gas_fee);
                     }
                     if sponsored_storage == 0 {
-                        need_balance += U256::from(*utx.storage_limit())
-                            * *DRIPS_PER_STORAGE_COLLATERAL_UNIT;
+                        need_balance = need_balance.saturating_add(
+                            U256::from(*utx.storage_limit())
+                                * *DRIPS_PER_STORAGE_COLLATERAL_UNIT,
+                        );
                     }
                 }
                 Transaction::Ethereum(ref utx) => {
-                    need_balance += utx.value().clone();
-                    need_balance += estimate_gas_fee;
+                    need_balance =
+                        need_balance.saturating_add(utx.value().clone());
+                    need_balance =
+                        need_balance.saturating_add(estimate_gas_fee);
                 }
             }
 

--- a/crates/rpc/rpc-cfx-types/src/transaction_request.rs
+++ b/crates/rpc/rpc-cfx-types/src/transaction_request.rs
@@ -135,6 +135,7 @@ impl TransactionRequest {
         self, epoch_height: u64, chain_id: u32, password: Option<String>,
         accounts: Arc<AccountProvider>,
     ) -> Result<TransactionWithSignature, String> {
+        let from = self.from.clone().ok_or("should have from")?;
         let gas = self.gas.ok_or("should have gas")?;
         let nonce = self.nonce.ok_or("should have nonce")?;
         let transaction_type = self.transaction_type();
@@ -213,11 +214,7 @@ impl TransactionRequest {
         let tx = Transaction::Native(typed_native_tx);
         let password = password.map(Password::from);
         let sig = accounts
-            .sign(
-                self.from.unwrap().into(),
-                password,
-                tx.hash_for_compute_signature(),
-            )
+            .sign(from.into(), password, tx.hash_for_compute_signature())
             // TODO: sign error into secret store error codes.
             .map_err(|e| format!("failed to sign transaction: {:?}", e))?;
 


### PR DESCRIPTION
Before calculating `need_balance`, there was no validation logic for the transaction's `value`, allowing `U256::max` to reach this point and cause an overflow panic. This PR adopts safe operations to handle it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3543)
<!-- Reviewable:end -->
