### PR TITLE
Clear crossbeam-epoch and quick-xml RustSec advisories failing CI

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,11 +1,11 @@
 [advisories]
 ignore = [
-    "RUSTSEC-2025-0055", # tracing-subscriber 0.2.25 Introduced by `revm`.
-    # quick-xml DoS advisories, patched only in >= 0.41.0; pulled via
-    # jemalloc_pprof -> inferno, whose APIs used here only write
-    # flamegraph SVG (no untrusted-XML parsing reachable). No inferno
-    # release uses quick-xml 0.41 yet. See deny.toml for details; drop
-    # when upstream catches up.
-    "RUSTSEC-2026-0194",
-    "RUSTSEC-2026-0195",
+    # tracing-subscriber 0.2.25 is an optional dep of ark-relations 0.5.x,
+    # reached only via revm-precompile -> ark-bn254 -> ark-r1cs-std ->
+    # ark-relations. ark-relations 0.6 moved to tracing-subscriber 0.3, but the
+    # whole arkworks 0.5 stack is pinned by revm-precompile, and no
+    # revm-precompile release (through 41.0.0) requires arkworks 0.6 yet, so
+    # there is no upgrade path. cargo-deny's resolved graph omits this edge;
+    # only the raw-lockfile cargo-audit scan flags it, hence audit-only.
+    "RUSTSEC-2025-0055",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2045,7 +2045,7 @@ dependencies = [
  "log4rs",
  "malloc_size_of",
  "malloc_size_of_derive",
- "memoffset 0.9.1",
+ "memoffset",
  "parking_lot 0.12.1",
  "primitives",
  "rand 0.9.3",
@@ -2592,7 +2592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2871,15 +2871,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.14"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
- "autocfg",
- "cfg-if 1.0.0",
  "crossbeam-utils",
- "memoffset 0.8.0",
- "scopeguard 1.1.0",
 ]
 
 [[package]]
@@ -4848,9 +4844,9 @@ dependencies = [
 
 [[package]]
 name = "inferno"
-version = "0.12.3"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96d2465363ed2d81857759fc864cf6bb7997f79327aec028d65bd7989393685"
+checksum = "d2c05b9ae050366b3363927f59d2c07f922a746e97e2e96f70d479a3c7dbbbe5"
 dependencies = [
  "ahash 0.8.11",
  "clap",
@@ -5681,15 +5677,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -6958,9 +6945,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -7691,7 +7678,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7761,7 +7748,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9251,7 +9238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "319c70195101a93f56db4c74733e272d720768e13471f400c78406a326b172b0"
 dependencies = [
  "cc",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -78,25 +78,14 @@ ignore = [
 
     # paste unmaintained; external transitive dep, no fix until upstream.
     "RUSTSEC-2024-0436",
-    # instant unmaintained; pulled by parking_lot 0.11 via prometheus 0.12.
+    # instant unmaintained; pulled by parking_lot 0.11, held by the abandoned
+    # jsonrpc-tcp-server 18 (via cfx-stratum). prometheus already moved to
+    # parking_lot 0.12 in 0.13+, but jsonrpc-tcp-server has no such release, so
+    # the instant edge stays until cfx-stratum drops parity jsonrpc.
     "RUSTSEC-2024-0384",
     # proc-macro-error2 is unmaintained; pulled by alloy-sol-macro 1.6.0
+    # (latest 1.6.0 still pins proc-macro-error2 <=2.0.1; no upstream fix).
     "RUSTSEC-2026-0173",
-    # quick-xml DoS advisories (quadratic duplicate-attribute check;
-    # unbounded NsReader namespace allocation), patched only in
-    # quick-xml >= 0.41.0. Pulled transitively for the heap-flamegraph
-    # SVG endpoint: jemalloc_pprof -> pprof_util -> inferno 0.12
-    # (quick-xml 0.37); pprof's unused "flamegraph" feature is disabled
-    # in Cargo.toml so the CPU-profiling path pulls no quick-xml. No
-    # inferno release depends on quick-xml 0.41 yet (latest 0.12.6 pins
-    # ^0.39), so no upgrade path exists. The vulnerable paths parse
-    # untrusted XML; the inferno APIs used here only *write* flamegraph
-    # SVG (its from_reader inputs are folded stack text; inferno's sole
-    # XML reader, collapse/xctrace, is never called), so they are
-    # unreachable. Drop these once inferno updates to quick-xml >= 0.41
-    # and jemalloc_pprof picks it up.
-    { id = "RUSTSEC-2026-0194", reason = "quick-xml used write-only via inferno flamegraph output; no patched upstream chain yet." },
-    { id = "RUSTSEC-2026-0195", reason = "NsReader not used by inferno; quick-xml write-only here; no patched upstream chain yet." },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/tools/consensus_bench/Cargo.lock
+++ b/tools/consensus_bench/Cargo.lock
@@ -2268,9 +2268,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/tools/evm-spec-tester/Cargo.lock
+++ b/tools/evm-spec-tester/Cargo.lock
@@ -2553,9 +2553,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
RUSTSEC-2026-0204 (crossbeam-epoch) fails cargo-audit and cargo-deny on every PR and on master, since crossbeam-epoch < 0.9.20 sits in all three committed lockfiles as a transitive dep; bump 0.9.14 (root) / 0.9.18 (both tools) → the patched 0.9.20, lockfile-only.

RUSTSEC-2026-0194/0195 (quick-xml) were ignored only pending a patched upstream chain; inferno 0.12.7 now requires quick-xml ^0.41, so bumping inferno 0.12.3 → 0.12.7 moves quick-xml 0.37.5 → 0.41.0 and lets both ignores be dropped from `.cargo/audit.toml` and `deny.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3570)
<!-- Reviewable:end -->
