### PR TITLE
Remove unimplemented OneStepSync/IncSync snapshot sync types and reject them at decode

### DIFF
--- a/crates/cfxcore/core/src/sync/message/snapshot_chunk_request.rs
+++ b/crates/cfxcore/core/src/sync/message/snapshot_chunk_request.rs
@@ -55,9 +55,6 @@ impl Handleable for SnapshotChunkRequest {
             SnapshotSyncCandidate::FullSync {
                 snapshot_epoch_id, ..
             } => snapshot_epoch_id,
-            _ => bail!(Error::NotSupported(
-                "OneStepSync/IncSync not yet implemented.".into()
-            )),
         };
         let chunk = match Chunk::load(
             snapshot_epoch_id,

--- a/crates/cfxcore/core/src/sync/message/state_sync_candidate_request.rs
+++ b/crates/cfxcore/core/src/sync/message/state_sync_candidate_request.rs
@@ -72,9 +72,6 @@ impl Handleable for StateSyncCandidateRequest {
                         }
                     }
                 }
-                _ => {
-                    warn!("Unsupported candidate: {:?}", candidate);
-                }
             }
         }
         ctx.send_response(&StateSyncCandidateResponse {

--- a/crates/cfxcore/core/src/sync/state/snapshot_chunk_sync.rs
+++ b/crates/cfxcore/core/src/sync/state/snapshot_chunk_sync.rs
@@ -71,8 +71,8 @@ impl Debug for Status {
     }
 }
 
-// TODO: Implement OneStepSync / IncSync as this is currently only implemented
-// for FullSync.
+// Only FullSync is supported. OneStepSync / IncSync were never implemented,
+// are deprecated, and rejected at decode (see `SnapshotSyncCandidate`).
 struct Inner {
     status: Status,
 

--- a/crates/cfxcore/core/src/sync/state/storage.rs
+++ b/crates/cfxcore/core/src/sync/state/storage.rs
@@ -22,17 +22,11 @@ use rlp_derive::{RlpDecodable, RlpEncodable};
     Clone, Hash, Ord, PartialOrd, PartialEq, Eq, Debug, DeriveMallocSizeOf,
 )]
 pub enum SnapshotSyncCandidate {
-    OneStepSync {
-        height: u64,
-        snapshot_epoch_id: EpochId,
-    },
+    // Wire type_id 0 (OneStepSync) and 2 (IncSync) were never implemented and
+    // have been deprecated and removed; `Decodable` rejects those ids. Do not
+    // reuse them for a new variant.
     FullSync {
         height: u64,
-        snapshot_epoch_id: EpochId,
-    },
-    IncSync {
-        height: u64,
-        base_snapshot_epoch_id: EpochId,
         snapshot_epoch_id: EpochId,
     },
 }
@@ -40,21 +34,13 @@ pub enum SnapshotSyncCandidate {
 impl SnapshotSyncCandidate {
     fn to_type_id(&self) -> u8 {
         match self {
-            SnapshotSyncCandidate::OneStepSync { .. } => 0,
             SnapshotSyncCandidate::FullSync { .. } => 1,
-            SnapshotSyncCandidate::IncSync { .. } => 2,
         }
     }
 
     pub fn get_snapshot_epoch_id(&self) -> &EpochId {
         match self {
-            SnapshotSyncCandidate::OneStepSync {
-                snapshot_epoch_id, ..
-            } => snapshot_epoch_id,
             SnapshotSyncCandidate::FullSync {
-                snapshot_epoch_id, ..
-            } => snapshot_epoch_id,
-            SnapshotSyncCandidate::IncSync {
                 snapshot_epoch_id, ..
             } => snapshot_epoch_id,
         }
@@ -64,15 +50,6 @@ impl SnapshotSyncCandidate {
 impl Encodable for SnapshotSyncCandidate {
     fn rlp_append(&self, s: &mut RlpStream) {
         match &self {
-            SnapshotSyncCandidate::OneStepSync {
-                height,
-                snapshot_epoch_id,
-            } => {
-                s.begin_list(3)
-                    .append(&self.to_type_id())
-                    .append(height)
-                    .append(snapshot_epoch_id);
-            }
             SnapshotSyncCandidate::FullSync {
                 height,
                 snapshot_epoch_id,
@@ -82,17 +59,6 @@ impl Encodable for SnapshotSyncCandidate {
                     .append(height)
                     .append(snapshot_epoch_id);
             }
-            SnapshotSyncCandidate::IncSync {
-                height,
-                base_snapshot_epoch_id,
-                snapshot_epoch_id,
-            } => {
-                s.begin_list(4)
-                    .append(&self.to_type_id())
-                    .append(height)
-                    .append(base_snapshot_epoch_id)
-                    .append(snapshot_epoch_id);
-            }
         }
     }
 }
@@ -100,28 +66,20 @@ impl Encodable for SnapshotSyncCandidate {
 impl Decodable for SnapshotSyncCandidate {
     fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
         let type_id: u8 = rlp.val_at(0)?;
-        let parsed = match type_id {
-            0 => SnapshotSyncCandidate::OneStepSync {
+        match type_id {
+            1 => Ok(SnapshotSyncCandidate::FullSync {
                 height: rlp.val_at(1)?,
                 snapshot_epoch_id: rlp.val_at(2)?,
-            },
-            1 => SnapshotSyncCandidate::FullSync {
-                height: rlp.val_at(1)?,
-                snapshot_epoch_id: rlp.val_at(2)?,
-            },
-            2 => SnapshotSyncCandidate::IncSync {
-                height: rlp.val_at(1)?,
-                base_snapshot_epoch_id: rlp.val_at(2)?,
-                snapshot_epoch_id: rlp.val_at(3)?,
-            },
-            _ => {
-                return Err(DecoderError::Custom(
-                    "Unknown SnapshotSyncCandidate type id",
-                ))
-            }
-        };
-        debug_assert_eq!(parsed.to_type_id(), type_id);
-        Ok(parsed)
+            }),
+            // type_id 0 (OneStepSync) and 2 (IncSync) were never implemented
+            // and are deprecated: reject them so they can never
+            // reach a handler. A peer that sends one is treated
+            // like any unknown/malformed type. Do not reuse these
+            // ids.
+            _ => Err(DecoderError::Custom(
+                "Unsupported SnapshotSyncCandidate type id",
+            )),
+        }
     }
 }
 
@@ -236,12 +194,6 @@ impl RangedManifest {
             SnapshotSyncCandidate::FullSync {
                 snapshot_epoch_id, ..
             } => snapshot_epoch_id,
-            SnapshotSyncCandidate::IncSync { .. } => {
-                unimplemented!();
-            }
-            SnapshotSyncCandidate::OneStepSync { .. } => {
-                unimplemented!();
-            }
         };
         debug!(
             "begin to load manifest, snapshot_epoch_id = {:?}, start_key = {:?}",


### PR DESCRIPTION
`OneStepSync` (type_id 0) and `IncSync` (type_id 2) snapshot-sync candidate types were never implemented — they hit `unimplemented!()` in `RangedManifest::load`. Because a peer picks the type in its `GET_SNAPSHOT_MANIFEST` request and the handler is dispatched with only throttling (no role/sync-phase/handshake gate), one unsolicited request panicked the handler thread; with no `catch_unwind` this could take down the node's networking, fully-synced nodes included. This removes both variants and rejects type_id 0/2 at decode, so an unsupported type can no longer reach any handler.

**Removing them is compatibility-safe.** `FullSync` (type_id 1) is the only candidate type any node ever constructs or sends, and its wire encoding is unchanged — so honest peers are unaffected and there is no consensus or DB change. `OneStepSync`/`IncSync` are never built anywhere in the code (they could only ever arrive by decoding a peer's message), so removing the variants breaks no caller; a peer that does send 0/2 is simply dropped like any unknown message type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3559)
<!-- Reviewable:end -->
