### PR TITLE
fix(executor): CIP-175: resolve EIP-7702 delegation in cross-space calls (CIP-…

### DIFF
--- a/crates/execution/executor/src/internal_contract/impls/cross_space.rs
+++ b/crates/execution/executor/src/internal_contract/impls/cross_space.rs
@@ -270,8 +270,15 @@ pub fn call_to_evmcore(
 
     let address = receiver.with_evm_space();
 
-    let code = context.state.code(&address)?;
-    let code_hash = context.state.code_hash(&address)?;
+    let (code, code_hash) = if context.spec.cip175 {
+        // CIP-175: resolve EIP-7702 delegation as an in-space call does.
+        context.state.code_with_hash_on_call(&address)?
+    } else {
+        (
+            context.state.code(&address)?,
+            context.state.code_hash(&address)?,
+        )
+    };
 
     let next_params = ActionParams {
         space: Space::Ethereum,

--- a/integration_tests/tests/transaction/eip7702/test_eip7702_cross_space.py
+++ b/integration_tests/tests/transaction/eip7702/test_eip7702_cross_space.py
@@ -1,0 +1,130 @@
+"""
+CIP-175: cross-space calls (callEVM / staticCallEVM / transferEVM) targeting an
+eSpace account with an EIP-7702 delegation must execute the delegated code,
+identically to an in-space call.
+"""
+
+import pytest
+from typing import cast
+from web3 import Web3
+from ethereum_test_tools import Initcode, Opcodes as Op
+
+from integration_tests.test_framework.util.eip7702.eip7702 import (
+    sign_authorization,
+    send_eip7702_transaction,
+)
+
+COUNTER_SLOT = 1
+
+
+def get_new_fund_account(ew3: Web3):
+    new_account = ew3.eth.account.create()
+    tx_hash = ew3.eth.send_transaction(
+        {
+            "to": new_account.address,
+            "value": ew3.to_wei(1, "ether"),
+        }
+    )
+    ew3.eth.wait_for_transaction_receipt(tx_hash)
+    return new_account
+
+
+def deploy_contract_using_deploy_code(ew3: Web3, deploy_code) -> str:
+    initcode = Initcode(deploy_code=deploy_code)
+    tx_hash = ew3.eth.send_transaction(
+        {
+            "data": bytes(initcode),
+        }
+    )
+    receipt = ew3.eth.wait_for_transaction_receipt(tx_hash)
+    return cast(str, receipt["contractAddress"])
+
+
+def delegate_to(ew3: Web3, contract_address: str):
+    """Create a fresh eSpace EOA delegated to `contract_address`."""
+    authority = get_new_fund_account(ew3)
+    sender = get_new_fund_account(ew3)
+    tx_hash = send_eip7702_transaction(
+        ew3,
+        sender,
+        {
+            "authorizationList": [
+                sign_authorization(
+                    contract_address=contract_address,
+                    chain_id=ew3.eth.chain_id,
+                    nonce=0,
+                    private_key=authority.key.to_0x_hex(),
+                )
+            ],
+            "to": ew3.eth.account.create().address,
+        },
+    )
+    ew3.eth.wait_for_transaction_receipt(tx_hash)
+    code = ew3.eth.get_code(authority.address)
+    assert code.to_0x_hex() == "0xef0100" + contract_address[2:].lower()
+    return authority
+
+
+@pytest.fixture(scope="module")
+def counter_contract_address(ew3: Web3) -> str:
+    # Increments a counter in the caller-context storage on every call.
+    code = Op.SSTORE(COUNTER_SLOT, Op.ADD(Op.SLOAD(COUNTER_SLOT), 1)) + Op.STOP
+    return deploy_contract_using_deploy_code(ew3, code)
+
+
+@pytest.fixture(scope="module")
+def reader_contract_address(ew3: Web3) -> str:
+    # Returns the constant 42 (static-call friendly: no state writes).
+    code = Op.MSTORE(0, 42) + Op.RETURN(0, 32)
+    return deploy_contract_using_deploy_code(ew3, code)
+
+
+def counter_value(ew3: Web3, address: str) -> int:
+    return int.from_bytes(ew3.eth.get_storage_at(address, COUNTER_SLOT), "big")
+
+
+def test_call_evm_to_delegated_account(
+    cw3, ew3: Web3, internal_contracts, counter_contract_address
+):
+    authority = delegate_to(ew3, counter_contract_address)
+    assert counter_value(ew3, authority.address) == 0
+
+    cross_space_call = internal_contracts["CrossSpaceCall"]
+    tx_hash = cross_space_call.functions.callEVM(authority.address, b"").transact()
+    receipt = cw3.cfx.wait_for_transaction_receipt(tx_hash)
+    assert receipt["outcomeStatus"] == 0
+
+    # The delegated code ran in the authority's context.
+    assert counter_value(ew3, authority.address) == 1
+    assert counter_value(ew3, counter_contract_address) == 0
+
+
+def test_static_call_evm_to_delegated_account(
+    ew3: Web3, internal_contracts, reader_contract_address
+):
+    authority = delegate_to(ew3, reader_contract_address)
+
+    cross_space_call = internal_contracts["CrossSpaceCall"]
+    output = cross_space_call.functions.staticCallEVM(
+        authority.address, b""
+    ).call()
+    assert int.from_bytes(output, "big") == 42
+
+
+def test_transfer_evm_to_delegated_account(
+    cw3, ew3: Web3, internal_contracts, counter_contract_address
+):
+    authority = delegate_to(ew3, counter_contract_address)
+    balance_before = ew3.eth.get_balance(authority.address)
+    counter_before = counter_value(ew3, authority.address)
+
+    cross_space_call = internal_contracts["CrossSpaceCall"]
+    tx_hash = cross_space_call.functions.transferEVM(authority.address).transact(
+        {"value": 10**18}
+    )
+    receipt = cw3.cfx.wait_for_transaction_receipt(tx_hash)
+    assert receipt["outcomeStatus"] == 0
+
+    # Value arrives and the delegated code runs, as for an in-space transfer.
+    assert ew3.eth.get_balance(authority.address) == balance_before + 10**18
+    assert counter_value(ew3, authority.address) == counter_before + 1

--- a/integration_tests/tests/transaction/eip7702/test_eip7702_cross_space_pre_activation.py
+++ b/integration_tests/tests/transaction/eip7702/test_eip7702_cross_space_pre_activation.py
@@ -1,0 +1,115 @@
+"""
+Before CIP-175 activation, a cross-space call to an eSpace account with an
+EIP-7702 delegation keeps the legacy behavior: the raw delegation designator
+is loaded as code and fails on the invalid 0xef opcode.
+"""
+
+import pytest
+from typing import cast
+from web3 import Web3
+from ethereum_test_tools import Initcode, Opcodes as Op
+
+from integration_tests.test_framework.test_framework import ConfluxTestFramework
+from integration_tests.test_framework.util.eip7702.eip7702 import (
+    sign_authorization,
+    send_eip7702_transaction,
+)
+
+MIN_NATIVE_BASE_PRICE = 10000
+EVM_CHAIN_ID = 11
+COUNTER_SLOT = 1
+
+
+@pytest.fixture(scope="module")
+def framework_class():
+    class CIP175PreActivationTestEnv(ConfluxTestFramework):
+        def set_test_params(self):
+            self.num_nodes = 1
+            self.conf_parameters["evm_chain_id"] = str(EVM_CHAIN_ID)
+            self.conf_parameters["min_native_base_price"] = MIN_NATIVE_BASE_PRICE
+            self.conf_parameters["eoa_code_transition_height"] = 1
+            self.conf_parameters["align_evm_transition_height"] = 1
+            self.conf_parameters["cip175_transition_height"] = 10**9
+            self.conf_parameters["evm_transaction_block_ratio"] = str(1)
+            self.conf_parameters["public_evm_rpc_apis"] = '"all"'
+            self.conf_parameters["executive_trace"] = "true"
+
+        def setup_network(self):
+            self.add_nodes(self.num_nodes)
+            self.start_node(0, ["--archive"])
+
+    return CIP175PreActivationTestEnv
+
+
+def get_new_fund_account(ew3: Web3):
+    new_account = ew3.eth.account.create()
+    tx_hash = ew3.eth.send_transaction(
+        {
+            "to": new_account.address,
+            "value": ew3.to_wei(1, "ether"),
+        }
+    )
+    ew3.eth.wait_for_transaction_receipt(tx_hash)
+    return new_account
+
+
+def deploy_contract_using_deploy_code(ew3: Web3, deploy_code) -> str:
+    initcode = Initcode(deploy_code=deploy_code)
+    tx_hash = ew3.eth.send_transaction(
+        {
+            "data": bytes(initcode),
+        }
+    )
+    receipt = ew3.eth.wait_for_transaction_receipt(tx_hash)
+    return cast(str, receipt["contractAddress"])
+
+
+def delegate_to(ew3: Web3, contract_address: str):
+    """Create a fresh eSpace EOA delegated to `contract_address`."""
+    authority = get_new_fund_account(ew3)
+    sender = get_new_fund_account(ew3)
+    tx_hash = send_eip7702_transaction(
+        ew3,
+        sender,
+        {
+            "authorizationList": [
+                sign_authorization(
+                    contract_address=contract_address,
+                    chain_id=ew3.eth.chain_id,
+                    nonce=0,
+                    private_key=authority.key.to_0x_hex(),
+                )
+            ],
+            "to": ew3.eth.account.create().address,
+        },
+    )
+    ew3.eth.wait_for_transaction_receipt(tx_hash)
+    code = ew3.eth.get_code(authority.address)
+    assert code.to_0x_hex() == "0xef0100" + contract_address[2:].lower()
+    return authority
+
+
+def counter_value(ew3: Web3, address: str) -> int:
+    return int.from_bytes(ew3.eth.get_storage_at(address, COUNTER_SLOT), "big")
+
+
+def test_call_evm_to_delegated_account_before_activation(
+    cw3, ew3: Web3, internal_contracts
+):
+    code = Op.SSTORE(COUNTER_SLOT, Op.ADD(Op.SLOAD(COUNTER_SLOT), 1)) + Op.STOP
+    counter_contract_address = deploy_contract_using_deploy_code(ew3, code)
+    authority = delegate_to(ew3, counter_contract_address)
+
+    cross_space_call = internal_contracts["CrossSpaceCall"]
+    # Provide gas and storageLimit explicitly: the call is expected to fail,
+    # so gas estimation would raise before sending the transaction.
+    tx_hash = cross_space_call.functions.callEVM(authority.address, b"").transact(
+        {"gas": 3_000_000, "storageLimit": 0, "gasPrice": MIN_NATIVE_BASE_PRICE}
+    )
+
+    # The designator bytes are executed as code and hit the invalid 0xef
+    # opcode (BadInstruction), so the call fails and the delegated code
+    # never runs. conflux-web3 raises on a failed transaction.
+    with pytest.raises(RuntimeError, match="BadInstruction"):
+        cw3.cfx.wait_for_transaction_receipt(tx_hash)
+    assert counter_value(ew3, authority.address) == 0


### PR DESCRIPTION
…175)

Cross-space calls (callEVM/staticCallEVM/transferEVM) loaded the eSpace callee's raw code, so a call to an account with an EIP-7702 delegation executed the designator bytes (0xef0100||address) and failed on the invalid 0xef opcode instead of running the delegated code.

Resolve the delegation via code_with_hash_on_call, matching the in-space call path. Gated by the cip175 spec flag (cip175_transition_height).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3587)
<!-- Reviewable:end -->
