### PR TITLE
build(deps): bump anyhow to 1.0.103 for RUSTSEC-2026-0190

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "app_dirs"


### PR DESCRIPTION
`anyhow` < 1.0.103 trips the new RUSTSEC-2026-0190 advisory (unsoundness in `Error::downcast_mut()`), failing `cargo-deny` repo-wide. Bump to the patched `1.0.103`; `Cargo.lock`-only, within the existing `anyhow = "1.0"` range.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3562)
<!-- Reviewable:end -->
