### PR TITLE
Migrate workspace to Rust 2024 edition (toolchain 1.96.1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ homepage = "https://confluxnetwork.org/"
 keywords = ["Conflux"]
 repository = "https://github.com/conflux-chain/conflux-rust"
 license-file = "LICENSE"
-edition = "2021"
+edition = "2024"
 
 [profile.test]
 debug-assertions = true

--- a/bins/cfx_key/Cargo.toml
+++ b/bins/cfx_key/Cargo.toml
@@ -3,7 +3,7 @@ description = "Conflux Core Space Keys Generator CLI"
 name = "cfxkey-cli"
 version = "1.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2021"
+edition = "2024"
 license-file.workspace = true
 
 [dependencies]

--- a/bins/cfx_store/Cargo.toml
+++ b/bins/cfx_store/Cargo.toml
@@ -3,7 +3,7 @@ description = "Parity Ethereum Key Management CLI"
 name = "cfxstore-cli"
 version = "0.1.1"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2021"
+edition = "2024"
 license-file.workspace = true
 
 [dependencies]

--- a/bins/cfx_store/src/main.rs
+++ b/bins/cfx_store/src/main.rs
@@ -18,7 +18,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{collections::VecDeque, env, fmt, fs, io::Read, process};
+use std::{collections::VecDeque, fmt, fs, io::Read, process};
 
 use cfxstore::{
     accounts_dir::{KeyDirectory, RootDiskDirectory},
@@ -286,12 +286,10 @@ impl fmt::Display for Error {
 
 fn main() {
     panic_hook::set_abort();
-    if env::var("RUST_LOG").is_err() {
-        // FIXME: Audit that the environment access only happens in
-        // single-threaded code.
-        unsafe { env::set_var("RUST_LOG", "warn") }
-    }
-    env_logger::try_init().expect("Logger initialized only once.");
+    env_logger::try_init_from_env(
+        env_logger::Env::default().default_filter_or("warn"),
+    )
+    .expect("Logger initialized only once.");
     let cli = Cli::parse();
 
     match execute(cli) {

--- a/bins/cfx_store/src/main.rs
+++ b/bins/cfx_store/src/main.rs
@@ -287,7 +287,9 @@ impl fmt::Display for Error {
 fn main() {
     panic_hook::set_abort();
     if env::var("RUST_LOG").is_err() {
-        env::set_var("RUST_LOG", "warn")
+        // FIXME: Audit that the environment access only happens in
+        // single-threaded code.
+        unsafe { env::set_var("RUST_LOG", "warn") }
     }
     env_logger::try_init().expect("Logger initialized only once.");
     let cli = Cli::parse();

--- a/bins/conflux/Cargo.toml
+++ b/bins/conflux/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "conflux"
 build = "build.rs"
-edition = "2021"
+edition = "2024"
 version.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/bins/conflux/src/main.rs
+++ b/bins/conflux/src/main.rs
@@ -8,7 +8,7 @@ static ALLOC: cfx_mallocator_utils::allocator::Allocator =
     cfx_mallocator_utils::allocator::new_allocator();
 // jemalloc profiling config
 #[allow(non_upper_case_globals)]
-#[export_name = "malloc_conf"]
+#[unsafe(export_name = "malloc_conf")]
 #[cfg(all(not(target_env = "msvc"), feature = "jemalloc-prof"))]
 pub static malloc_conf: &[u8] =
     b"prof:true,prof_active:true,lg_prof_sample:19\0"; // 512kb

--- a/crates/blockgen/Cargo.toml
+++ b/crates/blockgen/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "https://www.confluxnetwork.org"
 license = "GPL-3.0"
 name = "blockgen"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 cfxcore = { workspace = true }

--- a/crates/cfx_addr/Cargo.toml
+++ b/crates/cfx_addr/Cargo.toml
@@ -3,7 +3,7 @@ name = "cfx-addr"
 version = "0.2.0"
 license = "GPL-3.0"
 description = "Conflux Base32 Address Encoder/Decoder"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 cfx-types = { workspace = true }

--- a/crates/cfx_bytes/Cargo.toml
+++ b/crates/cfx_bytes/Cargo.toml
@@ -3,7 +3,7 @@ name = "cfx-bytes"
 version = "0.1.0"
 license = "GPL-3.0"
 description = "Conflux bytes"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 ethcore-bytes = { workspace = true }

--- a/crates/cfx_crypto/Cargo.toml
+++ b/crates/cfx_crypto/Cargo.toml
@@ -3,7 +3,7 @@ description = "Conflux Cryptographic Primitives"
 name = "cfx-crypto"
 version = "0.3.0"
 authors = ["Conflux Foundation"]
-edition = "2021"
+edition = "2024"
 license-file.workspace = true
 
 [dependencies]

--- a/crates/cfx_key/Cargo.toml
+++ b/crates/cfx_key/Cargo.toml
@@ -3,7 +3,7 @@ description = "Conflux Keys Generator"
 name = "cfxkey"
 version = "0.3.0"
 authors = ["Conflux Foundation"]
-edition = "2021"
+edition = "2024"
 license-file.workspace = true
 
 [dependencies]

--- a/crates/cfx_store/Cargo.toml
+++ b/crates/cfx_store/Cargo.toml
@@ -3,7 +3,7 @@ description = "Parity Ethereum Key Management"
 name = "cfxstore"
 version = "0.2.1"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2021"
+edition = "2024"
 license-file.workspace = true
 
 [dependencies]

--- a/crates/cfx_store/src/json/hash.rs
+++ b/crates/cfx_store/src/json/hash.rs
@@ -23,7 +23,7 @@ use serde::{
 use std::{cmp::Ordering, fmt, ops, str};
 
 macro_rules! impl_hash {
-    ($name:ident, $size:expr) => {
+    ($name:ident, $size:expr_2021) => {
         pub struct $name([u8; $size]);
 
         impl $name {

--- a/crates/cfx_types/Cargo.toml
+++ b/crates/cfx_types/Cargo.toml
@@ -3,7 +3,7 @@ name = "cfx-types"
 version = "0.2.0"
 license = "GPL-3.0"
 description = "Conflux types"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 ethereum-types = { workspace = true }

--- a/crates/cfxcore/core/Cargo.toml
+++ b/crates/cfxcore/core/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "https://www.confluxnetwork.org"
 license = "GPL-3.0"
 name = "cfxcore"
 version = { workspace = true }
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 byteorder = { workspace = true }

--- a/crates/cfxcore/core/src/consensus/consensus_graph/rpc_api/trace_provider.rs
+++ b/crates/cfxcore/core/src/consensus/consensus_graph/rpc_api/trace_provider.rs
@@ -58,7 +58,7 @@ impl ConsensusGraph {
         &self, filter: &'a LogFilter, epoch_number: u64, block_hash: H256,
         block_timestamp: Option<u64>, mut receipts: Vec<Receipt>,
         mut tx_hashes: Vec<H256>,
-    ) -> impl Iterator<Item = LocalizedLogEntry> + 'a {
+    ) -> impl Iterator<Item = LocalizedLogEntry> + 'a + use<'a> {
         // sanity check
         if receipts.len() != tx_hashes.len() {
             warn!("Block ({}) has different number of receipts ({}) to transactions ({}). Database corrupt?", block_hash, receipts.len(), tx_hashes.len());
@@ -113,7 +113,10 @@ impl ConsensusGraph {
     fn filter_block<'a>(
         &self, filter: &'a LogFilter, bloom_possibilities: &'a Vec<Bloom>,
         epoch: u64, pivot_hash: H256, block_hash: H256,
-    ) -> Result<impl Iterator<Item = LocalizedLogEntry> + 'a, FilterError> {
+    ) -> Result<
+        impl Iterator<Item = LocalizedLogEntry> + 'a + use<'a>,
+        FilterError,
+    > {
         // special case for genesis (for now, genesis has no logs)
         if epoch == 0 {
             return Ok(Either::Left(std::iter::empty()));
@@ -177,7 +180,10 @@ impl ConsensusGraph {
     fn filter_phantom_block<'a>(
         &self, filter: &'a LogFilter, bloom_possibilities: &'a Vec<Bloom>,
         epoch: u64, pivot_hash: H256,
-    ) -> Result<impl Iterator<Item = LocalizedLogEntry> + 'a, FilterError> {
+    ) -> Result<
+        impl Iterator<Item = LocalizedLogEntry> + 'a + use<'a>,
+        FilterError,
+    > {
         // special case for genesis (for now, genesis has no logs)
         if epoch == 0 {
             return Ok(Either::Left(std::iter::empty()));
@@ -319,7 +325,7 @@ impl ConsensusGraph {
     pub fn get_log_filter_epoch_range(
         &self, from_epoch: EpochNumber, to_epoch: EpochNumber,
         check_range: bool,
-    ) -> Result<impl Iterator<Item = u64>, FilterError> {
+    ) -> Result<impl Iterator<Item = u64> + use<>, FilterError> {
         // lock so that we have a consistent view
         let _inner = self.inner.read_recursive();
 
@@ -359,7 +365,7 @@ impl ConsensusGraph {
 
     pub fn get_trace_filter_epoch_range(
         &self, filter: &TraceFilter,
-    ) -> Result<impl Iterator<Item = u64>, FilterError> {
+    ) -> Result<impl Iterator<Item = u64> + use<>, FilterError> {
         // lock so that we have a consistent view
         let _inner = self.inner.read_recursive();
 

--- a/crates/cfxcore/core/src/light_protocol/handler/sync/block_txs.rs
+++ b/crates/cfxcore/core/src/light_protocol/handler/sync/block_txs.rs
@@ -95,7 +95,7 @@ impl BlockTxs {
     #[inline]
     pub fn request(
         &self, hash: H256,
-    ) -> impl Future<Output = Result<Vec<SignedTransaction>>> {
+    ) -> impl Future<Output = Result<Vec<SignedTransaction>>> + use<> {
         let mut verified = self.verified.write();
 
         if !verified.contains_key(&hash) {

--- a/crates/cfxcore/core/src/light_protocol/handler/sync/blooms.rs
+++ b/crates/cfxcore/core/src/light_protocol/handler/sync/blooms.rs
@@ -86,7 +86,9 @@ impl Blooms {
     }
 
     #[inline]
-    pub fn request(&self, epoch: u64) -> impl Future<Output = Result<Bloom>> {
+    pub fn request(
+        &self, epoch: u64,
+    ) -> impl Future<Output = Result<Bloom>> + use<> {
         let mut verified = self.verified.write();
 
         if epoch == 0 {

--- a/crates/cfxcore/core/src/light_protocol/handler/sync/receipts.rs
+++ b/crates/cfxcore/core/src/light_protocol/handler/sync/receipts.rs
@@ -87,7 +87,7 @@ impl Receipts {
     #[inline]
     pub fn request(
         &self, epoch: u64,
-    ) -> impl Future<Output = Result<Vec<BlockReceipts>>> {
+    ) -> impl Future<Output = Result<Vec<BlockReceipts>>> + use<> {
         let mut verified = self.verified.write();
 
         if epoch == 0 {

--- a/crates/cfxcore/core/src/light_protocol/handler/sync/state_entries.rs
+++ b/crates/cfxcore/core/src/light_protocol/handler/sync/state_entries.rs
@@ -91,7 +91,7 @@ impl StateEntries {
     #[inline]
     pub fn request_now(
         &self, io: &dyn NetworkContext, epoch: u64, key: Vec<u8>,
-    ) -> impl Future<Output = Result<StateEntry>> {
+    ) -> impl Future<Output = Result<StateEntry>> + use<> {
         let mut verified = self.verified.write();
         let key = StateKey { epoch, key };
 

--- a/crates/cfxcore/core/src/light_protocol/handler/sync/state_roots.rs
+++ b/crates/cfxcore/core/src/light_protocol/handler/sync/state_roots.rs
@@ -99,7 +99,7 @@ impl StateRoots {
     #[inline]
     pub fn request_now(
         &self, io: &dyn NetworkContext, epoch: u64,
-    ) -> impl Future<Output = Result<StateRoot>> {
+    ) -> impl Future<Output = Result<StateRoot>> + use<> {
         let mut verified = self.verified.write();
 
         if !verified.contains_key(&epoch) {
@@ -245,7 +245,7 @@ impl StateRoots {
         let snapshot_epoch_count = self.snapshot_epoch_count;
 
         match maybe_prev_snapshot_state_root {
-            Some(ref root) => {
+            Some(root) => {
                 // root provided for non-existent epoch
                 if current_epoch <= snapshot_epoch_count {
                     // previous root should not have been provided

--- a/crates/cfxcore/core/src/light_protocol/handler/sync/storage_roots.rs
+++ b/crates/cfxcore/core/src/light_protocol/handler/sync/storage_roots.rs
@@ -90,7 +90,7 @@ impl StorageRoots {
     #[inline]
     pub fn request_now(
         &self, io: &dyn NetworkContext, epoch: u64, address: H160,
-    ) -> impl Future<Output = Result<StorageRoot>> {
+    ) -> impl Future<Output = Result<StorageRoot>> + use<> {
         let mut verified = self.verified.write();
         let key = StorageRootKey { epoch, address };
 

--- a/crates/cfxcore/core/src/light_protocol/handler/sync/tx_infos.rs
+++ b/crates/cfxcore/core/src/light_protocol/handler/sync/tx_infos.rs
@@ -106,7 +106,7 @@ impl TxInfos {
     #[inline]
     pub fn request_now(
         &self, io: &dyn NetworkContext, hash: H256,
-    ) -> impl Future<Output = Result<TxInfoValidated>> {
+    ) -> impl Future<Output = Result<TxInfoValidated>> + use<> {
         let mut verified = self.verified.write();
 
         if !verified.contains_key(&hash) {

--- a/crates/cfxcore/core/src/light_protocol/handler/sync/txs.rs
+++ b/crates/cfxcore/core/src/light_protocol/handler/sync/txs.rs
@@ -78,7 +78,7 @@ impl Txs {
     #[inline]
     pub fn request_now(
         &self, io: &dyn NetworkContext, hash: H256,
-    ) -> impl Future<Output = Result<SignedTransaction>> {
+    ) -> impl Future<Output = Result<SignedTransaction>> + use<> {
         let mut verified = self.verified.write();
 
         if !verified.contains_key(&hash) {

--- a/crates/cfxcore/core/src/light_protocol/query_service.rs
+++ b/crates/cfxcore/core/src/light_protocol/query_service.rs
@@ -687,7 +687,7 @@ impl QueryService {
         epoch: u64, block_hash: H256, block_timestamp: Option<u64>,
         transaction_index: usize, num_logs_remaining: &mut usize,
         mut logs: Vec<LogEntry>, filter: LogFilter,
-    ) -> impl Iterator<Item = LocalizedLogEntry> {
+    ) -> impl Iterator<Item = LocalizedLogEntry> + use<> {
         let num_logs = logs.len();
 
         let log_base_index = *num_logs_remaining;
@@ -745,7 +745,7 @@ impl QueryService {
     /// Apply filter to all receipts within an epoch.
     fn filter_epoch_receipts(
         &self, epoch: u64, mut receipts: Vec<BlockReceipts>, filter: LogFilter,
-    ) -> Result<impl Iterator<Item = LocalizedLogEntry>, String> {
+    ) -> Result<impl Iterator<Item = LocalizedLogEntry> + use<>, String> {
         // get epoch blocks in execution order
         let mut hashes = self
             .ledger

--- a/crates/cfxcore/core/src/message.rs
+++ b/crates/cfxcore/core/src/message.rs
@@ -21,7 +21,7 @@ pub use network::{
 };
 
 macro_rules! build_msgid {
-    ($($name:ident = $value:expr)*) => {
+    ($($name:ident = $value:expr_2021)*) => {
         #[allow(dead_code)]
         pub mod msgid {
             use super::MsgId;
@@ -158,7 +158,7 @@ pub fn decode_msg(mut msg: &[u8]) -> Option<(MsgId, Rlp<'_>)> {
 }
 
 macro_rules! mark_msg_version_bound {
-    ($name:ident, $msg_ver:expr, $msg_valid_till_ver:expr) => {
+    ($name:ident, $msg_ver:expr_2021, $msg_valid_till_ver:expr_2021) => {
         impl MessageProtocolVersionBound for $name {
             fn version_introduced(&self) -> ProtocolVersion { $msg_ver }
 
@@ -172,10 +172,10 @@ macro_rules! mark_msg_version_bound {
 macro_rules! build_msg_basic {
     (
         $name:ident,
-        $msg:expr,
+        $msg:expr_2021,
         $name_str:literal,
-        $msg_ver:expr,
-        $msg_valid_till_ver:expr
+        $msg_ver:expr_2021,
+        $msg_valid_till_ver:expr_2021
     ) => {
         mark_msg_version_bound!($name, $msg_ver, $msg_valid_till_ver);
 
@@ -196,10 +196,10 @@ macro_rules! build_msg_basic {
 macro_rules! build_msg_impl {
     (
         $name:ident,
-        $msg:expr,
+        $msg:expr_2021,
         $name_str:literal,
-        $msg_ver:expr,
-        $msg_valid_till_ver:expr
+        $msg_ver:expr_2021,
+        $msg_valid_till_ver:expr_2021
     ) => {
         impl GetMaybeRequestId for $name {}
 
@@ -226,10 +226,10 @@ macro_rules! impl_request_id_methods {
 macro_rules! build_msg_with_request_id_impl {
     (
         $name:ident,
-        $msg:expr,
+        $msg:expr_2021,
         $name_str:literal,
-        $msg_ver:expr,
-        $msg_valid_till_ver:expr
+        $msg_ver:expr_2021,
+        $msg_valid_till_ver:expr_2021
     ) => {
         build_msg_basic!($name, $msg, $name_str, $msg_ver, $msg_valid_till_ver);
         impl_request_id_methods!($name);

--- a/crates/cfxcore/core/src/pos/consensus/round_manager.rs
+++ b/crates/cfxcore/core/src/pos/consensus/round_manager.rs
@@ -1097,18 +1097,21 @@ impl RoundManager {
                 }
                 id = executed_block.parent_id();
                 blocks.push(executed_block.block().clone());
-            } else if let Ok(Some(block)) =
-                self.block_store.get_ledger_block(&id)
-            {
-                if block.is_genesis_block() {
-                    break;
-                }
-                id = block.parent_id();
-                blocks.push(block);
             } else {
-                // TODO(lpl): This error may be needed in the future.
-                // status = BlockRetrievalStatus::NotEnoughBlocks;
-                break;
+                match self.block_store.get_ledger_block(&id) {
+                    Ok(Some(block)) => {
+                        if block.is_genesis_block() {
+                            break;
+                        }
+                        id = block.parent_id();
+                        blocks.push(block);
+                    }
+                    _ => {
+                        // TODO(lpl): This error may be needed in the future.
+                        // status = BlockRetrievalStatus::NotEnoughBlocks;
+                        break;
+                    }
+                }
             }
         }
 

--- a/crates/cfxcore/core/src/pos/consensus/round_manager.rs
+++ b/crates/cfxcore/core/src/pos/consensus/round_manager.rs
@@ -1097,21 +1097,18 @@ impl RoundManager {
                 }
                 id = executed_block.parent_id();
                 blocks.push(executed_block.block().clone());
-            } else {
-                match self.block_store.get_ledger_block(&id) {
-                    Ok(Some(block)) => {
-                        if block.is_genesis_block() {
-                            break;
-                        }
-                        id = block.parent_id();
-                        blocks.push(block);
-                    }
-                    _ => {
-                        // TODO(lpl): This error may be needed in the future.
-                        // status = BlockRetrievalStatus::NotEnoughBlocks;
-                        break;
-                    }
+            } else if let Ok(Some(block)) =
+                self.block_store.get_ledger_block(&id)
+            {
+                if block.is_genesis_block() {
+                    break;
                 }
+                id = block.parent_id();
+                blocks.push(block);
+            } else {
+                // TODO(lpl): This error may be needed in the future.
+                // status = BlockRetrievalStatus::NotEnoughBlocks;
+                break;
             }
         }
 

--- a/crates/cfxcore/core/src/pos/protocol/message/mod.rs
+++ b/crates/cfxcore/core/src/pos/protocol/message/mod.rs
@@ -47,7 +47,7 @@ build_msgid! {
 }
 
 macro_rules! build_msg_impl_with_serde_serialization {
-    ($name:ident, $msg:expr, $name_str:literal) => {
+    ($name:ident, $msg:expr_2021, $name_str:literal) => {
         impl GetMaybeRequestId for $name {}
 
         impl Message for $name {
@@ -66,7 +66,7 @@ macro_rules! build_msg_impl_with_serde_serialization {
 }
 
 macro_rules! build_msg_impl_with_serde_serialization_generic {
-    ($name:ident, $msg:expr, $name_str:literal) => {
+    ($name:ident, $msg:expr_2021, $name_str:literal) => {
         impl GetMaybeRequestId for $name {}
 
         impl Message for $name {
@@ -85,7 +85,7 @@ macro_rules! build_msg_impl_with_serde_serialization_generic {
 }
 
 macro_rules! build_msg_impl_with_request_id_and_serde_serialization {
-    ($name:ident, $msg:expr, $name_str:literal) => {
+    ($name:ident, $msg:expr_2021, $name_str:literal) => {
         impl Message for $name {
             fn msg_id(&self) -> MsgId { $msg }
 

--- a/crates/cfxcore/core/src/pos/protocol/request_manager/mod.rs
+++ b/crates/cfxcore/core/src/pos/protocol/request_manager/mod.rs
@@ -156,15 +156,17 @@ impl RequestManager {
     pub fn on_peer_disconnected(
         &self, _io: &dyn NetworkContext, peer: &NodeId,
     ) {
-        if let Some(unfinished_requests) =
-            self.request_handler.remove_peer(peer)
-        {
-            for mut msg in unfinished_requests {
-                msg.request
-                    .notify_error(Error::RpcCancelledByDisconnection.into());
+        match self.request_handler.remove_peer(peer) {
+            Some(unfinished_requests) => {
+                for mut msg in unfinished_requests {
+                    msg.request.notify_error(
+                        Error::RpcCancelledByDisconnection.into(),
+                    );
+                }
             }
-        } else {
-            debug!("Peer already removed form request manager when disconnected peer={}", peer);
+            _ => {
+                debug!("Peer already removed form request manager when disconnected peer={}", peer);
+            }
         }
     }
 }

--- a/crates/cfxcore/core/src/pos/protocol/request_manager/mod.rs
+++ b/crates/cfxcore/core/src/pos/protocol/request_manager/mod.rs
@@ -156,17 +156,15 @@ impl RequestManager {
     pub fn on_peer_disconnected(
         &self, _io: &dyn NetworkContext, peer: &NodeId,
     ) {
-        match self.request_handler.remove_peer(peer) {
-            Some(unfinished_requests) => {
-                for mut msg in unfinished_requests {
-                    msg.request.notify_error(
-                        Error::RpcCancelledByDisconnection.into(),
-                    );
-                }
+        if let Some(unfinished_requests) =
+            self.request_handler.remove_peer(peer)
+        {
+            for mut msg in unfinished_requests {
+                msg.request
+                    .notify_error(Error::RpcCancelledByDisconnection.into());
             }
-            _ => {
-                debug!("Peer already removed form request manager when disconnected peer={}", peer);
-            }
+        } else {
+            debug!("Peer already removed form request manager when disconnected peer={}", peer);
         }
     }
 }

--- a/crates/cfxcore/core/src/pos/protocol/request_manager/request_handler.rs
+++ b/crates/cfxcore/core/src/pos/protocol/request_manager/request_handler.rs
@@ -168,22 +168,24 @@ impl RequestHandler {
         let mut timeout_requests = Vec::new();
         let mut peers_to_disconnect = HashSet::new();
         for sync_req in self.get_timeout_sync_requests() {
-            if let Ok(req) =
-                self.match_request(io, &sync_req.peer_id, sync_req.request_id)
+            match self.match_request(io, &sync_req.peer_id, sync_req.request_id)
             {
-                let peer_id = &sync_req.peer_id;
-                if let Some(request_container) =
-                    self.peers.lock().get_mut(peer_id)
-                {
-                    if request_container
-                        .on_timeout_should_disconnect(&self.protocol_config)
+                Ok(req) => {
+                    let peer_id = &sync_req.peer_id;
+                    if let Some(request_container) =
+                        self.peers.lock().get_mut(peer_id)
                     {
-                        peers_to_disconnect.insert(*peer_id);
+                        if request_container
+                            .on_timeout_should_disconnect(&self.protocol_config)
+                        {
+                            peers_to_disconnect.insert(*peer_id);
+                        }
                     }
+                    timeout_requests.push(req);
                 }
-                timeout_requests.push(req);
-            } else {
-                debug!("Timeout a removed request {:?}", sync_req);
+                _ => {
+                    debug!("Timeout a removed request {:?}", sync_req);
+                }
             }
         }
         let op = if self.protocol_config.demote_peer_for_timeout {
@@ -294,14 +296,15 @@ impl RequestContainer {
     pub fn remove_inflight_request(
         &mut self, request_id: u64,
     ) -> Option<SynchronizationPeerRequest> {
-        if let Some(save_req) = self.inflight_requests.remove(&request_id) {
-            Some(save_req)
-        } else {
-            debug!(
-                "Remove out of bound request peer={} request_id={} next={}",
-                self.peer_id, request_id, self.next_request_id
-            );
-            None
+        match self.inflight_requests.remove(&request_id) {
+            Some(save_req) => Some(save_req),
+            _ => {
+                debug!(
+                    "Remove out of bound request peer={} request_id={} next={}",
+                    self.peer_id, request_id, self.next_request_id
+                );
+                None
+            }
         }
     }
 

--- a/crates/cfxcore/core/src/pos/protocol/request_manager/request_handler.rs
+++ b/crates/cfxcore/core/src/pos/protocol/request_manager/request_handler.rs
@@ -168,24 +168,22 @@ impl RequestHandler {
         let mut timeout_requests = Vec::new();
         let mut peers_to_disconnect = HashSet::new();
         for sync_req in self.get_timeout_sync_requests() {
-            match self.match_request(io, &sync_req.peer_id, sync_req.request_id)
+            if let Ok(req) =
+                self.match_request(io, &sync_req.peer_id, sync_req.request_id)
             {
-                Ok(req) => {
-                    let peer_id = &sync_req.peer_id;
-                    if let Some(request_container) =
-                        self.peers.lock().get_mut(peer_id)
+                let peer_id = &sync_req.peer_id;
+                if let Some(request_container) =
+                    self.peers.lock().get_mut(peer_id)
+                {
+                    if request_container
+                        .on_timeout_should_disconnect(&self.protocol_config)
                     {
-                        if request_container
-                            .on_timeout_should_disconnect(&self.protocol_config)
-                        {
-                            peers_to_disconnect.insert(*peer_id);
-                        }
+                        peers_to_disconnect.insert(*peer_id);
                     }
-                    timeout_requests.push(req);
                 }
-                _ => {
-                    debug!("Timeout a removed request {:?}", sync_req);
-                }
+                timeout_requests.push(req);
+            } else {
+                debug!("Timeout a removed request {:?}", sync_req);
             }
         }
         let op = if self.protocol_config.demote_peer_for_timeout {
@@ -296,15 +294,14 @@ impl RequestContainer {
     pub fn remove_inflight_request(
         &mut self, request_id: u64,
     ) -> Option<SynchronizationPeerRequest> {
-        match self.inflight_requests.remove(&request_id) {
-            Some(save_req) => Some(save_req),
-            _ => {
-                debug!(
-                    "Remove out of bound request peer={} request_id={} next={}",
-                    self.peer_id, request_id, self.next_request_id
-                );
-                None
-            }
+        if let Some(save_req) = self.inflight_requests.remove(&request_id) {
+            Some(save_req)
+        } else {
+            debug!(
+                "Remove out of bound request peer={} request_id={} next={}",
+                self.peer_id, request_id, self.next_request_id
+            );
+            None
         }
     }
 

--- a/crates/cfxcore/core/src/sync/request_manager/mod.rs
+++ b/crates/cfxcore/core/src/sync/request_manager/mod.rs
@@ -978,15 +978,14 @@ impl RequestManager {
     }
 
     pub fn on_peer_disconnected(&self, io: &dyn NetworkContext, peer: &NodeId) {
-        match self.request_handler.remove_peer(peer) {
-            Some(unfinished_requests) => {
-                for msg in unfinished_requests {
-                    self.resend_request_to_another_peer(io, &msg);
-                }
+        if let Some(unfinished_requests) =
+            self.request_handler.remove_peer(peer)
+        {
+            for msg in unfinished_requests {
+                self.resend_request_to_another_peer(io, &msg);
             }
-            _ => {
-                debug!("Peer already removed form request manager when disconnected peer={}", peer);
-            }
+        } else {
+            debug!("Peer already removed form request manager when disconnected peer={}", peer);
         }
     }
 

--- a/crates/cfxcore/core/src/sync/request_manager/mod.rs
+++ b/crates/cfxcore/core/src/sync/request_manager/mod.rs
@@ -978,14 +978,15 @@ impl RequestManager {
     }
 
     pub fn on_peer_disconnected(&self, io: &dyn NetworkContext, peer: &NodeId) {
-        if let Some(unfinished_requests) =
-            self.request_handler.remove_peer(peer)
-        {
-            for msg in unfinished_requests {
-                self.resend_request_to_another_peer(io, &msg);
+        match self.request_handler.remove_peer(peer) {
+            Some(unfinished_requests) => {
+                for msg in unfinished_requests {
+                    self.resend_request_to_another_peer(io, &msg);
+                }
             }
-        } else {
-            debug!("Peer already removed form request manager when disconnected peer={}", peer);
+            _ => {
+                debug!("Peer already removed form request manager when disconnected peer={}", peer);
+            }
         }
     }
 

--- a/crates/cfxcore/core/src/sync/request_manager/request_batcher.rs
+++ b/crates/cfxcore/core/src/sync/request_manager/request_batcher.rs
@@ -161,7 +161,7 @@ impl<T: Clone> DelayBucket<T> {
     /// The delay is the average of all requests in this bucket.
     fn batch_iter(
         &self, batch_size: usize,
-    ) -> impl Iterator<Item = (Duration, Vec<T>)> {
+    ) -> impl Iterator<Item = (Duration, Vec<T>)> + use<T> {
         let mut batches = Vec::new();
         for (delay_sum, bucket) in &self.buckets {
             if bucket.is_empty() {

--- a/crates/cfxcore/core/src/sync/request_manager/request_handler.rs
+++ b/crates/cfxcore/core/src/sync/request_manager/request_handler.rs
@@ -164,26 +164,25 @@ impl RequestHandler {
         let mut peers_to_disconnect = HashSet::new();
         let mut peers_to_send_pending_requests = HashSet::new();
         for sync_req in self.get_timeout_sync_requests() {
-            match self.match_request(&sync_req.peer_id, sync_req.request_id) {
-                Ok(mut req) => {
-                    let peer_id = sync_req.peer_id.clone();
-                    if let Some(request_container) =
-                        self.peers.lock().get_mut(&peer_id)
+            if let Ok(mut req) =
+                self.match_request(&sync_req.peer_id, sync_req.request_id)
+            {
+                let peer_id = sync_req.peer_id.clone();
+                if let Some(request_container) =
+                    self.peers.lock().get_mut(&peer_id)
+                {
+                    if request_container
+                        .on_timeout_should_disconnect(&self.protocol_config)
                     {
-                        if request_container
-                            .on_timeout_should_disconnect(&self.protocol_config)
-                        {
-                            peers_to_disconnect.insert(peer_id);
-                        } else {
-                            peers_to_send_pending_requests.insert(peer_id);
-                        }
+                        peers_to_disconnect.insert(peer_id);
+                    } else {
+                        peers_to_send_pending_requests.insert(peer_id);
                     }
-                    req.request.notify_timeout();
-                    timeout_requests.push(req);
                 }
-                _ => {
-                    debug!("Timeout a removed request {:?}", sync_req);
-                }
+                req.request.notify_timeout();
+                timeout_requests.push(req);
+            } else {
+                debug!("Timeout a removed request {:?}", sync_req);
             }
         }
         let op = if self.protocol_config.demote_peer_for_timeout {
@@ -297,15 +296,14 @@ impl RequestContainer {
     pub fn remove_inflight_request(
         &mut self, request_id: u64,
     ) -> Option<SynchronizationPeerRequest> {
-        match self.inflight_requests.remove(&request_id) {
-            Some(save_req) => Some(save_req),
-            _ => {
-                debug!(
-                    "Remove out of bound request peer={} request_id={} next={}",
-                    self.peer_id, request_id, self.next_request_id
-                );
-                None
-            }
+        if let Some(save_req) = self.inflight_requests.remove(&request_id) {
+            Some(save_req)
+        } else {
+            debug!(
+                "Remove out of bound request peer={} request_id={} next={}",
+                self.peer_id, request_id, self.next_request_id
+            );
+            None
         }
     }
 

--- a/crates/cfxcore/core/src/sync/request_manager/request_handler.rs
+++ b/crates/cfxcore/core/src/sync/request_manager/request_handler.rs
@@ -164,25 +164,26 @@ impl RequestHandler {
         let mut peers_to_disconnect = HashSet::new();
         let mut peers_to_send_pending_requests = HashSet::new();
         for sync_req in self.get_timeout_sync_requests() {
-            if let Ok(mut req) =
-                self.match_request(&sync_req.peer_id, sync_req.request_id)
-            {
-                let peer_id = sync_req.peer_id.clone();
-                if let Some(request_container) =
-                    self.peers.lock().get_mut(&peer_id)
-                {
-                    if request_container
-                        .on_timeout_should_disconnect(&self.protocol_config)
+            match self.match_request(&sync_req.peer_id, sync_req.request_id) {
+                Ok(mut req) => {
+                    let peer_id = sync_req.peer_id.clone();
+                    if let Some(request_container) =
+                        self.peers.lock().get_mut(&peer_id)
                     {
-                        peers_to_disconnect.insert(peer_id);
-                    } else {
-                        peers_to_send_pending_requests.insert(peer_id);
+                        if request_container
+                            .on_timeout_should_disconnect(&self.protocol_config)
+                        {
+                            peers_to_disconnect.insert(peer_id);
+                        } else {
+                            peers_to_send_pending_requests.insert(peer_id);
+                        }
                     }
+                    req.request.notify_timeout();
+                    timeout_requests.push(req);
                 }
-                req.request.notify_timeout();
-                timeout_requests.push(req);
-            } else {
-                debug!("Timeout a removed request {:?}", sync_req);
+                _ => {
+                    debug!("Timeout a removed request {:?}", sync_req);
+                }
             }
         }
         let op = if self.protocol_config.demote_peer_for_timeout {
@@ -296,14 +297,15 @@ impl RequestContainer {
     pub fn remove_inflight_request(
         &mut self, request_id: u64,
     ) -> Option<SynchronizationPeerRequest> {
-        if let Some(save_req) = self.inflight_requests.remove(&request_id) {
-            Some(save_req)
-        } else {
-            debug!(
-                "Remove out of bound request peer={} request_id={} next={}",
-                self.peer_id, request_id, self.next_request_id
-            );
-            None
+        match self.inflight_requests.remove(&request_id) {
+            Some(save_req) => Some(save_req),
+            _ => {
+                debug!(
+                    "Remove out of bound request peer={} request_id={} next={}",
+                    self.peer_id, request_id, self.next_request_id
+                );
+                None
+            }
         }
     }
 

--- a/crates/cfxcore/core/src/sync/synchronization_phases.rs
+++ b/crates/cfxcore/core/src/sync/synchronization_phases.rs
@@ -438,44 +438,41 @@ impl SynchronizationPhaseTrait for CatchUpFillBlockBodyPhase {
             // true genesis In both cases, we should set
             // `state_availability_boundary` to
             // `[cur_era_stable_height, cur_era_stable_height]`.
-            match &*sync_handler.synced_epoch_id.lock() {
-                Some(epoch_synced) => {
-                    let epoch_synced_height = self
-                        .graph
-                        .data_man
-                        .block_header_by_hash(epoch_synced)
-                        .expect("Header for checkpoint exists")
-                        .height();
-                    *self.graph.data_man.state_availability_boundary.write() =
-                        StateAvailabilityBoundary::new(
-                            *epoch_synced,
-                            epoch_synced_height,
-                            full_state_start_height,
-                            full_state_space,
-                        );
-                    self.graph
-                        .data_man
-                        .state_availability_boundary
-                        .write()
-                        .set_synced_state_height(epoch_synced_height);
-                }
-                _ => {
-                    let cur_era_stable_hash =
-                        self.graph.data_man.get_cur_consensus_era_stable_hash();
-                    let cur_era_stable_height = self
-                        .graph
-                        .data_man
-                        .block_header_by_hash(&cur_era_stable_hash)
-                        .expect("stable era block header must exist")
-                        .height();
-                    *self.graph.data_man.state_availability_boundary.write() =
-                        StateAvailabilityBoundary::new(
-                            cur_era_stable_hash,
-                            cur_era_stable_height,
-                            full_state_start_height,
-                            full_state_space,
-                        );
-                }
+            if let Some(epoch_synced) = &*sync_handler.synced_epoch_id.lock() {
+                let epoch_synced_height = self
+                    .graph
+                    .data_man
+                    .block_header_by_hash(epoch_synced)
+                    .expect("Header for checkpoint exists")
+                    .height();
+                *self.graph.data_man.state_availability_boundary.write() =
+                    StateAvailabilityBoundary::new(
+                        *epoch_synced,
+                        epoch_synced_height,
+                        full_state_start_height,
+                        full_state_space,
+                    );
+                self.graph
+                    .data_man
+                    .state_availability_boundary
+                    .write()
+                    .set_synced_state_height(epoch_synced_height);
+            } else {
+                let cur_era_stable_hash =
+                    self.graph.data_man.get_cur_consensus_era_stable_hash();
+                let cur_era_stable_height = self
+                    .graph
+                    .data_man
+                    .block_header_by_hash(&cur_era_stable_hash)
+                    .expect("stable era block header must exist")
+                    .height();
+                *self.graph.data_man.state_availability_boundary.write() =
+                    StateAvailabilityBoundary::new(
+                        cur_era_stable_hash,
+                        cur_era_stable_height,
+                        full_state_start_height,
+                        full_state_space,
+                    );
             }
             self.graph.inner.write().block_to_fill_set =
                 self.graph.consensus.get_blocks_needing_bodies();

--- a/crates/cfxcore/core/src/sync/synchronization_phases.rs
+++ b/crates/cfxcore/core/src/sync/synchronization_phases.rs
@@ -438,41 +438,44 @@ impl SynchronizationPhaseTrait for CatchUpFillBlockBodyPhase {
             // true genesis In both cases, we should set
             // `state_availability_boundary` to
             // `[cur_era_stable_height, cur_era_stable_height]`.
-            if let Some(epoch_synced) = &*sync_handler.synced_epoch_id.lock() {
-                let epoch_synced_height = self
-                    .graph
-                    .data_man
-                    .block_header_by_hash(epoch_synced)
-                    .expect("Header for checkpoint exists")
-                    .height();
-                *self.graph.data_man.state_availability_boundary.write() =
-                    StateAvailabilityBoundary::new(
-                        *epoch_synced,
-                        epoch_synced_height,
-                        full_state_start_height,
-                        full_state_space,
-                    );
-                self.graph
-                    .data_man
-                    .state_availability_boundary
-                    .write()
-                    .set_synced_state_height(epoch_synced_height);
-            } else {
-                let cur_era_stable_hash =
-                    self.graph.data_man.get_cur_consensus_era_stable_hash();
-                let cur_era_stable_height = self
-                    .graph
-                    .data_man
-                    .block_header_by_hash(&cur_era_stable_hash)
-                    .expect("stable era block header must exist")
-                    .height();
-                *self.graph.data_man.state_availability_boundary.write() =
-                    StateAvailabilityBoundary::new(
-                        cur_era_stable_hash,
-                        cur_era_stable_height,
-                        full_state_start_height,
-                        full_state_space,
-                    );
+            match &*sync_handler.synced_epoch_id.lock() {
+                Some(epoch_synced) => {
+                    let epoch_synced_height = self
+                        .graph
+                        .data_man
+                        .block_header_by_hash(epoch_synced)
+                        .expect("Header for checkpoint exists")
+                        .height();
+                    *self.graph.data_man.state_availability_boundary.write() =
+                        StateAvailabilityBoundary::new(
+                            *epoch_synced,
+                            epoch_synced_height,
+                            full_state_start_height,
+                            full_state_space,
+                        );
+                    self.graph
+                        .data_man
+                        .state_availability_boundary
+                        .write()
+                        .set_synced_state_height(epoch_synced_height);
+                }
+                _ => {
+                    let cur_era_stable_hash =
+                        self.graph.data_man.get_cur_consensus_era_stable_hash();
+                    let cur_era_stable_height = self
+                        .graph
+                        .data_man
+                        .block_header_by_hash(&cur_era_stable_hash)
+                        .expect("stable era block header must exist")
+                        .height();
+                    *self.graph.data_man.state_availability_boundary.write() =
+                        StateAvailabilityBoundary::new(
+                            cur_era_stable_hash,
+                            cur_era_stable_height,
+                            full_state_start_height,
+                            full_state_space,
+                        );
+                }
             }
             self.graph.inner.write().block_to_fill_set =
                 self.graph.consensus.get_blocks_needing_bodies();

--- a/crates/cfxcore/core/src/transaction_pool/nonce_pool/mod.rs
+++ b/crates/cfxcore/core/src/transaction_pool/nonce_pool/mod.rs
@@ -79,7 +79,7 @@ impl TxWithReadyInfo {
             // executed locally
             return Ok("tx has been executed");
         }
-        if let (Transaction::Native(ref tx), Transaction::Native(ref other)) =
+        if let (Transaction::Native(tx), Transaction::Native(other)) =
             (&self.unsigned, &x.unsigned)
         {
             if *tx.epoch_height()
@@ -201,7 +201,7 @@ impl NoncePool {
     #[inline]
     pub fn iter_tx_by_nonce(
         &self, nonce: &U256,
-    ) -> impl Iterator<Item = &TxWithReadyInfo> {
+    ) -> impl Iterator<Item = &TxWithReadyInfo> + use<'_> {
         self.map.iter_range(nonce)
     }
 

--- a/crates/cfxcore/core/src/transaction_pool/nonce_pool/nonce_pool_map.rs
+++ b/crates/cfxcore/core/src/transaction_pool/nonce_pool/nonce_pool_map.rs
@@ -41,7 +41,7 @@ impl NoncePoolMap {
     #[inline]
     pub fn iter_range(
         &self, nonce: &U256,
-    ) -> impl Iterator<Item = &TxWithReadyInfo> {
+    ) -> impl Iterator<Item = &TxWithReadyInfo> + use<'_> {
         self.0.iter_range(nonce).map(|x| &x.value)
     }
 

--- a/crates/cfxcore/internal_common/Cargo.toml
+++ b/crates/cfxcore/internal_common/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "https://www.confluxnetwork.org"
 license = "GPL-3.0"
 name = "cfx-internal-common"
 version = "1.0.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 cfx-bytes = { workspace = true }

--- a/crates/cfxcore/packing-pool/Cargo.toml
+++ b/crates/cfxcore/packing-pool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cfx-packing-pool"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license-file.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/cfxcore/pow/src/cache.rs
+++ b/crates/cfxcore/pow/src/cache.rs
@@ -85,51 +85,53 @@ fn make_memory_cache(num_nodes: usize, ident: &H256) -> Cache {
 // afterwards to be elided. Yes, really. I know, I want to refactor this to use
 // less `unsafe` as much as the next rustacean.
 unsafe fn initialize_memory(memory: *mut Node, num_nodes: usize, ident: &H256) {
-    // We use raw pointers here, see above
-    let dst = slice::from_raw_parts_mut(memory as *mut u8, NODE_BYTES);
-
-    debug_assert_eq!(ident.len(), 32);
-    keccak_512::write(&ident[..], dst);
-
-    for i in 1..num_nodes {
+    unsafe {
         // We use raw pointers here, see above
-        let dst = slice::from_raw_parts_mut(
-            memory.offset(i as _) as *mut u8,
-            NODE_BYTES,
-        );
-        let src = slice::from_raw_parts(
-            memory.offset(i as isize - 1) as *mut u8,
-            NODE_BYTES,
-        );
-        keccak_512::write(src, dst);
-    }
+        let dst = slice::from_raw_parts_mut(memory as *mut u8, NODE_BYTES);
 
-    // Now this is initialized, we can treat it as a slice.
-    let nodes: &mut [Node] = slice::from_raw_parts_mut(memory, num_nodes);
+        debug_assert_eq!(ident.len(), 32);
+        keccak_512::write(&ident[..], dst);
 
-    for _ in 0..POW_CACHE_ROUNDS {
-        for i in 0..num_nodes {
-            let data_idx = (num_nodes - 1 + i) % num_nodes;
-            let idx =
-                nodes.get_unchecked_mut(i).as_words()[0] as usize % num_nodes;
-
-            let data = {
-                let mut data: Node = nodes.get_unchecked(data_idx).clone();
-                let rhs: &Node = nodes.get_unchecked(idx);
-
-                for (a, b) in
-                    data.as_dwords_mut().iter_mut().zip(rhs.as_dwords())
-                {
-                    *a ^= *b;
-                }
-
-                data
-            };
-
-            keccak_512::write(
-                &data.bytes,
-                &mut nodes.get_unchecked_mut(i).bytes,
+        for i in 1..num_nodes {
+            // We use raw pointers here, see above
+            let dst = slice::from_raw_parts_mut(
+                memory.offset(i as _) as *mut u8,
+                NODE_BYTES,
             );
+            let src = slice::from_raw_parts(
+                memory.offset(i as isize - 1) as *mut u8,
+                NODE_BYTES,
+            );
+            keccak_512::write(src, dst);
+        }
+
+        // Now this is initialized, we can treat it as a slice.
+        let nodes: &mut [Node] = slice::from_raw_parts_mut(memory, num_nodes);
+
+        for _ in 0..POW_CACHE_ROUNDS {
+            for i in 0..num_nodes {
+                let data_idx = (num_nodes - 1 + i) % num_nodes;
+                let idx = nodes.get_unchecked_mut(i).as_words()[0] as usize
+                    % num_nodes;
+
+                let data = {
+                    let mut data: Node = nodes.get_unchecked(data_idx).clone();
+                    let rhs: &Node = nodes.get_unchecked(idx);
+
+                    for (a, b) in
+                        data.as_dwords_mut().iter_mut().zip(rhs.as_dwords())
+                    {
+                        *a ^= *b;
+                    }
+
+                    data
+                };
+
+                keccak_512::write(
+                    &data.bytes,
+                    &mut nodes.get_unchecked_mut(i).bytes,
+                );
+            }
         }
     }
 }

--- a/crates/cfxcore/pow/src/compute.rs
+++ b/crates/cfxcore/pow/src/compute.rs
@@ -251,17 +251,19 @@ fn hash_compute(
     }
 
     macro_rules! make_const_array {
-        ($n:expr, $value:expr) => {{
+        ($n:expr_2021, $value:expr_2021) => {{
             // We use explicit lifetimes to ensure that val's borrow is
             // invalidated until the transmuted val dies.
             unsafe fn make_const_array<T, U>(val: &mut [T]) -> &mut [U; $n] {
-                use ::std::mem;
+                unsafe {
+                    use ::std::mem;
 
-                debug_assert_eq!(
-                    val.len() * mem::size_of::<T>(),
-                    $n * mem::size_of::<U>()
-                );
-                &mut *(val.as_mut_ptr() as *mut [U; $n])
+                    debug_assert_eq!(
+                        val.len() * mem::size_of::<T>(),
+                        $n * mem::size_of::<U>()
+                    );
+                    &mut *(val.as_mut_ptr() as *mut [U; $n])
+                }
             }
 
             make_const_array($value)

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "client"
 version = { workspace = true }
-edition = "2021"
+edition = "2024"
 license-file.workspace = true
 
 [dependencies]

--- a/crates/client/src/common/mod.rs
+++ b/crates/client/src/common/mod.rs
@@ -85,13 +85,17 @@ impl<BlockGenT, Rest: MallocSizeOf> MallocSizeOf
     for ClientComponents<BlockGenT, Rest>
 {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        if let Some(data_man) = self.data_manager_weak_ptr.upgrade() {
-            let data_manager_size = data_man.size_of(ops);
-            data_manager_size + self.other_components.size_of(ops)
-        } else {
-            // If data_man is `None`, we will be just shutting down (dropping
-            // components) so we don't care about the size
-            0
+        match self.data_manager_weak_ptr.upgrade() {
+            Some(data_man) => {
+                let data_manager_size = data_man.size_of(ops);
+                data_manager_size + self.other_components.size_of(ops)
+            }
+            _ => {
+                // If data_man is `None`, we will be just shutting down
+                // (dropping components) so we don't care about
+                // the size
+                0
+            }
         }
     }
 }

--- a/crates/client/src/common/mod.rs
+++ b/crates/client/src/common/mod.rs
@@ -85,17 +85,13 @@ impl<BlockGenT, Rest: MallocSizeOf> MallocSizeOf
     for ClientComponents<BlockGenT, Rest>
 {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        match self.data_manager_weak_ptr.upgrade() {
-            Some(data_man) => {
-                let data_manager_size = data_man.size_of(ops);
-                data_manager_size + self.other_components.size_of(ops)
-            }
-            _ => {
-                // If data_man is `None`, we will be just shutting down
-                // (dropping components) so we don't care about
-                // the size
-                0
-            }
+        if let Some(data_man) = self.data_manager_weak_ptr.upgrade() {
+            let data_manager_size = data_man.size_of(ops);
+            data_manager_size + self.other_components.size_of(ops)
+        } else {
+            // If data_man is `None`, we will be just shutting down (dropping
+            // components) so we don't care about the size
+            0
         }
     }
 }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfx-config"
-edition = "2021"
+edition = "2024"
 version.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/config/src/config_macro.rs
+++ b/crates/config/src/config_macro.rs
@@ -12,7 +12,7 @@ macro_rules! if_option {
 }
 
 macro_rules! underscore_to_hyphen {
-    ($e:expr) => {
+    ($e:expr_2021) => {
         str::replace($e, "_", "-")
     };
 }
@@ -21,10 +21,10 @@ macro_rules! underscore_to_hyphen {
 macro_rules! build_config{
     (
         {
-            $(($name:ident, ($($type:tt)+), $default:expr))*
+            $(($name:ident, ($($type:tt)+), $default:expr_2021))*
         }
         {
-            $(($c_name:ident, ($($c_type:tt)+), $c_default:expr, $converter:expr))*
+            $(($c_name:ident, ($($c_type:tt)+), $c_default:expr_2021, $converter:expr_2021))*
         }
     ) => {
         use cfxcore::pow::ProofOfWorkConfig;
@@ -133,7 +133,7 @@ macro_rules! build_config{
 
 #[macro_export]
 macro_rules! set_conf {
-    ($src: expr; $dst: expr => {$($field: tt),* }) => {
+    ($src: expr_2021; $dst: expr_2021 => {$($field: tt),* }) => {
         {
             let number = $src;
             $($dst.$field = number;)*

--- a/crates/dbs/db-errors/Cargo.toml
+++ b/crates/dbs/db-errors/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "https://www.confluxnetwork.org"
 license = "GPL-3.0"
 name = "cfx-db-errors"
 version = "2.0.2"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 primitives = { workspace = true }

--- a/crates/dbs/db/Cargo.toml
+++ b/crates/dbs/db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "db"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license-file.workspace = true
 
 [dependencies]

--- a/crates/dbs/kvdb-rocksdb/Cargo.toml
+++ b/crates/dbs/kvdb-rocksdb/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-common"
 description = "kvdb implementation backed by rocksDB"
 license = "GPL-3.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 cfx-types = { workspace = true }

--- a/crates/dbs/statedb/Cargo.toml
+++ b/crates/dbs/statedb/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "https://www.confluxnetwork.org"
 license = "GPL-3.0"
 name = "cfx-statedb"
 version = "1.0.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 cfx-internal-common = { workspace = true }

--- a/crates/dbs/statedb/src/global_params.rs
+++ b/crates/dbs/statedb/src/global_params.rs
@@ -29,7 +29,7 @@ pub trait GlobalParamKey {
 
 #[macro_export]
 macro_rules! for_all_global_param_keys {
-    ($f:ident::<Key>($($args:expr),*);) => {
+    ($f:ident::<Key>($($args:expr_2021),*);) => {
         $f::<InterestRate>($($args),*);
         $f::<AccumulateInterestRate>($($args),*);
         $f::<TotalIssued>($($args),*);
@@ -45,7 +45,7 @@ macro_rules! for_all_global_param_keys {
         $f::<TotalBurnt1559>($($args),*);
         $f::<BaseFeeProp>($($args),*);
     };
-    ($f:ident::<Key>($($args:expr),*)?;) => {
+    ($f:ident::<Key>($($args:expr_2021),*)?;) => {
         $f::<InterestRate>($($args),*)?;
         $f::<AccumulateInterestRate>($($args),*)?;
         $f::<TotalIssued>($($args),*)?;

--- a/crates/dbs/storage/Cargo.toml
+++ b/crates/dbs/storage/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "https://www.confluxnetwork.org"
 license = "GPL-3.0"
 name = "cfx-storage"
 version = "1.0.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 cfg-if = { workspace = true }

--- a/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/lru.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/lru.rs
@@ -344,7 +344,7 @@ impl<PosT: PrimitiveNum, CacheIndexT: CacheIndexTrait> LRU<PosT, CacheIndexT> {
     unsafe fn get_unchecked_mut(
         &mut self, pos: PosT,
     ) -> &mut DoubleLinkListNode<PosT, CacheIndexT> {
-        self.recent.get_unchecked_mut(MyInto::<usize>::into(pos))
+        unsafe { self.recent.get_unchecked_mut(MyInto::<usize>::into(pos)) }
     }
 
     /// User may update the cache index.
@@ -352,8 +352,10 @@ impl<PosT: PrimitiveNum, CacheIndexT: CacheIndexTrait> LRU<PosT, CacheIndexT> {
     pub unsafe fn get_cache_index_mut(
         &mut self, handle: LRUHandle<PosT>,
     ) -> &mut CacheIndexT {
-        let pos = self.get_lru_pos_for_handle(&handle);
-        return &mut self.get_unchecked_mut(pos).cache_index;
+        unsafe {
+            let pos = self.get_lru_pos_for_handle(&handle);
+            return &mut self.get_unchecked_mut(pos).cache_index;
+        }
     }
 
     pub fn has_space(&self) -> bool { self.capacity != self.size }

--- a/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/removable_heap.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/cache/algorithm/removable_heap.rs
@@ -205,11 +205,11 @@ impl<PosT: PrimitiveNum, ValueType> RemovableHeap<PosT, ValueType> {
     pub fn get_array_mut(&mut self) -> &mut Vec<ValueType> { &mut self.array }
 
     pub unsafe fn get_unchecked(&self, pos: PosT) -> &ValueType {
-        self.array.get_unchecked(MyInto::<usize>::into(pos))
+        unsafe { self.array.get_unchecked(MyInto::<usize>::into(pos)) }
     }
 
     pub unsafe fn get_unchecked_mut(&mut self, pos: PosT) -> &mut ValueType {
-        self.array.get_unchecked_mut(MyInto::<usize>::into(pos))
+        unsafe { self.array.get_unchecked_mut(MyInto::<usize>::into(pos)) }
     }
 
     /// Replace an element with hole, and place the removed element at the end
@@ -222,21 +222,24 @@ impl<PosT: PrimitiveNum, ValueType> RemovableHeap<PosT, ValueType> {
         &mut self, pos: PosT, hole: &mut Hole<ValueType>,
         value_util: &mut ValueUtilT,
     ) -> PosT {
-        let array_pos = self.array.len();
+        unsafe {
+            let array_pos = self.array.len();
 
-        self.array.set_len(array_pos + 1);
-        let array_pos = PosT::from(array_pos);
-        if pos != array_pos {
-            ptr::copy_nonoverlapping(
-                self.get_unchecked(pos),
-                self.get_unchecked_mut(array_pos),
-                1,
-            );
-            value_util.set_handle(self.get_unchecked_mut(array_pos), array_pos);
+            self.array.set_len(array_pos + 1);
+            let array_pos = PosT::from(array_pos);
+            if pos != array_pos {
+                ptr::copy_nonoverlapping(
+                    self.get_unchecked(pos),
+                    self.get_unchecked_mut(array_pos),
+                    1,
+                );
+                value_util
+                    .set_handle(self.get_unchecked_mut(array_pos), array_pos);
+            }
+            hole.pointer_pos.write(self.get_unchecked_mut(pos));
+
+            array_pos
         }
-        hole.pointer_pos.write(self.get_unchecked_mut(pos));
-
-        array_pos
     }
 }
 
@@ -507,15 +510,17 @@ impl<PosT: PrimitiveNum, ValueType> RemovableHeap<PosT, ValueType> {
     >(
         &mut self, mut hole: Hole<ValueType>, value_util: &mut ValueUtilT,
     ) -> PosT {
-        let heap_size = self.heap_size;
-        self.hole_push_back_and_swap_unchecked(
-            heap_size, &mut hole, value_util,
-        );
+        unsafe {
+            let heap_size = self.heap_size;
+            self.hole_push_back_and_swap_unchecked(
+                heap_size, &mut hole, value_util,
+            );
 
-        self.sift_up_with_hole(heap_size, hole, value_util);
-        self.heap_size += PosT::from(1);
+            self.sift_up_with_hole(heap_size, hole, value_util);
+            self.heap_size += PosT::from(1);
 
-        heap_size
+            heap_size
+        }
     }
 
     // Used in tests and by a currently unused class.
@@ -547,13 +552,15 @@ impl<PosT: PrimitiveNum, ValueType> RemovableHeap<PosT, ValueType> {
         &mut self, hole: Hole<ValueType>, replaced: *mut ValueType,
         value_util: &mut ValueUtilT,
     ) {
-        ptr::copy_nonoverlapping(
-            self.get_unchecked_mut(PosT::from(0)),
-            replaced,
-            1,
-        );
+        unsafe {
+            ptr::copy_nonoverlapping(
+                self.get_unchecked_mut(PosT::from(0)),
+                replaced,
+                1,
+            );
 
-        self.sift_down_with_hole(PosT::from(0), hole, value_util);
+            self.sift_down_with_hole(PosT::from(0), hole, value_util);
+        }
     }
 
     /// The value is set to removed from heap. However if user provides a value
@@ -567,13 +574,15 @@ impl<PosT: PrimitiveNum, ValueType> RemovableHeap<PosT, ValueType> {
     >(
         &mut self, value: &mut ValueType, value_util: &mut ValueUtilT,
     ) {
-        let hole =
-            Hole::new_from_value_ptr_read(self.array.as_mut_ptr(), value);
+        unsafe {
+            let hole =
+                Hole::new_from_value_ptr_read(self.array.as_mut_ptr(), value);
 
-        // The value may be in-place updated so set_removed must be called
-        // before set_handle is called from Hole.
-        value_util.set_removed(value);
-        self.replace_head_unchecked_with_hole(hole, value, value_util);
+            // The value may be in-place updated so set_removed must be called
+            // before set_handle is called from Hole.
+            value_util.set_removed(value);
+            self.replace_head_unchecked_with_hole(hole, value, value_util);
+        }
     }
 
     // Used in tests and by a currently unused class.
@@ -636,20 +645,22 @@ impl<PosT: PrimitiveNum, ValueType> RemovableHeap<PosT, ValueType> {
         &mut self, pos: PosT, hole: Hole<ValueType>, replaced: *mut ValueType,
         value_util: &mut ValueUtilT,
     ) {
-        {
-            let src = self.get_unchecked_mut(pos) as *mut ValueType;
-            let dst = replaced;
-            if src != dst {
-                ptr::copy_nonoverlapping(src, dst, 1);
+        unsafe {
+            {
+                let src = self.get_unchecked_mut(pos) as *mut ValueType;
+                let dst = replaced;
+                if src != dst {
+                    ptr::copy_nonoverlapping(src, dst, 1);
+                }
             }
-        }
 
-        if value_util.get_key_for_comparison(self.get_unchecked_mut(pos))
-            < value_util.get_key_for_comparison(&hole.value)
-        {
-            self.sift_down_with_hole(pos, hole, value_util);
-        } else {
-            self.sift_up_with_hole(pos, hole, value_util);
+            if value_util.get_key_for_comparison(self.get_unchecked_mut(pos))
+                < value_util.get_key_for_comparison(&hole.value)
+            {
+                self.sift_down_with_hole(pos, hole, value_util);
+            } else {
+                self.sift_up_with_hole(pos, hole, value_util);
+            }
         }
     }
 
@@ -662,17 +673,19 @@ impl<PosT: PrimitiveNum, ValueType> RemovableHeap<PosT, ValueType> {
         &mut self, pos: PosT, value: &mut ValueType,
         value_util: &mut ValueUtilT,
     ) {
-        let hole = {
-            let replaced = self.get_unchecked_mut(pos);
-            let hole = Hole::new_from_value_ptr_read(replaced, value);
+        unsafe {
+            let hole = {
+                let replaced = self.get_unchecked_mut(pos);
+                let hole = Hole::new_from_value_ptr_read(replaced, value);
 
-            // The value may be in-place updated so set_removed must be
-            // called before set_handle is called from Hole.
-            value_util.set_removed(replaced);
+                // The value may be in-place updated so set_removed must be
+                // called before set_handle is called from Hole.
+                value_util.set_removed(replaced);
 
-            hole
-        };
-        self.replace_at_unchecked_with_hole(pos, hole, value, value_util);
+                hole
+            };
+            self.replace_at_unchecked_with_hole(pos, hole, value, value_util);
+        }
     }
 
     /// Unsafe because the pos is unchecked.
@@ -683,25 +696,27 @@ impl<PosT: PrimitiveNum, ValueType> RemovableHeap<PosT, ValueType> {
     >(
         &mut self, pos: PosT, value_util: &mut ValueUtilT,
     ) {
-        self.heap_size -= PosT::from(1);
-        let heap_last_pos = self.heap_size;
-        if pos < heap_last_pos {
-            let hole = Hole::new_from_value_ptr_read(
-                self.get_unchecked_mut(pos),
-                self.get_unchecked_mut(heap_last_pos),
-            );
-            let ptr_heap_last_element =
-                self.get_unchecked_mut(heap_last_pos) as *mut ValueType;
-            self.replace_at_unchecked_with_hole(
-                pos,
-                hole,
-                ptr_heap_last_element,
-                value_util,
-            );
-            value_util.set_handle(
-                self.get_unchecked_mut(heap_last_pos),
-                heap_last_pos,
-            );
+        unsafe {
+            self.heap_size -= PosT::from(1);
+            let heap_last_pos = self.heap_size;
+            if pos < heap_last_pos {
+                let hole = Hole::new_from_value_ptr_read(
+                    self.get_unchecked_mut(pos),
+                    self.get_unchecked_mut(heap_last_pos),
+                );
+                let ptr_heap_last_element =
+                    self.get_unchecked_mut(heap_last_pos) as *mut ValueType;
+                self.replace_at_unchecked_with_hole(
+                    pos,
+                    hole,
+                    ptr_heap_last_element,
+                    value_util,
+                );
+                value_util.set_handle(
+                    self.get_unchecked_mut(heap_last_pos),
+                    heap_last_pos,
+                );
+            }
         }
     }
 
@@ -711,42 +726,49 @@ impl<PosT: PrimitiveNum, ValueType> RemovableHeap<PosT, ValueType> {
     >(
         &mut self, pos: PosT, value_util: &mut ValueUtilT,
     ) -> ValueType {
-        let mut removed = MaybeUninit::uninit();
-        value_util.set_removed(self.get_unchecked_mut(pos));
-        let hole_pos = if self.heap_size > pos {
-            self.heap_size -= PosT::from(1);
-            let last_element_pos = self.heap_size;
-            if last_element_pos != pos {
-                let hole = Hole::new_from_value_ptr_read(
-                    self.get_unchecked_mut(pos),
-                    self.get_unchecked_mut(last_element_pos),
-                );
+        unsafe {
+            let mut removed = MaybeUninit::uninit();
+            value_util.set_removed(self.get_unchecked_mut(pos));
+            let hole_pos = if self.heap_size > pos {
+                self.heap_size -= PosT::from(1);
+                let last_element_pos = self.heap_size;
+                if last_element_pos != pos {
+                    let hole = Hole::new_from_value_ptr_read(
+                        self.get_unchecked_mut(pos),
+                        self.get_unchecked_mut(last_element_pos),
+                    );
 
-                self.replace_at_unchecked_with_hole(
-                    pos,
-                    hole,
+                    self.replace_at_unchecked_with_hole(
+                        pos,
+                        hole,
+                        removed.as_mut_ptr(),
+                        value_util,
+                    );
+                }
+                last_element_pos
+            } else {
+                let value_to_remove = self.get_unchecked_mut(pos);
+                ptr::copy_nonoverlapping(
+                    value_to_remove,
                     removed.as_mut_ptr(),
-                    value_util,
+                    1,
                 );
+                pos
+            };
+            let new_len = self.array.len() - 1;
+            if PosT::from(new_len) != hole_pos {
+                ptr::copy_nonoverlapping(
+                    self.get_unchecked(PosT::from(new_len)),
+                    self.get_unchecked_mut(hole_pos),
+                    1,
+                );
+                value_util
+                    .set_handle(self.get_unchecked_mut(hole_pos), hole_pos);
             }
-            last_element_pos
-        } else {
-            let value_to_remove = self.get_unchecked_mut(pos);
-            ptr::copy_nonoverlapping(value_to_remove, removed.as_mut_ptr(), 1);
-            pos
-        };
-        let new_len = self.array.len() - 1;
-        if PosT::from(new_len) != hole_pos {
-            ptr::copy_nonoverlapping(
-                self.get_unchecked(PosT::from(new_len)),
-                self.get_unchecked_mut(hole_pos),
-                1,
-            );
-            value_util.set_handle(self.get_unchecked_mut(hole_pos), hole_pos);
-        }
-        self.array.set_len(new_len);
+            self.array.set_len(new_len);
 
-        removed.assume_init()
+            removed.assume_init()
+        }
     }
 
     pub fn sift_up_with_hole<ValueUtilT: HeapValueUtil<ValueType, PosT>>(

--- a/crates/dbs/storage/src/impls/delta_mpt/cow_node_ref.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/cow_node_ref.rs
@@ -54,7 +54,7 @@ impl MaybeOwnedTrieNodeAsCowCallParam {
     unsafe fn owned_as_mut_unchecked<'a>(
         &mut self,
     ) -> &'a mut TrieNodeDeltaMpt {
-        &mut *self.trie_node
+        unsafe { &mut *self.trie_node }
     }
 
     /// Do not implement in a trait to keep the call private.
@@ -102,7 +102,7 @@ impl<'a> MaybeOwnedTrieNode<'a> {
     pub unsafe fn owned_as_mut_unchecked(
         &mut self,
     ) -> &'a mut TrieNodeDeltaMpt {
-        self.trie_node.get_as_mut()
+        unsafe { self.trie_node.get_as_mut() }
     }
 }
 
@@ -811,13 +811,15 @@ impl CowNodeRef {
     pub unsafe fn delete_value_unchecked_followed_by_node_deletion(
         &mut self, mut trie_node: GuardedMaybeOwnedTrieNodeAsCowCallParam,
     ) -> Box<[u8]> {
-        if self.owned {
-            trie_node
-                .as_mut()
-                .owned_as_mut_unchecked()
-                .delete_value_unchecked()
-        } else {
-            trie_node.as_ref().as_ref().value_clone().unwrap()
+        unsafe {
+            if self.owned {
+                trie_node
+                    .as_mut()
+                    .owned_as_mut_unchecked()
+                    .delete_value_unchecked()
+            } else {
+                trie_node.as_ref().as_ref().value_clone().unwrap()
+            }
         }
     }
 
@@ -856,22 +858,24 @@ impl CowNodeRef {
         owned_node_set: &mut OwnedNodeSet,
         trie_node: GuardedMaybeOwnedTrieNodeAsCowCallParam,
     ) -> Result<Box<[u8]>> {
-        self.cow_modify_with_operation(
-            &node_memory_manager.get_allocator(),
-            owned_node_set,
-            trie_node,
-            |owned_trie_node| owned_trie_node.delete_value_unchecked(),
-            |read_only_trie_node| {
-                (
-                    read_only_trie_node.copy_and_replace_fields(
-                        Some(None),
-                        None,
-                        None,
-                    ),
-                    read_only_trie_node.value_clone().unwrap(),
-                )
-            },
-        )
+        unsafe {
+            self.cow_modify_with_operation(
+                &node_memory_manager.get_allocator(),
+                owned_node_set,
+                trie_node,
+                |owned_trie_node| owned_trie_node.delete_value_unchecked(),
+                |read_only_trie_node| {
+                    (
+                        read_only_trie_node.copy_and_replace_fields(
+                            Some(None),
+                            None,
+                            None,
+                        ),
+                        read_only_trie_node.value_clone().unwrap(),
+                    )
+                },
+            )
+        }
     }
 
     pub fn cow_replace_value_valid(

--- a/crates/dbs/storage/src/impls/delta_mpt/mem_optimized_trie_node.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/mem_optimized_trie_node.rs
@@ -316,33 +316,41 @@ impl<CacheAlgoDataT: CacheAlgoDataTrait> TrieNodeTrait
     unsafe fn add_new_child_unchecked<T>(&mut self, child_index: u8, child: T)
     where ChildrenTableItem<NodeRefDeltaMptCompact>:
             WrappedCreateFrom<T, NodeRefDeltaMptCompact> {
-        self.children_table = CompactedChildrenTable::insert_child_unchecked(
-            self.children_table.to_ref(),
-            child_index,
-            ChildrenTableItem::<NodeRefDeltaMptCompact>::take(child),
-        );
+        unsafe {
+            self.children_table =
+                CompactedChildrenTable::insert_child_unchecked(
+                    self.children_table.to_ref(),
+                    child_index,
+                    ChildrenTableItem::<NodeRefDeltaMptCompact>::take(child),
+                );
+        }
     }
 
     unsafe fn get_child_mut_unchecked(
         &mut self, child_index: u8,
     ) -> &mut Self::NodeRefType {
-        self.children_table.get_child_mut_unchecked(child_index)
+        unsafe { self.children_table.get_child_mut_unchecked(child_index) }
     }
 
     unsafe fn replace_child_unchecked<T>(&mut self, child_index: u8, child: T)
     where ChildrenTableItem<NodeRefDeltaMptCompact>:
             WrappedCreateFrom<T, NodeRefDeltaMptCompact> {
-        self.children_table.set_child_unchecked(
-            child_index,
-            ChildrenTableItem::<NodeRefDeltaMptCompact>::take(child),
-        );
+        unsafe {
+            self.children_table.set_child_unchecked(
+                child_index,
+                ChildrenTableItem::<NodeRefDeltaMptCompact>::take(child),
+            );
+        }
     }
 
     unsafe fn delete_child_unchecked(&mut self, child_index: u8) {
-        self.children_table = CompactedChildrenTable::delete_child_unchecked(
-            self.children_table.to_ref(),
-            child_index,
-        );
+        unsafe {
+            self.children_table =
+                CompactedChildrenTable::delete_child_unchecked(
+                    self.children_table.to_ref(),
+                    child_index,
+                );
+        }
     }
 
     unsafe fn delete_value_unchecked(&mut self) -> Box<[u8]> {

--- a/crates/dbs/storage/src/impls/delta_mpt/node_memory_manager.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/node_memory_manager.rs
@@ -191,13 +191,13 @@ impl<
     pub unsafe fn get_in_memory_cell<'a>(
         allocator: AllocatorRefRef<'a, CacheAlgoDataT>, cache_slot: usize,
     ) -> &'a TrieNodeCell<CacheAlgoDataT> {
-        allocator.get_unchecked(cache_slot)
+        unsafe { allocator.get_unchecked(cache_slot) }
     }
 
     pub unsafe fn get_in_memory_node_mut<'a>(
         allocator: AllocatorRefRef<'a, CacheAlgoDataT>, cache_slot: usize,
     ) -> &'a mut MemOptimizedTrieNode<CacheAlgoDataT> {
-        allocator.get_unchecked(cache_slot).get_as_mut()
+        unsafe { allocator.get_unchecked(cache_slot).get_as_mut() }
     }
 
     fn load_from_db<'c: 'a, 'a>(
@@ -320,28 +320,30 @@ impl<
         cache_mut: &mut CacheManagerDeltaMpts<CacheAlgoDataT, CacheAlgorithmT>,
         evicted_keep_cache_algo_data_cache_index: CacheAlgorithmT::CacheIndex,
     ) {
-        // Remove evicted content from cache.
-        // Safe to unwrap because it's guaranteed by cache algorithm that the
-        // slot exists.
-        let slot = *cache_mut
-            .node_ref_map
-            .get_cache_info(evicted_keep_cache_algo_data_cache_index)
-            .unwrap()
-            .get_slot()
-            .unwrap() as usize;
+        unsafe {
+            // Remove evicted content from cache.
+            // Safe to unwrap because it's guaranteed by cache algorithm that
+            // the slot exists.
+            let slot = *cache_mut
+                .node_ref_map
+                .get_cache_info(evicted_keep_cache_algo_data_cache_index)
+                .unwrap()
+                .get_slot()
+                .unwrap() as usize;
 
-        cache_mut.node_ref_map.set_cache_info(
-            evicted_keep_cache_algo_data_cache_index,
-            CacheableNodeRefDeltaMpt::new(
-                TrieCacheSlotOrCacheAlgoData::CacheAlgoData(
-                    self.get_allocator()
-                        .get_unchecked(slot)
-                        .get_ref()
-                        .cache_algo_data,
+            cache_mut.node_ref_map.set_cache_info(
+                evicted_keep_cache_algo_data_cache_index,
+                CacheableNodeRefDeltaMpt::new(
+                    TrieCacheSlotOrCacheAlgoData::CacheAlgoData(
+                        self.get_allocator()
+                            .get_unchecked(slot)
+                            .get_ref()
+                            .cache_algo_data,
+                    ),
                 ),
-            ),
-        );
-        self.get_allocator().remove(slot).unwrap();
+            );
+            self.get_allocator().remove(slot).unwrap();
+        }
     }
 
     // TODO(yz): special thread local batching logic for access_hit?
@@ -391,17 +393,19 @@ impl<
         &self, allocator: AllocatorRefRef<'a, CacheAlgoDataT>,
         node: &mut NodeRefDeltaMpt,
     ) -> &'a mut MemOptimizedTrieNode<CacheAlgoDataT> {
-        match node {
+        unsafe {
+            match node {
             NodeRefDeltaMpt::Committed { db_key: _ } => {
                 unreachable!();
             }
-            NodeRefDeltaMpt::Dirty { ref index } => NodeMemoryManager::<
+            &mut NodeRefDeltaMpt::Dirty { ref index } => NodeMemoryManager::<
                 CacheAlgoDataT,
                 CacheAlgorithmT,
             >::get_in_memory_node_mut(
                 &allocator,
                 *index as usize,
             ),
+        }
         }
     }
 
@@ -425,84 +429,90 @@ impl<
             &'a TrieNodeCell<CacheAlgoDataT>,
         >,
     > {
-        match node {
-            NodeRefDeltaMpt::Committed { ref db_key } => {
-                let mut cache_manager_mut_wrapped = Some(cache_manager.lock());
+        unsafe {
+            match node {
+                NodeRefDeltaMpt::Committed { ref db_key } => {
+                    let mut cache_manager_mut_wrapped =
+                        Some(cache_manager.lock());
 
-                let maybe_cache_slot = cache_manager_mut_wrapped
-                    .as_mut()
-                    .unwrap()
-                    .node_ref_map
-                    .get_cache_info((mpt_id, *db_key))
-                    .and_then(|x| x.get_slot());
+                    let maybe_cache_slot = cache_manager_mut_wrapped
+                        .as_mut()
+                        .unwrap()
+                        .node_ref_map
+                        .get_cache_info((mpt_id, *db_key))
+                        .and_then(|x| x.get_slot());
 
-                let trie_node = match maybe_cache_slot {
-                    Some(cache_slot) => {
-                        // Fast path.
-                        NodeMemoryManager::<
+                    let trie_node = match maybe_cache_slot {
+                        Some(cache_slot) => {
+                            // Fast path.
+                            NodeMemoryManager::<
                             CacheAlgoDataT,
                             CacheAlgorithmT,
                         >::get_in_memory_cell(
                             &allocator, *cache_slot as usize
                         )
-                    }
-                    None => {
-                        // Slow path, load from db
-                        // Release the lock in fast path to prevent deadlock.
-                        cache_manager_mut_wrapped.take();
+                        }
+                        None => {
+                            // Slow path, load from db
+                            // Release the lock in fast path to prevent
+                            // deadlock.
+                            cache_manager_mut_wrapped.take();
 
-                        // The mutex is used. The preceding underscore is only
-                        // to make compiler happy.
-                        let _db_load_mutex = self.db_load_lock.lock();
-                        cache_manager_mut_wrapped = Some(cache_manager.lock());
-                        let maybe_cache_slot = cache_manager_mut_wrapped
-                            .as_mut()
-                            .unwrap()
-                            .node_ref_map
-                            .get_cache_info((mpt_id, *db_key))
-                            .and_then(|x| x.get_slot());
+                            // The mutex is used. The preceding underscore is
+                            // only to make compiler
+                            // happy.
+                            let _db_load_mutex = self.db_load_lock.lock();
+                            cache_manager_mut_wrapped =
+                                Some(cache_manager.lock());
+                            let maybe_cache_slot = cache_manager_mut_wrapped
+                                .as_mut()
+                                .unwrap()
+                                .node_ref_map
+                                .get_cache_info((mpt_id, *db_key))
+                                .and_then(|x| x.get_slot());
 
-                        match maybe_cache_slot {
-                            Some(cache_slot) => NodeMemoryManager::<
-                                CacheAlgoDataT,
-                                CacheAlgorithmT,
-                            >::get_in_memory_cell(
-                                &allocator,
-                                *cache_slot as usize,
-                            ),
-                            None => {
-                                // We would like to release the lock to
-                                // cache_manager during db IO.
-                                cache_manager_mut_wrapped.take();
+                            match maybe_cache_slot {
+                                Some(cache_slot) => NodeMemoryManager::<
+                                    CacheAlgoDataT,
+                                    CacheAlgorithmT,
+                                >::get_in_memory_cell(
+                                    &allocator,
+                                    *cache_slot as usize,
+                                ),
+                                None => {
+                                    // We would like to release the lock to
+                                    // cache_manager during db IO.
+                                    cache_manager_mut_wrapped.take();
 
-                                let (guard, loaded_trie_node) = self
-                                    .load_from_db(
-                                        allocator,
-                                        cache_manager,
-                                        db,
-                                        mpt_id,
-                                        *db_key,
-                                    )?
-                                    .into();
+                                    let (guard, loaded_trie_node) = self
+                                        .load_from_db(
+                                            allocator,
+                                            cache_manager,
+                                            db,
+                                            mpt_id,
+                                            *db_key,
+                                        )?
+                                        .into();
 
-                                cache_manager_mut_wrapped = Some(guard);
+                                    cache_manager_mut_wrapped = Some(guard);
 
-                                *is_loaded_from_db = true;
+                                    *is_loaded_from_db = true;
 
-                                loaded_trie_node
+                                    loaded_trie_node
+                                }
                             }
                         }
-                    }
-                };
+                    };
 
-                self.call_cache_algorithm_access(
-                    cache_manager_mut_wrapped.as_mut().unwrap(),
-                    (mpt_id, *db_key),
-                );
+                    self.call_cache_algorithm_access(
+                        cache_manager_mut_wrapped.as_mut().unwrap(),
+                        (mpt_id, *db_key),
+                    );
 
-                Ok(GuardedValue::new(cache_manager_mut_wrapped, trie_node))
+                    Ok(GuardedValue::new(cache_manager_mut_wrapped, trie_node))
+                }
+                NodeRefDeltaMpt::Dirty { index: _ } => unreachable!(),
             }
-            NodeRefDeltaMpt::Dirty { index: _ } => unreachable!(),
         }
     }
 
@@ -511,10 +521,12 @@ impl<
         &self, allocator: AllocatorRefRef<'a, CacheAlgoDataT>,
         slot: ActualSlabIndex,
     ) -> &'a mut MemOptimizedTrieNode<CacheAlgoDataT> {
-        NodeMemoryManager::<CacheAlgoDataT, CacheAlgorithmT>::get_in_memory_node_mut(
+        unsafe {
+            NodeMemoryManager::<CacheAlgoDataT, CacheAlgorithmT>::get_in_memory_node_mut(
             &allocator,
             slot as usize,
         )
+        }
     }
 
     /// cache_manager is assigned a different lifetime because the
@@ -616,7 +628,7 @@ impl<
         &self, node: &mut NodeRefDeltaMpt, mpt_id: DeltaMptId,
     ) {
         let slot = match node {
-            NodeRefDeltaMpt::Committed { ref db_key } => {
+            &mut NodeRefDeltaMpt::Committed { ref db_key } => {
                 let maybe_cache_info =
                     self.cache.lock().node_ref_map.delete((mpt_id, *db_key));
                 let maybe_cache_slot = maybe_cache_info
@@ -628,7 +640,7 @@ impl<
                     Some(slot) => *slot,
                 }
             }
-            NodeRefDeltaMpt::Dirty { ref index } => *index,
+            &mut NodeRefDeltaMpt::Dirty { ref index } => *index,
         };
 
         // A strong assertion that the remove should success. Otherwise it's a

--- a/crates/dbs/storage/src/impls/delta_mpt/slab/mod.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/slab/mod.rs
@@ -711,7 +711,7 @@ impl<T, E: EntryTrait<EntryType = T>> Slab<T, E> {
     ///     assert_eq!(slab.get_unchecked(key), &2);
     /// }
     pub unsafe fn get_unchecked(&self, key: usize) -> &T {
-        self.entries.get_unchecked(key).get_ref().get_occupied_ref()
+        unsafe { self.entries.get_unchecked(key).get_ref().get_occupied_ref() }
     }
 
     /// Return a mutable reference to the value associated with the given key
@@ -734,10 +734,12 @@ impl<T, E: EntryTrait<EntryType = T>> Slab<T, E> {
     /// assert_eq!(slab[key], 13);
     /// ```
     pub unsafe fn get_unchecked_mut(&mut self, key: usize) -> &mut T {
-        self.entries
-            .get_unchecked_mut(key)
-            .get_mut()
-            .get_occupied_mut()
+        unsafe {
+            self.entries
+                .get_unchecked_mut(key)
+                .get_mut()
+                .get_occupied_mut()
+        }
     }
 
     /// Insert a value in the slab, returning key assigned to the value.

--- a/crates/dbs/storage/src/impls/delta_mpt/subtrie_visitor.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/subtrie_visitor.rs
@@ -719,178 +719,186 @@ impl<'trie, 'db: 'trie> SubTrieVisitor<'trie, 'db> {
     unsafe fn insert_checked_value(
         mut self, key: KeyPart, value: Box<[u8]>,
     ) -> Result<(bool, NodeRefDeltaMptCompact)> {
-        let node_memory_manager = self.node_memory_manager();
-        let allocator = node_memory_manager.get_allocator();
-        let mut node_cow = self.root.take();
-        // TODO(yz): be compliant to borrow rule and avoid duplicated
+        unsafe {
+            let node_memory_manager = self.node_memory_manager();
+            let allocator = node_memory_manager.get_allocator();
+            let mut node_cow = self.root.take();
+            // TODO(yz): be compliant to borrow rule and avoid duplicated
 
-        let is_owned = node_cow.is_owned();
-        // FIXME: apply db_load_counter to all places where it matters, and also
-        // FIXME: pass down to recursion. (Also check other methods.)
-        let trie_node_ref = node_cow.get_trie_node(
-            node_memory_manager,
-            &allocator,
-            &mut *self.db.get_mut().to_owned_read()?,
-        )?;
-        trace!(
-            "insert_checked_value: trie_node.path={:?} {:?}",
-            trie_node_ref.compressed_path_ref(),
-            trie_node_ref.get_compressed_path_size()
-        );
-        match trie_node_ref.walk::<access_mode::Write>(key) {
-            WalkStop::Arrived => {
-                let node_ref_changed = !is_owned;
-                let trie_node = GuardedValue::take(trie_node_ref);
-                node_cow.cow_replace_value_valid(
-                    &node_memory_manager,
-                    self.owned_node_set.get_mut(),
-                    trie_node,
-                    value,
-                )?;
+            let is_owned = node_cow.is_owned();
+            // FIXME: apply db_load_counter to all places where it matters, and
+            // also FIXME: pass down to recursion. (Also check other
+            // methods.)
+            let trie_node_ref = node_cow.get_trie_node(
+                node_memory_manager,
+                &allocator,
+                &mut *self.db.get_mut().to_owned_read()?,
+            )?;
+            trace!(
+                "insert_checked_value: trie_node.path={:?} {:?}",
+                trie_node_ref.compressed_path_ref(),
+                trie_node_ref.get_compressed_path_size()
+            );
+            match trie_node_ref.walk::<access_mode::Write>(key) {
+                WalkStop::Arrived => {
+                    let node_ref_changed = !is_owned;
+                    let trie_node = GuardedValue::take(trie_node_ref);
+                    node_cow.cow_replace_value_valid(
+                        &node_memory_manager,
+                        self.owned_node_set.get_mut(),
+                        trie_node,
+                        value,
+                    )?;
 
-                Ok((node_ref_changed, node_cow.into_child().unwrap()))
-            }
-            WalkStop::Descent {
-                key_remaining,
-                child_node,
-                child_index,
-            } => {
-                drop(trie_node_ref);
-                let result = self
-                    .new_visitor_for_subtree(child_node.clone().into())
-                    .insert_checked_value(key_remaining, value);
-                if result.is_err() {
-                    node_cow.into_child();
-                    return result;
+                    Ok((node_ref_changed, node_cow.into_child().unwrap()))
                 }
-                let (child_changed, new_child_node) = result.unwrap();
+                WalkStop::Descent {
+                    key_remaining,
+                    child_node,
+                    child_index,
+                } => {
+                    drop(trie_node_ref);
+                    let result = self
+                        .new_visitor_for_subtree(child_node.clone().into())
+                        .insert_checked_value(key_remaining, value);
+                    if result.is_err() {
+                        node_cow.into_child();
+                        return result;
+                    }
+                    let (child_changed, new_child_node) = result.unwrap();
 
-                if child_changed {
-                    let node_ref_changed = !node_cow.is_owned();
-                    let trie_node =
-                        GuardedValue::take(node_cow.get_trie_node(
-                            node_memory_manager,
+                    if child_changed {
+                        let node_ref_changed = !node_cow.is_owned();
+                        let trie_node =
+                            GuardedValue::take(node_cow.get_trie_node(
+                                node_memory_manager,
+                                &allocator,
+                                &mut *self.db.get_mut().to_owned_read()?,
+                            )?);
+                        node_cow
+                            .cow_modify(
+                                &allocator,
+                                self.owned_node_set.get_mut(),
+                                trie_node,
+                            )?
+                            .replace_child_unchecked(
+                                child_index,
+                                new_child_node,
+                            );
+
+                        Ok((node_ref_changed, node_cow.into_child().unwrap()))
+                    } else {
+                        Ok((false, node_cow.into_child().unwrap()))
+                    }
+                }
+                WalkStop::PathDiverted {
+                    key_child_index,
+                    key_remaining,
+                    matched_path,
+                    unmatched_child_index,
+                    unmatched_path_remaining,
+                } => {
+                    // create a new node to replace self with compressed
+                    // path = matched_path, modify current
+                    // node with the remaining path, and attach it as child to
+                    // the replacement node create a new
+                    // node for insertion (if key_remaining
+                    // is non-empty), set it to child,
+                    // with key_remaining.
+                    let (new_node_cow, new_node_entry) =
+                        CowNodeRef::new_uninitialized_node(
                             &allocator,
-                            &mut *self.db.get_mut().to_owned_read()?,
-                        )?);
+                            self.owned_node_set.get_mut(),
+                            self.trie_ref.get_mpt_id(),
+                        )?;
+                    let mut new_node = MemOptimizedTrieNode::default();
+                    // set compressed path.
+                    new_node.set_compressed_path(matched_path);
+
+                    let trie_node = GuardedValue::take(trie_node_ref);
+                    node_cow.cow_set_compressed_path(
+                        &node_memory_manager,
+                        self.owned_node_set.get_mut(),
+                        unmatched_path_remaining,
+                        trie_node,
+                    )?;
+
+                    // It's safe because we know that this is the first child.
+                    new_node.set_first_child_unchecked(
+                        unmatched_child_index,
+                        // It's safe to unwrap because we know that it's not
+                        // none.
+                        node_cow.into_child().unwrap(),
+                    );
+
+                    // TODO(yz): remove duplicated code.
+                    match key_child_index {
+                        None => {
+                            // Insert value at the current node
+                            new_node.replace_value_valid(value);
+                        }
+                        Some(child_index) => {
+                            // TODO(yz): Maybe create CowNodeRef on NULL then
+                            // cow_set_value then set path.
+                            let (child_node_cow, child_node_entry) =
+                                CowNodeRef::new_uninitialized_node(
+                                    &allocator,
+                                    self.owned_node_set.get_mut(),
+                                    self.trie_ref.get_mpt_id(),
+                                )?;
+                            let mut new_child_node =
+                                MemOptimizedTrieNode::default();
+                            // set compressed path.
+                            new_child_node.copy_compressed_path(key_remaining);
+                            new_child_node.replace_value_valid(value);
+                            child_node_entry.insert(&new_child_node);
+
+                            // It's safe because it's guaranteed that
+                            // key_child_index != unmatched_child_index
+                            new_node.add_new_child_unchecked(
+                                child_index,
+                                // It's safe to unwrap here because it's not
+                                // null node.
+                                child_node_cow.into_child().unwrap(),
+                            );
+                        }
+                    }
+                    new_node_entry.insert(&new_node);
+                    Ok((true, new_node_cow.into_child().unwrap()))
+                }
+                WalkStop::ChildNotFound {
+                    key_remaining,
+                    child_index,
+                } => {
+                    // TODO(yz): Maybe create CowNodeRef on NULL then
+                    // cow_set_value then set path.
+                    let (child_node_cow, child_node_entry) =
+                        CowNodeRef::new_uninitialized_node(
+                            &allocator,
+                            self.owned_node_set.get_mut(),
+                            self.trie_ref.get_mpt_id(),
+                        )?;
+                    let mut new_child_node = MemOptimizedTrieNode::default();
+                    // set compressed path.
+                    new_child_node.copy_compressed_path(key_remaining);
+                    new_child_node.replace_value_valid(value);
+                    child_node_entry.insert(&new_child_node);
+
+                    let node_ref_changed = !is_owned;
+                    let trie_node = GuardedValue::take(trie_node_ref);
                     node_cow
                         .cow_modify(
                             &allocator,
                             self.owned_node_set.get_mut(),
                             trie_node,
                         )?
-                        .replace_child_unchecked(child_index, new_child_node);
-
-                    Ok((node_ref_changed, node_cow.into_child().unwrap()))
-                } else {
-                    Ok((false, node_cow.into_child().unwrap()))
-                }
-            }
-            WalkStop::PathDiverted {
-                key_child_index,
-                key_remaining,
-                matched_path,
-                unmatched_child_index,
-                unmatched_path_remaining,
-            } => {
-                // create a new node to replace self with compressed
-                // path = matched_path, modify current
-                // node with the remaining path, and attach it as child to the
-                // replacement node create a new node for
-                // insertion (if key_remaining is non-empty), set it to child,
-                // with key_remaining.
-                let (new_node_cow, new_node_entry) =
-                    CowNodeRef::new_uninitialized_node(
-                        &allocator,
-                        self.owned_node_set.get_mut(),
-                        self.trie_ref.get_mpt_id(),
-                    )?;
-                let mut new_node = MemOptimizedTrieNode::default();
-                // set compressed path.
-                new_node.set_compressed_path(matched_path);
-
-                let trie_node = GuardedValue::take(trie_node_ref);
-                node_cow.cow_set_compressed_path(
-                    &node_memory_manager,
-                    self.owned_node_set.get_mut(),
-                    unmatched_path_remaining,
-                    trie_node,
-                )?;
-
-                // It's safe because we know that this is the first child.
-                new_node.set_first_child_unchecked(
-                    unmatched_child_index,
-                    // It's safe to unwrap because we know that it's not none.
-                    node_cow.into_child().unwrap(),
-                );
-
-                // TODO(yz): remove duplicated code.
-                match key_child_index {
-                    None => {
-                        // Insert value at the current node
-                        new_node.replace_value_valid(value);
-                    }
-                    Some(child_index) => {
-                        // TODO(yz): Maybe create CowNodeRef on NULL then
-                        // cow_set_value then set path.
-                        let (child_node_cow, child_node_entry) =
-                            CowNodeRef::new_uninitialized_node(
-                                &allocator,
-                                self.owned_node_set.get_mut(),
-                                self.trie_ref.get_mpt_id(),
-                            )?;
-                        let mut new_child_node =
-                            MemOptimizedTrieNode::default();
-                        // set compressed path.
-                        new_child_node.copy_compressed_path(key_remaining);
-                        new_child_node.replace_value_valid(value);
-                        child_node_entry.insert(&new_child_node);
-
-                        // It's safe because it's guaranteed that
-                        // key_child_index != unmatched_child_index
-                        new_node.add_new_child_unchecked(
+                        .add_new_child_unchecked(
                             child_index,
-                            // It's safe to unwrap here because it's not null
-                            // node.
                             child_node_cow.into_child().unwrap(),
                         );
-                    }
+
+                    Ok((node_ref_changed, node_cow.into_child().unwrap()))
                 }
-                new_node_entry.insert(&new_node);
-                Ok((true, new_node_cow.into_child().unwrap()))
-            }
-            WalkStop::ChildNotFound {
-                key_remaining,
-                child_index,
-            } => {
-                // TODO(yz): Maybe create CowNodeRef on NULL then cow_set_value
-                // then set path.
-                let (child_node_cow, child_node_entry) =
-                    CowNodeRef::new_uninitialized_node(
-                        &allocator,
-                        self.owned_node_set.get_mut(),
-                        self.trie_ref.get_mpt_id(),
-                    )?;
-                let mut new_child_node = MemOptimizedTrieNode::default();
-                // set compressed path.
-                new_child_node.copy_compressed_path(key_remaining);
-                new_child_node.replace_value_valid(value);
-                child_node_entry.insert(&new_child_node);
-
-                let node_ref_changed = !is_owned;
-                let trie_node = GuardedValue::take(trie_node_ref);
-                node_cow
-                    .cow_modify(
-                        &allocator,
-                        self.owned_node_set.get_mut(),
-                        trie_node,
-                    )?
-                    .add_new_child_unchecked(
-                        child_index,
-                        child_node_cow.into_child().unwrap(),
-                    );
-
-                Ok((node_ref_changed, node_cow.into_child().unwrap()))
             }
         }
     }

--- a/crates/dbs/storage/src/impls/merkle_patricia_trie/children_table.rs
+++ b/crates/dbs/storage/src/impls/merkle_patricia_trie/children_table.rs
@@ -115,7 +115,7 @@ impl<NodeRefT: 'static + NodeRefTrait> VanillaChildrenTable<NodeRefT> {
     pub unsafe fn get_child_mut_unchecked(
         &mut self, child_index: u8,
     ) -> &mut NodeRefT {
-        self.table.get_unchecked_mut(child_index as usize)
+        unsafe { self.table.get_unchecked_mut(child_index as usize) }
     }
 
     pub fn iter(&self) -> VanillaChildrenTableIterator<'_, NodeRefT> {
@@ -310,13 +310,17 @@ impl<NodeRefT: NodeRefTrait> CompactedChildrenTable<NodeRefT> {
     pub unsafe fn get_child_mut_unchecked(
         &mut self, index: u8,
     ) -> &mut NodeRefT {
-        &mut *self.table_ptr.add(Self::lower_bound(self.bitmap, index))
+        unsafe {
+            &mut *self.table_ptr.add(Self::lower_bound(self.bitmap, index))
+        }
     }
 
     /// Unsafe because child must already exist at the index.
     pub unsafe fn set_child_unchecked(&mut self, index: u8, value: NodeRefT) {
-        *self.table_ptr.add(Self::lower_bound(self.bitmap, index)) =
-            value.clone();
+        unsafe {
+            *self.table_ptr.add(Self::lower_bound(self.bitmap, index)) =
+                value.clone();
+        }
     }
 
     pub fn new_from_one_child(index: u8, value: NodeRefT) -> Self {
@@ -332,37 +336,41 @@ impl<NodeRefT: NodeRefTrait> CompactedChildrenTable<NodeRefT> {
     pub unsafe fn insert_child_unchecked(
         old_table: ChildrenTableRef<NodeRefT>, index: u8, value: NodeRefT,
     ) -> Self {
-        let insertion_pos = Self::lower_bound(old_table.bitmap, index);
-        Self {
-            bitmap: old_table.bitmap | Self::bit(index.into()),
-            children_count: old_table.table.len() as u8 + 1,
-            table_ptr: Self::managed_slice_into_raw(
-                [
-                    &old_table.table[0..insertion_pos],
-                    &[value],
-                    &old_table.table[insertion_pos..],
-                ]
-                .concat()
-                .into_boxed_slice(),
-            ),
+        unsafe {
+            let insertion_pos = Self::lower_bound(old_table.bitmap, index);
+            Self {
+                bitmap: old_table.bitmap | Self::bit(index.into()),
+                children_count: old_table.table.len() as u8 + 1,
+                table_ptr: Self::managed_slice_into_raw(
+                    [
+                        &old_table.table[0..insertion_pos],
+                        &[value],
+                        &old_table.table[insertion_pos..],
+                    ]
+                    .concat()
+                    .into_boxed_slice(),
+                ),
+            }
         }
     }
 
     pub unsafe fn delete_child_unchecked(
         old_table: ChildrenTableRef<NodeRefT>, index: u8,
     ) -> Self {
-        let deletion_pos = Self::lower_bound(old_table.bitmap, index);
-        Self {
-            bitmap: old_table.bitmap & (!Self::bit(index.into())),
-            children_count: old_table.table.len() as u8 - 1,
-            table_ptr: Self::managed_slice_into_raw(
-                [
-                    &old_table.table[0..deletion_pos],
-                    &old_table.table[deletion_pos + 1..],
-                ]
-                .concat()
-                .into_boxed_slice(),
-            ),
+        unsafe {
+            let deletion_pos = Self::lower_bound(old_table.bitmap, index);
+            Self {
+                bitmap: old_table.bitmap & (!Self::bit(index.into())),
+                children_count: old_table.table.len() as u8 - 1,
+                table_ptr: Self::managed_slice_into_raw(
+                    [
+                        &old_table.table[0..deletion_pos],
+                        &old_table.table[deletion_pos + 1..],
+                    ]
+                    .concat()
+                    .into_boxed_slice(),
+                ),
+            }
         }
     }
 }
@@ -402,15 +410,17 @@ impl<NodeRefT: NodeRefTrait> Drop for CompactedChildrenTable<NodeRefT> {
 
 impl<NodeRefT: NodeRefTrait> CompactedChildrenTable<NodeRefT> {
     unsafe fn into_managed_slice(&self) -> Option<Vec<NodeRefT>> {
-        if self.children_count != 0 {
-            assert_ne!(self.table_ptr, null_mut());
-            Some(Vec::from_raw_parts(
-                self.table_ptr,
-                self.children_count.into(),
-                self.children_count.into(),
-            ))
-        } else {
-            None
+        unsafe {
+            if self.children_count != 0 {
+                assert_ne!(self.table_ptr, null_mut());
+                Some(Vec::from_raw_parts(
+                    self.table_ptr,
+                    self.children_count.into(),
+                    self.children_count.into(),
+                ))
+            } else {
+                None
+            }
         }
     }
 

--- a/crates/dbs/storage/src/impls/merkle_patricia_trie/maybe_in_place_byte_array.rs
+++ b/crates/dbs/storage/src/impls/merkle_patricia_trie/maybe_in_place_byte_array.rs
@@ -45,9 +45,11 @@ impl Default for MaybeInPlaceByteArray {
 pub trait MaybeInPlaceByteArrayMemoryManagerTrait: Drop {
     /// Unsafe because the size isn't set to 0.
     unsafe fn drop_value(&mut self) {
-        let size = self.get_size();
-        if size > MaybeInPlaceByteArray::MAX_INPLACE_SIZE {
-            self.get_in_place_byte_array_mut().ptr_into_vec(size);
+        unsafe {
+            let size = self.get_size();
+            if size > MaybeInPlaceByteArray::MAX_INPLACE_SIZE {
+                self.get_in_place_byte_array_mut().ptr_into_vec(size);
+            }
         }
     }
 
@@ -60,13 +62,15 @@ pub trait MaybeInPlaceByteArrayMemoryManagerTrait: Drop {
     unsafe fn move_byte_array_dest_unchecked(
         &mut self, free_dest: &mut MaybeInPlaceByteArray,
     ) {
-        self.set_size(0);
+        unsafe {
+            self.set_size(0);
 
-        std::ptr::copy_nonoverlapping(
-            self.get_in_place_byte_array(),
-            free_dest,
-            1,
-        );
+            std::ptr::copy_nonoverlapping(
+                self.get_in_place_byte_array(),
+                free_dest,
+                1,
+            );
+        }
     }
 
     fn move_to<T: MaybeInPlaceByteArrayMemoryManagerTrait>(
@@ -127,39 +131,45 @@ impl<
 impl MaybeInPlaceByteArray {
     /// Take ptr out and clear ptr.
     pub unsafe fn ptr_into_vec(&mut self, size: usize) -> Vec<u8> {
-        debug_assert!(!self.ptr.is_null() || size == 0);
-        let ptr = if self.ptr.is_null() {
-            NonNull::dangling().as_ptr()
-        } else {
-            self.ptr
-        };
-        let vec = Vec::from_raw_parts(ptr, size, size);
-        self.ptr = null_mut();
-        vec
+        unsafe {
+            debug_assert!(!self.ptr.is_null() || size == 0);
+            let ptr = if self.ptr.is_null() {
+                NonNull::dangling().as_ptr()
+            } else {
+                self.ptr
+            };
+            let vec = Vec::from_raw_parts(ptr, size, size);
+            self.ptr = null_mut();
+            vec
+        }
     }
 
     unsafe fn ptr_slice(&self, size: usize) -> &[u8] {
-        debug_assert!(!self.ptr.is_null() || size == 0);
-        slice::from_raw_parts(
-            if self.ptr.is_null() {
-                NonNull::dangling().as_ptr()
-            } else {
-                self.ptr
-            },
-            size,
-        )
+        unsafe {
+            debug_assert!(!self.ptr.is_null() || size == 0);
+            slice::from_raw_parts(
+                if self.ptr.is_null() {
+                    NonNull::dangling().as_ptr()
+                } else {
+                    self.ptr
+                },
+                size,
+            )
+        }
     }
 
     unsafe fn ptr_slice_mut(&mut self, size: usize) -> &mut [u8] {
-        debug_assert!(!self.ptr.is_null() || size == 0);
-        slice::from_raw_parts_mut(
-            if self.ptr.is_null() {
-                NonNull::dangling().as_ptr()
-            } else {
-                self.ptr
-            },
-            size,
-        )
+        unsafe {
+            debug_assert!(!self.ptr.is_null() || size == 0);
+            slice::from_raw_parts_mut(
+                if self.ptr.is_null() {
+                    NonNull::dangling().as_ptr()
+                } else {
+                    self.ptr
+                },
+                size,
+            )
+        }
     }
 
     pub fn get_slice_mut(&mut self, size: usize) -> &mut [u8] {

--- a/crates/dbs/storage/src/impls/merkle_patricia_trie/trie_node.rs
+++ b/crates/dbs/storage/src/impls/merkle_patricia_trie/trie_node.rs
@@ -132,33 +132,39 @@ where ChildrenTableItem<NodeRefT>: DefaultChildrenItem<NodeRefT>
 
     unsafe fn add_new_child_unchecked<T>(&mut self, child_index: u8, child: T)
     where ChildrenTableItem<NodeRefT>: WrappedCreateFrom<T, NodeRefT> {
-        ChildrenTableItem::<NodeRefT>::take_from(
-            self.children_table.get_child_mut_unchecked(child_index),
-            child,
-        );
-        *self.children_table.get_children_count_mut() += 1;
+        unsafe {
+            ChildrenTableItem::<NodeRefT>::take_from(
+                self.children_table.get_child_mut_unchecked(child_index),
+                child,
+            );
+            *self.children_table.get_children_count_mut() += 1;
+        }
     }
 
     unsafe fn get_child_mut_unchecked(
         &mut self, child_index: u8,
     ) -> &mut NodeRefT {
-        self.children_table.get_child_mut_unchecked(child_index)
+        unsafe { self.children_table.get_child_mut_unchecked(child_index) }
     }
 
     unsafe fn replace_child_unchecked<T>(&mut self, child_index: u8, child: T)
     where ChildrenTableItem<NodeRefT>: WrappedCreateFrom<T, NodeRefT> {
-        ChildrenTableItem::<NodeRefT>::take_from(
-            self.children_table.get_child_mut_unchecked(child_index),
-            child,
-        );
+        unsafe {
+            ChildrenTableItem::<NodeRefT>::take_from(
+                self.children_table.get_child_mut_unchecked(child_index),
+                child,
+            );
+        }
     }
 
     unsafe fn delete_child_unchecked(&mut self, child_index: u8) {
-        ChildrenTableItem::<NodeRefT>::take_from(
-            self.children_table.get_child_mut_unchecked(child_index),
-            ChildrenTableItem::<NodeRefT>::no_child(),
-        );
-        *self.children_table.get_children_count_mut() -= 1;
+        unsafe {
+            ChildrenTableItem::<NodeRefT>::take_from(
+                self.children_table.get_child_mut_unchecked(child_index),
+                ChildrenTableItem::<NodeRefT>::no_child(),
+            );
+            *self.children_table.get_children_count_mut() -= 1;
+        }
     }
 
     unsafe fn delete_value_unchecked(&mut self) -> Box<[u8]> {

--- a/crates/dbs/storage/src/impls/state.rs
+++ b/crates/dbs/storage/src/impls/state.rs
@@ -451,9 +451,9 @@ impl StateTraitExt for State {
             &self.maybe_intermediate_trie_key_padding,
         ) {
             (
-                Some(ref root_node),
-                Some(ref intermediate_trie),
-                Some(ref intermediate_trie_key_padding),
+                Some(root_node),
+                Some(intermediate_trie),
+                Some(intermediate_trie_key_padding),
             ) => {
                 let key = access_key
                     .to_delta_mpt_key_bytes(&intermediate_trie_key_padding);

--- a/crates/dbs/storage/src/impls/state_manager.rs
+++ b/crates/dbs/storage/src/impls/state_manager.rs
@@ -49,7 +49,11 @@ impl StateManager {
         debug!("Storage conf {:?}", conf);
         // Make sure sqlite temp directory is using the data disk instead of the
         // system disk.
-        std::env::set_var("SQLITE_TMPDIR", conf.path_snapshot_dir.clone());
+        // FIXME: Audit that the environment access only happens in
+        // single-threaded code.
+        unsafe {
+            std::env::set_var("SQLITE_TMPDIR", conf.path_snapshot_dir.clone())
+        };
 
         let single_mpt_storage_manager = if conf.enable_single_mpt_storage {
             Some(SingleMptStorageManager::new_arc(
@@ -167,39 +171,40 @@ impl StateManager {
             None => {
                 // This is the special scenario when the snapshot isn't
                 // available but the snapshot at the intermediate epoch exists.
-                if let Some(guarded_snapshot) =
-                    self.storage_manager.wait_for_snapshot(
-                        &state_index.intermediate_epoch_id,
-                        try_open,
-                        open_mpt_snapshot,
-                    )?
-                {
-                    snapshot = guarded_snapshot;
-                    maybe_intermediate_mpt = None;
-                    maybe_intermediate_mpt_key_padding = None;
-                    delta_mpt = match self
-                        .storage_manager
-                        .get_intermediate_mpt(
-                            &state_index.intermediate_epoch_id,
-                        )? {
-                        None => {
-                            warn!(
+                match self.storage_manager.wait_for_snapshot(
+                    &state_index.intermediate_epoch_id,
+                    try_open,
+                    open_mpt_snapshot,
+                )? {
+                    Some(guarded_snapshot) => {
+                        snapshot = guarded_snapshot;
+                        maybe_intermediate_mpt = None;
+                        maybe_intermediate_mpt_key_padding = None;
+                        delta_mpt = match self
+                            .storage_manager
+                            .get_intermediate_mpt(
+                                &state_index.intermediate_epoch_id,
+                            )? {
+                            None => {
+                                warn!(
                                     "get_state_trees, special case, \
                                     intermediate_mpt not found for epoch {:?}. StateIndex: {:?}.",
                                     state_index.intermediate_epoch_id,
                                     state_index,
                                 );
-                            return Ok(None);
-                        }
-                        Some(delta_mpt) => delta_mpt,
-                    };
-                } else {
-                    warn!(
-                        "get_state_trees, special case, \
+                                return Ok(None);
+                            }
+                            Some(delta_mpt) => delta_mpt,
+                        };
+                    }
+                    _ => {
+                        warn!(
+                            "get_state_trees, special case, \
                          snapshot not found for epoch {:?}. StateIndex: {:?}.",
-                        state_index.intermediate_epoch_id, state_index,
-                    );
-                    return Ok(None);
+                            state_index.intermediate_epoch_id, state_index,
+                        );
+                        return Ok(None);
+                    }
                 }
             }
             Some(guarded_snapshot) => {
@@ -509,41 +514,42 @@ impl StateManager {
                     // This is the special scenario when the snapshot isn't
                     // available but the snapshot at the intermediate epoch
                     // exists.
-                    if let Some(guarded_snapshot) =
-                        self.storage_manager.wait_for_snapshot(
-                            &intermediate_epoch_id,
-                            try_open,
-                            open_mpt_snapshot,
-                        )?
-                    {
-                        snapshot = guarded_snapshot;
-                        maybe_intermediate_mpt = None;
-                        maybe_intermediate_mpt_key_padding = None;
-                        delta_mpt = match self
-                            .storage_manager
-                            .get_intermediate_mpt(intermediate_epoch_id)?
-                        {
-                            None => {
-                                return {
-                                    warn!(
+                    match self.storage_manager.wait_for_snapshot(
+                        &intermediate_epoch_id,
+                        try_open,
+                        open_mpt_snapshot,
+                    )? {
+                        Some(guarded_snapshot) => {
+                            snapshot = guarded_snapshot;
+                            maybe_intermediate_mpt = None;
+                            maybe_intermediate_mpt_key_padding = None;
+                            delta_mpt = match self
+                                .storage_manager
+                                .get_intermediate_mpt(intermediate_epoch_id)?
+                            {
+                                None => {
+                                    return {
+                                        warn!(
                                     "get_state_trees_for_next_epoch, special case, \
                                     intermediate_mpt not found for epoch {:?}. StateIndex: {:?}.",
                                     intermediate_epoch_id,
                                     parent_state_index,
                                 );
-                                    Ok(None)
+                                        Ok(None)
+                                    }
                                 }
-                            }
-                            Some(delta_mpt) => delta_mpt,
-                        };
-                    } else {
-                        warn!(
+                                Some(delta_mpt) => delta_mpt,
+                            };
+                        }
+                        _ => {
+                            warn!(
                             "get_state_trees_for_next_epoch, special case, \
                             snapshot not found for epoch {:?}. StateIndex: {:?}.",
                             intermediate_epoch_id,
                             parent_state_index,
                         );
-                        return Ok(None);
+                            return Ok(None);
+                        }
                     }
                 }
                 Some(guarded_snapshot) => {

--- a/crates/dbs/storage/src/impls/state_manager.rs
+++ b/crates/dbs/storage/src/impls/state_manager.rs
@@ -171,40 +171,39 @@ impl StateManager {
             None => {
                 // This is the special scenario when the snapshot isn't
                 // available but the snapshot at the intermediate epoch exists.
-                match self.storage_manager.wait_for_snapshot(
-                    &state_index.intermediate_epoch_id,
-                    try_open,
-                    open_mpt_snapshot,
-                )? {
-                    Some(guarded_snapshot) => {
-                        snapshot = guarded_snapshot;
-                        maybe_intermediate_mpt = None;
-                        maybe_intermediate_mpt_key_padding = None;
-                        delta_mpt = match self
-                            .storage_manager
-                            .get_intermediate_mpt(
-                                &state_index.intermediate_epoch_id,
-                            )? {
-                            None => {
-                                warn!(
+                if let Some(guarded_snapshot) =
+                    self.storage_manager.wait_for_snapshot(
+                        &state_index.intermediate_epoch_id,
+                        try_open,
+                        open_mpt_snapshot,
+                    )?
+                {
+                    snapshot = guarded_snapshot;
+                    maybe_intermediate_mpt = None;
+                    maybe_intermediate_mpt_key_padding = None;
+                    delta_mpt = match self
+                        .storage_manager
+                        .get_intermediate_mpt(
+                            &state_index.intermediate_epoch_id,
+                        )? {
+                        None => {
+                            warn!(
                                     "get_state_trees, special case, \
                                     intermediate_mpt not found for epoch {:?}. StateIndex: {:?}.",
                                     state_index.intermediate_epoch_id,
                                     state_index,
                                 );
-                                return Ok(None);
-                            }
-                            Some(delta_mpt) => delta_mpt,
-                        };
-                    }
-                    _ => {
-                        warn!(
-                            "get_state_trees, special case, \
+                            return Ok(None);
+                        }
+                        Some(delta_mpt) => delta_mpt,
+                    };
+                } else {
+                    warn!(
+                        "get_state_trees, special case, \
                          snapshot not found for epoch {:?}. StateIndex: {:?}.",
-                            state_index.intermediate_epoch_id, state_index,
-                        );
-                        return Ok(None);
-                    }
+                        state_index.intermediate_epoch_id, state_index,
+                    );
+                    return Ok(None);
                 }
             }
             Some(guarded_snapshot) => {
@@ -514,42 +513,41 @@ impl StateManager {
                     // This is the special scenario when the snapshot isn't
                     // available but the snapshot at the intermediate epoch
                     // exists.
-                    match self.storage_manager.wait_for_snapshot(
-                        &intermediate_epoch_id,
-                        try_open,
-                        open_mpt_snapshot,
-                    )? {
-                        Some(guarded_snapshot) => {
-                            snapshot = guarded_snapshot;
-                            maybe_intermediate_mpt = None;
-                            maybe_intermediate_mpt_key_padding = None;
-                            delta_mpt = match self
-                                .storage_manager
-                                .get_intermediate_mpt(intermediate_epoch_id)?
-                            {
-                                None => {
-                                    return {
-                                        warn!(
+                    if let Some(guarded_snapshot) =
+                        self.storage_manager.wait_for_snapshot(
+                            &intermediate_epoch_id,
+                            try_open,
+                            open_mpt_snapshot,
+                        )?
+                    {
+                        snapshot = guarded_snapshot;
+                        maybe_intermediate_mpt = None;
+                        maybe_intermediate_mpt_key_padding = None;
+                        delta_mpt = match self
+                            .storage_manager
+                            .get_intermediate_mpt(intermediate_epoch_id)?
+                        {
+                            None => {
+                                return {
+                                    warn!(
                                     "get_state_trees_for_next_epoch, special case, \
                                     intermediate_mpt not found for epoch {:?}. StateIndex: {:?}.",
                                     intermediate_epoch_id,
                                     parent_state_index,
                                 );
-                                        Ok(None)
-                                    }
+                                    Ok(None)
                                 }
-                                Some(delta_mpt) => delta_mpt,
-                            };
-                        }
-                        _ => {
-                            warn!(
+                            }
+                            Some(delta_mpt) => delta_mpt,
+                        };
+                    } else {
+                        warn!(
                             "get_state_trees_for_next_epoch, special case, \
                             snapshot not found for epoch {:?}. StateIndex: {:?}.",
                             intermediate_epoch_id,
                             parent_state_index,
                         );
-                            return Ok(None);
-                        }
+                        return Ok(None);
                     }
                 }
                 Some(guarded_snapshot) => {

--- a/crates/dbs/storage/src/impls/state_manager.rs
+++ b/crates/dbs/storage/src/impls/state_manager.rs
@@ -49,8 +49,9 @@ impl StateManager {
         debug!("Storage conf {:?}", conf);
         // Make sure sqlite temp directory is using the data disk instead of the
         // system disk.
-        // FIXME: Audit that the environment access only happens in
-        // single-threaded code.
+        // SAFETY: Production calls this before starting worker threads. In unit
+        // tests, concurrent environment access is limited to this
+        // `std::env` call.
         unsafe {
             std::env::set_var("SQLITE_TMPDIR", conf.path_snapshot_dir.clone())
         };

--- a/crates/dbs/storage/src/impls/storage_db/snapshot_db_manager_sqlite.rs
+++ b/crates/dbs/storage/src/impls/storage_db/snapshot_db_manager_sqlite.rs
@@ -215,55 +215,51 @@ impl SnapshotDbManagerSqlite {
         // To serialize simultaneous opens.
         let _open_lock = self.open_create_delete_lock.lock();
 
-        match self.open_kv_snapshot_readonly(snapshot_path, try_open)? {
-            Some(snapshot_db) => {
-                let mpt_snapshot_db = if !snapshot_db
-                    .is_mpt_table_in_current_db()
-                    && read_mpt_snapshot
-                {
-                    // Use the existing directory for the specific database (for
-                    // ear checkpoint)
-                    let mpt_snapshot_path = if self
-                        .use_isolated_db_for_mpt_table
-                    {
-                        let mpt_snapshot_path =
-                            self.get_mpt_snapshot_db_path(snapshot_epoch_id);
-                        if mpt_snapshot_path.exists() {
-                            mpt_snapshot_path
-                        } else {
-                            if self.latest_snapshot_id.read().0
-                                == *snapshot_epoch_id
-                            {
-                                self.get_latest_mpt_snapshot_db_path()
-                            } else {
-                                error!("MPT DB not exist, latest snapshot id {:?}, try to open {:?}.", self.latest_snapshot_id.read().0, snapshot_epoch_id);
-                                return Ok(None);
-                            }
-                        }
+        if let Some(snapshot_db) =
+            self.open_kv_snapshot_readonly(snapshot_path, try_open)?
+        {
+            let mpt_snapshot_db = if !snapshot_db.is_mpt_table_in_current_db()
+                && read_mpt_snapshot
+            {
+                // Use the existing directory for the specific database (for ear
+                // checkpoint)
+                let mpt_snapshot_path = if self.use_isolated_db_for_mpt_table {
+                    let mpt_snapshot_path =
+                        self.get_mpt_snapshot_db_path(snapshot_epoch_id);
+                    if mpt_snapshot_path.exists() {
+                        mpt_snapshot_path
                     } else {
-                        error!("MPT table should be in snapshot database.");
-                        return Ok(None);
-                    };
-
-                    let mpt_snapshot_db = self.open_mpt_snapshot_readonly(
-                        mpt_snapshot_path,
-                        try_open,
-                        snapshot_epoch_id,
-                    )?;
-
-                    mpt_snapshot_db
+                        if self.latest_snapshot_id.read().0
+                            == *snapshot_epoch_id
+                        {
+                            self.get_latest_mpt_snapshot_db_path()
+                        } else {
+                            error!("MPT DB not exist, latest snapshot id {:?}, try to open {:?}.", self.latest_snapshot_id.read().0, snapshot_epoch_id);
+                            return Ok(None);
+                        }
+                    }
                 } else {
-                    None
+                    error!("MPT table should be in snapshot database.");
+                    return Ok(None);
                 };
 
-                return Ok(Some(SnapshotDbSqlite {
-                    snapshot_db,
-                    mpt_snapshot_db,
-                }));
-            }
-            _ => {
-                return Ok(None);
-            }
+                let mpt_snapshot_db = self.open_mpt_snapshot_readonly(
+                    mpt_snapshot_path,
+                    try_open,
+                    snapshot_epoch_id,
+                )?;
+
+                mpt_snapshot_db
+            } else {
+                None
+            };
+
+            return Ok(Some(SnapshotDbSqlite {
+                snapshot_db,
+                mpt_snapshot_db,
+            }));
+        } else {
+            return Ok(None);
         }
     }
 

--- a/crates/dbs/storage/src/impls/storage_db/snapshot_db_manager_sqlite.rs
+++ b/crates/dbs/storage/src/impls/storage_db/snapshot_db_manager_sqlite.rs
@@ -215,51 +215,55 @@ impl SnapshotDbManagerSqlite {
         // To serialize simultaneous opens.
         let _open_lock = self.open_create_delete_lock.lock();
 
-        if let Some(snapshot_db) =
-            self.open_kv_snapshot_readonly(snapshot_path, try_open)?
-        {
-            let mpt_snapshot_db = if !snapshot_db.is_mpt_table_in_current_db()
-                && read_mpt_snapshot
-            {
-                // Use the existing directory for the specific database (for ear
-                // checkpoint)
-                let mpt_snapshot_path = if self.use_isolated_db_for_mpt_table {
-                    let mpt_snapshot_path =
-                        self.get_mpt_snapshot_db_path(snapshot_epoch_id);
-                    if mpt_snapshot_path.exists() {
-                        mpt_snapshot_path
-                    } else {
-                        if self.latest_snapshot_id.read().0
-                            == *snapshot_epoch_id
-                        {
-                            self.get_latest_mpt_snapshot_db_path()
+        match self.open_kv_snapshot_readonly(snapshot_path, try_open)? {
+            Some(snapshot_db) => {
+                let mpt_snapshot_db = if !snapshot_db
+                    .is_mpt_table_in_current_db()
+                    && read_mpt_snapshot
+                {
+                    // Use the existing directory for the specific database (for
+                    // ear checkpoint)
+                    let mpt_snapshot_path = if self
+                        .use_isolated_db_for_mpt_table
+                    {
+                        let mpt_snapshot_path =
+                            self.get_mpt_snapshot_db_path(snapshot_epoch_id);
+                        if mpt_snapshot_path.exists() {
+                            mpt_snapshot_path
                         } else {
-                            error!("MPT DB not exist, latest snapshot id {:?}, try to open {:?}.", self.latest_snapshot_id.read().0, snapshot_epoch_id);
-                            return Ok(None);
+                            if self.latest_snapshot_id.read().0
+                                == *snapshot_epoch_id
+                            {
+                                self.get_latest_mpt_snapshot_db_path()
+                            } else {
+                                error!("MPT DB not exist, latest snapshot id {:?}, try to open {:?}.", self.latest_snapshot_id.read().0, snapshot_epoch_id);
+                                return Ok(None);
+                            }
                         }
-                    }
+                    } else {
+                        error!("MPT table should be in snapshot database.");
+                        return Ok(None);
+                    };
+
+                    let mpt_snapshot_db = self.open_mpt_snapshot_readonly(
+                        mpt_snapshot_path,
+                        try_open,
+                        snapshot_epoch_id,
+                    )?;
+
+                    mpt_snapshot_db
                 } else {
-                    error!("MPT table should be in snapshot database.");
-                    return Ok(None);
+                    None
                 };
 
-                let mpt_snapshot_db = self.open_mpt_snapshot_readonly(
-                    mpt_snapshot_path,
-                    try_open,
-                    snapshot_epoch_id,
-                )?;
-
-                mpt_snapshot_db
-            } else {
-                None
-            };
-
-            return Ok(Some(SnapshotDbSqlite {
-                snapshot_db,
-                mpt_snapshot_db,
-            }));
-        } else {
-            return Ok(None);
+                return Ok(Some(SnapshotDbSqlite {
+                    snapshot_db,
+                    mpt_snapshot_db,
+                }));
+            }
+            _ => {
+                return Ok(None);
+            }
         }
     }
 

--- a/crates/dbs/storage/src/impls/storage_db/sqlite.rs
+++ b/crates/dbs/storage/src/impls/storage_db/sqlite.rs
@@ -423,10 +423,12 @@ impl ScopedStatement {
     /// This method is unsafe because it extended the lifetime of Statement to
     /// infinity.
     unsafe fn new<'a>(scoped_statement: Statement<'a>) -> Self {
-        Self {
-            stmt: std::mem::transmute::<Statement<'a>, Statement<'static>>(
-                scoped_statement,
-            ),
+        unsafe {
+            Self {
+                stmt: std::mem::transmute::<Statement<'a>, Statement<'static>>(
+                    scoped_statement,
+                ),
+            }
         }
     }
 

--- a/crates/dbs/storage/src/impls/storage_manager/storage_manager.rs
+++ b/crates/dbs/storage/src/impls/storage_manager/storage_manager.rs
@@ -185,16 +185,17 @@ impl InProgressSnapshotTask {
     // Returns None if the thread has been joined already. Returns the
     // background snapshotting result when the thread is first joined.
     pub fn join(&mut self) -> Option<Result<()>> {
-        match self.thread_handle.take() {
-            Some(join_handle) => match join_handle.join() {
+        if let Some(join_handle) = self.thread_handle.take() {
+            match join_handle.join() {
                 Ok(task_result) => Some(task_result),
                 Err(_) => Some(Err(Error::ThreadPanicked(format!(
                     "Background Snapshotting for {:?} panicked.",
                     self.snapshot_info
                 ))
                 .into())),
-            },
-            _ => None,
+            }
+        } else {
+            None
         }
     }
 }
@@ -344,34 +345,33 @@ impl StorageManager {
                 drop(_snapshot_info_lock);
                 drop(guard);
                 // Wait for in progress snapshot.
-                match self
+                if let Some(in_progress_snapshot_task) = self
                     .in_progress_snapshotting_tasks
                     .read()
                     .get(snapshot_epoch_id)
                     .cloned()
                 {
-                    Some(in_progress_snapshot_task) => {
-                        // Snapshotting error is thrown-out when the snapshot is
-                        // first requested here.
-                        if let Some(result) =
-                            in_progress_snapshot_task.write().join()
-                        {
-                            result?;
-                        }
-                        let guard = self.current_snapshots.read();
-                        match self.snapshot_manager.get_snapshot_by_epoch_id(
-                            snapshot_epoch_id,
-                            try_open,
-                            open_mpt_snapshot,
-                        ) {
-                            Err(e) => Err(e),
-                            Ok(None) => Ok(None),
-                            Ok(Some(snapshot_db)) => {
-                                Ok(Some(GuardedValue::new(guard, snapshot_db)))
-                            }
+                    // Snapshotting error is thrown-out when the snapshot is
+                    // first requested here.
+                    if let Some(result) =
+                        in_progress_snapshot_task.write().join()
+                    {
+                        result?;
+                    }
+                    let guard = self.current_snapshots.read();
+                    match self.snapshot_manager.get_snapshot_by_epoch_id(
+                        snapshot_epoch_id,
+                        try_open,
+                        open_mpt_snapshot,
+                    ) {
+                        Err(e) => Err(e),
+                        Ok(None) => Ok(None),
+                        Ok(Some(snapshot_db)) => {
+                            Ok(Some(GuardedValue::new(guard, snapshot_db)))
                         }
                     }
-                    _ => Ok(None),
+                } else {
+                    Ok(None)
                 }
             }
         }

--- a/crates/dbs/storage/src/impls/storage_manager/storage_manager.rs
+++ b/crates/dbs/storage/src/impls/storage_manager/storage_manager.rs
@@ -185,17 +185,16 @@ impl InProgressSnapshotTask {
     // Returns None if the thread has been joined already. Returns the
     // background snapshotting result when the thread is first joined.
     pub fn join(&mut self) -> Option<Result<()>> {
-        if let Some(join_handle) = self.thread_handle.take() {
-            match join_handle.join() {
+        match self.thread_handle.take() {
+            Some(join_handle) => match join_handle.join() {
                 Ok(task_result) => Some(task_result),
                 Err(_) => Some(Err(Error::ThreadPanicked(format!(
                     "Background Snapshotting for {:?} panicked.",
                     self.snapshot_info
                 ))
                 .into())),
-            }
-        } else {
-            None
+            },
+            _ => None,
         }
     }
 }
@@ -345,33 +344,34 @@ impl StorageManager {
                 drop(_snapshot_info_lock);
                 drop(guard);
                 // Wait for in progress snapshot.
-                if let Some(in_progress_snapshot_task) = self
+                match self
                     .in_progress_snapshotting_tasks
                     .read()
                     .get(snapshot_epoch_id)
                     .cloned()
                 {
-                    // Snapshotting error is thrown-out when the snapshot is
-                    // first requested here.
-                    if let Some(result) =
-                        in_progress_snapshot_task.write().join()
-                    {
-                        result?;
-                    }
-                    let guard = self.current_snapshots.read();
-                    match self.snapshot_manager.get_snapshot_by_epoch_id(
-                        snapshot_epoch_id,
-                        try_open,
-                        open_mpt_snapshot,
-                    ) {
-                        Err(e) => Err(e),
-                        Ok(None) => Ok(None),
-                        Ok(Some(snapshot_db)) => {
-                            Ok(Some(GuardedValue::new(guard, snapshot_db)))
+                    Some(in_progress_snapshot_task) => {
+                        // Snapshotting error is thrown-out when the snapshot is
+                        // first requested here.
+                        if let Some(result) =
+                            in_progress_snapshot_task.write().join()
+                        {
+                            result?;
+                        }
+                        let guard = self.current_snapshots.read();
+                        match self.snapshot_manager.get_snapshot_by_epoch_id(
+                            snapshot_epoch_id,
+                            try_open,
+                            open_mpt_snapshot,
+                        ) {
+                            Err(e) => Err(e),
+                            Ok(None) => Ok(None),
+                            Ok(Some(snapshot_db)) => {
+                                Ok(Some(GuardedValue::new(guard, snapshot_db)))
+                            }
                         }
                     }
-                } else {
-                    Ok(None)
+                    _ => Ok(None),
                 }
             }
         }

--- a/crates/dbs/storage/src/utils/mod.rs
+++ b/crates/dbs/storage/src/utils/mod.rs
@@ -91,7 +91,7 @@ impl<T: Sized> UnsafeCellExtension<T> for UnsafeCell<T> {
 
     fn get_mut(&mut self) -> &mut T { unsafe { &mut *self.get() } }
 
-    unsafe fn get_as_mut(&self) -> &mut T { &mut *self.get() }
+    unsafe fn get_as_mut(&self) -> &mut T { unsafe { &mut *self.get() } }
 }
 
 /// Only used by storage benchmark due to incompatibility of rlp crate version.

--- a/crates/eest_types/Cargo.toml
+++ b/crates/eest_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eest_types"
-edition = "2021"
+edition = "2024"
 description = "Ethereum execution spec test types"
 version.workspace = true
 authors.workspace = true

--- a/crates/execution/cfx-vm-tracer-derive/Cargo.toml
+++ b/crates/execution/cfx-vm-tracer-derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cfx-vm-tracer-derive"
 version = "0.1.0"
 authors = ["Your Name <your.email@example.com>"]
-edition = "2021"
+edition = "2024"
 license-file.workspace = true
 
 # Set the crate type to "proc-macro"

--- a/crates/execution/cfx-vm-tracer-derive/src/lib.rs
+++ b/crates/execution/cfx-vm-tracer-derive/src/lib.rs
@@ -5,7 +5,7 @@ use syn::{Data, DataStruct, DeriveInput, Error, Fields, Ident};
 type Result<T> = std::result::Result<T, Error>;
 
 macro_rules! unwrap_or_compile_error {
-    ($e:expr) => {
+    ($e:expr_2021) => {
         match $e {
             Ok(x) => x,
             Err(e) => return e.into_compile_error().into(),

--- a/crates/execution/execute-helper/Cargo.toml
+++ b/crates/execution/execute-helper/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "https://www.confluxnetwork.org"
 license = "GPL-3.0"
 name = "cfx-execute-helper"
 version = "2.0.2"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 cfx-parameters = { workspace = true }

--- a/crates/execution/executor/Cargo.toml
+++ b/crates/execution/executor/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "https://www.confluxnetwork.org"
 license = "GPL-3.0"
 name = "cfx-executor"
 version = "2.0.2"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 substrate-bn = { workspace = true, default-features = false }

--- a/crates/execution/executor/src/builtin/bls12_381/mod.rs
+++ b/crates/execution/executor/src/builtin/bls12_381/mod.rs
@@ -49,7 +49,7 @@ pub fn bls12_builtin_factory(name: &str) -> Box<dyn Precompile> {
 }
 
 macro_rules! bls12_precompile {
-    ($address:expr, $price_fn:path, $impl_fn:path) => {
+    ($address:expr_2021, $price_fn:path, $impl_fn:path) => {
         (
             $address,
             Box::new(StaticPlan($price_fn())),

--- a/crates/execution/executor/src/executive/fresh_executive.rs
+++ b/crates/execution/executor/src/executive/fresh_executive.rs
@@ -17,7 +17,7 @@ use primitives::{
 };
 
 macro_rules! early_return_on_err {
-    ($e:expr) => {
+    ($e:expr_2021) => {
         match $e {
             Ok(x) => x,
             Err(exec_outcom) => {

--- a/crates/execution/executor/src/internal_contract/components/activation.rs
+++ b/crates/execution/executor/src/internal_contract/components/activation.rs
@@ -9,7 +9,7 @@ macro_rules! group_impl_is_active {
     ("genesis" $(, $name:ident)* $(,)?) => {
         group_impl_is_active!(|_| true $(, $name)*);
     };
-    ($is_active:expr $(, $name:ident)* $(,)?) => {
+    ($is_active:expr_2021 $(, $name:ident)* $(,)?) => {
         $(impl IsActive for $name {
             fn is_active(&self, spec: &Spec) -> bool { $is_active(spec) }
         })*

--- a/crates/execution/executor/src/internal_contract/components/contract.rs
+++ b/crates/execution/executor/src/internal_contract/components/contract.rs
@@ -83,17 +83,17 @@ fn load_solidity_fn<'a>(
 /// A marco to implement an internal contract.
 #[macro_export]
 macro_rules! make_solidity_contract {
-    ( $(#[$attr:meta])* $visibility:vis struct $name:ident ($addr:expr, "placeholder"); ) => {
+    ( $(#[$attr:meta])* $visibility:vis struct $name:ident ($addr:expr_2021, "placeholder"); ) => {
         $crate::make_solidity_contract! {
             $(#[$attr])* $visibility struct $name ($addr, || Default::default(), initialize: |_: &CommonParams| u64::MAX, is_active: |_: &Spec| false);
         }
     };
-    ( $(#[$attr:meta])* $visibility:vis struct $name:ident ($addr:expr, $gen_table:expr, "active_at_genesis"); ) => {
+    ( $(#[$attr:meta])* $visibility:vis struct $name:ident ($addr:expr_2021, $gen_table:expr_2021, "active_at_genesis"); ) => {
         $crate::make_solidity_contract! {
             $(#[$attr])* $visibility struct $name ($addr, $gen_table, initialize: |_: &CommonParams| 0u64, is_active: |_: &Spec| true);
         }
     };
-    ( $(#[$attr:meta])* $visibility:vis struct $name:ident ($addr:expr, $gen_table:expr, initialize: $init:expr, is_active: $is_active:expr); ) => {
+    ( $(#[$attr:meta])* $visibility:vis struct $name:ident ($addr:expr_2021, $gen_table:expr_2021, initialize: $init:expr_2021, is_active: $is_active:expr_2021); ) => {
         $(#[$attr])*
         $visibility struct $name {
             function_table: SolFnTable

--- a/crates/execution/executor/src/internal_contract/components/event.rs
+++ b/crates/execution/executor/src/internal_contract/components/event.rs
@@ -26,7 +26,7 @@ pub trait SolidityEventTrait: Send + Sync {
 
 #[macro_export]
 macro_rules! make_solidity_event {
-    ( $(#[$attr:meta])* $visibility:vis struct $name:ident ($interface:expr $(, indexed: $indexed:ty)? $(, non_indexed: $non_indexed:ty)?); ) => {
+    ( $(#[$attr:meta])* $visibility:vis struct $name:ident ($interface:expr_2021 $(, indexed: $indexed:ty)? $(, non_indexed: $non_indexed:ty)?); ) => {
         $(#[$attr])*
         #[derive(Copy, Clone)]
         $visibility struct $name;

--- a/crates/execution/executor/src/internal_contract/components/function.rs
+++ b/crates/execution/executor/src/internal_contract/components/function.rs
@@ -197,12 +197,12 @@ impl<T: PreExecCheckConfTrait> PreExecCheckTrait for T {
 /// ```
 /// If the function has no return value, the third parameter can be omitted.
 macro_rules! make_solidity_function {
-    ( $(#[$attr:meta])* $visibility:vis struct $name:ident ($input:ty, $interface:expr ); ) => {
+    ( $(#[$attr:meta])* $visibility:vis struct $name:ident ($input:ty, $interface:expr_2021 ); ) => {
         $crate::make_solidity_function! {
             $(#[$attr])* $visibility struct $name ($input, $interface, () );
         }
     };
-    ( $(#[$attr:meta])* $visibility:vis struct $name:ident ($input:ty, $interface:expr, $output:ty ); ) => {
+    ( $(#[$attr:meta])* $visibility:vis struct $name:ident ($input:ty, $interface:expr_2021, $output:ty ); ) => {
         $(#[$attr])*
         #[derive(Copy, Clone)]
         $visibility struct $name {
@@ -228,16 +228,16 @@ macro_rules! make_solidity_function {
 
 #[macro_export]
 macro_rules! impl_function_type {
-    ( $name:ident, "non_payable_write" $(, gas: $gas:expr)? ) => {
+    ( $name:ident, "non_payable_write" $(, gas: $gas:expr_2021)? ) => {
         $crate::impl_function_type!(@inner, $name, false, true $(, $gas)?);
     };
-    ( $name:ident, "payable_write" $(, gas: $gas:expr)? ) => {
+    ( $name:ident, "payable_write" $(, gas: $gas:expr_2021)? ) => {
         $crate::impl_function_type!(@inner, $name, true, true $(, $gas)?);
     };
-    ( $name:ident, "query" $(, gas: $gas:expr)? ) => {
+    ( $name:ident, "query" $(, gas: $gas:expr_2021)? ) => {
         $crate::impl_function_type!(@inner, $name, false, false $(, $gas)?);
     };
-    ( @inner, $name:ident, $payable:expr, $has_write_op:expr $(, $gas:expr)? ) => {
+    ( @inner, $name:ident, $payable:expr_2021, $has_write_op:expr_2021 $(, $gas:expr_2021)? ) => {
         impl PreExecCheckConfTrait for $name {
             const PAYABLE: bool = $payable;
             const HAS_WRITE_OP: bool = $has_write_op;

--- a/crates/execution/executor/src/internal_contract/contracts/cross_space.rs
+++ b/crates/execution/executor/src/internal_contract/contracts/cross_space.rs
@@ -129,8 +129,8 @@ impl_function_type!(CallToEVM, "payable_write");
 
 impl UpfrontPaymentTrait for CallToEVM {
     fn upfront_gas_payment(
-        &self, (ref receiver, ref data): &(Bytes20, Bytes),
-        params: &ActionParams, context: &InternalRefContext,
+        &self, (receiver, data): &(Bytes20, Bytes), params: &ActionParams,
+        context: &InternalRefContext,
     ) -> DbResult<U256> {
         call_gas(H160(*receiver), params, context, data)
     }

--- a/crates/execution/executor/src/internal_contract/utils.rs
+++ b/crates/execution/executor/src/internal_contract/utils.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 #[macro_export]
 macro_rules! check_func_signature {
-    ($interface:ident, $signature:expr) => {
+    ($interface:ident, $signature:expr_2021) => {
         assert_eq!(
             $interface::FUNC_SIG.to_vec(),
             $signature.from_hex::<Vec<u8>>().unwrap(),
@@ -14,7 +14,7 @@ macro_rules! check_func_signature {
 #[cfg(test)]
 #[macro_export]
 macro_rules! check_event_signature {
-    ($interface:ident, $signature:expr) => {
+    ($interface:ident, $signature:expr_2021) => {
         assert_eq!(
             $interface::EVENT_SIG.0.to_vec(),
             $signature.from_hex::<Vec<u8>>().unwrap(),
@@ -25,10 +25,10 @@ macro_rules! check_event_signature {
 
 #[macro_export]
 macro_rules! internal_bail {
-    ($e:expr) => {
+    ($e:expr_2021) => {
         return Err(cfx_vm_types::Error::InternalContract($e.into()));
     };
-    ($fmt:expr, $($arg:tt)+) => {
+    ($fmt:expr_2021, $($arg:tt)+) => {
         return Err(cfx_vm_types::Error::InternalContract(format!($fmt, $($arg)+)));
     };
 }

--- a/crates/execution/executor/src/macros.rs
+++ b/crates/execution/executor/src/macros.rs
@@ -1,6 +1,6 @@
 #[macro_export]
 macro_rules! try_loaded {
-    ($expr:expr) => {
+    ($expr:expr_2021) => {
         match $expr {
             Err(e) => {
                 return Err(e);
@@ -15,7 +15,7 @@ macro_rules! try_loaded {
 
 #[macro_export]
 macro_rules! return_if {
-    ($expr:expr) => {
+    ($expr:expr_2021) => {
         if $expr {
             return Ok(Default::default());
         }
@@ -24,13 +24,13 @@ macro_rules! return_if {
 
 #[macro_export]
 macro_rules! unwrap_or_return {
-    ($option:expr) => {
+    ($option:expr_2021) => {
         match $option {
             Some(val) => val,
             None => return Default::default(),
         }
     };
-    ($option:expr, $ret:expr) => {
+    ($option:expr_2021, $ret:expr_2021) => {
         match $option {
             Some(val) => val,
             None => return $ret,

--- a/crates/execution/executor/src/state/checkpoints/lazy_discarded_vec.rs
+++ b/crates/execution/executor/src/state/checkpoints/lazy_discarded_vec.rs
@@ -72,7 +72,7 @@ impl<T: CheckpointLayerTrait> LazyDiscardedVec<T> {
 
     pub fn revert_to_checkpoint(
         &mut self,
-    ) -> Option<impl Iterator<Item = (usize, T)>> {
+    ) -> Option<impl Iterator<Item = (usize, T)> + use<T>> {
         let first_layer_id = self.bundle_start_indices.pop()?;
         assert!(first_layer_id < self.total_len());
         let last_layer_id = self.total_len() - 1;

--- a/crates/execution/executor/src/state/state_object/basic_fields.rs
+++ b/crates/execution/executor/src/state/state_object/basic_fields.rs
@@ -201,12 +201,11 @@ impl State {
         &self, address: &AddressWithSpace, transaction_hash: H256,
     ) -> DbResult<bool> {
         Ok(
-            if let Some(acc) =
-                self.read_account_ext_lock(&address, RequireFields::None)?
-            {
-                acc.create_transaction_hash() == Some(transaction_hash)
-            } else {
-                false
+            match self.read_account_ext_lock(&address, RequireFields::None)? {
+                Some(acc) => {
+                    acc.create_transaction_hash() == Some(transaction_hash)
+                }
+                _ => false,
             },
         )
     }

--- a/crates/execution/executor/src/state/state_object/basic_fields.rs
+++ b/crates/execution/executor/src/state/state_object/basic_fields.rs
@@ -201,11 +201,12 @@ impl State {
         &self, address: &AddressWithSpace, transaction_hash: H256,
     ) -> DbResult<bool> {
         Ok(
-            match self.read_account_ext_lock(&address, RequireFields::None)? {
-                Some(acc) => {
-                    acc.create_transaction_hash() == Some(transaction_hash)
-                }
-                _ => false,
+            if let Some(acc) =
+                self.read_account_ext_lock(&address, RequireFields::None)?
+            {
+                acc.create_transaction_hash() == Some(transaction_hash)
+            } else {
+                false
             },
         )
     }

--- a/crates/execution/executor/src/state/state_object/checkpoints.rs
+++ b/crates/execution/executor/src/state/state_object/checkpoints.rs
@@ -67,7 +67,7 @@ impl State {
         // cleared directly, thus, the accounts in state's cache should
         // all discard all checkpoints
         for addr in cleared_addresses {
-            if let Some(AccountEntry::Cached(ref mut overlay_account, _dirty)) =
+            if let Some(AccountEntry::Cached(overlay_account, _dirty)) =
                 self.cache.get_mut().get_mut(&addr).map(|x| &mut x.entry)
             {
                 overlay_account.clear_checkpoint();

--- a/crates/execution/executor/src/state/state_object/storage_entry.rs
+++ b/crates/execution/executor/src/state/state_object/storage_entry.rs
@@ -183,7 +183,7 @@ impl State {
             for checkpoint in &mut checkpoints_iter {
                 match checkpoint.as_hash_map().get(address) {
                     Some(Recorded(AccountEntryWithWarm {
-                        entry: AccountEntry::Cached(ref account, _),
+                        entry: AccountEntry::Cached(account, _),
                         ..
                     })) => {
                         first_account = Some(account);
@@ -230,7 +230,7 @@ impl State {
                 let mut require_cache = true;
                 for checkpoint in checkpoints_iter {
                     if let Some(Recorded(AccountEntryWithWarm {
-                        entry: AccountEntry::Cached(ref account, _),
+                        entry: AccountEntry::Cached(account, _),
                         ..
                     })) = checkpoint.as_hash_map().get(address)
                     {
@@ -257,7 +257,7 @@ impl State {
                 if !account_changed && require_cache {
                     let outer_cache = self.cache.read();
                     if let Some(AccountEntryWithWarm {
-                        entry: AccountEntry::Cached(ref account, _),
+                        entry: AccountEntry::Cached(account, _),
                         ..
                     }) = outer_cache.get(address)
                     {

--- a/crates/execution/geth-tracer/Cargo.toml
+++ b/crates/execution/geth-tracer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geth-tracer"
-edition = "2021"
+edition = "2024"
 version.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/execution/parity-trace-types/Cargo.toml
+++ b/crates/execution/parity-trace-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfx-parity-trace-types"
-edition = "2021"
+edition = "2024"
 version.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/execution/solidity-abi-derive/Cargo.toml
+++ b/crates/execution/solidity-abi-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solidity-abi-derive"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license-file.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/execution/solidity-abi/Cargo.toml
+++ b/crates/execution/solidity-abi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solidity-abi"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license-file.workspace = true
 
 [dependencies]

--- a/crates/execution/vm-interpreter/Cargo.toml
+++ b/crates/execution/vm-interpreter/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "https://www.confluxnetwork.org"
 license = "GPL-3.0"
 name = "cfx-vm-interpreter"
 version = "2.0.2"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 bit-set = { workspace = true }

--- a/crates/execution/vm-interpreter/src/instructions.rs
+++ b/crates/execution/vm-interpreter/src/instructions.rs
@@ -28,7 +28,7 @@ macro_rules! enum_with_from_u8 {
 	(
 		$( #[$enum_attr:meta] )*
 		pub enum $name:ident {
-			$( $( #[$variant_attr:meta] )* $variant:ident = $discriminator:expr ),+,
+			$( $( #[$variant_attr:meta] )* $variant:ident = $discriminator:expr_2021 ),+,
 		}
 	) => {
 		$( #[$enum_attr] )*

--- a/crates/execution/vm-interpreter/src/interpreter/gasometer.rs
+++ b/crates/execution/vm-interpreter/src/interpreter/gasometer.rs
@@ -32,7 +32,7 @@ use super::{
 use crate::CostType;
 
 macro_rules! overflowing {
-    ($x:expr) => {{
+    ($x:expr_2021) => {{
         let (v, overflow) = $x;
         if overflow {
             return Err(vm::Error::OutOfGas);

--- a/crates/execution/vm-interpreter/src/interpreter/informant.rs
+++ b/crates/execution/vm-interpreter/src/interpreter/informant.rs
@@ -24,7 +24,7 @@ pub use self::inner::*;
 #[cfg(not(feature = "evm-debug"))]
 mod inner {
     macro_rules! evm_debug {
-        ($x:expr) => {};
+        ($x:expr_2021) => {};
     }
 
     pub struct EvmInformant;

--- a/crates/execution/vm-types/Cargo.toml
+++ b/crates/execution/vm-types/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "https://www.confluxnetwork.org"
 license = "GPL-3.0"
 name = "cfx-vm-types"
 version = "2.0.2"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 cfx-bytes = { workspace = true }

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "network"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license-file.workspace = true
 
 [dependencies]

--- a/crates/network/src/service.rs
+++ b/crates/network/src/service.rs
@@ -1050,11 +1050,10 @@ impl NetworkServiceInner {
         let mut kill = false;
         let mut token_to_disconnect = None;
 
-        let session = match self.sessions.get(stream) {
-            Some(session) => session,
-            _ => {
-                return;
-            }
+        let session = if let Some(session) = self.sessions.get(stream) {
+            session
+        } else {
+            return;
         };
 
         // We check dropped_nodes first to make sure we stop processing
@@ -1736,18 +1735,19 @@ impl IoHandler<NetworkIoMessage> for NetworkServiceInner {
             NetworkIoMessage::DispatchWork {
                 protocol,
                 work_type,
-            } => match self.handlers.read().get(protocol).cloned() {
-                Some(handler) => {
+            } => {
+                if let Some(handler) =
+                    self.handlers.read().get(protocol).cloned()
+                {
                     let network_context =
                         NetworkContext::new(io, handler, *protocol, self);
                     network_context
                         .protocol_handler()
                         .on_work_dispatch(&network_context, *work_type);
-                }
-                _ => {
+                } else {
                     warn!("Work is dispatched to unknown handler");
                 }
-            },
+            }
             NetworkIoMessage::HandleProtocolMessage {
                 protocol,
                 peer: _,
@@ -1755,19 +1755,18 @@ impl IoHandler<NetworkIoMessage> for NetworkServiceInner {
                 data,
             } => {
                 debug!("Receive ProtocolMsg {:?}", protocol);
-                match self.handlers.read().get(protocol).cloned() {
-                    Some(handler) => {
-                        let network_context =
-                            NetworkContext::new(io, handler, *protocol, self);
-                        network_context.protocol_handler().on_message(
-                            &network_context,
-                            node_id,
-                            data,
-                        );
-                    }
-                    _ => {
-                        warn!("Work is handled by unknown handler");
-                    }
+                if let Some(handler) =
+                    self.handlers.read().get(protocol).cloned()
+                {
+                    let network_context =
+                        NetworkContext::new(io, handler, *protocol, self);
+                    network_context.protocol_handler().on_message(
+                        &network_context,
+                        node_id,
+                        data,
+                    );
+                } else {
+                    warn!("Work is handled by unknown handler");
                 }
             }
         }

--- a/crates/network/src/service.rs
+++ b/crates/network/src/service.rs
@@ -1050,10 +1050,11 @@ impl NetworkServiceInner {
         let mut kill = false;
         let mut token_to_disconnect = None;
 
-        let session = if let Some(session) = self.sessions.get(stream) {
-            session
-        } else {
-            return;
+        let session = match self.sessions.get(stream) {
+            Some(session) => session,
+            _ => {
+                return;
+            }
         };
 
         // We check dropped_nodes first to make sure we stop processing
@@ -1709,9 +1710,9 @@ impl IoHandler<NetworkIoMessage> for NetworkServiceInner {
                 callback.send(()).expect("protocol register error");
             }
             NetworkIoMessage::AddTimer {
-                ref protocol,
-                ref delay,
-                ref token,
+                protocol,
+                delay,
+                token,
             } => {
                 let handler_token = {
                     let mut timer_counter = self.timer_counter.write();
@@ -1733,40 +1734,40 @@ impl IoHandler<NetworkIoMessage> for NetworkServiceInner {
                     });
             }
             NetworkIoMessage::DispatchWork {
-                ref protocol,
-                ref work_type,
-            } => {
-                if let Some(handler) =
-                    self.handlers.read().get(protocol).cloned()
-                {
+                protocol,
+                work_type,
+            } => match self.handlers.read().get(protocol).cloned() {
+                Some(handler) => {
                     let network_context =
                         NetworkContext::new(io, handler, *protocol, self);
                     network_context
                         .protocol_handler()
                         .on_work_dispatch(&network_context, *work_type);
-                } else {
+                }
+                _ => {
                     warn!("Work is dispatched to unknown handler");
                 }
-            }
+            },
             NetworkIoMessage::HandleProtocolMessage {
-                ref protocol,
+                protocol,
                 peer: _,
-                ref node_id,
-                ref data,
+                node_id,
+                data,
             } => {
                 debug!("Receive ProtocolMsg {:?}", protocol);
-                if let Some(handler) =
-                    self.handlers.read().get(protocol).cloned()
-                {
-                    let network_context =
-                        NetworkContext::new(io, handler, *protocol, self);
-                    network_context.protocol_handler().on_message(
-                        &network_context,
-                        node_id,
-                        data,
-                    );
-                } else {
-                    warn!("Work is handled by unknown handler");
+                match self.handlers.read().get(protocol).cloned() {
+                    Some(handler) => {
+                        let network_context =
+                            NetworkContext::new(io, handler, *protocol, self);
+                        network_context.protocol_handler().on_message(
+                            &network_context,
+                            node_id,
+                            data,
+                        );
+                    }
+                    _ => {
+                        warn!("Work is handled by unknown handler");
+                    }
                 }
             }
         }

--- a/crates/parameters/Cargo.toml
+++ b/crates/parameters/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "https://www.confluxnetwork.org"
 license = "GPL-3.0"
 name = "cfx-parameters"
 version = "1.0.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 cfx-types = { workspace = true }

--- a/crates/pos/common/bounded-executor/Cargo.toml
+++ b/crates/pos/common/bounded-executor/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/diem/diem"
 homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
-edition = "2018"
+edition = "2024"
 
 [dependencies]
 futures = { workspace = true }

--- a/crates/pos/common/channel/Cargo.toml
+++ b/crates/pos/common/channel/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/diem/diem"
 homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
-edition = "2018"
+edition = "2024"
 
 [dependencies]
 anyhow = "1.0.38"

--- a/crates/pos/common/channel/src/diem_channel.rs
+++ b/crates/pos/common/channel/src/diem_channel.rs
@@ -183,18 +183,24 @@ impl<K: Eq + Hash + Clone, M> Stream for Receiver<K, M> {
         self: Pin<&mut Self>, cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         let mut shared_state = self.shared_state.lock();
-        if let Some((val, status_ch)) = shared_state.internal_queue.pop() {
-            if let Some(status_ch) = status_ch {
-                let _err = status_ch.send(ElementStatus::Dequeued);
+        match shared_state.internal_queue.pop() {
+            Some((val, status_ch)) => {
+                if let Some(status_ch) = status_ch {
+                    let _err = status_ch.send(ElementStatus::Dequeued);
+                }
+                Poll::Ready(Some(val))
+                // all senders have been dropped (and so the stream is
+                // terminated)
             }
-            Poll::Ready(Some(val))
-        // all senders have been dropped (and so the stream is terminated)
-        } else if shared_state.num_senders == 0 {
-            shared_state.stream_terminated = true;
-            Poll::Ready(None)
-        } else {
-            shared_state.waker = Some(cx.waker().clone());
-            Poll::Pending
+            _ => {
+                if shared_state.num_senders == 0 {
+                    shared_state.stream_terminated = true;
+                    Poll::Ready(None)
+                } else {
+                    shared_state.waker = Some(cx.waker().clone());
+                    Poll::Pending
+                }
+            }
         }
     }
 }

--- a/crates/pos/common/channel/src/diem_channel.rs
+++ b/crates/pos/common/channel/src/diem_channel.rs
@@ -183,24 +183,18 @@ impl<K: Eq + Hash + Clone, M> Stream for Receiver<K, M> {
         self: Pin<&mut Self>, cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         let mut shared_state = self.shared_state.lock();
-        match shared_state.internal_queue.pop() {
-            Some((val, status_ch)) => {
-                if let Some(status_ch) = status_ch {
-                    let _err = status_ch.send(ElementStatus::Dequeued);
-                }
-                Poll::Ready(Some(val))
-                // all senders have been dropped (and so the stream is
-                // terminated)
+        if let Some((val, status_ch)) = shared_state.internal_queue.pop() {
+            if let Some(status_ch) = status_ch {
+                let _err = status_ch.send(ElementStatus::Dequeued);
             }
-            _ => {
-                if shared_state.num_senders == 0 {
-                    shared_state.stream_terminated = true;
-                    Poll::Ready(None)
-                } else {
-                    shared_state.waker = Some(cx.waker().clone());
-                    Poll::Pending
-                }
-            }
+            Poll::Ready(Some(val))
+        // all senders have been dropped (and so the stream is terminated)
+        } else if shared_state.num_senders == 0 {
+            shared_state.stream_terminated = true;
+            Poll::Ready(None)
+        } else {
+            shared_state.waker = Some(cx.waker().clone());
+            Poll::Pending
         }
     }
 }

--- a/crates/pos/common/logger/Cargo.toml
+++ b/crates/pos/common/logger/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/diem/diem"
 homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
-edition = "2018"
+edition = "2024"
 
 # Do NOT add any inter-project dependencies.
 # This is to avoid ever having a circular dependency with the diem-logger crate.

--- a/crates/pos/common/logger/derive/Cargo.toml
+++ b/crates/pos/common/logger/derive/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/diem/diem"
 homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
-edition = "2018"
+edition = "2024"
 
 [lib]
 proc-macro = true

--- a/crates/pos/common/logger/src/json_log.rs
+++ b/crates/pos/common/logger/src/json_log.rs
@@ -30,7 +30,7 @@ const MAX_EVENTS_IN_QUEUE: usize = 10_000;
 // TODO: ideally we want to unify it with existing logger
 #[macro_export]
 macro_rules! event {
-    ($name:expr, $($json:tt)*) => {
+    ($name:expr_2021, $($json:tt)*) => {
         $crate::json_log::send_json_log($crate::json_log::JsonLogEntry::new(
             $name,
             serde_json::json!({$($json)+}),

--- a/crates/pos/common/logger/src/macros.rs
+++ b/crates/pos/common/logger/src/macros.rs
@@ -12,7 +12,7 @@
 #[macro_export]
 macro_rules! log {
     // Entry, Log Level + stuff
-    ($level:expr, $($args:tt)+) => {{
+    ($level:expr_2021, $($args:tt)+) => {{
         const METADATA: $crate::Metadata = $crate::Metadata::new(
             $level,
             env!("CARGO_CRATE_NAME"),
@@ -78,7 +78,7 @@ macro_rules! schema {
     //
     // base case
     //
-    (@ { $(,)* $($val:expr),* $(,)* } $(,)*) => {
+    (@ { $(,)* $($val:expr_2021),* $(,)* } $(,)*) => {
         &[ $($val),* ]
     };
 
@@ -87,109 +87,109 @@ macro_rules! schema {
     //
 
     // format args
-    (@ { $(,)* $($out:expr),* }, $template:literal, $($args:tt)*) => {
+    (@ { $(,)* $($out:expr_2021),* }, $template:literal, $($args:tt)*) => {
         $crate::schema!(
             @ { $($out),* }
         )
     };
-    (@ { $(,)* $($out:expr),* }, $template:literal) => {
+    (@ { $(,)* $($out:expr_2021),* }, $template:literal) => {
         $crate::schema!(
             @ { $($out),* }
         )
     };
 
     // Identifier Keys
-    (@ { $(,)* $($out:expr),* }, $($k:ident).+ = $val:expr, $($args:tt)*) => {
+    (@ { $(,)* $($out:expr_2021),* }, $($k:ident).+ = $val:expr_2021, $($args:tt)*) => {
         $crate::schema!(
             @ { $($out),*, &$crate::KeyValue::new($crate::__log_stringify!($($k).+), $crate::Value::from_serde(&$val)) },
             $($args)*
         )
     };
 
-    (@ { $(,)* $($out:expr),* }, $($k:ident).+ = $val:expr) => {
+    (@ { $(,)* $($out:expr_2021),* }, $($k:ident).+ = $val:expr_2021) => {
         $crate::schema!(
             @ { $($out),*, &$crate::KeyValue::new($crate::__log_stringify!($($k).+), $crate::Value::from_serde(&$val)) },
         )
     };
 
     // Identifier Keys debug
-    (@ { $(,)* $($out:expr),* }, $($k:ident).+ = ?$val:expr, $($args:tt)*) => {
+    (@ { $(,)* $($out:expr_2021),* }, $($k:ident).+ = ?$val:expr_2021, $($args:tt)*) => {
         $crate::schema!(
             @ { $($out),*, &$crate::KeyValue::new($crate::__log_stringify!($($k).+), $crate::Value::from_debug(&$val)) },
             $($args)*
         )
     };
 
-    (@ { $(,)* $($out:expr),* }, $($k:ident).+ = ?$val:expr) => {
+    (@ { $(,)* $($out:expr_2021),* }, $($k:ident).+ = ?$val:expr_2021) => {
         $crate::schema!(
             @ { $($out),*, &$crate::KeyValue::new($crate::__log_stringify!($($k).+), $crate::Value::from_debug($val)) },
         )
     };
 
     // Identifier Keys display
-    (@ { $(,)* $($out:expr),* }, $($k:ident).+ = %$val:expr, $($args:tt)*) => {
+    (@ { $(,)* $($out:expr_2021),* }, $($k:ident).+ = %$val:expr_2021, $($args:tt)*) => {
         $crate::schema!(
             @ { $($out),*, &$crate::KeyValue::new($crate::__log_stringify!($($k).+), $crate::Value::from_display(&$val)) },
             $($args)*
         )
     };
 
-    (@ { $(,)* $($out:expr),* }, $($k:ident).+ = %$val:expr) => {
+    (@ { $(,)* $($out:expr_2021),* }, $($k:ident).+ = %$val:expr_2021) => {
         $crate::schema!(
             @ { $($out),*, &$crate::KeyValue::new($crate::__log_stringify!($($k).+), $crate::Value::from_display(&$val)) },
         )
     };
 
     // Literal Keys
-    (@ { $(,)* $($out:expr),* }, $k:literal = $val:expr, $($args:tt)*) => {
+    (@ { $(,)* $($out:expr_2021),* }, $k:literal = $val:expr_2021, $($args:tt)*) => {
         $crate::schema!(
             @ { $($out),*, &$crate::KeyValue::new($k, $crate::Value::from_serde(&$val)) },
             $($args)*
         )
     };
 
-    (@ { $(,)* $($out:expr),* }, $k:literal = $val:expr) => {
+    (@ { $(,)* $($out:expr_2021),* }, $k:literal = $val:expr_2021) => {
         $crate::schema!(
             @ { $($out),*, &$crate::KeyValue::new($k, $crate::Value::from_serde(&$val)) },
         )
     };
 
     // Literal Keys debug
-    (@ { $(,)* $($out:expr),* }, $k:literal = ?$val:expr, $($args:tt)*) => {
+    (@ { $(,)* $($out:expr_2021),* }, $k:literal = ?$val:expr_2021, $($args:tt)*) => {
         $crate::schema!(
             @ { $($out),*, &$crate::KeyValue::new($k, $crate::Value::from_debug(&$val)) },
             $($args)*
         )
     };
 
-    (@ { $(,)* $($out:expr),* }, $k:literal = ?$val:expr) => {
+    (@ { $(,)* $($out:expr_2021),* }, $k:literal = ?$val:expr_2021) => {
         $crate::schema!(
             @ { $($out),*, &$crate::KeyValue::new($k, $crate::Value::from_debug(&$val)) },
         )
     };
 
     // Literal Keys display
-    (@ { $(,)* $($out:expr),* }, $k:literal = %$val:expr, $($args:tt)*) => {
+    (@ { $(,)* $($out:expr_2021),* }, $k:literal = %$val:expr_2021, $($args:tt)*) => {
         $crate::schema!(
             @ { $($out),*, &$crate::KeyValue::new($k, $crate::Value::from_display(&$val)) },
             $($args)*
         )
     };
 
-    (@ { $(,)* $($out:expr),* }, $k:literal = %$val:expr) => {
+    (@ { $(,)* $($out:expr_2021),* }, $k:literal = %$val:expr_2021) => {
         $crate::schema!(
             @ { $($out),*, &$crate::KeyValue::new($k, $crate::Value::from_display(&$val)) },
         )
     };
 
     // Lone Schemas
-    (@ { $(,)* $($out:expr),* }, $schema:expr, $($args:tt)*) => {
+    (@ { $(,)* $($out:expr_2021),* }, $schema:expr_2021, $($args:tt)*) => {
         $crate::schema!(
             @ { $($out),*, &$schema },
             $($args)*
         )
     };
-    (@ { $(,)* $($out:expr),* }, $schema:expr) => {
+    (@ { $(,)* $($out:expr_2021),* }, $schema:expr_2021) => {
         $crate::schema!(
             @ { $($out),*, &$schema },
         )
@@ -222,68 +222,68 @@ macro_rules! fmt_args {
     };
 
     // Identifier Keys
-    ($($k:ident).+ = $val:expr, $($args:tt)*) => {
+    ($($k:ident).+ = $val:expr_2021, $($args:tt)*) => {
         $crate::fmt_args!(
             $($args)*
         )
     };
-    ($($k:ident).+ = $val:expr) => {
+    ($($k:ident).+ = $val:expr_2021) => {
         $crate::fmt_args!()
     };
     // Identifier Keys with Debug
-    ($($k:ident).+ = ?$val:expr, $($args:tt)*) => {
+    ($($k:ident).+ = ?$val:expr_2021, $($args:tt)*) => {
         $crate::fmt_args!(
             $($args)*
         )
     };
-    ($($k:ident).+ = ?$val:expr) => {
+    ($($k:ident).+ = ?$val:expr_2021) => {
         $crate::fmt_args!()
     };
     // Identifier Keys with Display
-    ($($k:ident).+ = %$val:expr, $($args:tt)*) => {
+    ($($k:ident).+ = %$val:expr_2021, $($args:tt)*) => {
         $crate::fmt_args!(
             $($args)*
         )
     };
-    ($($k:ident).+ = %$val:expr) => {
+    ($($k:ident).+ = %$val:expr_2021) => {
         $crate::fmt_args!()
     };
 
     // Literal Keys
-    ($k:literal = $val:expr, $($args:tt)*) => {
+    ($k:literal = $val:expr_2021, $($args:tt)*) => {
         $crate::fmt_args!(
             $($args)*
         )
     };
-    ($k:literal = $val:expr) => {
+    ($k:literal = $val:expr_2021) => {
         $crate::fmt_args!()
     };
     // Literal Keys with Debug
-    ($k:literal = ?$val:expr, $($args:tt)*) => {
+    ($k:literal = ?$val:expr_2021, $($args:tt)*) => {
         $crate::fmt_args!(
             $($args)*
         )
     };
-    ($k:literal = ?$val:expr) => {
+    ($k:literal = ?$val:expr_2021) => {
         $crate::fmt_args!()
     };
     // Literal Keys with Display
-    ($k:literal = %$val:expr, $($args:tt)*) => {
+    ($k:literal = %$val:expr_2021, $($args:tt)*) => {
         $crate::fmt_args!(
             $($args)*
         )
     };
-    ($k:literal = %$val:expr) => {
+    ($k:literal = %$val:expr_2021) => {
         $crate::fmt_args!()
     };
 
     // Lone Schemas
-    ($schema:expr, $($args:tt)*) => {
+    ($schema:expr_2021, $($args:tt)*) => {
         $crate::fmt_args!(
             $($args)*
         )
     };
-    ($schema:expr) => {
+    ($schema:expr_2021) => {
         $crate::fmt_args!()
     };
 }
@@ -291,7 +291,7 @@ macro_rules! fmt_args {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __log_stringify {
-    ($s:expr) => {
+    ($s:expr_2021) => {
         stringify!($s)
     };
 }

--- a/crates/pos/common/logger/src/sample.rs
+++ b/crates/pos/common/logger/src/sample.rs
@@ -93,11 +93,11 @@ impl Sampling {
 /// logs or metrics on high throughput pieces of code.
 #[macro_export]
 macro_rules! sample {
-    ($sample_rate:expr, $($args:expr)+ ,) => {
+    ($sample_rate:expr_2021, $($args:expr_2021)+ ,) => {
         $crate::sample!($sample_rate, $($args)+);
     };
 
-    ($sample_rate:expr, $($args:tt)+) => {{
+    ($sample_rate:expr_2021, $($args:tt)+) => {{
         static SAMPLING: Sampling = $crate::sample::Sampling::new($sample_rate);
         if SAMPLING.sample() {
             $($args)+

--- a/crates/pos/config/config/Cargo.toml
+++ b/crates/pos/config/config/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/diem/diem"
 homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
-edition = "2018"
+edition = "2024"
 
 [dependencies]
 serde = { version = "1.0.124", features = ["rc"], default-features = false }

--- a/crates/pos/config/global-constants/Cargo.toml
+++ b/crates/pos/config/global-constants/Cargo.toml
@@ -7,4 +7,4 @@ repository = "https://github.com/diem/diem"
 homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
-edition = "2018"
+edition = "2024"

--- a/crates/pos/consensus/consensus-types/Cargo.toml
+++ b/crates/pos/consensus/consensus-types/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Diem Association <opensource@diem.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2018"
+edition = "2024"
 
 [dependencies]
 anyhow = "1.0.38"

--- a/crates/pos/consensus/executor/Cargo.toml
+++ b/crates/pos/consensus/executor/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/diem/diem"
 homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
-edition = "2018"
+edition = "2024"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/pos/consensus/safety-rules/Cargo.toml
+++ b/crates/pos/consensus/safety-rules/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Diem Association <opensource@diem.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2018"
+edition = "2024"
 
 [dependencies]
 rand_08 = { workspace = true }

--- a/crates/pos/crypto/crypto-derive/Cargo.toml
+++ b/crates/pos/crypto/crypto-derive/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/diem/diem"
 homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
-edition = "2018"
+edition = "2024"
 
 [lib]
 proc-macro = true

--- a/crates/pos/crypto/crypto-derive/src/lib.rs
+++ b/crates/pos/crypto/crypto-derive/src/lib.rs
@@ -117,7 +117,7 @@ use unions::*;
 pub fn silent_display(source: TokenStream) -> TokenStream {
     let ast: DeriveInput = syn::parse(source).expect("Incorrect macro input");
     let name = &ast.ident;
-    let gen = quote! {
+    let r#gen = quote! {
         // In order to ensure that secrets are never leaked, Display is elided
         impl ::std::fmt::Display for #name {
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -125,14 +125,14 @@ pub fn silent_display(source: TokenStream) -> TokenStream {
             }
         }
     };
-    gen.into()
+    r#gen.into()
 }
 
 #[proc_macro_derive(SilentDebug)]
 pub fn silent_debug(source: TokenStream) -> TokenStream {
     let ast: DeriveInput = syn::parse(source).expect("Incorrect macro input");
     let name = &ast.ident;
-    let gen = quote! {
+    let r#gen = quote! {
         // In order to ensure that secrets are never leaked, Debug is elided
         impl ::std::fmt::Debug for #name {
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
@@ -140,7 +140,7 @@ pub fn silent_debug(source: TokenStream) -> TokenStream {
             }
         }
     };
-    gen.into()
+    r#gen.into()
 }
 
 /// Deserialize from a human readable format where applicable
@@ -149,7 +149,7 @@ pub fn deserialize_key(source: TokenStream) -> TokenStream {
     let ast: DeriveInput = syn::parse(source).expect("Incorrect macro input");
     let name = &ast.ident;
     let name_string = name.to_string();
-    let gen = quote! {
+    let r#gen = quote! {
         impl<'de> ::serde::Deserialize<'de> for #name {
             fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
             where
@@ -175,7 +175,7 @@ pub fn deserialize_key(source: TokenStream) -> TokenStream {
             }
         }
     };
-    gen.into()
+    r#gen.into()
 }
 
 /// Serialize into a human readable format where applicable
@@ -184,7 +184,7 @@ pub fn serialize_key(source: TokenStream) -> TokenStream {
     let ast: DeriveInput = syn::parse(source).expect("Incorrect macro input");
     let name = &ast.ident;
     let name_string = name.to_string();
-    let gen = quote! {
+    let r#gen = quote! {
         impl ::serde::Serialize for #name {
             fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
             where
@@ -204,7 +204,7 @@ pub fn serialize_key(source: TokenStream) -> TokenStream {
             }
         }
     };
-    gen.into()
+    r#gen.into()
 }
 
 #[proc_macro_derive(Deref)]

--- a/crates/pos/crypto/crypto/Cargo.toml
+++ b/crates/pos/crypto/crypto/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/diem/diem"
 homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
-edition = "2018"
+edition = "2024"
 
 [dependencies]
 anyhow = "1.0.38"

--- a/crates/pos/crypto/crypto/src/hash.rs
+++ b/crates/pos/crypto/crypto/src/hash.rs
@@ -174,13 +174,13 @@ impl HashValue {
     /// Create a cryptographically random instance.
     pub fn random() -> Self {
         let mut rng = OsRng;
-        let hash: [u8; HashValue::LENGTH] = rng.gen();
+        let hash: [u8; HashValue::LENGTH] = rng.r#gen();
         HashValue { hash }
     }
 
     /// Creates a random instance with given rng. Useful in unit tests.
     pub fn random_with_rng<R: Rng>(rng: &mut R) -> Self {
-        let hash: [u8; HashValue::LENGTH] = rng.gen();
+        let hash: [u8; HashValue::LENGTH] = rng.r#gen();
         HashValue { hash }
     }
 
@@ -506,7 +506,7 @@ impl fmt::Debug for DefaultHasher {
 macro_rules! define_hasher {
     (
         $(#[$attr:meta])*
-        ($hasher_type: ident, $hasher_name: ident, $seed_name: ident, $salt: expr)
+        ($hasher_type: ident, $hasher_name: ident, $seed_name: ident, $salt: expr_2021)
     ) => {
 
         #[derive(Clone, Debug)]

--- a/crates/pos/secure/storage/Cargo.toml
+++ b/crates/pos/secure/storage/Cargo.toml
@@ -7,7 +7,7 @@ description = "Diem's Persistent, Secure Storage"
 homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
-edition = "2018"
+edition = "2024"
 
 [dependencies]
 base64 = "0.13.0"

--- a/crates/pos/secure/storage/src/crypto_kv_storage.rs
+++ b/crates/pos/secure/storage/src/crypto_kv_storage.rs
@@ -114,7 +114,7 @@ impl<T: CryptoKVStorage> CryptoStorage for T {
 
 fn new_key_pair<SK: SigningKey + Uniform>() -> (SK, SK::PublicKeyMaterial) {
     let mut seed_rng = OsRng;
-    let mut rng = rand::rngs::StdRng::from_seed(seed_rng.gen());
+    let mut rng = rand::rngs::StdRng::from_seed(seed_rng.r#gen());
     let private_key = SK::generate(&mut rng);
     let public_key = private_key.public_key();
     (private_key, public_key)

--- a/crates/pos/storage/accumulator/Cargo.toml
+++ b/crates/pos/storage/accumulator/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/diem/diem"
 homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
-edition = "2018"
+edition = "2024"
 
 [dependencies]
 anyhow = "1.0.38"

--- a/crates/pos/storage/cached-pos-ledger-db/Cargo.toml
+++ b/crates/pos/storage/cached-pos-ledger-db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cached-pos-ledger-db"
 version = "0.1.0"
-edition = "2018"
+edition = "2024"
 license-file.workspace = true
 
 [dependencies]

--- a/crates/pos/storage/pos-ledger-db/Cargo.toml
+++ b/crates/pos/storage/pos-ledger-db/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/diem/diem"
 homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
-edition = "2018"
+edition = "2024"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/pos/storage/pos-ledger-db/src/test_helper.rs
+++ b/crates/pos/storage/pos-ledger-db/src/test_helper.rs
@@ -128,7 +128,7 @@ prop_compose! {
                 let block_size = txn_gens.len();
                 let txns_to_commit = txn_gens
                         .into_iter()
-                        .map(|gen| gen.materialize(&mut universe))
+                        .map(|r#gen| r#gen.materialize(&mut universe))
                         .collect();
                 let ledger_info = ledger_info_gen.materialize(&mut universe, block_size);
                 let validator_set = universe.get_validator_set(ledger_info.epoch()).to_vec();

--- a/crates/pos/storage/pos-ledger-db/src/transaction_store/test.rs
+++ b/crates/pos/storage/pos-ledger-db/src/transaction_store/test.rs
@@ -116,9 +116,9 @@ fn init_store(
 ) -> Vec<Transaction> {
     let txns = gens
         .into_iter()
-        .map(|(index, gen)| {
+        .map(|(index, r#gen)| {
             Transaction::UserTransaction(
-                gen.materialize(index, &mut universe).into_inner(),
+                r#gen.materialize(index, &mut universe).into_inner(),
             )
         })
         .collect::<Vec<_>>();

--- a/crates/pos/storage/schemadb/Cargo.toml
+++ b/crates/pos/storage/schemadb/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/diem/diem"
 homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
-edition = "2018"
+edition = "2024"
 
 [dependencies]
 anyhow = "1.0.38"

--- a/crates/pos/storage/schemadb/src/schema.rs
+++ b/crates/pos/storage/schemadb/src/schema.rs
@@ -71,7 +71,7 @@ use std::fmt::Debug;
 /// ```
 #[macro_export]
 macro_rules! define_schema {
-    ($schema_type:ident, $key_type:ty, $value_type:ty, $cf_name:expr) => {
+    ($schema_type:ident, $key_type:ty, $value_type:ty, $cf_name:expr_2021) => {
         pub(crate) struct $schema_type;
 
         impl $crate::schema::Schema for $schema_type {

--- a/crates/pos/storage/state-view/Cargo.toml
+++ b/crates/pos/storage/state-view/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/diem/diem"
 homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
-edition = "2018"
+edition = "2024"
 
 [dependencies]
 diem-crypto = { workspace = true }

--- a/crates/pos/storage/storage-interface/Cargo.toml
+++ b/crates/pos/storage/storage-interface/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/diem/diem"
 homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
-edition = "2018"
+edition = "2024"
 
 [dependencies]
 anyhow = "1.0.38"

--- a/crates/pos/types/executor-types/Cargo.toml
+++ b/crates/pos/types/executor-types/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/diem/diem"
 homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
-edition = "2018"
+edition = "2024"
 
 [dependencies]
 anyhow = "1.0.38"

--- a/crates/pos/types/move-core-types/Cargo.toml
+++ b/crates/pos/types/move-core-types/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/diem/diem"
 homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
-edition = "2018"
+edition = "2024"
 
 [dependencies]
 anyhow = "1.0.38"

--- a/crates/pos/types/move-core-types/src/account_address.rs
+++ b/crates/pos/types/move-core-types/src/account_address.rs
@@ -25,7 +25,7 @@ impl AccountAddress {
 
     pub fn random() -> Self {
         let mut rng = OsRng;
-        let buf: [u8; Self::LENGTH] = rng.gen();
+        let buf: [u8; Self::LENGTH] = rng.r#gen();
         Self(buf)
     }
 

--- a/crates/pos/types/move-core-types/src/vm_status.rs
+++ b/crates/pos/types/move-core-types/src/vm_status.rs
@@ -157,7 +157,7 @@ macro_rules! derive_status_try_from_repr {
         $( #[$metas:meta] )*
         $vis:vis enum $enum_name:ident {
             $(
-                $variant:ident = $value: expr
+                $variant:ident = $value: expr_2021
             ),*
             $( , )?
         }

--- a/crates/pos/types/pow-types/Cargo.toml
+++ b/crates/pos/types/pow-types/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pow-types"
 version = "0.1.0"
 authors = ["Peilun Li <peilun.li@conflux-chain.org>"]
-edition = "2018"
+edition = "2024"
 license-file.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/pos/types/types/Cargo.toml
+++ b/crates/pos/types/types/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/diem/diem"
 homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
-edition = "2018"
+edition = "2024"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/pos/types/types/src/ledger_info.rs
+++ b/crates/pos/types/types/src/ledger_info.rs
@@ -186,7 +186,7 @@ impl Deref for LedgerInfoWithSignatures {
 impl DerefMut for LedgerInfoWithSignatures {
     fn deref_mut(&mut self) -> &mut LedgerInfoWithV0 {
         match self {
-            LedgerInfoWithSignatures::V0(ref mut ledger) => ledger,
+            LedgerInfoWithSignatures::V0(ledger) => ledger,
         }
     }
 }

--- a/crates/pos/types/types/src/proptest_types.rs
+++ b/crates/pos/types/types/src/proptest_types.rs
@@ -486,7 +486,7 @@ impl Arbitrary for TransactionToCommit {
             any_with::<AccountInfoUniverse>(1),
             any::<TransactionToCommitGen>(),
         )
-            .prop_map(|(mut universe, gen)| gen.materialize(&mut universe))
+            .prop_map(|(mut universe, r#gen)| r#gen.materialize(&mut universe))
             .boxed()
     }
 }

--- a/crates/pos/types/types/src/transaction/authenticator.rs
+++ b/crates/pos/types/types/src/transaction/authenticator.rs
@@ -254,7 +254,7 @@ impl AuthenticationKey {
     /// Create a random authentication key. For testing only
     pub fn random() -> Self {
         let mut rng = OsRng;
-        let buf: [u8; Self::LENGTH] = rng.gen();
+        let buf: [u8; Self::LENGTH] = rng.r#gen();
         AuthenticationKey::new(buf)
     }
 }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "primitives"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 license-file.workspace = true
 
 [dependencies]

--- a/crates/rpc/rpc-builder/Cargo.toml
+++ b/crates/rpc/rpc-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfx-rpc-builder"
-edition = "2021"
+edition = "2024"
 version.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/rpc/rpc-cfx-impl/Cargo.toml
+++ b/crates/rpc/rpc-cfx-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfx-rpc-cfx-impl"
-edition = "2021"
+edition = "2024"
 version = { workspace = true }
 license-file = { workspace = true }
 

--- a/crates/rpc/rpc-cfx-impl/src/pos_handler.rs
+++ b/crates/rpc/rpc-cfx-impl/src/pos_handler.rs
@@ -391,34 +391,44 @@ impl PosHandler {
                 // pivot decision would be missing.
                 // If this consensus block is not on a fork, its CommittedBlock
                 // should be accessible in this case.
-                if let Ok(executed_block) =
-                    self.pos_handler.cached_db().get_block(&b.id())
-                {
-                    let executed = executed_block.lock();
-                    if let Some(version) = executed.output().version() {
-                        rpc_block.last_tx_number = U64::from(version);
-                    }
-                    rpc_block.pivot_decision = executed
-                        .output()
-                        .pivot_block()
-                        .as_ref()
-                        .map(|p| Decision::from(p));
-                    rpc_block.height = U64::from(
-                        executed
+                match self.pos_handler.cached_db().get_block(&b.id()) {
+                    Ok(executed_block) => {
+                        let executed = executed_block.lock();
+                        if let Some(version) = executed.output().version() {
+                            rpc_block.last_tx_number = U64::from(version);
+                        }
+                        rpc_block.pivot_decision = executed
                             .output()
-                            .executed_trees()
-                            .pos_state()
-                            .current_view(),
-                    );
-                } else if let Ok(committed_block) = self
-                    .pos_handler
-                    .pos_ledger_db()
-                    .get_committed_block_by_hash(&b.id())
-                {
-                    rpc_block.last_tx_number = committed_block.version.into();
-                    rpc_block.pivot_decision =
-                        Some(Decision::from(&committed_block.pivot_decision));
-                    rpc_block.height = U64::from(committed_block.view);
+                            .pivot_block()
+                            .as_ref()
+                            .map(|p| Decision::from(p));
+                        rpc_block.height = U64::from(
+                            executed
+                                .output()
+                                .executed_trees()
+                                .pos_state()
+                                .current_view(),
+                        );
+                    }
+                    _ => {
+                        match self
+                            .pos_handler
+                            .pos_ledger_db()
+                            .get_committed_block_by_hash(&b.id())
+                        {
+                            Ok(committed_block) => {
+                                rpc_block.last_tx_number =
+                                    committed_block.version.into();
+                                rpc_block.pivot_decision =
+                                    Some(Decision::from(
+                                        &committed_block.pivot_decision,
+                                    ));
+                                rpc_block.height =
+                                    U64::from(committed_block.view);
+                            }
+                            _ => {}
+                        }
+                    }
                 }
                 if let Some(qc) = qcs.get(&b.id()) {
                     let signatures = qc

--- a/crates/rpc/rpc-cfx-impl/src/pos_handler.rs
+++ b/crates/rpc/rpc-cfx-impl/src/pos_handler.rs
@@ -391,44 +391,34 @@ impl PosHandler {
                 // pivot decision would be missing.
                 // If this consensus block is not on a fork, its CommittedBlock
                 // should be accessible in this case.
-                match self.pos_handler.cached_db().get_block(&b.id()) {
-                    Ok(executed_block) => {
-                        let executed = executed_block.lock();
-                        if let Some(version) = executed.output().version() {
-                            rpc_block.last_tx_number = U64::from(version);
-                        }
-                        rpc_block.pivot_decision = executed
+                if let Ok(executed_block) =
+                    self.pos_handler.cached_db().get_block(&b.id())
+                {
+                    let executed = executed_block.lock();
+                    if let Some(version) = executed.output().version() {
+                        rpc_block.last_tx_number = U64::from(version);
+                    }
+                    rpc_block.pivot_decision = executed
+                        .output()
+                        .pivot_block()
+                        .as_ref()
+                        .map(|p| Decision::from(p));
+                    rpc_block.height = U64::from(
+                        executed
                             .output()
-                            .pivot_block()
-                            .as_ref()
-                            .map(|p| Decision::from(p));
-                        rpc_block.height = U64::from(
-                            executed
-                                .output()
-                                .executed_trees()
-                                .pos_state()
-                                .current_view(),
-                        );
-                    }
-                    _ => {
-                        match self
-                            .pos_handler
-                            .pos_ledger_db()
-                            .get_committed_block_by_hash(&b.id())
-                        {
-                            Ok(committed_block) => {
-                                rpc_block.last_tx_number =
-                                    committed_block.version.into();
-                                rpc_block.pivot_decision =
-                                    Some(Decision::from(
-                                        &committed_block.pivot_decision,
-                                    ));
-                                rpc_block.height =
-                                    U64::from(committed_block.view);
-                            }
-                            _ => {}
-                        }
-                    }
+                            .executed_trees()
+                            .pos_state()
+                            .current_view(),
+                    );
+                } else if let Ok(committed_block) = self
+                    .pos_handler
+                    .pos_ledger_db()
+                    .get_committed_block_by_hash(&b.id())
+                {
+                    rpc_block.last_tx_number = committed_block.version.into();
+                    rpc_block.pivot_decision =
+                        Some(Decision::from(&committed_block.pivot_decision));
+                    rpc_block.height = U64::from(committed_block.view);
                 }
                 if let Some(qc) = qcs.get(&b.id()) {
                     let signatures = qc

--- a/crates/rpc/rpc-cfx-impl/src/pubsub.rs
+++ b/crates/rpc/rpc-cfx-impl/src/pubsub.rs
@@ -78,7 +78,7 @@ impl PubSubHandler {
         }
     }
 
-    fn new_headers_stream(&self) -> impl Stream<Item = Header> {
+    fn new_headers_stream(&self) -> impl Stream<Item = Header> + use<> {
         let receiver = self.head_sender.subscribe();
         BroadcastStream::new(receiver)
             .filter(|item| {
@@ -94,7 +94,7 @@ impl PubSubHandler {
 
     fn new_epoch_stream(
         &self, epoch: SubscriptionEpoch,
-    ) -> impl Stream<Item = pubsub::Result> {
+    ) -> impl Stream<Item = pubsub::Result> + use<> {
         let receiver = match epoch {
             SubscriptionEpoch::LatestState => {
                 self.latest_state_epoch_task.sender.subscribe()
@@ -122,7 +122,7 @@ impl PubSubHandler {
 
     fn new_logs_stream(
         &self, filter: LogFilter,
-    ) -> impl Stream<Item = pubsub::Result> {
+    ) -> impl Stream<Item = pubsub::Result> + use<> {
         let receiver;
         let senders = self.log_senders.read();
         if !senders.contains_key(&filter) {

--- a/crates/rpc/rpc-cfx-types/Cargo.toml
+++ b/crates/rpc/rpc-cfx-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfx-rpc-cfx-types"
-edition = "2021"
+edition = "2024"
 version.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/rpc/rpc-common-impl/Cargo.toml
+++ b/crates/rpc/rpc-common-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfx-rpc-common-impl"
-edition = "2021"
+edition = "2024"
 version.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfx-rpc-eth-api"
-edition = "2021"
+edition = "2024"
 version.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/rpc/rpc-eth-impl/Cargo.toml
+++ b/crates/rpc/rpc-eth-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfx-rpc-eth-impl"
-edition = "2021"
+edition = "2024"
 version.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/rpc/rpc-eth-impl/src/eth.rs
+++ b/crates/rpc/rpc-eth-impl/src/eth.rs
@@ -913,7 +913,7 @@ impl SpawnBlocking for EthApi {
 impl EthApi {
     pub fn async_transaction_by_hash(
         &self, hash: H256,
-    ) -> impl Future<Output = Result<Option<Transaction>, RpcError>> + Send
+    ) -> impl Future<Output = Result<Option<Transaction>, RpcError>> + Send + use<>
     {
         let self_clone = self.clone();
         async move {

--- a/crates/rpc/rpc-eth-impl/src/pubsub.rs
+++ b/crates/rpc/rpc-eth-impl/src/pubsub.rs
@@ -65,7 +65,7 @@ impl PubSubApi {
         }
     }
 
-    fn new_headers_stream(&self) -> impl Stream<Item = Header> {
+    fn new_headers_stream(&self) -> impl Stream<Item = Header> + use<> {
         let receiver = self.head_sender.subscribe();
         BroadcastStream::new(receiver)
             .filter(|item| {
@@ -79,7 +79,9 @@ impl PubSubApi {
             .map(|item| item.expect("should not be an error"))
     }
 
-    fn new_logs_stream(&self, filter: LogFilter) -> impl Stream<Item = Log> {
+    fn new_logs_stream(
+        &self, filter: LogFilter,
+    ) -> impl Stream<Item = Log> + use<> {
         let receiver;
         let senders = self.log_senders.read();
         if !senders.contains_key(&filter) {

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfx-rpc-eth-types"
-edition = "2021"
+edition = "2024"
 version.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/rpc/rpc-eth-types/src/trace.rs
+++ b/crates/rpc/rpc-eth-types/src/trace.rs
@@ -85,8 +85,8 @@ impl Default for Action {
 impl Action {
     pub fn gas(&self) -> Option<U256> {
         match self {
-            Action::Call(ref call) => Some(call.gas),
-            Action::Create(ref create) => Some(create.gas),
+            Action::Call(call) => Some(call.gas),
+            Action::Create(create) => Some(create.gas),
             Action::SelfDestruct(_) => None,
         }
     }

--- a/crates/rpc/rpc-eth-types/src/tx_pool.rs
+++ b/crates/rpc/rpc-eth-types/src/tx_pool.rs
@@ -187,7 +187,7 @@ impl<T> TxpoolContent<T> {
     /// specific sender
     pub fn pending_transactions_from(
         &self, sender: &Address,
-    ) -> impl Iterator<Item = &T> {
+    ) -> impl Iterator<Item = &T> + use<'_, T> {
         self.pending
             .get(sender)
             .into_iter()
@@ -198,7 +198,7 @@ impl<T> TxpoolContent<T> {
     /// specific sender
     pub fn queued_transactions_from(
         &self, sender: &Address,
-    ) -> impl Iterator<Item = &T> {
+    ) -> impl Iterator<Item = &T> + use<'_, T> {
         self.queued
             .get(sender)
             .into_iter()
@@ -225,7 +225,7 @@ impl<T> TxpoolContent<T> {
     /// from a specific sender
     pub fn into_pending_transactions_from(
         mut self, sender: &Address,
-    ) -> impl Iterator<Item = T> {
+    ) -> impl Iterator<Item = T> + use<T> {
         self.pending
             .remove(sender)
             .into_iter()
@@ -236,7 +236,7 @@ impl<T> TxpoolContent<T> {
     /// from a specific sender
     pub fn into_queued_transactions_from(
         mut self, sender: &Address,
-    ) -> impl Iterator<Item = T> {
+    ) -> impl Iterator<Item = T> + use<T> {
         self.queued
             .remove(sender)
             .into_iter()

--- a/crates/rpc/rpc-middlewares/Cargo.toml
+++ b/crates/rpc/rpc-middlewares/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfx-rpc-middlewares"
-edition = "2021"
+edition = "2024"
 version.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/rpc/rpc-primitives/Cargo.toml
+++ b/crates/rpc/rpc-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfx-rpc-primitives"
-edition = "2021"
+edition = "2024"
 version.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/rpc/rpc-utils/Cargo.toml
+++ b/crates/rpc/rpc-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfx-rpc-utils"
-edition = "2021"
+edition = "2024"
 version.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/secret_store/Cargo.toml
+++ b/crates/secret_store/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "https://www.confluxnetwork.org"
 license = "GPL-3.0"
 name = "secret-store"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 parking_lot = { workspace = true }

--- a/crates/stratum/Cargo.toml
+++ b/crates/stratum/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "https://www.confluxnetwork.org"
 name = "cfx-stratum"
 version = "1.12.0"
 license = "GPL-3.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 cfx-types = { workspace = true }

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfx-tasks"
-edition = "2021"
+edition = "2024"
 version.workspace = true
 authors.workspace = true
 documentation.workspace = true

--- a/crates/transactiongen/Cargo.toml
+++ b/crates/transactiongen/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "https://www.confluxnetwork.org"
 license = "GPL-3.0"
 name = "txgen"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 cfxcore = { workspace = true }

--- a/crates/transactiongen/src/lib.rs
+++ b/crates/transactiongen/src/lib.rs
@@ -470,16 +470,14 @@ impl DirectTransactionGenerator {
             }
 
             // Calls transfer of ERC20 contract.
+            let h: H256 = BigEndianHash::from_uint(&balance_to_transfer);
+            let value_hex = h.0.to_hex::<String>();
             let tx_data = (String::new()
                 + "a9059cbb000000000000000000000000"
                 + &receiver_address.0.to_hex::<String>()[2..]
-                + {
-                    let h: H256 =
-                        BigEndianHash::from_uint(&balance_to_transfer);
-                    &h.0.to_hex::<String>()[2..]
-                })
-            .from_hex()
-            .unwrap();
+                + &value_hex[2..])
+                .from_hex()
+                .unwrap();
 
             let tx: Transaction = NativeTransaction {
                 nonce: sender_nonce,

--- a/crates/util/cfx_math/Cargo.toml
+++ b/crates/util/cfx_math/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "https://www.confluxnetwork.org"
 license = "GPL-3.0"
 name = "cfx-math"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 num = { workspace = true }

--- a/crates/util/cfx_math/src/nth_root/compute.rs
+++ b/crates/util/cfx_math/src/nth_root/compute.rs
@@ -115,7 +115,7 @@ impl NthRoot for u64 {
                 InitRoot::Done(N::nth_root_lookup(self))
             } else {
                 let (small, rot) =
-                    self.truncate(N::LOOKUP_BITS as usize, N::USIZE);
+                    NthRoot::truncate(self, N::LOOKUP_BITS as usize, N::USIZE);
                 InitRoot::Init(
                     (N::nth_root_lookup(small) + 1) << (rot / N::USIZE),
                 )
@@ -153,7 +153,7 @@ impl NthRoot for u128 {
             InitRoot::Done(compute_next(self))
         } else {
             InitRoot::Init({
-                let (next, rot) = self.truncate(64, N::USIZE);
+                let (next, rot) = NthRoot::truncate(self, 64, N::USIZE);
                 (compute_next(next) + 1) << (rot / N::USIZE)
             })
         }

--- a/crates/util/cfx_math/src/nth_root/root_degree/logarithmic_table.rs
+++ b/crates/util/cfx_math/src/nth_root/root_degree/logarithmic_table.rs
@@ -157,7 +157,7 @@ macro_rules! build_lookup {
 }
 
 macro_rules! init_lookup_params {
-    (pow: $pow:expr, $max:expr) => {{
+    (pow: $pow:expr_2021, $max:expr_2021) => {{
         LookupParam {
             pow: $pow,
             max: $max,
@@ -168,7 +168,7 @@ macro_rules! init_lookup_params {
 }
 
 macro_rules! build_lookup_params {
-    ($last_param:ident, $last_build:ident, $max:expr) => {{
+    ($last_param:ident, $last_build:ident, $max:expr_2021) => {{
         LookupParam {
             pow: $last_param.pow,
             max: $max,

--- a/crates/util/dag/Cargo.toml
+++ b/crates/util/dag/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dag"
 version = "0.1.0"
 authors = ["Peilun Li <peilun.li@conflux-chain.org>"]
-edition = "2021"
+edition = "2024"
 license-file.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/util/delegate/Cargo.toml
+++ b/crates/util/delegate/Cargo.toml
@@ -11,7 +11,7 @@
 # will likely look very different (and much more reasonable)
 
 [package]
-edition = "2021"
+edition = "2024"
 name = "delegate"
 version = "0.4.2"
 authors = ["Godfrey Chan <godfreykfc@gmail.com>", "Jakub Beránek <berykubik@gmail.com>"]

--- a/crates/util/heap-map/Cargo.toml
+++ b/crates/util/heap-map/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "heap-map"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license-file.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/util/heap-map/src/tests.rs
+++ b/crates/util/heap-map/src/tests.rs
@@ -15,10 +15,11 @@ impl<K: hash::Hash + Eq + Copy + Debug, V: Eq + Ord + Clone> HeapMap<K, V> {
     #[allow(dead_code)]
     fn check_mono(&self) -> bool {
         let mut me = self.clone();
-        let mut last_value = if let Some((_k, v)) = me.pop() {
-            v
-        } else {
-            return true;
+        let mut last_value = match me.pop() {
+            Some((_k, v)) => v,
+            _ => {
+                return true;
+            }
         };
 
         while let Some((_k, v)) = me.pop() {

--- a/crates/util/heap-map/src/tests.rs
+++ b/crates/util/heap-map/src/tests.rs
@@ -15,11 +15,10 @@ impl<K: hash::Hash + Eq + Copy + Debug, V: Eq + Ord + Clone> HeapMap<K, V> {
     #[allow(dead_code)]
     fn check_mono(&self) -> bool {
         let mut me = self.clone();
-        let mut last_value = match me.pop() {
-            Some((_k, v)) => v,
-            _ => {
-                return true;
-            }
+        let mut last_value = if let Some((_k, v)) = me.pop() {
+            v
+        } else {
+            return true;
         };
 
         while let Some((_k, v)) = me.pop() {

--- a/crates/util/hibitset/Cargo.toml
+++ b/crates/util/hibitset/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["bitset", "container", "data-structures", "hierarchical"]
 categories = ["data-structures"]
 license = "MIT/Apache-2.0"
 authors = ["csheratt"]
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 atom = { workspace = true }

--- a/crates/util/io/Cargo.toml
+++ b/crates/util/io/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "http://conflux-chain.io"
 license = "GPL-3.0"
 name = "io"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 mio = { workspace = true, features = ["os-ext", "net", "os-poll"] }

--- a/crates/util/link-cut-tree/Cargo.toml
+++ b/crates/util/link-cut-tree/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "link-cut-tree"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license-file.workspace = true
 
 [dependencies]

--- a/crates/util/log_device/Cargo.toml
+++ b/crates/util/log_device/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "log-device"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license-file.workspace = true
 
 [dependencies]

--- a/crates/util/malloc_size_of/Cargo.toml
+++ b/crates/util/malloc_size_of/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "malloc_size_of"
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 license = "MIT/Apache-2.0"
 
 [dependencies]

--- a/crates/util/malloc_size_of/src/lib.rs
+++ b/crates/util/malloc_size_of/src/lib.rs
@@ -71,10 +71,12 @@ impl MallocSizeOfOps {
     /// Call `size_of_op` on `ptr`, first checking that the allocation isn't
     /// empty, because some types (such as `Vec`) utilize empty allocations.
     pub unsafe fn malloc_size_of<T: ?Sized>(&self, ptr: *const T) -> usize {
-        if MallocSizeOfOps::is_empty(ptr) {
-            0
-        } else {
-            (self.size_of_op)(ptr as *const c_void)
+        unsafe {
+            if MallocSizeOfOps::is_empty(ptr) {
+                0
+            } else {
+                (self.size_of_op)(ptr as *const c_void)
+            }
         }
     }
 
@@ -86,8 +88,10 @@ impl MallocSizeOfOps {
     /// Call `enclosing_size_of_op`, which must be available, on `ptr`, which
     /// must not be empty.
     pub unsafe fn malloc_enclosing_size_of<T>(&self, ptr: *const T) -> usize {
-        assert!(!MallocSizeOfOps::is_empty(ptr));
-        (self.enclosing_size_of_op.unwrap())(ptr as *const c_void)
+        unsafe {
+            assert!(!MallocSizeOfOps::is_empty(ptr));
+            (self.enclosing_size_of_op.unwrap())(ptr as *const c_void)
+        }
     }
 }
 
@@ -433,7 +437,7 @@ impl<T: MallocSizeOf> MallocSizeOf for Reverse<T> {
 }
 
 macro_rules! impl_smallvec {
-    ($size:expr) => {
+    ($size:expr_2021) => {
         impl<T> MallocSizeOf for smallvec::SmallVec<[T; $size]>
         where T: MallocSizeOf
         {
@@ -536,7 +540,7 @@ mod usable_size {
 
             /// Get the size of a heap block.
             /// Call windows allocator through `winapi` crate
-            pub unsafe extern "C" fn malloc_usable_size(mut ptr: *const c_void) -> usize {
+            pub unsafe extern "C" fn malloc_usable_size(mut ptr: *const c_void) -> usize { unsafe {
 
                 let heap = GetProcessHeap();
 
@@ -545,26 +549,26 @@ mod usable_size {
                 }
 
                 HeapSize(heap, 0, ptr) as usize
-            }
+            }}
 
         } else if #[cfg(feature = "jemalloc")] {
 
             /// Use of jemalloc usable size C function through jemallocator crate call.
-            pub unsafe extern "C" fn malloc_usable_size(ptr: *const c_void) -> usize {
+            pub unsafe extern "C" fn malloc_usable_size(ptr: *const c_void) -> usize { unsafe {
                 tikv_jemallocator::usable_size(ptr)
-            }
+            }}
 
         } else if #[cfg(target_os = "linux")] {
 
             // Linux call system allocator (currently malloc).
-            extern "C" {
+            unsafe extern "C" {
                 pub fn malloc_usable_size(ptr: *const c_void) -> usize;
             }
 
         } else if #[cfg(target_os = "macos")] {
 
             // Linux call system allocator (currently malloc).
-            extern "C" {
+            unsafe extern "C" {
                 #[link_name = "malloc_size"]
                 pub fn malloc_usable_size(ptr: *const c_void) -> usize;
             }

--- a/crates/util/malloc_size_of_derive/Cargo.toml
+++ b/crates/util/malloc_size_of_derive/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Servo Project Developers"]
 license = "MIT/Apache-2.0"
 description = "Crate for Firefox memory reporting, not intended for external use"
 repository = "https://github.com/bholley/malloc_size_of_derive"
-edition = "2021"
+edition = "2024"
 
 [lib]
 proc-macro = true

--- a/crates/util/malloc_size_of_derive/src/lib.rs
+++ b/crates/util/malloc_size_of_derive/src/lib.rs
@@ -95,7 +95,7 @@ fn test_struct() {
     let expanded = malloc_size_of_derive(source).to_string();
     let mut no_space = expanded.replace(" ", "");
     macro_rules! match_count {
-        ($e:expr, $count:expr) => {
+        ($e:expr_2021, $count:expr_2021) => {
             assert_eq!(
                 no_space.matches(&$e.replace(" ", "")).count(),
                 $count,

--- a/crates/util/memory-cache/Cargo.toml
+++ b/crates/util/memory-cache/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "An LRU-cache which operates on memory used"
 license = "GPL3"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 malloc_size_of = { workspace = true }

--- a/crates/util/metrics/Cargo.toml
+++ b/crates/util/metrics/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "metrics"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license-file.workspace = true
 
 [dependencies]

--- a/crates/util/priority-send-queue/Cargo.toml
+++ b/crates/util/priority-send-queue/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "priority-send-queue"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license-file.workspace = true
 
 [dependencies]

--- a/crates/util/random_crash/Cargo.toml
+++ b/crates/util/random_crash/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "https://www.confluxnetwork.org"
 license = "GPL-3.0"
 name = "random-crash"
 version = "1.0.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 lazy_static = { workspace = true }

--- a/crates/util/rlp_compat/Cargo.toml
+++ b/crates/util/rlp_compat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rlp-compat"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license-file.workspace = true
 
 [dependencies]

--- a/crates/util/serde_utils/Cargo.toml
+++ b/crates/util/serde_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-utils"
-edition = "2021"
+edition = "2024"
 version.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/util/sha3-macro/Cargo.toml
+++ b/crates/util/sha3-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sha3-macro"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license-file.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/util/throttling/Cargo.toml
+++ b/crates/util/throttling/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "throttling"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license-file.workspace = true
 [dependencies]
 parking_lot = { workspace = true }

--- a/crates/util/treap-map/Cargo.toml
+++ b/crates/util/treap-map/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "treap-map"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license-file.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/util/treap-map/src/map.rs
+++ b/crates/util/treap-map/src/map.rs
@@ -127,17 +127,16 @@ impl<C: TreapMapConfig> TreapMap<C> {
         U: FnOnce(&mut Node<C>) -> Result<ApplyOpOutcome<T>, E>,
         I: FnOnce(&mut dyn RngCore) -> Result<(Node<C>, T), E>,
     {
-        let sort_key = match self.ext_map.get_sort_key(key) {
-            Some(sort_key) => sort_key,
-            _ => {
-                return match insert(&mut self.rng) {
-                    Ok((node, ret)) => {
-                        self.insert(node.key, node.value, node.weight);
-                        Ok(ret)
-                    }
-                    Err(err) => Err(err),
-                };
-            }
+        let sort_key = if let Some(sort_key) = self.ext_map.get_sort_key(key) {
+            sort_key
+        } else {
+            return match insert(&mut self.rng) {
+                Ok((node, ret)) => {
+                    self.insert(node.key, node.value, node.weight);
+                    Ok(ret)
+                }
+                Err(err) => Err(err),
+            };
         };
         let rng = &mut self.rng;
         let (res, _, _) = Node::update_inner(

--- a/crates/util/treap-map/src/map.rs
+++ b/crates/util/treap-map/src/map.rs
@@ -127,16 +127,17 @@ impl<C: TreapMapConfig> TreapMap<C> {
         U: FnOnce(&mut Node<C>) -> Result<ApplyOpOutcome<T>, E>,
         I: FnOnce(&mut dyn RngCore) -> Result<(Node<C>, T), E>,
     {
-        let sort_key = if let Some(sort_key) = self.ext_map.get_sort_key(key) {
-            sort_key
-        } else {
-            return match insert(&mut self.rng) {
-                Ok((node, ret)) => {
-                    self.insert(node.key, node.value, node.weight);
-                    Ok(ret)
-                }
-                Err(err) => Err(err),
-            };
+        let sort_key = match self.ext_map.get_sort_key(key) {
+            Some(sort_key) => sort_key,
+            _ => {
+                return match insert(&mut self.rng) {
+                    Ok((node, ret)) => {
+                        self.insert(node.key, node.value, node.weight);
+                        Ok(ret)
+                    }
+                    Err(err) => Err(err),
+                };
+            }
         };
         let rng = &mut self.rng;
         let (res, _, _) = Node::update_inner(

--- a/crates/util/util-macros/Cargo.toml
+++ b/crates/util/util-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfx-util-macros"
-edition = "2021"
+edition = "2024"
 version.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/util/util-macros/src/lib.rs
+++ b/crates/util/util-macros/src/lib.rs
@@ -10,10 +10,10 @@ macro_rules! unwrap_option_or_return_result_none {
 
 #[macro_export]
 macro_rules! bail {
-    ($e:expr) => {
+    ($e:expr_2021) => {
         return Err($e.into());
     };
-    ($fmt:expr, $($arg:tt)+) => {
+    ($fmt:expr_2021, $($arg:tt)+) => {
         return Err(format!($fmt, $($arg)+).into());
     };
 }

--- a/crates/util/version/Cargo.toml
+++ b/crates/util/version/Cargo.toml
@@ -4,7 +4,7 @@ name = "parity-version"
 version = "3.3.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
-edition = "2021"
+edition = "2024"
 license-file.workspace = true
 
 [package.metadata]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.94"
+channel = "1.96.1"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
-edition = "2021"
+edition = "2024"
 unstable_features = true
 max_width = 80
 comment_width = 80
@@ -31,3 +31,4 @@ imports_indent = "Block"
 hard_tabs = false
 format_macro_matchers = true
 format_macro_bodies = true
+style_edition = "2021"


### PR DESCRIPTION
## Why

The workspace was split across three editions — 22 `crates/pos/*` on 2018 and everything else on 2021 — which is accumulating migration debt and locks out 2024-only language changes; the one that matters most for this codebase is the if-let / tail-expression temporary-scope rule, under which a lock guard created in an `if let` condition or a block's tail expression is released earlier, turning a class of "read guard held into an `else` that takes a write lock" latent deadlocks into non-issues going forward.

This moves all 96 workspace members to edition 2024 on a pinned 1.96.1 toolchain.

## What changed

`rust-toolchain` is bumped 1.94 -> 1.96.1; that bump alone surfaced an `unstable_name_collisions` error in `cfx-math` (its `NthRoot::truncate` now collides with a newly-added std `truncate`), fixed by using fully-qualified `NthRoot::truncate(self, ...)` at the two call sites.

The edition change itself is almost entirely mechanical `cargo fix --edition` output — `unsafe_op_in_unsafe_fn` inner-`unsafe` wraps, return-position `impl Trait` `+ use<>` captures, macro `expr` -> `expr_2021`, and `unsafe extern` blocks.

The only hand-written code change is in `transactiongen`: edition 2024's shorter temporary lifetime freed a borrowed `to_hex()[2..]` slice mid-statement (E0716), so the two hex strings are now bound to locals before the concatenation.

`rustfmt.toml` is set to parse edition 2024 while keeping `style_edition = "2021"`, so the bump does not trigger a repository-wide reformat.

## Drop-order review

Edition 2024's `tail_expr_drop_order` and `if_let_rescope` changes are silent once a crate is on 2024 (the migration warning disappears), so every flagged site was reviewed individually before flipping — 80 sites in the previously-un-migrated crates plus the delta-MPT / snapshot sites in `cfx-storage`.

All are safe to adopt the 2024 order: deliberate lock-holding-for-an-invariant is written as a named `let` binding whose drop timing is unchanged by the edition, and the lint only moves anonymous temporaries; where guards do reorder, the guarded value is copied/cloned/moved out first and no `else`/trailing path re-acquires the same lock.

`cargo fix` had mechanically rewritten the 23 `if let ... else` sites into its drop-order-preserving `match ... { pat => ..., _ => ... }` form; given the review verdict, the second commit restores the original `if let` text at those sites (14 of the 16 touched files return byte-identical to their pre-migration state), so they adopt the 2024 semantics instead of freezing the old drop order in a less idiomatic shape.

## Testing

`cargo check --workspace --all-targets` is clean under `-D warnings` on 1.96.1 (macOS host), and the rocksdb-free crates additionally cross-check clean for `x86_64-unknown-linux-gnu`.

Kept as a **draft** pending two things this change still needs: the full Linux CI build (the vendored rocksdb fork's build script does not cross-compile from macOS, so CI is the authoritative Linux check) and the `dev-support/test.sh` integration suite, particularly around the consensus / sync / pos paths.

The branch is currently based a few commits behind `master` and will be rebased before it is marked ready for review.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3572)
<!-- Reviewable:end -->
