### PR TITLE
fix(rpc): share throttling token buckets across requests on the jsonrpsee stack

### DIFF
--- a/crates/rpc/rpc-builder/src/cfx/mod.rs
+++ b/crates/rpc/rpc-builder/src/cfx/mod.rs
@@ -3,7 +3,9 @@ mod module;
 pub use crate::{
     error::*, id_provider::SubscriptionIdProvider, RpcServerHandle,
 };
-use cfx_rpc_middlewares::{maybe_cors_layer, Logger, Metrics, Throttle};
+use cfx_rpc_middlewares::{
+    load_throttling_manager, maybe_cors_layer, Logger, Metrics, Throttle,
+};
 pub use module::{CfxRpcModule, RpcModuleSelection};
 
 use blockgen::BlockGeneratorTestApi;
@@ -423,15 +425,22 @@ impl RpcServerConfig {
         throttling_conf_file: Option<String>, throttling_section: &str,
         enable_metrics: bool,
     ) -> Result<RpcServerHandle, RpcError<CfxRpcModule>> {
-        let throttling_section = throttling_section.to_string();
+        // No server to build: skip loading (and maybe panicking on) the conf.
+        if !self.has_server() {
+            return Ok(RpcServerHandle {
+                http_local_addr: None,
+                ws_local_addr: None,
+                http: None,
+                ws: None,
+            });
+        }
+
+        let throttle_manager = load_throttling_manager(
+            throttling_conf_file.as_deref(),
+            throttling_section,
+        );
         let rpc_middleware = RpcServiceBuilder::new()
-            .layer_fn(move |s| {
-                Throttle::new(
-                    throttling_conf_file.as_ref().map(|s| s.as_str()),
-                    throttling_section.as_str(),
-                    s,
-                )
-            })
+            .layer_fn(move |s| Throttle::new(throttle_manager.clone(), s))
             .layer_fn(move |s| Metrics::new(s, enable_metrics))
             .layer_fn(|s| Logger::new(s));
 

--- a/crates/rpc/rpc-builder/src/eth/mod.rs
+++ b/crates/rpc/rpc-builder/src/eth/mod.rs
@@ -32,7 +32,9 @@ mod module;
 pub use crate::{
     error::*, id_provider::SubscriptionIdProvider, RpcServerHandle,
 };
-use cfx_rpc_middlewares::{maybe_cors_layer, Logger, Metrics, Throttle};
+use cfx_rpc_middlewares::{
+    load_throttling_manager, maybe_cors_layer, Logger, Metrics, Throttle,
+};
 pub use module::{EthRpcModule, RpcModuleSelection};
 
 use cfx_rpc_cfx_types::RpcImplConfiguration;
@@ -461,14 +463,20 @@ impl RpcServerConfig {
         self, modules: &TransportRpcModules,
         throttling_conf_file: Option<String>, enable_metrics: bool,
     ) -> Result<RpcServerHandle, RpcError> {
+        // No server to build: skip loading (and maybe panicking on) the conf.
+        if !self.has_server() {
+            return Ok(RpcServerHandle {
+                http_local_addr: None,
+                ws_local_addr: None,
+                http: None,
+                ws: None,
+            });
+        }
+
+        let throttle_manager =
+            load_throttling_manager(throttling_conf_file.as_deref(), "rpc");
         let rpc_middleware = RpcServiceBuilder::new()
-            .layer_fn(move |s| {
-                Throttle::new(
-                    throttling_conf_file.as_ref().map(|s| s.as_str()),
-                    "rpc",
-                    s,
-                )
-            })
+            .layer_fn(move |s| Throttle::new(throttle_manager.clone(), s))
             .layer_fn(move |s| Metrics::new(s, enable_metrics))
             .layer_fn(|s| Logger::new(s));
 

--- a/crates/rpc/rpc-middlewares/examples/middleware.rs
+++ b/crates/rpc/rpc-middlewares/examples/middleware.rs
@@ -41,7 +41,7 @@
 
 use std::{future::Future, net::SocketAddr};
 
-use cfx_rpc_middlewares::{Metrics, Throttle};
+use cfx_rpc_middlewares::{load_throttling_manager, Metrics, Throttle};
 use jsonrpsee::{
     core::client::ClientT,
     rpc_params,
@@ -118,10 +118,10 @@ async fn run_server() -> anyhow::Result<SocketAddr> {
 
     debug!("throttling config path: {:?}", config_path);
 
+    let throttle_manager =
+        load_throttling_manager(Some(config_path.to_str().unwrap()), "test");
     let rpc_middleware = RpcServiceBuilder::new()
-        .layer_fn(move |s| {
-            Throttle::new(Some(config_path.to_str().unwrap()), "test", s)
-        })
+        .layer_fn(move |s| Throttle::new(throttle_manager.clone(), s))
         .layer_fn(|s| Metrics::new(s, true));
 
     let server = Server::builder()

--- a/crates/rpc/rpc-middlewares/src/lib.rs
+++ b/crates/rpc/rpc-middlewares/src/lib.rs
@@ -6,4 +6,4 @@ mod throttle;
 pub use cors::{create_cors_layer, maybe_cors_layer, CorsDomainError};
 pub use log::Logger;
 pub use metrics::Metrics;
-pub use throttle::Throttle;
+pub use throttle::{load_throttling_manager, Throttle};

--- a/crates/rpc/rpc-middlewares/src/throttle.rs
+++ b/crates/rpc/rpc-middlewares/src/throttle.rs
@@ -21,14 +21,22 @@ pub struct Throttle<S> {
     manager: TokenBucketManager,
 }
 
-impl<S> Throttle<S> {
-    pub fn new(file: Option<&str>, section: &str, s: S) -> Self {
-        let manager = match file {
-            Some(file) => TokenBucketManager::load(file, Some(section))
-                .expect("invalid throttling configuration file"),
-            None => TokenBucketManager::default(),
-        };
+/// jsonrpsee re-runs the rpc middleware factory per HTTP request / WS
+/// connection, so build the manager once here and clone it into each
+/// `Throttle` (clones share the token buckets); building it inside `layer_fn`
+/// would reset the buckets every request.
+pub fn load_throttling_manager(
+    file: Option<&str>, section: &str,
+) -> TokenBucketManager {
+    match file {
+        Some(file) => TokenBucketManager::load(file, Some(section))
+            .expect("invalid throttling configuration file"),
+        None => TokenBucketManager::default(),
+    }
+}
 
+impl<S> Throttle<S> {
+    pub fn new(manager: TokenBucketManager, s: S) -> Self {
         Throttle {
             service: s,
             manager,

--- a/integration_tests/tests/cross_space/phantom_transaction_test.py
+++ b/integration_tests/tests/cross_space/phantom_transaction_test.py
@@ -365,7 +365,7 @@ def test_phantom_transaction(network):
     assert_equal(len(receipts[3]["logs"]), 0)
     assert_equal(len(receipts[4]["logs"]), 2)
     assert_equal(receipts[4]["logs"][0]["data"], number_to_topic(23))
-    assert_equal(receipts[4]["logs"][0]["data"], number_to_topic(23))
+    assert_equal(receipts[4]["logs"][1]["data"], number_to_topic(23))
 
     assert_equal(len(receipts[5]["logs"]), 1)
     assert_equal(receipts[5]["logs"][0]["data"], number_to_topic(25))
@@ -377,7 +377,7 @@ def test_phantom_transaction(network):
     assert_equal(len(receipts[8]["logs"]), 0)
     assert_equal(len(receipts[9]["logs"]), 2)
     assert_equal(receipts[9]["logs"][0]["data"], number_to_topic(26))
-    assert_equal(receipts[9]["logs"][0]["data"], number_to_topic(26))
+    assert_equal(receipts[9]["logs"][1]["data"], number_to_topic(26))
 
     # ---------------------------------------------------------------------
 

--- a/tests/storage_root_test.py
+++ b/tests/storage_root_test.py
@@ -52,8 +52,8 @@ class StorageRootTest(ConfluxTestFramework):
         root = self.rpc[FULLNODE0].get_storage_root("0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6")
 
         assert_equal(root["delta"], None)
-        assert_equal(root["delta"], None)
-        assert_equal(root["delta"], None)
+        assert_equal(root["intermediate"], None)
+        assert_equal(root["snapshot"], None)
 
         # deploy storage test contract
         bytecode_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), CONTRACT_PATH)

--- a/tests/throttle_test.py
+++ b/tests/throttle_test.py
@@ -46,7 +46,7 @@ class ThrottleRpcTests(ConfluxTestFramework):
         # throttled
         try:
             client.epoch_number()
-            assert "should be throttled"
+            assert False, "should be throttled"
         except ReceivedErrorResponseError as e:
             assert e.response.code == -32072
             assert e.response.data.startswith("throttled in ")
@@ -54,7 +54,7 @@ class ThrottleRpcTests(ConfluxTestFramework):
     # allow to tolerate 1 time even throttled
         try:
             client.epoch_number()
-            assert "should be throttled"
+            assert False, "should be throttled"
         except ReceivedErrorResponseError as e:
             assert e.response.code == -32072
             assert e.response.data.startswith("throttled in ")
@@ -62,7 +62,7 @@ class ThrottleRpcTests(ConfluxTestFramework):
         # already throttled
         try:
             client.epoch_number()
-            assert "should be throttled"
+            assert False, "should be throttled"
         except ReceivedErrorResponseError as e:
             assert e.response.code == -32072
             assert e.response.data == "already throttled, please try again later"
@@ -75,7 +75,7 @@ class ThrottleRpcTests(ConfluxTestFramework):
         # throttled
         try:
             client.gas_price()
-            assert "should be throttled"
+            assert False, "should be throttled"
         except ReceivedErrorResponseError as e:
             assert e.response.code == -32072
             assert e.response.data.startswith("throttled in ")
@@ -83,7 +83,7 @@ class ThrottleRpcTests(ConfluxTestFramework):
         # do not tolerate once throttled
         try:
             client.gas_price()
-            assert "should be throttled"
+            assert False, "should be throttled"
         except ReceivedErrorResponseError as e:
             assert e.response.code == -32072
             assert e.response.data == "already throttled, please try again later"
@@ -98,7 +98,7 @@ class ThrottleRpcTests(ConfluxTestFramework):
         # throttled again
         try:
             client.gas_price()
-            assert "should be throttled"
+            assert False, "should be throttled"
         except ReceivedErrorResponseError as e:
             assert e.response.code == -32072
             assert e.response.data.startswith("throttled in ")


### PR DESCRIPTION
Since the jsonrpsee migration, `throttling_conf` has been unenforced over HTTP: jsonrpsee re-runs the rpc middleware factory per request, and `Throttle::new` built a fresh `TokenBucketManager` inside `layer_fn`, so every request got a full bucket. The old `ThrottleInterceptor` built it once per server.

Fix: load the manager once per `start()` and clone it into the `Throttle` layer — clones share the `Arc<Mutex<TokenBucket>>` buckets, so limits accumulate across requests again. HTTP and WS on one `start()` deliberately share one bucket set.

The other two rpc middlewares in the stack are unaffected: `Metrics` keeps its state in a `lazy_static` global and `Logger` is stateless, so `Throttle` was the only one holding accumulate-across-requests state in its per-instance struct.

The bug was masked by truthy `assert "should be throttled"` literals in `throttle_test.py` that never fail; fixing them to `assert False` makes the test red on the old code and green with this change. The same sweep fixes duplicated no-op asserts in `storage_root_test.py` and `phantom_transaction_test.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3569)
<!-- Reviewable:end -->
