### PR TITLE
Wire --port and RocksDB CLI flags to their config fields; remove dead flags

### DIFF
--- a/bins/conflux/src/cli.rs
+++ b/bins/conflux/src/cli.rs
@@ -15,7 +15,9 @@ pub struct Cli {
     pub mode: Option<String>,
 
     /// Specify the port for P2P connections.
-    #[arg(long, short = 'p', value_name = "PORT")]
+    // clap `id` must equal the hyphenated config field (`tcp_port`) that
+    // `RawConfiguration::parse` looks up; the user-facing flag stays `--port`.
+    #[arg(id = "tcp-port", long = "port", short = 'p', value_name = "PORT")]
     pub port: Option<String>,
 
     /// Specify the UDP port for peer discovery.
@@ -88,10 +90,6 @@ pub struct Cli {
     #[arg(id = "net-key", long = "net-key", value_name = "KEY")]
     pub net_key: Option<String>,
 
-    /// Start mining if set to true. Ensure that mining-author is set.
-    #[arg(id = "start-mining", long = "start-mining", value_name = "BOOL")]
-    pub start_mining: Option<String>,
-
     /// Set the address to receive mining rewards.
     #[arg(
         id = "mining-author",
@@ -109,7 +107,11 @@ pub struct Cli {
     pub ledger_cache_size: Option<String>,
 
     /// Sets the db cache size.
-    #[arg(id = "db-cache-size", long = "db-cache-size", value_name = "SIZE")]
+    #[arg(
+        id = "rocksdb-cache-size",
+        long = "db-cache-size",
+        value_name = "SIZE"
+    )]
     pub db_cache_size: Option<String>,
 
     /// Enable discovery protocol.
@@ -137,13 +139,9 @@ pub struct Cli {
     )]
     pub node_table_promotion_timeout_s: Option<String>,
 
-    /// Sets test mode for adding latency
-    #[arg(id = "test-mode", long = "test-mode", value_name = "BOOL")]
-    pub test_mode: Option<String>,
-
     /// Sets the compaction profile of RocksDB.
     #[arg(
-        id = "db-compact-profile",
+        id = "rocksdb-compaction-profile",
         long = "db-compact-profile",
         value_name = "ENUM"
     )]
@@ -152,14 +150,6 @@ pub struct Cli {
     /// Sets the root path of db.
     #[arg(id = "block-db-dir", long = "block-db-dir", value_name = "DIR")]
     pub block_db_dir: Option<String>,
-
-    /// Sets the test chain json file.
-    #[arg(
-        id = "load-test-chain",
-        long = "load-test-chain",
-        value_name = "FILE"
-    )]
-    pub load_test_chain: Option<String>,
 
     /// Sets egress queue capacity of P2P network.
     #[arg(
@@ -246,8 +236,6 @@ pub struct Cli {
     pub light: bool,
     #[arg(long)]
     pub archive: bool,
-    #[arg(long)]
-    pub tg_archive: bool,
     #[arg(long)]
     pub full: bool,
 
@@ -1440,4 +1428,61 @@ pub struct RpcLocalPosVotingStatusArgs {
         hide = true
     )]
     pub rpc_method: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Cli;
+    use clap::CommandFactory;
+    use client::configuration::RawConfiguration;
+    use std::collections::HashSet;
+
+    // clap ids consumed directly in `Configuration::parse` /
+    // `RawConfiguration::parse` rather than through a config-field lookup.
+    const EXPLICIT_HANDLERS: &[&str] = &["config", "archive", "full", "light"];
+
+    #[test]
+    fn port_flag_overrides_tcp_port() {
+        let matches = Cli::command()
+            .try_get_matches_from(["conflux", "--port", "42424"])
+            .expect("--port should parse");
+        let raw = RawConfiguration::parse(&matches).expect("config parses");
+        assert_eq!(raw.tcp_port, 42424);
+    }
+
+    #[test]
+    fn db_flags_override_rocksdb_config() {
+        let matches = Cli::command()
+            .try_get_matches_from([
+                "conflux",
+                "--db-cache-size",
+                "256",
+                "--db-compact-profile",
+                "hdd",
+            ])
+            .expect("db flags should parse");
+        let raw = RawConfiguration::parse(&matches).expect("config parses");
+        assert_eq!(raw.rocksdb_cache_size, Some(256));
+        assert_eq!(raw.rocksdb_compaction_profile, Some("hdd".to_string()));
+    }
+
+    // Guards against the id/field mismatch class: a declared option whose clap
+    // `id` matches no config field (and no explicit handler) is silently
+    // dropped at parse time, so the flag looks documented but does nothing.
+    #[test]
+    fn every_top_level_option_is_wired() {
+        let keys: HashSet<String> =
+            RawConfiguration::cli_lookup_keys().into_iter().collect();
+        for arg in Cli::command().get_arguments() {
+            let id = arg.get_id().as_str();
+            if id == "help" || id == "version" {
+                continue;
+            }
+            assert!(
+                keys.contains(id) || EXPLICIT_HANDLERS.contains(&id),
+                "CLI option `{}` resolves to no config field or handler",
+                id
+            );
+        }
+    }
 }

--- a/crates/config/src/config_macro.rs
+++ b/crates/config/src/config_macro.rs
@@ -92,6 +92,16 @@ macro_rules! build_config{
                 )*
                 Ok(config)
             }
+            // The hyphenated keys `parse` looks up (one per config field). A
+            // CLI option whose clap `id` is not in this set is silently
+            // ignored — the bug class exercised by the exhaustiveness test in
+            // the `conflux` binary.
+            pub fn cli_lookup_keys() -> Vec<String> {
+                let mut keys = Vec::new();
+                $( keys.push(underscore_to_hyphen!(stringify!($name))); )*
+                $( keys.push(underscore_to_hyphen!(stringify!($c_name))); )*
+                keys
+            }
             pub fn from_file(config_path: &str) ->  Result<RawConfiguration, String> {
 
                 let mut config = RawConfiguration::default();

--- a/tests/tg_archive_tests/example_test.py
+++ b/tests/tg_archive_tests/example_test.py
@@ -23,7 +23,7 @@ class ExampleTest(ConfluxTestFramework):
     def setup_network(self):
         self.add_nodes(self.num_nodes, is_consortium=True)
         for i in range(self.num_nodes):
-            self.start_node(i, ["--tg_archive"], phase_to_wait=None)
+            self.start_node(i, phase_to_wait=None)
         connect_sample_nodes(self.nodes, self.log, latency_max=1)
 
     def run_test(self):

--- a/tests/tg_archive_tests/health_check.py
+++ b/tests/tg_archive_tests/health_check.py
@@ -528,7 +528,7 @@ class TreeGraphTracing(ConfluxTestFramework):
     def setup_nodes(self):
         self.add_nodes(self.num_nodes, auto_recovery=True, is_consortium=True)
         for i in range(0, self.num_nodes):
-            self.start_node(i, extra_args=["--tg_archive"], phase_to_wait=None)
+            self.start_node(i, phase_to_wait=None)
 
     def setup_network(self):
         self.log.info("setup nodes ...")


### PR DESCRIPTION
The CLI-to-config bridge looks up each config field by its hyphenated name (e.g. `tcp-port`), so a flag is honored only when its clap `id` equals that key. `--port` (id `port`), `--db-cache-size` (id `db-cache-size`) and `--db-compact-profile` (id `db-compact-profile`) never matched their fields (`tcp_port`, `rocksdb_cache_size`, `rocksdb_compaction_profile`) and were silently ignored in favor of the default/config-file value.

Set each flag's clap `id` to the hyphenated field name while keeping the user-facing spelling, so the value reaches the intended field.

Remove four flags that were never wired to anything (`--start-mining`, `--test-mode`, `--load-test-chain`, `--tg_archive`); they now fail fast instead of being silently ignored.

Add a test asserting every top-level option resolves to a config field or handler, so a future id/field mismatch fails the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3564)
<!-- Reviewable:end -->
