### PR TITLE
config: reserve V3.1 transition heights for CIP-172/174/175/176

### DIFF
--- a/crates/cfxcore/core/src/verification.rs
+++ b/crates/cfxcore/core/src/verification.rs
@@ -804,7 +804,7 @@ impl VerificationConfig {
         let cip7702 = height >= transitions.cip7702;
         let cip645 = height >= transitions.cip645;
         let eip7623 = height >= transitions.eip7623;
-        let canonical_tx_rlp = height >= transitions.canonical_tx_rlp;
+        let cip172 = height >= transitions.cip172;
 
         if let Transaction::Native(ref tx) = tx.unsigned {
             Self::verify_transaction_epoch_height(
@@ -848,7 +848,7 @@ impl VerificationConfig {
 
         Self::check_gas_limit(tx, cip76, eip7623, &mode)?;
         Self::check_gas_limit_with_calldata(tx, cip130)?;
-        Self::check_canonical_rlp(tx, canonical_tx_rlp, &mode)?;
+        Self::check_canonical_rlp(tx, cip172, &mode)?;
 
         Ok(())
     }
@@ -858,15 +858,14 @@ impl VerificationConfig {
     /// packing / RPC) rejects it outright; as a block-validity rule this is a
     /// consensus change, so Remote only rejects at/after the gate height.
     fn check_canonical_rlp(
-        tx: &TransactionWithSignature, canonical_tx_rlp: bool,
-        mode: &VerifyTxMode,
+        tx: &TransactionWithSignature, cip172: bool, mode: &VerifyTxMode,
     ) -> Result<(), TransactionError> {
         if tx.is_canonical_rlp() {
             return Ok(());
         }
         let rejected = match mode {
             VerifyTxMode::Local(..) => true,
-            VerifyTxMode::Remote(_) => canonical_tx_rlp,
+            VerifyTxMode::Remote(_) => cip172,
         };
         if rejected {
             bail!(TransactionError::InvalidRlp(

--- a/crates/config/src/configuration.rs
+++ b/crates/config/src/configuration.rs
@@ -208,7 +208,10 @@ build_config! {
         (osaka_opcode_transition_height, (Option<u64>), None)
         (cip166_transition_height, (Option<u64>), None)
         (cip167_transition_height, (Option<u64>), None)
-        (canonical_tx_rlp_transition_height, (Option<u64>), None)
+        (cip172_transition_height, (Option<u64>), None)
+        (cip174_transition_height, (Option<u64>), None)
+        (cip175_transition_height, (Option<u64>), None)
+        (cip176_transition_height, (Option<u64>), None)
 
         // Mining section.
         (mining_author, (Option<String>), None)
@@ -1535,7 +1538,7 @@ impl Configuration {
         // hardfork (V3.1)
         set_conf!(
             self.raw_conf.osaka_opcode_transition_height.unwrap_or(default_transition_time);
-            params.transition_heights => { cip166, cip167 }
+            params.transition_heights => { cip166, cip167, cip172, cip174, cip175, cip176 }
         );
         if let Some(x) = self.raw_conf.cip166_transition_height {
             params.transition_heights.cip166 = x;
@@ -1543,11 +1546,18 @@ impl Configuration {
         if let Some(x) = self.raw_conf.cip167_transition_height {
             params.transition_heights.cip167 = x;
         }
-
-        params.transition_heights.canonical_tx_rlp = self
-            .raw_conf
-            .canonical_tx_rlp_transition_height
-            .unwrap_or(default_transition_time);
+        if let Some(x) = self.raw_conf.cip172_transition_height {
+            params.transition_heights.cip172 = x;
+        }
+        if let Some(x) = self.raw_conf.cip174_transition_height {
+            params.transition_heights.cip174 = x;
+        }
+        if let Some(x) = self.raw_conf.cip175_transition_height {
+            params.transition_heights.cip175 = x;
+        }
+        if let Some(x) = self.raw_conf.cip176_transition_height {
+            params.transition_heights.cip176 = x;
+        }
     }
 }
 

--- a/crates/execution/executor/src/spec.rs
+++ b/crates/execution/executor/src/spec.rs
@@ -162,9 +162,16 @@ pub struct TransitionsEpochHeight {
     pub cip166: BlockHeight,
     /// EIP-7212 / RIP-7212: precompile secp256r1 activation height
     pub cip167: BlockHeight,
-    /// Height at/after which a block with a non-canonically-encoded tx is
-    /// invalid. Far-future until a CIP/height is scheduled.
-    pub canonical_tx_rlp: BlockHeight,
+    /// CIP-172: Canonical Transaction RLP Encoding. Height at/after which a
+    /// block with a non-canonically-encoded tx is invalid.
+    pub cip172: BlockHeight,
+    /// CIP-174: EIP-7823 (ModExp input upper bounds) and EIP-7883 (ModExp
+    /// gas cost increase)
+    pub cip174: BlockHeight,
+    /// CIP-175: Resolve EIP-7702 Delegation in Cross-Space Calls
+    pub cip175: BlockHeight,
+    /// CIP-176: Merge Storage Keys of Repeated Addresses in an Access List
+    pub cip176: BlockHeight,
 }
 
 impl Default for CommonParams {
@@ -236,7 +243,10 @@ impl CommonParams {
         spec.cip_c2_fix = height >= self.transition_heights.cip_c2_fix;
         spec.cancun_opcodes = number >= self.transition_numbers.cancun_opcodes;
         spec.align_evm = height >= self.transition_heights.align_evm && cip645;
-        spec.eip7939 = height >= self.transition_heights.cip166;
+        spec.cip166 = height >= self.transition_heights.cip166;
+        spec.cip174 = height >= self.transition_heights.cip174;
+        spec.cip175 = height >= self.transition_heights.cip175;
+        spec.cip176 = height >= self.transition_heights.cip176;
 
         spec.overwrite_gas_plan_by_cip();
 

--- a/crates/execution/vm-interpreter/src/instructions.rs
+++ b/crates/execution/vm-interpreter/src/instructions.rs
@@ -382,7 +382,7 @@ impl Instruction {
         if instruction == Some(BASEFEE) && !spec.cip1559 {
             instruction = None;
         }
-        if instruction == Some(CLZ) && !spec.eip7939 {
+        if instruction == Some(CLZ) && !spec.cip166 {
             instruction = None;
         }
         return instruction;
@@ -432,16 +432,16 @@ impl Instruction {
 
     /// Returns the instruction info.
     pub fn info<const CANCUN: bool>(
-        &self, cip645: bool, eip7939: bool,
+        &self, cip645: bool, cip166: bool,
     ) -> &InstructionInfo {
         let instrs = if !CANCUN {
             &*INSTRUCTIONS
         } else if !cip645 {
             &*INSTRUCTIONS_CANCUN
-        } else if !eip7939 {
+        } else if !cip166 {
             &*INSTRUCTIONS_CIP645
         } else {
-            &*INSTRUCTIONS_EIP7939
+            &*INSTRUCTIONS_CIP166
         };
 
         instrs[*self as usize].as_ref().expect("A instruction is defined in Instruction enum, but it is not found in InstructionInfo struct; this indicates a logic failure in the code.")
@@ -682,7 +682,7 @@ lazy_static! {
         arr
     };
 
-    pub static ref INSTRUCTIONS_EIP7939: [Option<InstructionInfo>; 0x100] = {
+    pub static ref INSTRUCTIONS_CIP166: [Option<InstructionInfo>; 0x100] = {
         let mut arr = *INSTRUCTIONS_CIP645;
         arr[CLZ as usize] = Some(InstructionInfo::new("CLZ", 1, 1, GasPriceTier::Low));
 

--- a/crates/execution/vm-interpreter/src/interpreter/mod.rs
+++ b/crates/execution/vm-interpreter/src/interpreter/mod.rs
@@ -571,7 +571,7 @@ impl<Cost: CostType, const CANCUN: bool> Interpreter<Cost, CANCUN> {
 
         let info = instruction.info::<CANCUN>(
             context.spec().cip645.opcode_update,
-            context.spec().eip7939,
+            context.spec().cip166,
         );
         self.last_stack_ret_len = info.ret;
         if let Err(e) = self.verify_instruction(context, instruction, info) {

--- a/crates/execution/vm-types/src/spec.rs
+++ b/crates/execution/vm-types/src/spec.rs
@@ -202,8 +202,15 @@ pub struct Spec {
     pub eip7623: bool,
     pub align_evm: bool,
     pub cip_c2_fix: bool,
-    /// EIP-7939: Count Leading Zeros Instruction
-    pub eip7939: bool,
+    /// CIP-166: EIP-7939 Count Leading Zeros Instruction
+    pub cip166: bool,
+    /// CIP-174: EIP-7823 (ModExp input upper bounds) and EIP-7883 (ModExp
+    /// gas cost increase)
+    pub cip174: bool,
+    /// CIP-175: Resolve EIP-7702 Delegation in Cross-Space Calls
+    pub cip175: bool,
+    /// CIP-176: Merge Storage Keys of Repeated Addresses in an Access List
+    pub cip176: bool,
 }
 
 /// Represents the feature flags for CIP-645 implementation.
@@ -415,7 +422,10 @@ impl Spec {
             eip7623: false,
             cip_c2_fix: false,
             align_evm: false,
-            eip7939: false,
+            cip166: false,
+            cip174: false,
+            cip175: false,
+            cip176: false,
         }
     }
 

--- a/integration_tests/conflux/config.py
+++ b/integration_tests/conflux/config.py
@@ -62,9 +62,9 @@ small_local_test_conf = dict(
     min_phase_change_normal_peer_count = 1,
     dao_vote_transition_number = 2**31,
     dao_vote_transition_height = 2**31,
-    # Canonical-tx-RLP hardfork: far-future by default so the integration suite
-    # is unaffected; tests exercising it set it explicitly.
-    canonical_tx_rlp_transition_height = 2**31,
+    # CIP-172 (canonical tx RLP): far-future by default so the integration
+    # suite is unaffected; tests exercising it set it explicitly.
+    cip172_transition_height = 2**31,
     enable_single_mpt_storage = "true",
     rpc_enable_metrics = "true",
 )

--- a/tests/conflux/config.py
+++ b/tests/conflux/config.py
@@ -62,9 +62,9 @@ small_local_test_conf = dict(
     min_phase_change_normal_peer_count = 1,
     dao_vote_transition_number = 2**31,
     dao_vote_transition_height = 2**31,
-    # Canonical-tx-RLP hardfork: far-future by default so the integration suite
-    # is unaffected; tests exercising it set it explicitly.
-    canonical_tx_rlp_transition_height = 2**31,
+    # CIP-172 (canonical tx RLP): far-future by default so the integration
+    # suite is unaffected; tests exercising it set it explicitly.
+    cip172_transition_height = 2**31,
     enable_single_mpt_storage = "true",
     rpc_enable_metrics = "true",
 )


### PR DESCRIPTION
Wire the hardfork gates of the CIPs under development into the configuration and spec plumbing, without any of their execution logic, so the implementation PRs stop colliding on these few files.

- Add `cipNNN_transition_height` for CIP-174, CIP-175 and CIP-176 with the matching `TransitionsEpochHeight` and `Spec` flags. Nothing reads the new flags yet.
- Rename `canonical_tx_rlp` to `cip172` and fold it into the V3.1 hardfork group, now that the rule has a CIP number. The integration suite keeps its far-future override under the new key, so test behavior is unchanged.
- Rename `Spec::eip7939` to `cip166`, following the `cipNNN` naming the other gates use.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3588)
<!-- Reviewable:end -->
