### PR TITLE
Fix 4byteTracer dropping bare-selector (zero-argument) calls

### DIFF
--- a/crates/execution/geth-tracer/Cargo.toml
+++ b/crates/execution/geth-tracer/Cargo.toml
@@ -28,5 +28,8 @@ revm-interpreter = { workspace = true }
 revm-bytecode = { workspace = true }
 alloy-primitives-wrapper = { workspace = true }
 
+[dev-dependencies]
+cfx-vm-types = { workspace = true, features = ["testonly_code"] }
+
 [features]
 serde = []

--- a/crates/execution/geth-tracer/src/fourbyte.rs
+++ b/crates/execution/geth-tracer/src/fourbyte.rs
@@ -48,7 +48,7 @@ impl FourByteInspector {
 
     pub fn record_call(&mut self, params: &ActionParams) {
         if let Some(input) = &params.data {
-            if input.len() > 4 {
+            if input.len() >= 4 {
                 let selector = Selector::try_from(&input[..4])
                     .expect("input is at least 4 bytes");
                 let calldata_size = input[4..].len();
@@ -74,5 +74,47 @@ impl From<FourByteInspector> for FourByteFrame {
                 })
                 .collect(),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cfx_vm_types::ActionParams;
+
+    fn record(data: Vec<u8>) -> FourByteInspector {
+        let mut inspector = FourByteInspector::new();
+        let params = ActionParams {
+            data: Some(data),
+            ..Default::default()
+        };
+        inspector.record_call(&params);
+        inspector
+    }
+
+    #[test]
+    fn record_call_selector_boundary() {
+        let selector = Selector::from([0x12, 0x34, 0x56, 0x78]);
+
+        // A bare selector (exactly 4 bytes, no arguments) must count as a
+        // `<selector>-0` entry, matching geth/reth. This is the case the old
+        // `> 4` guard dropped.
+        assert_eq!(
+            record(vec![0x12, 0x34, 0x56, 0x78])
+                .inner()
+                .get(&(selector, 0)),
+            Some(&1)
+        );
+
+        // calldata_size counts only the bytes after the 4-byte selector.
+        assert_eq!(
+            record(vec![0x12, 0x34, 0x56, 0x78, 0xaa])
+                .inner()
+                .get(&(selector, 1)),
+            Some(&1)
+        );
+
+        // Fewer than 4 bytes has no selector and is ignored.
+        assert!(record(vec![0x12, 0x34, 0x56]).inner().is_empty());
     }
 }


### PR DESCRIPTION
The eSpace debug `4byteTracer` guarded on `input.len() > 4`, so a call whose calldata is exactly the 4-byte selector (any zero-argument function call) was dropped, and the `<selector>-0` bucket that geth/reth always emit never appeared. It's diagnostic-only (debug RPC), so this is a trace-accuracy bug, not a consensus/state issue.

geth (`len(input) < 4`) and reth's `FourByteInspector`, which this file was ported from, both record exactly-4-byte inputs — so change the guard to `>= 4` to match.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3568)
<!-- Reviewable:end -->
