### PR TITLE
fix(storage): parenthesize ROW_NUMBER_LIMIT so the delta-MPT cap is 2^(BITS-1)-1

### DIFF
--- a/crates/dbs/storage/src/impls/delta_mpt/row_number.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/row_number.rs
@@ -20,11 +20,12 @@ pub struct RowNumber {
 }
 
 impl RowNumber {
-    /// It's an error for row number to go higher than max u32 4_294_967_296. It
-    /// shouldn't happen because for 2h lifetime it requires 596523 nodes /
-    /// sec.
+    /// Cap at `2^(BITS-1) - 1` (2^31-1 for u32, 2^63-1 for u64): the compact
+    /// node ref (`node_ref.rs`) reserves the top bit of a committed db_key for
+    /// its persistent-key encoding, so a db_key must keep its MSB clear, and
+    /// this is the largest value that does.
     pub const ROW_NUMBER_LIMIT: RowNumberUnderlyingType =
-        1 << (RowNumberUnderlyingType::BITS - 1) - 1;
+        (1 << (RowNumberUnderlyingType::BITS - 1)) - 1;
 
     pub fn get_next(&self) -> Result<RowNumber> {
         if self.value != Self::ROW_NUMBER_LIMIT {


### PR DESCRIPTION
Rust binds `-` tighter than `<<`, so `1 << (BITS - 1) - 1` parsed as `1 << (BITS - 2)`, silently halving the delta-MPT row-number cap to 2^30 (u32) / 2^62 (u64) instead of the intended `(1 << (BITS - 1)) - 1` = 2^31-1 / 2^63-1.

The accidental cap was merely stricter, so nothing was ever at risk — but `2^(BITS-1) - 1` is the exact bound the compact node ref needs (a committed `db_key` must keep its MSB clear), so this restores it and rewrites the stale doc comment.

Tests: `cargo test -p cfx-storage` passes for both default (u32) and `u64_mpt_db_key`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3573)
<!-- Reviewable:end -->
