### PR TITLE
log the direct source IP and node_id of NewBlockHashes of new PoW blocks

### DIFF
--- a/crates/cfxcore/core/src/sync/message/handleable.rs
+++ b/crates/cfxcore/core/src/sync/message/handleable.rs
@@ -14,6 +14,9 @@ pub struct Context<'a> {
     pub io: &'a dyn NetworkContext,
     pub node_id: NodeId,
     pub manager: &'a SynchronizationProtocolHandler,
+    /// Remote socket address of the peer that sent the message.
+    /// None if the peer is no longer connected or address is unavailable.
+    pub peer_addr: Option<String>,
 }
 
 impl<'a> Context<'a> {

--- a/crates/cfxcore/core/src/sync/message/new_block_hashes.rs
+++ b/crates/cfxcore/core/src/sync/message/new_block_hashes.rs
@@ -8,6 +8,7 @@ use crate::sync::{
 };
 use cfx_types::H256;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+use std::collections::HashSet;
 
 #[derive(Debug, PartialEq)]
 pub struct NewBlockHashes {
@@ -31,9 +32,52 @@ impl Handleable for NewBlockHashes {
     fn handle(self, ctx: &Context) -> Result<(), Error> {
         debug!("on_new_block_hashes, msg={:?}", self);
 
-        // Log the source peer information for each NewBlockHashes message.
-        // This is controlled by the log_block_source config flag and is
-        // designed for bootnode deployment to track block propagation.
+        // Filter out block hashes whose headers we already have.
+        //
+        // This serves a dual purpose: (1) it avoids redundant header requests
+        // for blocks we already know about, and (2) when `log_block_source`
+        // is enabled, it provides approximate first-seen deduplication so
+        // that only the first peer to propagate a block hash (before we
+        // download its header) generates a [BLOCK_SOURCE] log entry.
+        //
+        // Trade-offs of this approach:
+        //
+        // Advantages:
+        // - Zero additional memory: reuses the existing block_header_by_hash
+        //   lookup (in-memory HashMap + DB fallback) already used for request
+        //   filtering. No new data structure is needed.
+        // - No disk I/O overhead: the in-memory HashMap cache hits for recent
+        //   blocks. The DB lookup is already performed by the existing filter
+        //   below, so logging adds no extra queries.
+        // - No eviction management: existing CacheManager GC handles cleanup.
+        //
+        // Limitations:
+        // - Not a strict first-seen guarantee. If multiple peers send the same
+        //   NewBlockHashes within the short window before we download and cache
+        //   the header (typically milliseconds to a few seconds), each such
+        //   peer will generate a [BLOCK_SOURCE] log entry. In practice this
+        //   window is small because the first receipt triggers an immediate
+        //   header request, and the header arrives quickly for nearby peers.
+        //   The duplicate ratio depends on peer count and network latency, but
+        //   is expected to be low on a well-connected bootnode.
+        // - After the header is downloaded and inserted, all subsequent
+        //   NewBlockHashes for the same block are silently suppressed. This
+        //   means the log captures the first peer *from which we learned* the
+        //   block hash, which is the desired behavior for tracking block
+        //   propagation sources.
+        let known_hashes: HashSet<H256> = self
+            .block_hashes
+            .iter()
+            .filter(|hash| {
+                ctx.manager
+                    .graph
+                    .data_man
+                    .block_header_by_hash(hash)
+                    .is_some()
+            })
+            .cloned()
+            .collect();
+
         if ctx.manager.protocol_config.log_block_source {
             let peer_addr = ctx
                 .peer_addr
@@ -41,10 +85,12 @@ impl Handleable for NewBlockHashes {
                 .map(|s| s.as_str())
                 .unwrap_or("unknown");
             for hash in &self.block_hashes {
-                info!(
-                    "[BLOCK_SOURCE] hash={:#x} from_node={} from_addr={}",
-                    hash, ctx.node_id, peer_addr
-                );
+                if !known_hashes.contains(hash) {
+                    info!(
+                        "[BLOCK_SOURCE] hash={:#x} from_node={} from_addr={}",
+                        hash, ctx.node_id, peer_addr
+                    );
+                }
             }
         }
 
@@ -65,13 +111,7 @@ impl Handleable for NewBlockHashes {
         let headers_to_request = self
             .block_hashes
             .iter()
-            .filter(|hash| {
-                ctx.manager
-                    .graph
-                    .data_man
-                    .block_header_by_hash(&hash)
-                    .is_none()
-            })
+            .filter(|hash| !known_hashes.contains(hash))
             .cloned()
             .collect::<Vec<_>>();
 

--- a/crates/cfxcore/core/src/sync/message/new_block_hashes.rs
+++ b/crates/cfxcore/core/src/sync/message/new_block_hashes.rs
@@ -31,6 +31,23 @@ impl Handleable for NewBlockHashes {
     fn handle(self, ctx: &Context) -> Result<(), Error> {
         debug!("on_new_block_hashes, msg={:?}", self);
 
+        // Log the source peer information for each NewBlockHashes message.
+        // This is controlled by the log_block_source config flag and is
+        // designed for bootnode deployment to track block propagation.
+        if ctx.manager.protocol_config.log_block_source {
+            let peer_addr = ctx
+                .peer_addr
+                .as_ref()
+                .map(|s| s.as_str())
+                .unwrap_or("unknown");
+            for hash in &self.block_hashes {
+                info!(
+                    "[BLOCK_SOURCE] hash={:#x} from_node={} from_addr={}",
+                    hash, ctx.node_id, peer_addr
+                );
+            }
+        }
+
         if ctx.manager.catch_up_mode() {
             // If a node is in catch-up mode and we are not in test-mode, we
             // just simple ignore new block hashes.
@@ -67,5 +84,54 @@ impl Handleable for NewBlockHashes {
         );
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rlp_round_trip_empty() {
+        let original = NewBlockHashes {
+            block_hashes: vec![],
+        };
+        let encoded = rlp::encode(&original);
+        let decoded: NewBlockHashes = rlp::decode(&encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn rlp_round_trip_single_hash() {
+        let original = NewBlockHashes {
+            block_hashes: vec![H256::from_low_u64_be(42)],
+        };
+        let encoded = rlp::encode(&original);
+        let decoded: NewBlockHashes = rlp::decode(&encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn rlp_round_trip_multiple_hashes() {
+        let original = NewBlockHashes {
+            block_hashes: vec![
+                H256::from_low_u64_be(1),
+                H256::from_low_u64_be(2),
+                H256::from_low_u64_be(3),
+                H256::random(),
+            ],
+        };
+        let encoded = rlp::encode(&original);
+        let decoded: NewBlockHashes = rlp::decode(&encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn rlp_decode_rejects_short_element() {
+        // 0xc1 0x01 is an RLP list with one 1-byte element.
+        // H256 requires 32 bytes, so this should fail to decode.
+        let short_element: &[u8] = &[0xc1, 0x01];
+        let result: Result<NewBlockHashes, _> = rlp::decode(short_element);
+        assert!(result.is_err());
     }
 }

--- a/crates/cfxcore/core/src/sync/message/new_block_hashes.rs
+++ b/crates/cfxcore/core/src/sync/message/new_block_hashes.rs
@@ -29,76 +29,14 @@ impl Decodable for NewBlockHashes {
 
 impl Handleable for NewBlockHashes {
     fn handle(self, ctx: &Context) -> Result<(), Error> {
-        debug!("on_new_block_hashes, msg={:?}", self);
+        debug!(
+            "on_new_block_hashes, msg={:?} from_node={} from_addr={}",
+            self,
+            ctx.node_id,
+            ctx.peer_addr.as_deref().unwrap_or("unknown")
+        );
 
-        // Determine which block hashes are unknown to us, but only when at
-        // least one consumer actually needs the result.
-        //
-        // Two consumers exist:
-        //   1. The `log_block_source` logging path, which uses the unknown
-        //      hashes for approximate first-seen deduplication so that only the
-        //      first peer to propagate a block hash (before we download its
-        //      header) generates a [BLOCK_SOURCE] log entry.
-        //   2. The header-request path (active only outside catch-up mode),
-        //      which filters out hashes whose headers we already have to avoid
-        //      redundant requests.
-        //
-        // When neither consumer is active — i.e. we are in catch-up mode with
-        // logging disabled — the `block_header_by_hash` lookups are skipped
-        // entirely and `unknown_hashes` stays empty (no allocation). This
-        // restores the pre-logging performance characteristics: zero overhead
-        // in catch-up mode.
-        //
-        // The result is computed once and shared by both consumers, avoiding
-        // duplicate lookups. A `Vec<&H256>` is used instead of a `HashSet`
-        // because the typical NewBlockHashes message contains only 1–2 hashes,
-        // making linear iteration cheaper than HashSet allocation and hashing.
-        //
-        // Trade-off: this uses the existing block_header_by_hash lookup
-        // (in-memory HashMap + DB fallback) for approximate first-seen
-        // deduplication. It is not a strict first-seen guarantee: multiple
-        // peers propagating the same hash within the header-download window
-        // (typically milliseconds to a few seconds) each generate a log
-        // entry. After the header is cached, all subsequent NewBlockHashes
-        // for the same block are silently suppressed, which is the desired
-        // behavior for tracking block propagation sources.
-        let in_catch_up_mode = ctx.manager.catch_up_mode();
-
-        let unknown_hashes: Vec<&H256> = if ctx
-            .manager
-            .protocol_config
-            .log_block_source
-            || !in_catch_up_mode
-        {
-            self.block_hashes
-                .iter()
-                .filter(|hash| {
-                    ctx.manager
-                        .graph
-                        .data_man
-                        .block_header_by_hash(hash)
-                        .is_none()
-                })
-                .collect()
-        } else {
-            Vec::new()
-        };
-
-        if ctx.manager.protocol_config.log_block_source {
-            let peer_addr = ctx
-                .peer_addr
-                .as_ref()
-                .map(|s| s.as_str())
-                .unwrap_or("unknown");
-            for hash in &unknown_hashes {
-                info!(
-                    "[BLOCK_SOURCE] hash={:#x} from_node={} from_addr={}",
-                    hash, ctx.node_id, peer_addr
-                );
-            }
-        }
-
-        if in_catch_up_mode {
+        if ctx.manager.catch_up_mode() {
             // If a node is in catch-up mode and we are not in test-mode, we
             // just simple ignore new block hashes.
             if ctx.manager.protocol_config.test_mode {
@@ -112,8 +50,18 @@ impl Handleable for NewBlockHashes {
             return Ok(());
         }
 
-        let headers_to_request: Vec<H256> =
-            unknown_hashes.into_iter().cloned().collect();
+        let headers_to_request = self
+            .block_hashes
+            .iter()
+            .filter(|hash| {
+                ctx.manager
+                    .graph
+                    .data_man
+                    .block_header_by_hash(&hash)
+                    .is_none()
+            })
+            .cloned()
+            .collect::<Vec<_>>();
 
         ctx.manager.request_block_headers(
             ctx.io,
@@ -124,54 +72,5 @@ impl Handleable for NewBlockHashes {
         );
 
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn rlp_round_trip_empty() {
-        let original = NewBlockHashes {
-            block_hashes: vec![],
-        };
-        let encoded = rlp::encode(&original);
-        let decoded: NewBlockHashes = rlp::decode(&encoded).unwrap();
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    fn rlp_round_trip_single_hash() {
-        let original = NewBlockHashes {
-            block_hashes: vec![H256::from_low_u64_be(42)],
-        };
-        let encoded = rlp::encode(&original);
-        let decoded: NewBlockHashes = rlp::decode(&encoded).unwrap();
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    fn rlp_round_trip_multiple_hashes() {
-        let original = NewBlockHashes {
-            block_hashes: vec![
-                H256::from_low_u64_be(1),
-                H256::from_low_u64_be(2),
-                H256::from_low_u64_be(3),
-                H256::random(),
-            ],
-        };
-        let encoded = rlp::encode(&original);
-        let decoded: NewBlockHashes = rlp::decode(&encoded).unwrap();
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    fn rlp_decode_rejects_short_element() {
-        // 0xc1 0x01 is an RLP list with one 1-byte element.
-        // H256 requires 32 bytes, so this should fail to decode.
-        let short_element: &[u8] = &[0xc1, 0x01];
-        let result: Result<NewBlockHashes, _> = rlp::decode(short_element);
-        assert!(result.is_err());
     }
 }

--- a/crates/cfxcore/core/src/sync/message/new_block_hashes.rs
+++ b/crates/cfxcore/core/src/sync/message/new_block_hashes.rs
@@ -8,7 +8,6 @@ use crate::sync::{
 };
 use cfx_types::H256;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
-use std::collections::HashSet;
 
 #[derive(Debug, PartialEq)]
 pub struct NewBlockHashes {
@@ -32,51 +31,58 @@ impl Handleable for NewBlockHashes {
     fn handle(self, ctx: &Context) -> Result<(), Error> {
         debug!("on_new_block_hashes, msg={:?}", self);
 
-        // Filter out block hashes whose headers we already have.
+        // Determine which block hashes are unknown to us, but only when at
+        // least one consumer actually needs the result.
         //
-        // This serves a dual purpose: (1) it avoids redundant header requests
-        // for blocks we already know about, and (2) when `log_block_source`
-        // is enabled, it provides approximate first-seen deduplication so
-        // that only the first peer to propagate a block hash (before we
-        // download its header) generates a [BLOCK_SOURCE] log entry.
+        // Two consumers exist:
+        //   1. The `log_block_source` logging path, which uses the unknown
+        //      hashes for approximate first-seen deduplication so that only the
+        //      first peer to propagate a block hash (before we download its
+        //      header) generates a [BLOCK_SOURCE] log entry.
+        //   2. The header-request path (active only outside catch-up mode),
+        //      which filters out hashes whose headers we already have to avoid
+        //      redundant requests.
         //
-        // Trade-offs of this approach:
+        // When neither consumer is active — i.e. we are in catch-up mode with
+        // logging disabled — the `block_header_by_hash` lookups are skipped
+        // entirely and `unknown_hashes` stays empty (no allocation). This
+        // restores the pre-logging performance characteristics: zero overhead
+        // in catch-up mode.
         //
-        // Advantages:
-        // - Zero additional memory: reuses the existing block_header_by_hash
-        //   lookup (in-memory HashMap + DB fallback) already used for request
-        //   filtering. No new data structure is needed.
-        // - No disk I/O overhead: the in-memory HashMap cache hits for recent
-        //   blocks. The DB lookup is already performed by the existing filter
-        //   below, so logging adds no extra queries.
-        // - No eviction management: existing CacheManager GC handles cleanup.
+        // The result is computed once and shared by both consumers, avoiding
+        // duplicate lookups. A `Vec<&H256>` is used instead of a `HashSet`
+        // because the typical NewBlockHashes message contains only 1–2 hashes,
+        // making linear iteration cheaper than HashSet allocation and hashing.
         //
-        // Limitations:
-        // - Not a strict first-seen guarantee. If multiple peers send the same
-        //   NewBlockHashes within the short window before we download and cache
-        //   the header (typically milliseconds to a few seconds), each such
-        //   peer will generate a [BLOCK_SOURCE] log entry. In practice this
-        //   window is small because the first receipt triggers an immediate
-        //   header request, and the header arrives quickly for nearby peers.
-        //   The duplicate ratio depends on peer count and network latency, but
-        //   is expected to be low on a well-connected bootnode.
-        // - After the header is downloaded and inserted, all subsequent
-        //   NewBlockHashes for the same block are silently suppressed. This
-        //   means the log captures the first peer *from which we learned* the
-        //   block hash, which is the desired behavior for tracking block
-        //   propagation sources.
-        let known_hashes: HashSet<H256> = self
-            .block_hashes
-            .iter()
-            .filter(|hash| {
-                ctx.manager
-                    .graph
-                    .data_man
-                    .block_header_by_hash(hash)
-                    .is_some()
-            })
-            .cloned()
-            .collect();
+        // Trade-off: this uses the existing block_header_by_hash lookup
+        // (in-memory HashMap + DB fallback) for approximate first-seen
+        // deduplication. It is not a strict first-seen guarantee: multiple
+        // peers propagating the same hash within the header-download window
+        // (typically milliseconds to a few seconds) each generate a log
+        // entry. After the header is cached, all subsequent NewBlockHashes
+        // for the same block are silently suppressed, which is the desired
+        // behavior for tracking block propagation sources.
+        let in_catch_up_mode = ctx.manager.catch_up_mode();
+
+        let unknown_hashes: Vec<&H256> = if ctx
+            .manager
+            .protocol_config
+            .log_block_source
+            || !in_catch_up_mode
+        {
+            self.block_hashes
+                .iter()
+                .filter(|hash| {
+                    ctx.manager
+                        .graph
+                        .data_man
+                        .block_header_by_hash(hash)
+                        .is_none()
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
 
         if ctx.manager.protocol_config.log_block_source {
             let peer_addr = ctx
@@ -84,17 +90,15 @@ impl Handleable for NewBlockHashes {
                 .as_ref()
                 .map(|s| s.as_str())
                 .unwrap_or("unknown");
-            for hash in &self.block_hashes {
-                if !known_hashes.contains(hash) {
-                    info!(
-                        "[BLOCK_SOURCE] hash={:#x} from_node={} from_addr={}",
-                        hash, ctx.node_id, peer_addr
-                    );
-                }
+            for hash in &unknown_hashes {
+                info!(
+                    "[BLOCK_SOURCE] hash={:#x} from_node={} from_addr={}",
+                    hash, ctx.node_id, peer_addr
+                );
             }
         }
 
-        if ctx.manager.catch_up_mode() {
+        if in_catch_up_mode {
             // If a node is in catch-up mode and we are not in test-mode, we
             // just simple ignore new block hashes.
             if ctx.manager.protocol_config.test_mode {
@@ -108,12 +112,8 @@ impl Handleable for NewBlockHashes {
             return Ok(());
         }
 
-        let headers_to_request = self
-            .block_hashes
-            .iter()
-            .filter(|hash| !known_hashes.contains(hash))
-            .cloned()
-            .collect::<Vec<_>>();
+        let headers_to_request: Vec<H256> =
+            unknown_hashes.into_iter().cloned().collect();
 
         ctx.manager.request_block_headers(
             ctx.io,

--- a/crates/cfxcore/core/src/sync/state/snapshot_chunk_sync.rs
+++ b/crates/cfxcore/core/src/sync/state/snapshot_chunk_sync.rs
@@ -396,6 +396,7 @@ impl SnapshotChunkSync {
                 node_id: Default::default(),
                 io,
                 manager: sync_handler,
+                peer_addr: None,
             },
         );
 

--- a/crates/cfxcore/core/src/sync/synchronization_protocol_handler.rs
+++ b/crates/cfxcore/core/src/sync/synchronization_protocol_handler.rs
@@ -427,11 +427,6 @@ pub struct ProtocolConfiguration {
     pub check_status_genesis: bool,
 
     pub pos_started_as_voter: bool,
-
-    /// Enable logging of NewBlockHashes source peer information (IP and
-    /// NodeId). Designed for bootnode deployment to track block propagation.
-    /// Default: false. Set to true in production via config to enable.
-    pub log_block_source: bool,
 }
 
 impl SynchronizationProtocolHandler {

--- a/crates/cfxcore/core/src/sync/synchronization_protocol_handler.rs
+++ b/crates/cfxcore/core/src/sync/synchronization_protocol_handler.rs
@@ -427,6 +427,11 @@ pub struct ProtocolConfiguration {
     pub check_status_genesis: bool,
 
     pub pos_started_as_voter: bool,
+
+    /// Enable logging of NewBlockHashes source peer information (IP and
+    /// NodeId). Designed for bootnode deployment to track block propagation.
+    /// Default: false. Set to true in production via config to enable.
+    pub log_block_source: bool,
 }
 
 impl SynchronizationProtocolHandler {
@@ -578,6 +583,7 @@ impl SynchronizationProtocolHandler {
             node_id: *peer,
             io,
             manager: self,
+            peer_addr: io.get_peer_addr(peer),
         };
 
         if !handle_rlp_message(msg_id, &ctx, &rlp)? {
@@ -1023,6 +1029,7 @@ impl SynchronizationProtocolHandler {
                 node_id: io.self_node_id(),
                 io,
                 manager: self,
+                peer_addr: None,
             };
 
             ctx.send_response(&block_headers_resp)

--- a/crates/config/src/configuration.rs
+++ b/crates/config/src/configuration.rs
@@ -405,6 +405,9 @@ build_config! {
         (pos_fix_cip156_transition_view, (u64), u64::MAX)
         (dev_pos_private_key_encryption_password, (Option<String>), None)
         (pos_started_as_voter, (bool), true)
+        // Enable logging of NewBlockHashes source peer (IP and NodeId) for
+        // bootnode deployment to track block propagation. Default: false.
+        (log_block_source, (bool), false)
 
         // Light node section
         (ln_epoch_request_batch_size, (Option<usize>), None)
@@ -957,6 +960,7 @@ impl Configuration {
                 .expect("set to genesis if none"),
             check_status_genesis: self.raw_conf.check_status_genesis,
             pos_started_as_voter: self.raw_conf.pos_started_as_voter,
+            log_block_source: self.raw_conf.log_block_source,
         }
     }
 

--- a/crates/config/src/configuration.rs
+++ b/crates/config/src/configuration.rs
@@ -405,9 +405,6 @@ build_config! {
         (pos_fix_cip156_transition_view, (u64), u64::MAX)
         (dev_pos_private_key_encryption_password, (Option<String>), None)
         (pos_started_as_voter, (bool), true)
-        // Enable logging of NewBlockHashes source peer (IP and NodeId) for
-        // bootnode deployment to track block propagation. Default: false.
-        (log_block_source, (bool), false)
 
         // Light node section
         (ln_epoch_request_batch_size, (Option<usize>), None)
@@ -960,7 +957,6 @@ impl Configuration {
                 .expect("set to genesis if none"),
             check_status_genesis: self.raw_conf.check_status_genesis,
             pos_started_as_voter: self.raw_conf.pos_started_as_voter,
-            log_block_source: self.raw_conf.log_block_source,
         }
     }
 

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -299,6 +299,10 @@ pub trait NetworkContext {
     fn is_peer_self(&self, _node_id: &NodeId) -> bool;
 
     fn self_node_id(&self) -> NodeId;
+
+    /// Get the remote socket address of a connected peer by its NodeId.
+    /// Returns None if the peer is not currently connected.
+    fn get_peer_addr(&self, _node_id: &NodeId) -> Option<String>;
 }
 
 #[derive(Debug, Clone)]

--- a/crates/network/src/service.rs
+++ b/crates/network/src/service.rs
@@ -1957,6 +1957,16 @@ impl<'a> NetworkContextTrait for NetworkContext<'a> {
 
     fn self_node_id(&self) -> NodeId { *self.network_service.metadata.id() }
 
+    fn get_peer_addr(&self, node_id: &NodeId) -> Option<String> {
+        match self.network_service.sessions.get_by_id(node_id) {
+            Some(session) => {
+                let sess = session.read();
+                Some(sess.address().to_string())
+            }
+            None => None,
+        }
+    }
+
     /// Message is sent through this method.
     fn send(
         &self, node_id: &NodeId, msg: Vec<u8>,


### PR DESCRIPTION
Add the ability to log the direct source IP and NodeId for each received NewBlockHashes message. This feature is controlled by the log_block_source config flag **(default: false)**. To track **PoW** block propagation patterns.

```
[BLOCK_SOURCE] hash=0x... from_node=0x... from_addr=1.2.3.4:32323
```

Changes:
- Add get_peer_addr() method to NetworkContext trait
- Implement get_peer_addr() in network service to look up session address
- Add peer_addr field to sync message Context struct
- Populate peer_addr when dispatching messages
- Log [BLOCK_SOURCE] with block hash, source NodeId and IP when enabled
- Add log_block_source config option in ProtocolConfiguration and configuration.rs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3583)
<!-- Reviewable:end -->
