### PR TITLE
impl CIP-174: modexp input upper bounds and gas repricing

### DIFF
--- a/crates/execution/executor/src/builtin/mod.rs
+++ b/crates/execution/executor/src/builtin/mod.rs
@@ -53,7 +53,7 @@ use blake2f::compress;
 
 use bls12_381::bls12_builtin_factory;
 use modexp::ModexpImpl;
-pub(crate) use modexp::ModexpPricer;
+pub(crate) use modexp::{ModexpPricePlan, ModexpPricer};
 pub(crate) use pricer::{
     AltBn128PairingPricer, Blake2FPricer, ConstPricer, Linear,
 };
@@ -557,10 +557,12 @@ impl Precompile for KzgPointEval {
 mod tests {
     use super::{
         builtin_factory, modexp::modexp as me, price_plan::StaticPlan,
-        ActivateAt, Blake2FPricer, Builtin, Linear, ModexpPricer,
+        ActivateAt, Blake2FPricer, Builtin, Linear, ModexpPricePlan,
+        ModexpPricer,
     };
     use cfx_bytes::BytesRef;
     use cfx_types::U256;
+    use cfx_vm_types::{CIP645Spec, Spec};
     use num::{BigUint, One, Zero};
     use rustc_hex::FromHex;
 
@@ -872,6 +874,127 @@ mod tests {
             assert_eq!(output.len(), 0); // shouldn't have written any output.
             assert_eq!(f.cost_on_genesis(&input[..]), expected_cost.into());
         }
+    }
+
+    // CIP-174: EIP-7823 + EIP-7883
+    #[test]
+    fn modexp_osaka() {
+        let f = Builtin {
+            price_plan: Box::new(StaticPlan(ModexpPricer::new_osaka(500))),
+            native: builtin_factory("modexp"),
+            activate_at: ALWAYS,
+        };
+
+        // fermat's little theorem example: 32-byte exponent with the top bit
+        // set gives iteration_count = 255; multiplication_complexity = 16.
+        {
+            let input: Vec<u8> = FromHex::from_hex(
+                "\
+				0000000000000000000000000000000000000000000000000000000000000001\
+				0000000000000000000000000000000000000000000000000000000000000020\
+				0000000000000000000000000000000000000000000000000000000000000020\
+				03\
+				fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2e\
+				fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+            )
+            .unwrap();
+            // max(500, 16 * 255) = 4080
+            assert_eq!(f.cost_on_genesis(&input[..]), U256::from(4080));
+        }
+
+        // small work is charged the 500 minimum: two-byte exponent 0xffff
+        // gives iteration_count = 15, 16 * 15 = 240 < 500.
+        {
+            let input: Vec<u8> = FromHex::from_hex(
+                "\
+				0000000000000000000000000000000000000000000000000000000000000001\
+				0000000000000000000000000000000000000000000000000000000000000002\
+				0000000000000000000000000000000000000000000000000000000000000020\
+				03\
+				ffff\
+				80",
+            )
+            .unwrap();
+            assert_eq!(f.cost_on_genesis(&input[..]), U256::from(500));
+        }
+
+        // empty base and modulus no longer short-circuit: a 64-byte exponent
+        // still pays iteration costs (16 * (64 - 32) = 512 iterations,
+        // multiplication_complexity = 16).
+        {
+            let input: Vec<u8> = FromHex::from_hex(
+                "\
+				0000000000000000000000000000000000000000000000000000000000000000\
+				0000000000000000000000000000000000000000000000000000000000000040\
+				0000000000000000000000000000000000000000000000000000000000000000",
+            )
+            .unwrap();
+            assert_eq!(f.cost_on_genesis(&input[..]), U256::from(8192));
+        }
+
+        // EIP-7823: lengths up to 1024 bytes are priced normally; 1024-byte
+        // base and modulus give words = 128, 2 * 128^2 = 32768.
+        {
+            let input: Vec<u8> = FromHex::from_hex(
+                "\
+				0000000000000000000000000000000000000000000000000000000000000400\
+				0000000000000000000000000000000000000000000000000000000000000000\
+				0000000000000000000000000000000000000000000000000000000000000400",
+            )
+            .unwrap();
+            assert_eq!(f.cost_on_genesis(&input[..]), U256::from(32768));
+        }
+
+        // EIP-7823: any length above 1024 bytes fails, consuming all gas.
+        for oversized in [
+            "\
+			0000000000000000000000000000000000000000000000000000000000000401\
+			0000000000000000000000000000000000000000000000000000000000000001\
+			0000000000000000000000000000000000000000000000000000000000000001",
+            "\
+			0000000000000000000000000000000000000000000000000000000000000001\
+			0000000000000000000000000000000000000000000000000000000000000401\
+			0000000000000000000000000000000000000000000000000000000000000001",
+            "\
+			0000000000000000000000000000000000000000000000000000000000000001\
+			0000000000000000000000000000000000000000000000000000000000000001\
+			0000000000000000000000000000000000000000000000000000000000000401",
+        ] {
+            let input: Vec<u8> = FromHex::from_hex(oversized).unwrap();
+            assert_eq!(f.cost_on_genesis(&input[..]), U256::max_value());
+        }
+    }
+
+    #[test]
+    fn modexp_price_plan_selection() {
+        let f = Builtin {
+            price_plan: Box::new(ModexpPricePlan::new(
+                ModexpPricer::new_osaka(500),
+                ModexpPricer::new_berlin(200),
+                ModexpPricer::new_byzantium(20),
+            )),
+            native: builtin_factory("modexp"),
+            activate_at: ALWAYS,
+        };
+        let input: Vec<u8> = FromHex::from_hex(
+            "\
+			0000000000000000000000000000000000000000000000000000000000000001\
+			0000000000000000000000000000000000000000000000000000000000000020\
+			0000000000000000000000000000000000000000000000000000000000000020\
+			03\
+			fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2e\
+			fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+        )
+        .unwrap();
+
+        let mut spec = Spec::genesis_spec();
+        assert_eq!(f.cost(&input[..], &spec), U256::from(13056)); // Byzantium
+
+        spec.cip645 = CIP645Spec::new(true);
+        assert_eq!(f.cost(&input[..], &spec), U256::from(1360)); // Berlin
+
+        spec.cip174 = true;
+        assert_eq!(f.cost(&input[..], &spec), U256::from(4080)); // Osaka
     }
 
     #[test]

--- a/crates/execution/executor/src/builtin/mod.rs
+++ b/crates/execution/executor/src/builtin/mod.rs
@@ -568,6 +568,33 @@ mod tests {
 
     const ALWAYS: ActivateAt = ActivateAt::GENESIS;
 
+    fn modexp_input(base: &[u8], exponent: &[u8], modulus: &[u8]) -> Vec<u8> {
+        let mut input =
+            modexp_input_header(base.len(), exponent.len(), modulus.len());
+        input.extend_from_slice(base);
+        input.extend_from_slice(exponent);
+        input.extend_from_slice(modulus);
+        input
+    }
+
+    fn modexp_input_header(
+        base_len: usize, exponent_len: usize, modulus_len: usize,
+    ) -> Vec<u8> {
+        let mut input = vec![0u8; 96];
+        input[24..32].copy_from_slice(&(base_len as u64).to_be_bytes());
+        input[56..64].copy_from_slice(&(exponent_len as u64).to_be_bytes());
+        input[88..96].copy_from_slice(&(modulus_len as u64).to_be_bytes());
+        input
+    }
+
+    fn osaka_modexp_builtin() -> Builtin {
+        Builtin {
+            price_plan: Box::new(StaticPlan(ModexpPricer::new_osaka(500))),
+            native: builtin_factory("modexp"),
+            activate_at: ALWAYS,
+        }
+    }
+
     #[test]
     fn modexp_func() {
         // n^0 % m == 1
@@ -879,11 +906,7 @@ mod tests {
     // CIP-174: EIP-7823 + EIP-7883
     #[test]
     fn modexp_osaka() {
-        let f = Builtin {
-            price_plan: Box::new(StaticPlan(ModexpPricer::new_osaka(500))),
-            native: builtin_factory("modexp"),
-            activate_at: ALWAYS,
-        };
+        let f = osaka_modexp_builtin();
 
         // fermat's little theorem example: 32-byte exponent with the top bit
         // set gives iteration_count = 255; multiplication_complexity = 16.
@@ -963,6 +986,112 @@ mod tests {
             let input: Vec<u8> = FromHex::from_hex(oversized).unwrap();
             assert_eq!(f.cost_on_genesis(&input[..]), U256::max_value());
         }
+    }
+
+    #[test]
+    fn modexp_osaka_eip7883_gas_branches() {
+        let f = osaka_modexp_builtin();
+
+        let mut exponent_40_head_bit_set = vec![0u8; 40];
+        exponent_40_head_bit_set[0] = 0x80;
+
+        let mut exponent_40_tail_bit_set = vec![0u8; 40];
+        exponent_40_tail_bit_set[39] = 1;
+
+        let cases = [
+            // Empty input: complexity and iteration count are both clamped.
+            (modexp_input(&[], &[], &[]), 500u64),
+            // exponent_length <= 32 and exponent == 0.
+            (modexp_input(&[1; 32], &[0; 32], &[2; 32]), 500),
+            // exponent_length <= 32 and exponent != 0: bit index 255.
+            (modexp_input(&[1; 32], &[0xff; 32], &[2; 32]), 4080),
+            // exponent_length > 32 and the first 32 bytes are zero.
+            (modexp_input(&[1; 16], &[0; 40], &[2; 16]), 2048),
+            // Bytes after the first 32 exponent bytes do not affect the bit
+            // index portion of the iteration count.
+            (
+                modexp_input(&[1; 16], &exponent_40_tail_bit_set, &[2; 16]),
+                2048,
+            ),
+            // exponent_length > 32 and the exponent head is non-zero:
+            // (16 * 8 + 255) * 16 = 6128.
+            (
+                modexp_input(&[1; 16], &exponent_40_head_bit_set, &[2; 16]),
+                6128,
+            ),
+            // max_length = 33: words = ceil(33 / 8) = 5 and complexity = 50.
+            (modexp_input(&[1; 33], &[0xff; 32], &[2; 33]), 12750),
+            // Exact word boundary: max_length = 40 also gives words = 5.
+            (modexp_input(&[1; 40], &[0xff; 32], &[2; 40]), 12750),
+            // One byte beyond the word boundary: words = 6, complexity = 72.
+            (modexp_input(&[1; 41], &[0xff; 32], &[2; 41]), 18360),
+            // Maximum accepted zero exponent length:
+            // 16 * (1024 - 32) iterations at complexity 16.
+            (modexp_input(&[1; 32], &[0; 1024], &[]), 253952),
+        ];
+
+        for (input, expected_cost) in cases {
+            assert_eq!(
+                f.cost_on_genesis(&input),
+                U256::from(expected_cost),
+                "unexpected Osaka cost for lengths ({}, {}, {})",
+                U256::from_big_endian(&input[0..32]),
+                U256::from_big_endian(&input[32..64]),
+                U256::from_big_endian(&input[64..96]),
+            );
+        }
+    }
+
+    #[test]
+    fn modexp_osaka_eip7823_length_boundaries() {
+        let osaka = osaka_modexp_builtin();
+
+        // Each length is accepted at exactly 1024 bytes.
+        for input in [
+            modexp_input_header(1024, 0, 0),
+            modexp_input_header(0, 1024, 0),
+            modexp_input_header(0, 0, 1024),
+            modexp_input_header(1024, 1024, 1024),
+        ] {
+            assert_ne!(osaka.cost_on_genesis(&input), U256::max_value());
+        }
+
+        // Any individual length, or a combination of lengths, above 1024
+        // bytes is rejected through the maximal-cost OOG path.
+        for input in [
+            modexp_input_header(1025, 0, 0),
+            modexp_input_header(0, 1025, 0),
+            modexp_input_header(0, 0, 1025),
+            modexp_input_header(1025, 0, 1025),
+            modexp_input_header(1025, 1025, 1025),
+        ] {
+            assert_eq!(osaka.cost_on_genesis(&input), U256::max_value());
+        }
+
+        // Length words are full U256 values, not truncated to their low 64
+        // bits. Exercise a high byte in each of the three fields.
+        for high_byte_offset in [0, 32, 64] {
+            let mut input = vec![0u8; 96];
+            input[high_byte_offset] = 1;
+            assert_eq!(osaka.cost_on_genesis(&input), U256::max_value());
+        }
+
+        // A truncated first length word is right-padded with zeroes and becomes
+        // a very large U256 length, so it must also take the OOG path.
+        assert_eq!(
+            osaka.cost_on_genesis(&[0x9e, 0x5f, 0xaa, 0xfc]),
+            U256::max_value(),
+        );
+
+        // The EIP-7823 cap is fork-specific. The same 1025-byte declaration
+        // remains normally priced under the pre-Osaka Berlin rules.
+        let berlin = Builtin {
+            price_plan: Box::new(StaticPlan(ModexpPricer::new_berlin(200))),
+            native: builtin_factory("modexp"),
+            activate_at: ALWAYS,
+        };
+        let oversized_base = modexp_input_header(1025, 0, 1);
+        assert_ne!(berlin.cost_on_genesis(&oversized_base), U256::max_value());
     }
 
     #[test]

--- a/crates/execution/executor/src/builtin/modexp.rs
+++ b/crates/execution/executor/src/builtin/modexp.rs
@@ -1,12 +1,17 @@
-use super::{Error, Precompile, Pricer};
+use super::{Error, Precompile, PricePlan, Pricer};
 use byteorder::{BigEndian, ByteOrder};
 use cfx_bytes::BytesRef;
 use cfx_types::U256;
+use cfx_vm_types::Spec;
 use num::{BigUint, One, Zero};
 use std::{
     cmp::{max, min},
     io::{self, Read},
 };
+
+/// EIP-7823: upper bound (in bytes) for each of the base, exponent and
+/// modulus length inputs.
+const EIP7823_INPUT_LEN_LIMIT: u64 = 1024;
 
 #[derive(Debug)]
 #[allow(dead_code)]
@@ -132,6 +137,8 @@ pub(crate) enum ModexpPricer {
     Byzantium { divisor: usize },
     // CIP-645e: EIP-2565
     Berlin { base: usize },
+    // CIP-174: EIP-7823 + EIP-7883
+    Osaka { base: usize },
 }
 
 impl ModexpPricer {
@@ -141,6 +148,42 @@ impl ModexpPricer {
 
     pub(crate) fn new_berlin(base: usize) -> ModexpPricer {
         ModexpPricer::Berlin { base }
+    }
+
+    pub(crate) fn new_osaka(base: usize) -> ModexpPricer {
+        ModexpPricer::Osaka { base }
+    }
+}
+
+/// Selects the modexp pricer by the active spec: Osaka (CIP-174), Berlin
+/// (CIP-645e) or Byzantium.
+pub(crate) struct ModexpPricePlan {
+    osaka: ModexpPricer,
+    berlin: ModexpPricer,
+    byzantium: ModexpPricer,
+}
+
+impl ModexpPricePlan {
+    pub(crate) fn new(
+        osaka: ModexpPricer, berlin: ModexpPricer, byzantium: ModexpPricer,
+    ) -> Self {
+        Self {
+            osaka,
+            berlin,
+            byzantium,
+        }
+    }
+}
+
+impl PricePlan for ModexpPricePlan {
+    fn pricer(&self, spec: &Spec) -> &dyn Pricer {
+        if spec.cip174 {
+            &self.osaka
+        } else if spec.cip645.eip2565 {
+            &self.berlin
+        } else {
+            &self.byzantium
+        }
     }
 }
 
@@ -160,11 +203,25 @@ impl Pricer for ModexpPricer {
         let exp_len = read_len();
         let mod_len = read_len();
 
+        // EIP-7823: over-limit inputs make the precompile fail; returning
+        // the maximal cost makes the call run out of gas, which consumes
+        // all gas passed to the call as the EIP requires.
+        if matches!(self, Self::Osaka { .. }) {
+            let limit = U256::from(EIP7823_INPUT_LEN_LIMIT);
+            if base_len > limit || exp_len > limit || mod_len > limit {
+                return U256::max_value();
+            }
+        }
+
         if mod_len.is_zero() && base_len.is_zero() {
-            return match self {
-                Self::Byzantium { .. } => 0.into(),
-                Self::Berlin { base } => (*base).into(),
-            };
+            match self {
+                Self::Byzantium { .. } => return 0.into(),
+                Self::Berlin { base } => return (*base).into(),
+                // EIP-7883: multiplication complexity is at least 16, so a
+                // long exponent still charges iteration costs even with
+                // empty base and modulus — fall through to the full formula.
+                Self::Osaka { .. } => {}
+            }
         }
 
         let max_len = U256::from(u32::max_value() / 2);
@@ -188,7 +245,13 @@ impl Pricer for ModexpPricer {
                 .expect("reading from zero-extended memory cannot fail; qed");
             U256::from_big_endian(&buf[..])
         };
-        let iter_count = max(Self::adjusted_exp_len(exp_len, exp_low), 1);
+        // EIP-7883 doubles the per-byte cost of the exponent tail.
+        let exp_byte_factor = match self {
+            ModexpPricer::Osaka { .. } => 16,
+            _ => 8,
+        };
+        let iter_count =
+            max(Self::adjusted_exp_len(exp_len, exp_low, exp_byte_factor), 1);
 
         match self {
             ModexpPricer::Byzantium { divisor } => Self::byzantium_gas_calc(
@@ -196,6 +259,9 @@ impl Pricer for ModexpPricer {
             ),
             ModexpPricer::Berlin { base } => {
                 Self::berlin_gas_calc(base_len, mod_len, iter_count, *base)
+            }
+            ModexpPricer::Osaka { base } => {
+                Self::osaka_gas_calc(base_len, mod_len, iter_count, *base)
             }
         }
     }
@@ -214,7 +280,7 @@ impl ModexpPricer {
         (gas / divisor as u64).into()
     }
 
-    fn adjusted_exp_len(len: u64, exp_low: U256) -> u64 {
+    fn adjusted_exp_len(len: u64, exp_low: U256, byte_factor: u64) -> u64 {
         let bit_index = if exp_low.is_zero() {
             0
         } else {
@@ -223,7 +289,7 @@ impl ModexpPricer {
         if len <= 32 {
             bit_index
         } else {
-            8 * (len - 32) + bit_index
+            byte_factor * (len - 32) + bit_index
         }
     }
 
@@ -260,5 +326,24 @@ impl ModexpPricer {
             gas.as_u64()
         };
         max(base_gas as u64, gas_u64).into()
+    }
+
+    // CIP-174: EIP-7883. Inputs are bounded by EIP-7823 (checked in `cost`),
+    // so none of the arithmetic below can overflow u64.
+    pub fn osaka_gas_calc(
+        base_len: u64, mod_len: u64, iter_count: u64, base_gas: usize,
+    ) -> U256 {
+        let max_len = max(base_len, mod_len);
+        let mut words = max_len / 8;
+        if max_len % 8 > 0 {
+            words += 1;
+        }
+        let multiplication_complexity = if max_len <= 32 {
+            16
+        } else {
+            2 * words * words
+        };
+        let gas = multiplication_complexity * iter_count;
+        max(base_gas as u64, gas).into()
     }
 }

--- a/crates/execution/executor/src/builtin/modexp.rs
+++ b/crates/execution/executor/src/builtin/modexp.rs
@@ -338,11 +338,8 @@ impl ModexpPricer {
         if max_len % 8 > 0 {
             words += 1;
         }
-        let multiplication_complexity = if max_len <= 32 {
-            16
-        } else {
-            2 * words * words
-        };
+        let multiplication_complexity =
+            if max_len <= 32 { 16 } else { 2 * words * words };
         let gas = multiplication_complexity * iter_count;
         max(base_gas as u64, gas).into()
     }

--- a/crates/execution/executor/src/machine/mod.rs
+++ b/crates/execution/executor/src/machine/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         build_bls12_builtin_map, builtin_factory,
         secp256r1::{P256VERIFY_ADDRESS, P256VERIFY_BASE_GAS_FEE_OSAKA},
         ActivateAt, AltBn128PairingPricer, Blake2FPricer, Builtin, ConstPricer,
-        IfPricer, Linear, ModexpPricer, StaticPlan,
+        IfPricer, Linear, ModexpPricePlan, ModexpPricer, StaticPlan,
     },
     internal_contract::InternalContractMap,
     spec::{CommonParams, TransitionsBlockNumber, TransitionsEpochHeight},
@@ -186,9 +186,9 @@ fn new_builtin_map(
         ),
     );
 
-    // CIP-645e: EIP-2565
-    let mod_exp_pricer = IfPricer::new(
-        |spec| spec.cip645.eip2565,
+    // CIP-645e: EIP-2565; CIP-174: EIP-7823 + EIP-7883
+    let mod_exp_pricer = ModexpPricePlan::new(
+        ModexpPricer::new_osaka(500),
         ModexpPricer::new_berlin(200),
         ModexpPricer::new_byzantium(20),
     );


### PR DESCRIPTION
Follow EIP-7823 (reject length inputs above 1024 bytes, consuming all gas) and EIP-7883 (Osaka pricing: min 500 gas, complexity floor 16, doubled exponent byte factor, no division by 3) behind the new cip174 transition height, bundled into osaka_opcode_transition_height.

Also rename spec.eip7939 / INSTRUCTIONS_EIP7939 to cip166 to keep CIP naming consistent with the transition height field.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3585)
<!-- Reviewable:end -->
