### PR TITLE
Enforce snapshot manifest boundary ordering and harden state sync

### DIFF
--- a/crates/cfxcore/core/src/sync/state/snapshot_chunk_sync.rs
+++ b/crates/cfxcore/core/src/sync/state/snapshot_chunk_sync.rs
@@ -220,27 +220,29 @@ impl SnapshotChunkSync {
             let r = manifest_manager
                 .handle_snapshot_manifest_response(ctx, response, request)?;
             if let Some(related_data) = r {
-                // update status
+                // Build into a local first: if `new_and_start` fails, setting
+                // status to `DownloadingChunks` before it would leave
+                // `chunk_manager == None` and panic the next `update_status`.
+                let chunk_manager = SnapshotChunkManager::new_and_start(
+                    ctx,
+                    manifest_manager.snapshot_candidate.clone(),
+                    related_data.snapshot_info.clone(),
+                    related_data.parent_snapshot_info.clone(),
+                    manifest_manager.chunk_boundaries.clone(),
+                    manifest_manager.chunk_boundary_proofs.clone(),
+                    manifest_manager.active_peers.clone(),
+                    self.config.chunk_config(),
+                    // This delta_root is the intermediate_delta_root of
+                    // the new snapshot, and this field will be used to
+                    // fill new state_root in
+                    // get_state_trees_for_next_epoch
+                    related_data
+                        .true_state_root_by_blame_info
+                        .state_root
+                        .delta_root,
+                )?;
                 inner.status = Status::DownloadingChunks(Instant::now());
-                inner.chunk_manager =
-                    Some(SnapshotChunkManager::new_and_start(
-                        ctx,
-                        manifest_manager.snapshot_candidate.clone(),
-                        related_data.snapshot_info.clone(),
-                        related_data.parent_snapshot_info.clone(),
-                        manifest_manager.chunk_boundaries.clone(),
-                        manifest_manager.chunk_boundary_proofs.clone(),
-                        manifest_manager.active_peers.clone(),
-                        self.config.chunk_config(),
-                        // This delta_root is the intermediate_delta_root of
-                        // the new snapshot, and this field will be used to
-                        // fill new state_root in
-                        // get_state_trees_for_next_epoch
-                        related_data
-                            .true_state_root_by_blame_info
-                            .state_root
-                            .delta_root,
-                    )?);
+                inner.chunk_manager = Some(chunk_manager);
                 inner.related_data = Some(related_data);
             }
             debug!("sync state progress: {:?}", *inner);
@@ -370,10 +372,20 @@ impl SnapshotChunkSync {
         if inner.manifest_attempts
             >= self.config.max_downloading_manifest_attempts
         {
-            panic!(
-                "Exceed max manifest attempts {}",
+            // Remote-triggerable (peers serving unusable manifests/chunks), so
+            // panicking here would be a remote crash; reset and fall through to
+            // restart candidate discovery instead.
+            error!(
+                "Exceeded max manifest download attempts ({}); resetting state \
+                 sync and restarting candidate discovery. This usually means \
+                 peers served unusable manifests or chunks.",
                 self.config.max_downloading_manifest_attempts
             );
+            inner.manifest_attempts = 0;
+            inner.status = Status::Inactive;
+            inner.manifest_manager = None;
+            inner.chunk_manager = None;
+            inner.related_data = None;
         }
 
         debug!("sync state status before updating: {:?}", *inner);

--- a/crates/cfxcore/core/src/sync/state/state_sync_manifest/snapshot_manifest_manager.rs
+++ b/crates/cfxcore/core/src/sync/state/state_sync_manifest/snapshot_manifest_manager.rs
@@ -167,9 +167,8 @@ impl SnapshotManifestManager {
                     }
                 };
 
-            // Check proofs for keys.
             if let Err(e) =
-                response.manifest.validate(&snapshot_info.merkle_root)
+                response.manifest.validate(&snapshot_info.merkle_root, None)
             {
                 warn!("failed to validate snapshot manifest, error = {:?}", e);
                 bail!(Error::InvalidSnapshotManifest(
@@ -191,28 +190,27 @@ impl SnapshotManifestManager {
                     "Non-initial manifest is not expected".into()
                 ));
             }
-            debug_assert_eq!(
-                request.start_chunk.as_ref(),
-                self.chunk_boundaries.last()
-            );
-            if let Some(related_data) = &self.related_data {
-                // Check proofs for keys.
-                if let Err(e) = response
-                    .manifest
-                    .validate(&related_data.snapshot_info.merkle_root)
-                {
-                    warn!(
-                        "failed to validate snapshot manifest, error = {:?}",
-                        e
-                    );
-                    bail!(Error::InvalidSnapshotManifest(
-                        "invalid chunk proofs in manifest".into(),
-                    ));
-                }
+            if request.start_chunk.as_ref() != self.chunk_boundaries.last() {
+                bail!(Error::InvalidSnapshotManifest(
+                    "manifest start does not match accumulated boundary".into(),
+                ));
+            }
+            let related_data = match &self.related_data {
+                Some(related_data) => related_data,
+                None => bail!(Error::InvalidSnapshotManifest(
+                    "missing related data for non-initial manifest".into(),
+                )),
+            };
+            if let Err(e) = response.manifest.validate(
+                &related_data.snapshot_info.merkle_root,
+                self.chunk_boundaries.last().map(|b| b.as_slice()),
+            ) {
+                warn!("failed to validate snapshot manifest, error = {:?}", e);
+                bail!(Error::InvalidSnapshotManifest(
+                    "invalid chunk proofs in manifest".into(),
+                ));
             }
         }
-        // The first element is `start_key` and overlaps with the previous
-        // manifest.
         self.chunk_boundaries
             .extend_from_slice(&response.manifest.chunk_boundaries);
         self.chunk_boundary_proofs

--- a/crates/cfxcore/core/src/sync/state/storage.rs
+++ b/crates/cfxcore/core/src/sync/state/storage.rs
@@ -170,10 +170,11 @@ impl Decodable for RangedManifest {
 }
 
 impl RangedManifest {
-    /// Validate the manifest with specified snapshot merkle root and the
-    /// requested start chunk key. Basically, the retrieved chunks should
-    /// not be empty, and the proofs of all chunk keys are valid.
-    pub fn validate(&self, snapshot_root: &MerkleHash) -> Result<(), Error> {
+    /// `lower_bound_excl` is the previous page's last boundary (the
+    /// continuation `start_chunk`), or `None` for the initial page.
+    pub fn validate(
+        &self, snapshot_root: &MerkleHash, lower_bound_excl: Option<&[u8]>,
+    ) -> Result<(), Error> {
         if self.chunk_boundaries.len() != self.chunk_boundary_proofs.len() {
             bail!(Error::InvalidSnapshotManifest(
                 "chunk and proof number do not match".into(),
@@ -186,6 +187,22 @@ impl RangedManifest {
                     "next does not match last boundary".into(),
                 )),
             }
+        }
+
+        // The per-key proofs below are order-independent, so this is what
+        // rejects a permuted/duplicated boundary list (which would otherwise
+        // become impossible empty download ranges).
+        let mut prev_excl = lower_bound_excl;
+        for boundary in &self.chunk_boundaries {
+            let boundary = boundary.as_slice();
+            if let Some(prev) = prev_excl {
+                if boundary <= prev {
+                    bail!(Error::InvalidSnapshotManifest(
+                        "chunk boundaries are not strictly increasing".into(),
+                    ));
+                }
+            }
+            prev_excl = Some(boundary);
         }
 
         // validate the trie proof for all chunks
@@ -275,6 +292,9 @@ impl RangedManifest {
         let mut manifest = RangedManifest::default();
         let mut has_next = true;
 
+        // The slicer advances monotonically through the trie, so the boundaries
+        // come out strictly increasing -- the invariant the receiver enforces
+        // in `validate`.
         for i in 0..max_chunks {
             trace!("cut chunks for manifest, loop = {}", i);
             slicer.advance(chunk_size)?;
@@ -422,4 +442,80 @@ impl Chunk {
     }
 }
 
-// todo add necessary unit tests when code is stable
+#[cfg(test)]
+mod tests {
+    use super::RangedManifest;
+    use cfx_storage::TrieProof;
+    use cfx_types::H256;
+
+    fn manifest(boundaries: Vec<Vec<u8>>) -> RangedManifest {
+        let chunk_boundary_proofs =
+            boundaries.iter().map(|_| TrieProof::default()).collect();
+        RangedManifest {
+            chunk_boundaries: boundaries,
+            chunk_boundary_proofs,
+            next: None,
+        }
+    }
+
+    // Non-null so the default proofs fail their root check, letting tests tell
+    // the ordering error apart from the proof error.
+    fn non_null_root() -> H256 { H256::from_low_u64_be(1) }
+
+    #[test]
+    fn reversed_boundaries_are_rejected() {
+        let err = manifest(vec![vec![2], vec![1]])
+            .validate(&non_null_root(), None)
+            .expect_err("reversed boundaries must be rejected");
+        assert!(
+            err.to_string().contains("strictly increasing"),
+            "expected ordering error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn duplicate_boundaries_are_rejected() {
+        let err = manifest(vec![vec![1], vec![1]])
+            .validate(&non_null_root(), None)
+            .expect_err("duplicate boundaries must be rejected");
+        assert!(
+            err.to_string().contains("strictly increasing"),
+            "expected ordering error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn boundary_not_greater_than_lower_bound_is_rejected() {
+        let err = manifest(vec![vec![5]])
+            .validate(&non_null_root(), Some(&[5]))
+            .expect_err("boundary equal to lower bound must be rejected");
+        assert!(
+            err.to_string().contains("strictly increasing"),
+            "expected ordering error, got: {}",
+            err
+        );
+
+        let err = manifest(vec![vec![4]])
+            .validate(&non_null_root(), Some(&[5]))
+            .expect_err("boundary below lower bound must be rejected");
+        assert!(
+            err.to_string().contains("strictly increasing"),
+            "expected ordering error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn in_order_boundaries_pass_ordering_check() {
+        let err = manifest(vec![vec![1], vec![2]])
+            .validate(&non_null_root(), Some(&[0]))
+            .expect_err("dummy proofs must fail the proof check");
+        assert!(
+            !err.to_string().contains("strictly increasing"),
+            "in-order boundaries must pass the ordering check, got: {}",
+            err
+        );
+    }
+}

--- a/crates/dbs/storage/src/impls/snapshot_sync/restoration/full_sync_verifier.rs
+++ b/crates/dbs/storage/src/impls/snapshot_sync/restoration/full_sync_verifier.rs
@@ -33,11 +33,21 @@ impl<SnapshotDbManager: SnapshotDbManagerTrait>
             bail!(Error::InvalidSnapshotSyncProof)
         }
         let mut chunk_index_by_upper_key = HashMap::new();
+        let mut prev_boundary: Option<&[u8]> = None;
         for (chunk_index, (chunk_boundary, proof)) in chunk_boundaries
             .iter()
             .zip(chunk_boundary_proofs.iter())
             .enumerate()
         {
+            // Strictly increasing: `chunk_index_by_upper_key` is keyed by
+            // boundary and `restore_chunk` derives ranges from adjacent
+            // boundaries, so a duplicate would silently collapse chunk indexes.
+            if let Some(prev) = prev_boundary {
+                if chunk_boundary.as_slice() <= prev {
+                    bail!(Error::InvalidSnapshotSyncProof)
+                }
+            }
+            prev_boundary = Some(chunk_boundary.as_slice());
             if merkle_root.ne(proof.get_merkle_root()) {
                 bail!(Error::InvalidSnapshotSyncProof)
             }


### PR DESCRIPTION
Snapshot state-sync validated manifests only by per-key trie proofs, which are order-independent, so a peer could return chunk boundaries reversed or duplicated. Those boundaries become half-open download ranges directly, so a non-increasing pair is an impossible empty range no peer can serve — stalling sync and eventually crashing the catch-up worker.

Enforce strictly-increasing boundaries in `RangedManifest::validate` (and at `FullSyncVerifier` construction), and harden the state machine so an unusable manifest can no longer panic a catching-up node — the "max manifest attempts" path now resets and retries instead of crashing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3563)
<!-- Reviewable:end -->
