### PR TITLE
Fix non-pivot staking events poisoning the PoS event cache

### DIFF
--- a/crates/cfxcore/core/src/consensus/consensus_inner/consensus_executor/epoch_execution.rs
+++ b/crates/cfxcore/core/src/consensus/consensus_inner/consensus_executor/epoch_execution.rs
@@ -97,7 +97,12 @@ impl ConsensusExecutionHandler {
             std::mem::swap(&mut epoch_recorder.geth_traces, task.answer);
         }
 
-        if !dry_run && self.pos_verifier.pos_option().is_some() {
+        // Persist staking events only from canonical (local-pivot) execution,
+        // so every saved row can be trusted as canonical on read.
+        if !dry_run
+            && on_local_pivot
+            && self.pos_verifier.pos_option().is_some()
+        {
             debug!(
                 "put_staking_events: {:?} height={} len={}",
                 pivot_block.hash(),

--- a/crates/cfxcore/core/src/pos/consensus/consensusdb/mod.rs
+++ b/crates/cfxcore/core/src/pos/consensus/consensusdb/mod.rs
@@ -230,7 +230,10 @@ impl ConsensusDB {
         self.commit(batch, true)
     }
 
-    /// Save staking events between two pivot decisions.
+    /// Read the cached staking events for the range `(parent_decision,
+    /// me_decision]`. Rows are written only by canonical (local-pivot)
+    /// execution, so saved rows are trusted; only the endpoints are checked
+    /// against the requested decisions.
     pub fn get_staking_events(
         &self, parent_decision: PivotBlockDecision,
         me_decision: PivotBlockDecision,


### PR DESCRIPTION
The PoW→PoS staking-event cache is keyed by epoch height only. A non-canonical execution from the mining fork-state path (`compute_state_for_block`, `on_local_pivot=false`) wrote that fork's staking events under a canonical height, overwriting the canonical row, and PoS proposal generation and validation read them back as if canonical.

Gate the cache write on `on_local_pivot` so only canonical execution persists rows; saved rows are then canonical by construction, consistent with how other persisted execution data is trusted on read.

Gating the write alone is sufficient because a pivot reorg already rewinds the executed-state frontier to the fork point and re-executes the new pivot chain with `on_local_pivot=true`, overwriting each affected height's row (through normal execution, or the receipt-replay rewrite when the block was already executed as a fork). PoS pivot decisions only reference state at or below the executed frontier, so a height cannot enter a decision range until it has been re-executed and its row refreshed; reads therefore always see the current canonical row, and the range endpoints are additionally checked against the decisions. No per-read re-validation or schema/DB change is needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3558)
<!-- Reviewable:end -->
