### PR TITLE
fix(storage): out-of-bounds unchecked access in Slab::remove bound check

### DIFF
--- a/crates/dbs/storage/src/impls/delta_mpt/slab/mod.rs
+++ b/crates/dbs/storage/src/impls/delta_mpt/slab/mod.rs
@@ -846,7 +846,7 @@ impl<T, E: EntryTrait<EntryType = T>> Slab<T, E> {
     /// assert_eq!(slab.remove(hello), "hello");
     /// assert!(!slab.contains(hello));
     pub fn remove(&self, key: usize) -> Result<T> {
-        if key > self.entries.len() {
+        if key >= self.entries.len() {
             // Index out of range.
             return Err(Error::SlabKeyError);
         }
@@ -1022,5 +1022,31 @@ impl<'a, T, E: EntryTrait<EntryType = T>> Iterator for IterMut<'a, T, E> {
         }
 
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `entries` is kept filled to capacity, so `capacity()` is exactly the
+    // first out-of-bounds key; an off-by-one bound check in `remove` turns
+    // it into a one-past-the-end unchecked access.
+    #[test]
+    fn remove_key_at_capacity_is_rejected() {
+        let slab: Slab<u32> = Slab::with_capacity(10);
+        slab.insert(1).unwrap();
+        assert!(matches!(
+            slab.remove(slab.capacity()),
+            Err(Error::SlabKeyError)
+        ));
+    }
+
+    // Zero-capacity slab: entries' buffer is unallocated, so key 0 must
+    // already be rejected by the bound check.
+    #[test]
+    fn remove_from_empty_slab_is_rejected() {
+        let empty: Slab<u32> = Slab::default();
+        assert!(matches!(empty.remove(0), Err(Error::SlabKeyError)));
     }
 }


### PR DESCRIPTION
`Slab::remove` checked `key > entries.len()` before an unchecked slot access; since `entries` is kept filled to capacity, `key == entries.len()` passed the guard and read one past the end of the buffer — UB reachable from a safe fn. Fix is the boundary: `>=`.

No behavior change for existing callers: all in-tree `remove` calls pass keys previously returned by `allocate`/`vacant_entry` (always in bounds), so this only hardens the API against future misuse.

The two regression tests abort on the unfixed code via std's debug `ub_checks` (`slice::get_unchecked` precondition) and pass with the corrected bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3574)
<!-- Reviewable:end -->
