### PR TITLE
txpool + consensus: reject non-canonically-encoded transactions

### DIFF
--- a/crates/cfxcore/core/src/transaction_pool/mod.rs
+++ b/crates/cfxcore/core/src/transaction_pool/mod.rs
@@ -657,6 +657,13 @@ impl TransactionPool {
         &self, inner: &mut TransactionPoolInner, state: &StateProvider,
         transaction: Arc<SignedTransaction>, packed: bool, force: bool,
     ) -> Result<(), TransactionPoolError> {
+        // Never pool a non-canonical tx: packing one builds a
+        // `transactions_root` the canonical re-encoded body won't match.
+        if !transaction.is_canonical_rlp() {
+            return Err(TransactionPoolError::RlpDecodeError(
+                "non-canonical transaction RLP encoding".into(),
+            ));
+        }
         inner.insert_transaction_with_readiness_check(
             state,
             transaction,

--- a/crates/cfxcore/core/src/transaction_pool/mod.rs
+++ b/crates/cfxcore/core/src/transaction_pool/mod.rs
@@ -657,8 +657,11 @@ impl TransactionPool {
         &self, inner: &mut TransactionPoolInner, state: &StateProvider,
         transaction: Arc<SignedTransaction>, packed: bool, force: bool,
     ) -> Result<(), TransactionPoolError> {
-        // Never pool a non-canonical tx: packing one builds a
-        // `transactions_root` the canonical re-encoded body won't match.
+        // `verify_transaction_common` already rejects non-canonical txs in
+        // Local mode, but the recycle path (`recycle_transactions`,
+        // basic_check=false) bypasses it. This chokepoint is the single funnel
+        // every insertion passes through, so packing a tx whose canonical
+        // re-encoding won't reproduce the `transactions_root` is impossible.
         if !transaction.is_canonical_rlp() {
             return Err(TransactionPoolError::RlpDecodeError(
                 "non-canonical transaction RLP encoding".into(),

--- a/crates/cfxcore/core/src/verification.rs
+++ b/crates/cfxcore/core/src/verification.rs
@@ -829,12 +829,7 @@ impl VerificationConfig {
 
         Self::check_gas_limit(tx, cip76, eip7623, &mode)?;
         Self::check_gas_limit_with_calldata(tx, cip130)?;
-
-        if !Self::check_canonical_rlp(tx, canonical_tx_rlp, &mode) {
-            bail!(TransactionError::InvalidRlp(
-                "non-canonical transaction RLP encoding".into()
-            ));
-        }
+        Self::check_canonical_rlp(tx, canonical_tx_rlp, &mode)?;
 
         Ok(())
     }
@@ -846,14 +841,20 @@ impl VerificationConfig {
     fn check_canonical_rlp(
         tx: &TransactionWithSignature, canonical_tx_rlp: bool,
         mode: &VerifyTxMode,
-    ) -> bool {
+    ) -> Result<(), TransactionError> {
         if tx.is_canonical_rlp() {
-            return true;
+            return Ok(());
         }
-        match mode {
-            VerifyTxMode::Local(..) => false,
-            VerifyTxMode::Remote(_) => !canonical_tx_rlp,
+        let rejected = match mode {
+            VerifyTxMode::Local(..) => true,
+            VerifyTxMode::Remote(_) => canonical_tx_rlp,
+        };
+        if rejected {
+            bail!(TransactionError::InvalidRlp(
+                "non-canonical transaction RLP encoding".into()
+            ));
         }
+        Ok(())
     }
 
     fn check_eip155_transaction(

--- a/crates/cfxcore/core/src/verification.rs
+++ b/crates/cfxcore/core/src/verification.rs
@@ -755,6 +755,14 @@ impl VerificationConfig {
             bail!(TransactionError::ZeroGasPrice);
         }
 
+        // Non-canonical txs are accepted in blocks today, so rejecting them
+        // unconditionally would fork; gate it to a hardfork height.
+        if height >= transitions.canonical_tx_rlp && !tx.is_canonical_rlp() {
+            bail!(TransactionError::InvalidRlp(
+                "non-canonical transaction RLP encoding".into()
+            ));
+        }
+
         if matches!(mode, VerifyTxMode::Local(..))
             && tx.space() == Space::Native
         {

--- a/crates/cfxcore/core/src/verification.rs
+++ b/crates/cfxcore/core/src/verification.rs
@@ -755,14 +755,6 @@ impl VerificationConfig {
             bail!(TransactionError::ZeroGasPrice);
         }
 
-        // Non-canonical txs are accepted in blocks today, so rejecting them
-        // unconditionally would fork; gate it to a hardfork height.
-        if height >= transitions.canonical_tx_rlp && !tx.is_canonical_rlp() {
-            bail!(TransactionError::InvalidRlp(
-                "non-canonical transaction RLP encoding".into()
-            ));
-        }
-
         if matches!(mode, VerifyTxMode::Local(..))
             && tx.space() == Space::Native
         {
@@ -793,6 +785,7 @@ impl VerificationConfig {
         let cip7702 = height >= transitions.cip7702;
         let cip645 = height >= transitions.cip645;
         let eip7623 = height >= transitions.eip7623;
+        let canonical_tx_rlp = height >= transitions.canonical_tx_rlp;
 
         if let Transaction::Native(ref tx) = tx.unsigned {
             Self::verify_transaction_epoch_height(
@@ -837,7 +830,30 @@ impl VerificationConfig {
         Self::check_gas_limit(tx, cip76, eip7623, &mode)?;
         Self::check_gas_limit_with_calldata(tx, cip130)?;
 
+        if !Self::check_canonical_rlp(tx, canonical_tx_rlp, &mode) {
+            bail!(TransactionError::InvalidRlp(
+                "non-canonical transaction RLP encoding".into()
+            ));
+        }
+
         Ok(())
+    }
+
+    /// A non-canonical encoding hashes to a value the canonical re-encoding
+    /// won't reproduce, so packing one orphans the block. Local (mempool /
+    /// packing / RPC) rejects it outright; as a block-validity rule this is a
+    /// consensus change, so Remote only rejects at/after the gate height.
+    fn check_canonical_rlp(
+        tx: &TransactionWithSignature, canonical_tx_rlp: bool,
+        mode: &VerifyTxMode,
+    ) -> bool {
+        if tx.is_canonical_rlp() {
+            return true;
+        }
+        match mode {
+            VerifyTxMode::Local(..) => false,
+            VerifyTxMode::Remote(_) => !canonical_tx_rlp,
+        }
     }
 
     fn check_eip155_transaction(

--- a/crates/config/src/configuration.rs
+++ b/crates/config/src/configuration.rs
@@ -208,6 +208,7 @@ build_config! {
         (osaka_opcode_transition_height, (Option<u64>), None)
         (cip166_transition_height, (Option<u64>), None)
         (cip167_transition_height, (Option<u64>), None)
+        (canonical_tx_rlp_transition_height, (Option<u64>), None)
 
         // Mining section.
         (mining_author, (Option<String>), None)
@@ -1542,6 +1543,11 @@ impl Configuration {
         if let Some(x) = self.raw_conf.cip167_transition_height {
             params.transition_heights.cip167 = x;
         }
+
+        params.transition_heights.canonical_tx_rlp = self
+            .raw_conf
+            .canonical_tx_rlp_transition_height
+            .unwrap_or(default_transition_time);
     }
 }
 

--- a/crates/execution/executor/src/spec.rs
+++ b/crates/execution/executor/src/spec.rs
@@ -162,6 +162,9 @@ pub struct TransitionsEpochHeight {
     pub cip166: BlockHeight,
     /// EIP-7212 / RIP-7212: precompile secp256r1 activation height
     pub cip167: BlockHeight,
+    /// Height at/after which a block with a non-canonically-encoded tx is
+    /// invalid. Far-future until a CIP/height is scheduled.
+    pub canonical_tx_rlp: BlockHeight,
 }
 
 impl Default for CommonParams {

--- a/crates/execution/executor/src/spec.rs
+++ b/crates/execution/executor/src/spec.rs
@@ -186,7 +186,13 @@ impl Default for CommonParams {
             params_dao_vote_period: DAO_PARAMETER_VOTE_PERIOD,
             early_set_internal_contracts_states: false,
             transition_numbers: Default::default(),
-            transition_heights: Default::default(),
+            // `canonical_tx_rlp` is a far-future hardfork; the derived `0`
+            // default would activate it at genesis for bare-default callers
+            // (e.g. test harnesses). `Configuration` overrides it per network.
+            transition_heights: TransitionsEpochHeight {
+                canonical_tx_rlp: u64::MAX,
+                ..Default::default()
+            },
             min_base_price: SpaceMap::default(),
         }
     }

--- a/crates/execution/executor/src/spec.rs
+++ b/crates/execution/executor/src/spec.rs
@@ -186,13 +186,7 @@ impl Default for CommonParams {
             params_dao_vote_period: DAO_PARAMETER_VOTE_PERIOD,
             early_set_internal_contracts_states: false,
             transition_numbers: Default::default(),
-            // `canonical_tx_rlp` is a far-future hardfork; the derived `0`
-            // default would activate it at genesis for bare-default callers
-            // (e.g. test harnesses). `Configuration` overrides it per network.
-            transition_heights: TransitionsEpochHeight {
-                canonical_tx_rlp: u64::MAX,
-                ..Default::default()
-            },
+            transition_heights: Default::default(),
             min_base_price: SpaceMap::default(),
         }
     }

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1211,7 +1211,12 @@ mod canonical_rlp_tests {
     fn malleate(p: &TransactionWithSignatureSerializePart) -> Vec<u8> {
         let mut s = rlp::encode(p).to_vec();
         if is_list_form(p) {
-            assert!((0xc0..=0xf7).contains(&s[0]));
+            // Only short-form list headers (payload <= 55 bytes) — the
+            // single-byte length can be bumped. Keep test variants small.
+            assert!(
+                (0xc0..=0xf7).contains(&s[0]),
+                "malleate: long-form list header not supported"
+            );
             s[0] += 1;
             s.push(0xb8);
             s

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -944,10 +944,14 @@ impl TransactionWithSignature {
         }
     }
 
-    /// Used to compute hash of created transactions
+    /// keccak of the canonical RLP re-encoding — unlike `hash`, which is over
+    /// the (possibly non-canonical) bytes the tx was decoded from.
+    pub fn canonical_hash(&self) -> H256 {
+        keccak(&*self.transaction.rlp_bytes())
+    }
+
     fn compute_hash(mut self) -> TransactionWithSignature {
-        let hash = keccak(&*self.transaction.rlp_bytes());
-        self.hash = hash;
+        self.hash = self.canonical_hash();
         self
     }
 
@@ -981,6 +985,12 @@ impl TransactionWithSignature {
     }
 
     pub fn hash(&self) -> H256 { self.hash }
+
+    /// False when the lenient decoder accepted a non-canonical encoding (e.g. a
+    /// trailing partial item): same fields, different cached hash.
+    pub fn is_canonical_rlp(&self) -> bool {
+        self.hash == self.canonical_hash()
+    }
 
     /// Recovers the public key of the sender.
     pub fn recover_public(&self) -> Result<Public, keylib::Error> {
@@ -1160,5 +1170,113 @@ impl SignedTransaction {
 impl MallocSizeOf for SignedTransaction {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         self.transaction.size_of(ops)
+    }
+}
+
+#[cfg(test)]
+mod canonical_rlp_tests {
+    use super::*;
+    use EthereumTransaction::*;
+    use TypedNativeTransaction::*;
+
+    fn part(unsigned: Transaction) -> TransactionWithSignatureSerializePart {
+        TransactionWithSignatureSerializePart {
+            unsigned,
+            v: 1,
+            r: U256::from(0x1234u64),
+            s: U256::from(0x5678u64),
+        }
+    }
+
+    fn is_list_form(p: &TransactionWithSignatureSerializePart) -> bool {
+        matches!(
+            p.unsigned,
+            Transaction::Native(Cip155(_)) | Transaction::Ethereum(Eip155(_))
+        )
+    }
+
+    // `decode` takes a bare list (legacy) or an RLP-string-wrapped
+    // `type||list` (typed).
+    fn wire(p: &TransactionWithSignatureSerializePart) -> Vec<u8> {
+        let s = rlp::encode(p).to_vec();
+        if is_list_form(p) {
+            s
+        } else {
+            rlp::encode(&s).to_vec()
+        }
+    }
+
+    // Non-canonical, same fields: a trailing partial item (0xb8) the decoder
+    // tolerates; for a list, bump the header length so it stays inside.
+    fn malleate(p: &TransactionWithSignatureSerializePart) -> Vec<u8> {
+        let mut s = rlp::encode(p).to_vec();
+        if is_list_form(p) {
+            assert!((0xc0..=0xf7).contains(&s[0]));
+            s[0] += 1;
+            s.push(0xb8);
+            s
+        } else {
+            s.push(0xb8);
+            rlp::encode(&s).to_vec()
+        }
+    }
+
+    fn assert_predicate(p: TransactionWithSignatureSerializePart) {
+        let canon: TransactionWithSignature = rlp::decode(&wire(&p)).unwrap();
+        assert_eq!(canon.transaction, p);
+        assert!(canon.is_canonical_rlp());
+
+        let mall: TransactionWithSignature =
+            rlp::decode(&malleate(&p)).unwrap();
+        assert_eq!(mall.transaction, p);
+        assert!(!mall.is_canonical_rlp());
+
+        let raw = rlp::encode(&p).to_vec();
+        assert!(TransactionWithSignature::from_raw(&raw)
+            .unwrap()
+            .is_canonical_rlp());
+    }
+
+    // One case per encoded form: list vs typed-string, Ethereum vs native.
+    #[test]
+    fn is_canonical_rlp_all_variants() {
+        let variants = [
+            Transaction::Ethereum(Eip155(Eip155Transaction {
+                chain_id: Some(1),
+                ..Default::default()
+            })),
+            // pre-155: chain_id None -> v = 27/28.
+            Transaction::Ethereum(Eip155(Eip155Transaction {
+                chain_id: None,
+                ..Default::default()
+            })),
+            Transaction::Native(Cip155(NativeTransaction {
+                chain_id: 1,
+                ..Default::default()
+            })),
+            Transaction::Ethereum(Eip2930(Eip2930Transaction {
+                chain_id: 1,
+                ..Default::default()
+            })),
+            Transaction::Ethereum(Eip1559(Eip1559Transaction {
+                chain_id: 1,
+                ..Default::default()
+            })),
+            Transaction::Ethereum(Eip7702(Eip7702Transaction {
+                chain_id: 1,
+                ..Default::default()
+            })),
+            Transaction::Native(Cip2930(Cip2930Transaction {
+                chain_id: 1,
+                ..Default::default()
+            })),
+            Transaction::Native(Cip1559(Cip1559Transaction {
+                chain_id: 1,
+                ..Default::default()
+            })),
+        ];
+        for unsigned in variants {
+            assert_predicate(part(unsigned));
+        }
     }
 }

--- a/integration_tests/conflux/config.py
+++ b/integration_tests/conflux/config.py
@@ -62,6 +62,9 @@ small_local_test_conf = dict(
     min_phase_change_normal_peer_count = 1,
     dao_vote_transition_number = 2**31,
     dao_vote_transition_height = 2**31,
+    # Canonical-tx-RLP hardfork: far-future by default so the integration suite
+    # is unaffected; tests exercising it set it explicitly.
+    canonical_tx_rlp_transition_height = 2**31,
     enable_single_mpt_storage = "true",
     rpc_enable_metrics = "true",
 )

--- a/tests/conflux/config.py
+++ b/tests/conflux/config.py
@@ -62,6 +62,9 @@ small_local_test_conf = dict(
     min_phase_change_normal_peer_count = 1,
     dao_vote_transition_number = 2**31,
     dao_vote_transition_height = 2**31,
+    # Canonical-tx-RLP hardfork: far-future by default so the integration suite
+    # is unaffected; tests exercising it set it explicitly.
+    canonical_tx_rlp_transition_height = 2**31,
     enable_single_mpt_storage = "true",
     rpc_enable_metrics = "true",
 )


### PR DESCRIPTION
## Summary

The RLP decoder is lenient, so a transaction can decode to identical fields from a non-canonical encoding (e.g. one with a trailing partial RLP item) while caching its hash over the *received* bytes instead of the canonical re-encoding. A node re-encodes canonically when it relays or mines and commits that cached hash in `transactions_root` (and consumes it in execution) — so packing such a transaction yields roots that diverge from what peers recompute from the canonical body.

## Change

- `TransactionWithSignature::is_canonical_rlp()` — the cached hash equals the canonical re-encoding.
- **Mempool:** reject non-canonical transactions at the single pool-insertion chokepoint, so they're never pooled, relayed, or packed. Node-local; effective on upgrade.
- **Consensus:** at/after a new height-gated transition (`canonical_tx_rlp`, far-future by default, assigned per network when scheduled), a block containing a non-canonical transaction is invalid. A no-op before the height; honestly-encoded transactions are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3561)
<!-- Reviewable:end -->
