### PR TITLE
fix: U256 addition overflow issue in tx pool insert operation

### DIFF
--- a/crates/cfxcore/core/src/transaction_pool/transaction_pool_inner.rs
+++ b/crates/cfxcore/core/src/transaction_pool/transaction_pool_inner.rs
@@ -1029,18 +1029,24 @@ impl TransactionPoolInner {
             );
             match transaction.unsigned {
                 Transaction::Native(ref utx) => {
-                    need_balance += utx.value().clone();
+                    need_balance =
+                        need_balance.saturating_add(utx.value().clone());
                     if sponsored_gas == U256::from(0) {
-                        need_balance += estimate_gas_fee;
+                        need_balance =
+                            need_balance.saturating_add(estimate_gas_fee);
                     }
                     if sponsored_storage == 0 {
-                        need_balance += U256::from(*utx.storage_limit())
-                            * *DRIPS_PER_STORAGE_COLLATERAL_UNIT;
+                        need_balance = need_balance.saturating_add(
+                            U256::from(*utx.storage_limit())
+                                * *DRIPS_PER_STORAGE_COLLATERAL_UNIT,
+                        );
                     }
                 }
                 Transaction::Ethereum(ref utx) => {
-                    need_balance += utx.value().clone();
-                    need_balance += estimate_gas_fee;
+                    need_balance =
+                        need_balance.saturating_add(utx.value().clone());
+                    need_balance =
+                        need_balance.saturating_add(estimate_gas_fee);
                 }
             }
 


### PR DESCRIPTION
Before calculating need_balance, there was no validation logic for the transaction's value, allowing U256::max to reach this point and cause an overflow panic. This PR adopts safe operations to handle it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3544)
<!-- Reviewable:end -->
