### PR TITLE
ci: build titan portable in all test.yml jobs to fix clang-18 AVX10.1 -Werror

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Every job below that compiles RocksDB/titan builds it portable (no -march=native);
+# otherwise clang-18 rejects +avx10.1 under -Werror on AVX10-capable runners.
 jobs:
   check-workspace:
     runs-on: ubuntu-24.04
@@ -52,7 +54,7 @@ jobs:
         env:
           RUSTFLAGS: -D warnings
         run: |
-          cargo check --all --locked
+          cargo check --all --locked --features rocksdb/portable
 
   check-individual-crates:
     runs-on: ubuntu-24.04
@@ -70,7 +72,7 @@ jobs:
         uses: ./.github/actions/install-dependencies
       - name: Check individual crates
         run: |
-          ./dev-support/check-crates.sh
+          ./dev-support/check-crates.sh --portable
 
   workspace-tests:
     runs-on: ubuntu-24.04
@@ -90,14 +92,14 @@ jobs:
         env:
           RUSTFLAGS: -D warnings
         run: |
-          cargo bench --all --no-run
+          cargo bench --all --no-run --features rocksdb/portable
 
       - name: Run workspace tests
         env:
           RUSTFLAGS: -D warnings
         run: |
           cargo install cargo-nextest --version "0.9.104" --locked
-          cargo nextest run --no-fail-fast --release --workspace
+          cargo nextest run --no-fail-fast --release --workspace --features rocksdb/portable
 
   cfx-addr-tests:
     runs-on: ubuntu-24.04
@@ -136,7 +138,7 @@ jobs:
         env:
           CMAKE_POLICY_VERSION_MINIMUM: 3.5
         run: |
-          cargo doc --document-private-items
+          cargo doc --document-private-items --features rocksdb/portable
 
   evm-spec-tests:
     runs-on: ubuntu-24.04
@@ -164,7 +166,8 @@ jobs:
         working-directory: ./tools/evm-spec-tester
         env:
           RUSTFLAGS: -D warnings
-        run: cargo run --release --locked -- statetest ../../testdata/evm-spec-test
+        run: |
+          cargo run --release --locked --features portable -- statetest ../../testdata/evm-spec-test
 
   consensus-bench-test:
     runs-on: ubuntu-24.04
@@ -187,4 +190,4 @@ jobs:
         env:
           RUSTFLAGS: -D warnings
         run: |
-          cargo check --locked
+          cargo check --locked --features portable

--- a/crates/cfxcore/core/Cargo.toml
+++ b/crates/cfxcore/core/Cargo.toml
@@ -126,6 +126,7 @@ default = []
 testonly_code = []
 consensus_bench = []
 fuzzing = ["proptest", "proptest-derive"]
+portable = ["db/portable"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mirai)'] }

--- a/crates/dbs/db/Cargo.toml
+++ b/crates/dbs/db/Cargo.toml
@@ -7,3 +7,6 @@ license-file.workspace = true
 [dependencies]
 log = { workspace = true }
 kvdb-rocksdb = { workspace = true }
+
+[features]
+portable = ["kvdb-rocksdb/portable"]

--- a/crates/dbs/kvdb-rocksdb/Cargo.toml
+++ b/crates/dbs/kvdb-rocksdb/Cargo.toml
@@ -19,5 +19,11 @@ malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 rocksdb = { workspace = true }
 
+[features]
+# Forward RocksDB's `portable` feature so builds can disable its `-march=native`.
+# Non-portable titan under clang-18 emits `+avx10.1-256`, which `-Werror` rejects
+# on newer AVX10-capable CI runners.
+portable = ["rocksdb/portable"]
+
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/dev-support/check-crates.sh
+++ b/dev-support/check-crates.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
 
 set -e
-grep -oP '^\s*\K[\w-]+(?=\s*=\s*{ path)' Cargo.toml | \
-xargs -I {} sh -c \
-    'echo "\n\033[1;36m    Checking individual crate {}\033[0m\n" && \
-    cargo check -p {} && \
-    cargo check --tests -p {}' 
+
+# --portable: build RocksDB/titan portable (no -march=native) for CI. Co-selecting
+# `-p kvdb-rocksdb` (a direct rocksdb dependent) with its `portable` feature makes
+# Cargo unify rocksdb/portable across the whole resolve; a bare `-p <crate>` can't
+# request rocksdb/portable unless that crate itself directly depends on rocksdb.
+portable_args=()
+if [ "$1" = "--portable" ]; then
+  portable_args=(-p kvdb-rocksdb --features kvdb-rocksdb/portable)
+fi
+
+for crate in $(grep -oP '^\s*\K[\w-]+(?=\s*=\s*{ path)' Cargo.toml); do
+  printf '\n\033[1;36m    Checking individual crate %s\033[0m\n\n' "$crate"
+  cargo check -p "$crate" "${portable_args[@]}"
+  cargo check --tests -p "$crate" "${portable_args[@]}"
+done
 cargo check -p cfx-addr --no-default-features --tests

--- a/tools/consensus_bench/Cargo.toml
+++ b/tools/consensus_bench/Cargo.toml
@@ -12,6 +12,10 @@ cfx-types = { path = "../../crates/cfx_types" }
 log4rs = { version = "1.4.0", features = ["background_rotation", "gzip"] }
 log = "0.4"
 
+[features]
+# portable RocksDB/titan build — see kvdb-rocksdb/Cargo.toml. Used by consensus-bench-test.
+portable = ["cfxcore/portable"]
+
 [workspace]
 
 [patch.crates-io]

--- a/tools/evm-spec-tester/Cargo.toml
+++ b/tools/evm-spec-tester/Cargo.toml
@@ -37,6 +37,8 @@ clap-verbosity-flag = "3"
 
 [features]
 default = ["cfx-executor/align_evm", "cfx-statedb/testonly_code"]
+# portable RocksDB/titan build — see kvdb-rocksdb/Cargo.toml. Used by evm-spec-tests.
+portable = ["cfxcore/portable"]
 
 [workspace]
 


### PR DESCRIPTION
When RocksDB/titan is built non-portable, RocksDB's CMake adds `-march=native`; on the AVX10.1-capable runners GitHub has started using, clang-18 turns that into `+avx10.1-256` and rejects it under `-Werror` — so any `test.yml` job that recompiles titan fails as soon as it lands on one of those runners.

This makes every such job build titan with the `rocksdb/portable` feature (which drops `-march=native`), matching what the release workflows already do. The feature stays off by default and only changes how the C++ is optimized, not what it does — the same configuration the release binaries already ship — so there is no behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3577)
<!-- Reviewable:end -->
