### PR TITLE
Handle quick-xml RUSTSEC-2026-0194/0195

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,4 +1,11 @@
 [advisories]
 ignore = [
     "RUSTSEC-2025-0055", # tracing-subscriber 0.2.25 Introduced by `revm`.
+    # quick-xml DoS advisories, patched only in >= 0.41.0; pulled via
+    # jemalloc_pprof -> inferno, whose APIs used here only write
+    # flamegraph SVG (no untrusted-XML parsing reachable). No inferno
+    # release uses quick-xml 0.41 yet. See deny.toml for details; drop
+    # when upstream catches up.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4848,24 +4848,6 @@ dependencies = [
 
 [[package]]
 name = "inferno"
-version = "0.11.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
-dependencies = [
- "ahash 0.8.11",
- "indexmap 2.8.0",
- "is-terminal",
- "itoa",
- "log",
- "num-format",
- "once_cell",
- "quick-xml 0.26.0",
- "rgb",
- "str_stack",
-]
-
-[[package]]
-name = "inferno"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e96d2465363ed2d81857759fc864cf6bb7997f79327aec028d65bd7989393685"
@@ -4881,7 +4863,7 @@ dependencies = [
  "log",
  "num-format",
  "once_cell",
- "quick-xml 0.37.5",
+ "quick-xml",
  "rgb",
  "str_stack",
 ]
@@ -4954,17 +4936,6 @@ checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
 dependencies = [
  "memchr",
  "serde",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6674,7 +6645,6 @@ dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
  "findshlibs",
- "inferno 0.11.21",
  "libc",
  "log",
  "nix",
@@ -6697,7 +6667,7 @@ dependencies = [
  "anyhow",
  "backtrace",
  "flate2",
- "inferno 0.12.3",
+ "inferno",
  "num",
  "paste",
  "prost",
@@ -6985,15 +6955,6 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quick-xml"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "quick-xml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,8 +296,10 @@ tikv-jemallocator = { version = "0.6", features = ["profiling", "unprefixed_mall
 # tikv-jemalloc-ctl = { version = "0.6", features = ["use_std", "stats"] }
 # tikv-jemalloc-sys = { version = "0.6", features = ["profiling"] }
 jemalloc_pprof = { version = "0.8", features = ["symbolize", "flamegraph"] }
-# CPU profiling
-pprof = { version = "0.15", features = ["flamegraph", "protobuf-codec"] }
+# CPU profiling. No "flamegraph" feature: CPU profiles are served as pprof
+# protobuf only, and the feature would pull inferno -> quick-xml
+# (RustSec-flagged, see deny.toml).
+pprof = { version = "0.15", features = ["protobuf-codec"] }
 tracy-client = "0.18.0"
 snmalloc-rs = { version = "0.3.7", features = ["build_cc"] }
 

--- a/deny.toml
+++ b/deny.toml
@@ -80,18 +80,6 @@ ignore = [
     "RUSTSEC-2024-0436",
     # instant unmaintained; pulled by parking_lot 0.11 via prometheus 0.12.
     "RUSTSEC-2024-0384",
-    # rand 0.7/0.8 unsound `ThreadRng` reseed-in-custom-logger
-    # (RUSTSEC-2026-0097). The 0.9.x code path is patched here by bumping
-    # workspace rand to 0.9.3. rand 0.7.3 and 0.8.5 still appear in
-    # Cargo.lock via external transitive deps that cannot be upgraded
-    # without upstream work (fixed-hash, parity-secp256k1,
-    # ark-std, alloy-rpc-types, proptest, revm,
-    # substrate-bn for 0.8.x) and first-party pos/diem-crypto plus cfx_key
-    # bound to the unmaintained parity-secp256k1 fork. The exploit requires
-    # a custom log::Log impl that calls rand::thread_rng() inside its log
-    # method and triggers a reseed there, which this repo does not do.
-    # Follow-ups will migrate pos/diem-crypto and replace parity-secp256k1.
-    { id = "RUSTSEC-2026-0097", reason = "rand 0.9 patched; 0.7/0.8 forced by transitive deps and upstream pins; vulnerable code path not reachable here." },
     # proc-macro-error2 is unmaintained; pulled by alloy-sol-macro 1.6.0
     "RUSTSEC-2026-0173",
     # quick-xml DoS advisories (quadratic duplicate-attribute check;

--- a/deny.toml
+++ b/deny.toml
@@ -94,6 +94,21 @@ ignore = [
     { id = "RUSTSEC-2026-0097", reason = "rand 0.9 patched; 0.7/0.8 forced by transitive deps and upstream pins; vulnerable code path not reachable here." },
     # proc-macro-error2 is unmaintained; pulled by alloy-sol-macro 1.6.0
     "RUSTSEC-2026-0173",
+    # quick-xml DoS advisories (quadratic duplicate-attribute check;
+    # unbounded NsReader namespace allocation), patched only in
+    # quick-xml >= 0.41.0. Pulled transitively for the heap-flamegraph
+    # SVG endpoint: jemalloc_pprof -> pprof_util -> inferno 0.12
+    # (quick-xml 0.37); pprof's unused "flamegraph" feature is disabled
+    # in Cargo.toml so the CPU-profiling path pulls no quick-xml. No
+    # inferno release depends on quick-xml 0.41 yet (latest 0.12.6 pins
+    # ^0.39), so no upgrade path exists. The vulnerable paths parse
+    # untrusted XML; the inferno APIs used here only *write* flamegraph
+    # SVG (its from_reader inputs are folded stack text; inferno's sole
+    # XML reader, collapse/xctrace, is never called), so they are
+    # unreachable. Drop these once inferno updates to quick-xml >= 0.41
+    # and jemalloc_pprof picks it up.
+    { id = "RUSTSEC-2026-0194", reason = "quick-xml used write-only via inferno flamegraph output; no patched upstream chain yet." },
+    { id = "RUSTSEC-2026-0195", reason = "NsReader not used by inferno; quick-xml write-only here; no patched upstream chain yet." },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
The quick-xml DoS fixes ship only in 0.41.0 and no inferno release depends on it yet, so the advisories can't be fixed by upgrading today.

Dropping pprof's unused `flamegraph` feature removes one vulnerable copy (quick-xml 0.26) outright; the remaining copy behind jemalloc_pprof's heap-flamegraph endpoint only writes SVG and never parses untrusted XML, so both advisories are ignored with justification in `deny.toml`/`.cargo/audit.toml` until inferno adopts quick-xml >= 0.41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3567)
<!-- Reviewable:end -->
