### PR TITLE
pos: record disputes so their evidence cannot be replayed

### DIFF
--- a/crates/cfxcore/core/src/consensus/pos_handler.rs
+++ b/crates/cfxcore/core/src/consensus/pos_handler.rs
@@ -10,7 +10,7 @@ use diem_types::{
     contract_event::ContractEvent,
     epoch_state::EpochState,
     reward_distribution_event::RewardDistributionEventV2,
-    term_state::{DisputeEvent, UnlockEvent},
+    term_state::{decode_dispute_event, UnlockEvent},
     validator_config::{ConsensusPrivateKey, ConsensusVRFPrivateKey},
 };
 use keccak_hash::keccak;
@@ -330,15 +330,11 @@ impl PosHandler {
     pub fn get_disputed_nodes(
         &self, h: &PosBlockId, parent_pos_ref: &PosBlockId,
     ) -> Vec<NodeId> {
-        let dispute_event_key = DisputeEvent::event_key();
         let mut disputed_nodes = Vec::new();
         for event in self.pos().get_events(parent_pos_ref, h) {
-            if *event.key() == dispute_event_key {
-                let dispute_event =
-                    DisputeEvent::from_bytes(event.event_data())
-                        .expect("key checked");
-                disputed_nodes
-                    .push(H256::from_slice(dispute_event.node_id.as_ref()));
+            if let Some(dispute) = decode_dispute_event(&event) {
+                let (node_id, _) = dispute.expect("key checked");
+                disputed_nodes.push(H256::from_slice(node_id.as_ref()));
             }
         }
         disputed_nodes

--- a/crates/cfxcore/core/src/pos/mempool/core_mempool/mempool.rs
+++ b/crates/cfxcore/core/src/pos/mempool/core_mempool/mempool.rs
@@ -99,15 +99,16 @@ impl Mempool {
                     continue;
                 }
                 TransactionPayload::Dispute(dispute_payload) => {
-                    // TODO(lpl): Only dispute a node once.
-                    pos_state.validate_dispute(dispute_payload).and(
-                        verify_dispute(
-                            dispute_payload,
-                            pos_state.current_view(),
-                        )
-                        .then_some(())
-                        .ok_or(anyhow::anyhow!("invalid dispute")),
-                    )
+                    // Every candidate sees the same unchanged state, so this
+                    // thins duplicates out without ruling them out.
+                    verify_dispute(dispute_payload, pos_state.current_view())
+                        .ok_or(anyhow::anyhow!("invalid dispute"))
+                        .and_then(|offense_epoch| {
+                            pos_state.validate_dispute(
+                                dispute_payload,
+                                offense_epoch,
+                            )
+                        })
                 }
                 _ => {
                     continue;

--- a/crates/pos/consensus/executor/src/lib.rs
+++ b/crates/pos/consensus/executor/src/lib.rs
@@ -52,8 +52,8 @@ use crate::{
     vm::PosVM,
 };
 use diem_types::term_state::{
+    decode_dispute_event,
     pos_state_config::{PosStateConfigTrait, POS_STATE_CONFIG},
-    DisputeEvent,
 };
 
 pub mod db_bootstrapper;
@@ -109,7 +109,6 @@ impl Executor {
         let retire_event_key = RetireEvent::event_key();
         let register_event_key = RegisterEvent::event_key();
         let update_voting_power_event_key = UpdateVotingPowerEvent::event_key();
-        let dispute_event_key = DisputeEvent::event_key();
 
         // Find the next pivot block.
         let mut pivot_decision = None;
@@ -129,10 +128,9 @@ impl Executor {
                     let election_event =
                         ElectionEvent::from_bytes(event.event_data())?;
                     new_pos_state.new_node_elected(&election_event)?;
-                } else if *event.key() == dispute_event_key {
-                    let dispute_event =
-                        DisputeEvent::from_bytes(event.event_data())?;
-                    new_pos_state.forfeit_node(&dispute_event.node_id)?;
+                } else if let Some(dispute) = decode_dispute_event(event) {
+                    let (node_id, offense_epoch) = dispute?;
+                    new_pos_state.forfeit_node(&node_id, offense_epoch)?;
                 }
             }
         }

--- a/crates/pos/consensus/executor/src/vm.rs
+++ b/crates/pos/consensus/executor/src/vm.rs
@@ -440,8 +440,8 @@ mod tests {
     /// equivocation, which the QC check made unusable before the gate.
     #[track_caller]
     fn enabled(evidence: &DisputePayload) {
-        assert!(!verify_dispute(evidence, BEFORE));
-        assert!(verify_dispute(evidence, TRANSITION));
+        assert_eq!(verify_dispute(evidence, BEFORE), None);
+        assert_eq!(verify_dispute(evidence, TRANSITION), Some(EPOCH));
     }
 
     #[track_caller]

--- a/crates/pos/consensus/executor/src/vm.rs
+++ b/crates/pos/consensus/executor/src/vm.rs
@@ -193,15 +193,23 @@ impl ExecutableBuiltinTx for DisputePayload {
         &self, state_view: &dyn StateView, _tx: &SignatureCheckedTransaction,
         _spec: &Spec,
     ) -> Result<Vec<ContractEvent>, VMStatus> {
-        state_view.pos_state().validate_dispute(self).map_err(|e| {
-            diem_error!("dispute tx error: {:?}", e);
-            VMStatus::Error(StatusCode::CFX_INVALID_TX)
-        })?;
         let view = state_view.pos_state().current_view();
-        if !verify_dispute(self, view) {
-            return Err(VMStatus::Error(StatusCode::CFX_INVALID_TX));
-        }
-        Ok(vec![self.to_event()])
+        let offense_epoch = verify_dispute(self, view)
+            .ok_or(VMStatus::Error(StatusCode::CFX_INVALID_TX))?;
+        state_view
+            .pos_state()
+            .validate_dispute(self, offense_epoch)
+            .map_err(|e| {
+                diem_error!("dispute tx error: {:?}", e);
+                VMStatus::Error(StatusCode::CFX_INVALID_TX)
+            })?;
+        Ok(vec![
+            if POS_STATE_CONFIG.cip173_active(view) {
+                self.to_event_v2(offense_epoch)
+            } else {
+                self.to_event()
+            },
+        ])
     }
 }
 
@@ -251,17 +259,15 @@ fn verify_dispute_proposal(
     }
 }
 
-/// Return true if the dispute is valid.
-/// Return false if the encoding is invalid or the provided signatures are
-/// not from the same round.
-pub fn verify_dispute(dispute: &DisputePayload, view: u64) -> bool {
+/// The epoch the offence claims, or `None` if the evidence is invalid.
+pub fn verify_dispute(dispute: &DisputePayload, view: u64) -> Option<u64> {
     let computed_address =
         from_consensus_public_key(&dispute.bls_pub_key, &dispute.vrf_pub_key);
     if dispute.address != computed_address {
         diem_trace!("Incorrect address and public keys");
-        return false;
+        return None;
     }
-    let enforce_conflict = POS_STATE_CONFIG.enforce_dispute_conflict(view);
+    let enforce_conflict = POS_STATE_CONFIG.cip173_active(view);
     match &dispute.conflicting_votes {
         ConflictSignature::Proposal((proposal_byte1, proposal_byte2)) => {
             let proposal1: Block =
@@ -269,7 +275,7 @@ pub fn verify_dispute(dispute: &DisputePayload, view: u64) -> bool {
                     Ok(proposal) => proposal,
                     Err(e) => {
                         diem_trace!("1st proposal encoding error: {:?}", e);
-                        return false;
+                        return None;
                     }
                 };
             let proposal2: Block =
@@ -277,7 +283,7 @@ pub fn verify_dispute(dispute: &DisputePayload, view: u64) -> bool {
                     Ok(proposal) => proposal,
                     Err(e) => {
                         diem_trace!("2nd proposal encoding error: {:?}", e);
-                        return false;
+                        return None;
                     }
                 };
             if (proposal1.block_data().epoch()
@@ -286,7 +292,7 @@ pub fn verify_dispute(dispute: &DisputePayload, view: u64) -> bool {
                     != proposal2.block_data().round())
             {
                 diem_trace!("Two proposals are from different rounds");
-                return false;
+                return None;
             }
             let temp_verifier = ValidatorVerifier::new_single(
                 dispute.address,
@@ -303,33 +309,34 @@ pub fn verify_dispute(dispute: &DisputePayload, view: u64) -> bool {
                     dispute.address,
                     &temp_verifier,
                 ) {
-                    return false;
+                    return None;
                 }
                 // `id()` is the hash of `block_data` only (excludes
                 // signature/vrf).
                 if proposal1.id() == proposal2.id() {
                     diem_trace!("Two proposals are identical");
-                    return false;
+                    return None;
                 }
             } else if proposal1.validate_signature(&temp_verifier).is_err()
                 || proposal2.validate_signature(&temp_verifier).is_err()
             {
-                return false;
+                return None;
             }
+            return Some(proposal1.block_data().epoch());
         }
         ConflictSignature::Vote((vote_byte1, vote_byte2)) => {
             let vote1: Vote = match bcs::from_bytes(vote_byte1.as_slice()) {
                 Ok(vote) => vote,
                 Err(e) => {
                     diem_trace!("1st vote encoding error: {:?}", e);
-                    return false;
+                    return None;
                 }
             };
             let vote2: Vote = match bcs::from_bytes(vote_byte2.as_slice()) {
                 Ok(vote) => vote,
                 Err(e) => {
                     diem_trace!("2nd vote encoding error: {:?}", e);
-                    return false;
+                    return None;
                 }
             };
             if (vote1.vote_data().proposed().epoch()
@@ -338,7 +345,17 @@ pub fn verify_dispute(dispute: &DisputePayload, view: u64) -> bool {
                     != vote2.vote_data().proposed().round())
             {
                 diem_trace!("Two votes are from different rounds");
-                return false;
+                return None;
+            }
+            // `new_single` already forces this as a side effect of holding one
+            // member; stated outright, a wider verifier cannot silently let
+            // A's equivocation convict B.
+            if enforce_conflict
+                && (vote1.author() != dispute.address
+                    || vote2.author() != dispute.address)
+            {
+                diem_trace!("Dispute vote authored by another validator");
+                return None;
             }
             let temp_verifier = ValidatorVerifier::new_single(
                 dispute.address,
@@ -349,7 +366,7 @@ pub fn verify_dispute(dispute: &DisputePayload, view: u64) -> bool {
                 || vote2.verify(&temp_verifier).is_err()
             {
                 diem_trace!("dispute vote verification error: vote1_r={:?} vote2_r={:?}", vote1.verify(&temp_verifier), vote2.verify(&temp_verifier));
-                return false;
+                return None;
             }
             // Compare `LedgerInfo` by hash, not serialized bytes: the optional
             // `timeout_signature` is not part of the `LedgerInfo`.
@@ -357,11 +374,11 @@ pub fn verify_dispute(dispute: &DisputePayload, view: u64) -> bool {
                 && vote1.ledger_info().hash() == vote2.ledger_info().hash()
             {
                 diem_trace!("Two votes share the same ledger info");
-                return false;
+                return None;
             }
+            return Some(vote1.vote_data().proposed().epoch());
         }
     }
-    true
 }
 
 #[cfg(test)]
@@ -397,7 +414,8 @@ mod tests {
     };
     use std::{collections::BTreeMap, convert::TryFrom};
 
-    const TRANSITION: u64 = 100;
+    /// Must start a term — `PosStateConfig::new` rejects anything else.
+    const TRANSITION: u64 = 2 * 60;
     const BEFORE: u64 = 0;
 
     /// Every piece of evidence below shares this epoch/round, so the epoch and
@@ -408,20 +426,20 @@ mod tests {
 
     #[track_caller]
     fn accepted(evidence: &DisputePayload) {
-        assert!(verify_dispute(evidence, BEFORE));
-        assert!(verify_dispute(evidence, TRANSITION));
+        assert_eq!(verify_dispute(evidence, BEFORE), Some(EPOCH));
+        assert_eq!(verify_dispute(evidence, TRANSITION), Some(EPOCH));
     }
 
     #[track_caller]
     fn gated(evidence: &DisputePayload) {
-        assert!(verify_dispute(evidence, BEFORE));
-        assert!(!verify_dispute(evidence, TRANSITION));
+        assert_eq!(verify_dispute(evidence, BEFORE), Some(EPOCH));
+        assert_eq!(verify_dispute(evidence, TRANSITION), None);
     }
 
     #[track_caller]
     fn rejected(evidence: &DisputePayload) {
-        assert!(!verify_dispute(evidence, BEFORE));
-        assert!(!verify_dispute(evidence, TRANSITION));
+        assert_eq!(verify_dispute(evidence, BEFORE), None);
+        assert_eq!(verify_dispute(evidence, TRANSITION), None);
     }
 
     /// The last argument is `cip173_transition_view`; `M` leaves every other
@@ -631,8 +649,6 @@ mod tests {
         let foreign_b = make_vote(other, impostor, 2);
         // `author` is the target but the signature is the impostor's.
         let forged = make_vote(other, target.address, 2);
-        // Signed by the target but naming someone else: only the author
-        // comparison rejects this one.
         let misnamed = make_vote(signer, impostor, 2);
 
         rejected(&target.votes(&foreign_a, &foreign_b));

--- a/crates/pos/storage/pos-ledger-db/src/ledger_store/mod.rs
+++ b/crates/pos/storage/pos-ledger-db/src/ledger_store/mod.rs
@@ -84,7 +84,17 @@ impl LedgerStore {
                 db.get::<PosStateSchema>(
                     &ledger_info.ledger_info().consensus_block_id(),
                 )
-                .unwrap()
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "Cannot read the committed PoS state: {:#}. A state \
+                         written after a hardfork this binary does not \
+                         implement is unreadable here; restore a backup taken \
+                         before the activation instead of deleting pos_db, \
+                         which would lose reward events that are never \
+                         re-derived.",
+                        e
+                    )
+                })
                 .expect("pos state and ledger info both committed")
             })
             .unwrap_or(PosState::new_empty());

--- a/crates/pos/storage/pos-ledger-db/src/schema/pos_state/mod.rs
+++ b/crates/pos/storage/pos-ledger-db/src/schema/pos_state/mod.rs
@@ -42,12 +42,10 @@ impl KeyCodec<PosStateSchema> for HashValue {
 }
 
 impl ValueCodec<PosStateSchema> for PosState {
-    fn encode_value(&self) -> Result<Vec<u8>> {
-        bcs::to_bytes(self).map_err(Into::into)
-    }
+    fn encode_value(&self) -> Result<Vec<u8>> { self.encode_persisted() }
 
     fn decode_value(data: &[u8]) -> Result<Self> {
-        bcs::from_bytes(data).map_err(Into::into)
+        PosState::decode_persisted(data)
     }
 }
 

--- a/crates/pos/storage/pos-ledger-db/src/schema/pos_state/test.rs
+++ b/crates/pos/storage/pos-ledger-db/src/schema/pos_state/test.rs
@@ -6,8 +6,14 @@
 // See http://www.gnu.org/licenses/
 
 use super::*;
+use diem_types::term_state::pos_state_config::{
+    PosStateConfig, POS_STATE_CONFIG,
+};
 use proptest::prelude::*;
 use schemadb::schema::assert_encode_decode;
+
+/// The encoding reads the CIP-173 transition view, so the codec needs a config.
+fn install_config() { POS_STATE_CONFIG.get_or_init(PosStateConfig::default); }
 
 proptest! {
     #![proptest_config(ProptestConfig {
@@ -19,6 +25,7 @@ proptest! {
         block_id in any::<HashValue>(),
         pos_state in any::<PosState>(),
     ) {
+        install_config();
         assert_encode_decode::<PosStateSchema>(&block_id, &pos_state);
     }
 }

--- a/crates/pos/types/types/src/term_state.rs
+++ b/crates/pos/types/types/src/term_state.rs
@@ -21,7 +21,7 @@ use diem_crypto::{
 };
 use diem_logger::prelude::*;
 pub use incentives::*;
-use lock_status::NodeLockStatus;
+use lock_status::{ForfeitRule, NodeLockStatus};
 use move_core_types::vm_status::DiscardedVMStatus;
 use pos_state_config::{PosStateConfigTrait, POS_STATE_CONFIG};
 use pow_types::StakingEvent;
@@ -467,6 +467,16 @@ impl TermList {
     }
 }
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+pub struct DisputeRecord {
+    /// Outlives `lock_until`: it is what stops the same evidence being filed
+    /// again once the lock expires. Accepting `n` consumes every epoch below.
+    last_offense_epoch: u64,
+    /// Absolute, so a lost callback loses the bookkeeping but not the penalty.
+    lock_until: View,
+}
+
 #[derive(Clone, Serialize, Eq, PartialEq, Deserialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct PosState {
@@ -496,6 +506,119 @@ pub struct PosState {
     /// PosState is the same as its parent. These skipped blocks have the
     /// same view as their parents and should not be saved as `CommittedBlock`.
     skipped: bool,
+
+    /// Must stay last: BCS is a non-backtracking prefix parser, so a tail
+    /// field is unambiguously absent from an older encoding, while one added
+    /// earlier could be absorbed by a following length-prefixed field and
+    /// decode as garbage.
+    dispute_records: BTreeMap<AccountAddress, DisputeRecord>,
+}
+
+/// The layout before CIP-173 appended `dispute_records`. Must reuse the same
+/// inner types: `NodeData`'s unchecked BLS deserializer accepts keys the
+/// checked one rejects.
+#[derive(Deserialize)]
+struct PosStateV1 {
+    node_map: HashMap<AccountAddress, NodeData>,
+    current_view: Round,
+    epoch_state: EpochState,
+    term_list: TermList,
+    retiring_nodes: VecDeque<AccountAddress>,
+    pivot_decision: PivotBlockDecision,
+    node_map_hint: HashMap<View, HashSet<AccountAddress>>,
+    unlock_event_hint: HashSet<AccountAddress>,
+    skipped: bool,
+}
+
+/// Encoding twin of [`PosStateV1`]; borrows to avoid cloning `node_map`.
+#[derive(Serialize)]
+struct PosStateV1Ref<'a> {
+    node_map: &'a HashMap<AccountAddress, NodeData>,
+    current_view: &'a Round,
+    epoch_state: &'a EpochState,
+    term_list: &'a TermList,
+    retiring_nodes: &'a VecDeque<AccountAddress>,
+    pivot_decision: &'a PivotBlockDecision,
+    node_map_hint: &'a HashMap<View, HashSet<AccountAddress>>,
+    unlock_event_hint: &'a HashSet<AccountAddress>,
+    skipped: &'a bool,
+}
+
+impl From<PosStateV1> for PosState {
+    fn from(v1: PosStateV1) -> Self {
+        Self {
+            node_map: v1.node_map,
+            current_view: v1.current_view,
+            epoch_state: v1.epoch_state,
+            term_list: v1.term_list,
+            retiring_nodes: v1.retiring_nodes,
+            pivot_decision: v1.pivot_decision,
+            node_map_hint: v1.node_map_hint,
+            unlock_event_hint: v1.unlock_event_hint,
+            skipped: v1.skipped,
+            // The only reachable answer: a CIP-156 lock is indistinguishable
+            // from an ordinary withdrawal, so locks already running cannot be
+            // reconstructed and keep the pre-CIP-173 rules until they expire.
+            dispute_records: BTreeMap::new(),
+        }
+    }
+}
+
+/// The on-disk encoding. Kept off the `Serialize`/`Deserialize` impls so a
+/// future in-memory use of `PosState` cannot inherit the format fork.
+impl PosState {
+    pub fn encode_persisted(&self) -> Result<Vec<u8>> {
+        // Past the gate the new layout goes out even when the map is empty, so
+        // that a binary without CIP-173 fails to read the row instead of
+        // booting and executing disputes under rules the chain has left.
+        if self.dispute_records.is_empty()
+            && !POS_STATE_CONFIG.cip173_active(self.current_view)
+        {
+            bcs::to_bytes(&PosStateV1Ref {
+                node_map: &self.node_map,
+                current_view: &self.current_view,
+                epoch_state: &self.epoch_state,
+                term_list: &self.term_list,
+                retiring_nodes: &self.retiring_nodes,
+                pivot_decision: &self.pivot_decision,
+                node_map_hint: &self.node_map_hint,
+                unlock_event_hint: &self.unlock_event_hint,
+                skipped: &self.skipped,
+            })
+            .map_err(Into::into)
+        } else {
+            bcs::to_bytes(self).map_err(Into::into)
+        }
+    }
+
+    pub fn decode_persisted(data: &[u8]) -> Result<Self> {
+        // Complete BCS encodings are prefix-free, so the trial order is safe:
+        // old bytes hit `Eof` under the current layout, and current bytes
+        // leave a trailing map that `from_bytes` rejects as `RemainingInput`.
+        let current_err = match bcs::from_bytes::<PosState>(data) {
+            Ok(state) => return Ok(state),
+            Err(e) => e,
+        };
+        let legacy: PosStateV1 =
+            bcs::from_bytes(data).map_err(|legacy_err| {
+                anyhow!(
+                "PoS state decodes in neither layout: current={}, legacy={}",
+                current_err,
+                legacy_err
+            )
+            })?;
+        // A state *at* the transition view came from a block whose parent was
+        // still pre-CIP-173, so an older binary that stopped here was in the
+        // right. One view further and it executed a block it should not have.
+        ensure!(
+            legacy.current_view <= POS_STATE_CONFIG.cip173_transition_view(),
+            "PoS state at view {} is stored in the pre-CIP-173 layout, so it \
+             was written past the transition view by a binary without \
+             CIP-173; its dispute state is missing and cannot be recovered",
+            legacy.current_view
+        );
+        Ok(legacy.into())
+    }
 }
 
 impl Debug for PosState {
@@ -522,7 +645,13 @@ impl PosState {
         for (node_id, total_voting_power) in initial_nodes {
             let mut lock_status = NodeLockStatus::default();
             // The genesis block should not have updates for lock status.
-            lock_status.new_lock(0, total_voting_power, true, &mut Vec::new());
+            lock_status.new_lock(
+                0,
+                total_voting_power,
+                true,
+                None,
+                &mut Vec::new(),
+            );
             node_map.insert(
                 node_id.addr.clone(),
                 NodeData {
@@ -570,6 +699,7 @@ impl PosState {
             node_map_hint: Default::default(),
             unlock_event_hint: Default::default(),
             skipped: false,
+            dispute_records: Default::default(),
         };
         let (verifier, vrf_seed) = pos_state.get_committee_at(0).unwrap();
         pos_state.epoch_state = EpochState::new(0, verifier, vrf_seed);
@@ -595,6 +725,7 @@ impl PosState {
                 height: 0,
             },
             skipped: false,
+            dispute_records: Default::default(),
         }
     }
 
@@ -847,20 +978,58 @@ impl PosState {
     }
 
     pub fn validate_dispute(
-        &self, dispute_payload: &DisputePayload,
+        &self, dispute_payload: &DisputePayload, offense_epoch: u64,
     ) -> Result<()> {
-        if let Some(node_status) = self.node_map.get(&dispute_payload.address) {
-            if node_status.lock_status.exempt_from_forfeit().is_none() {
-                Ok(())
-            } else {
-                bail!(
-                    "Dispute a forfeited node: {:?}",
-                    dispute_payload.address
-                );
-            }
-        } else {
-            bail!("Unknown dispute node: {:?}", dispute_payload.address);
+        let node =
+            self.node_map.get(&dispute_payload.address).ok_or_else(|| {
+                anyhow!("Unknown dispute node: {:?}", dispute_payload.address)
+            })?;
+        ensure!(
+            node.lock_status.exempt_from_forfeit().is_none(),
+            "Dispute a forfeited node: {:?}",
+            dispute_payload.address
+        );
+        if POS_STATE_CONFIG.cip173_active(self.current_view) {
+            self.check_dispute_admissible(
+                &dispute_payload.address,
+                offense_epoch,
+            )?;
         }
+        Ok(())
+    }
+
+    fn check_dispute_admissible(
+        &self, address: &AccountAddress, offense_epoch: u64,
+    ) -> Result<()> {
+        let first_admissible = POS_STATE_CONFIG
+            .dispute_first_admissible_epoch()
+            .ok_or_else(|| {
+                anyhow!("CIP-173 active with no scheduled transition view")
+            })?;
+        ensure!(
+            offense_epoch >= first_admissible,
+            "Dispute evidence predates CIP-173: offence epoch {}, first \
+             admissible {}",
+            offense_epoch,
+            first_admissible
+        );
+        ensure!(
+            offense_epoch <= self.epoch_state.epoch,
+            "Dispute evidence claims an unreached epoch: offence epoch {}, \
+             current epoch {}",
+            offense_epoch,
+            self.epoch_state.epoch
+        );
+        if let Some(record) = self.dispute_records.get(address) {
+            ensure!(
+                offense_epoch > record.last_offense_epoch,
+                "Dispute evidence already punished: offence epoch {}, \
+                 watermark {}",
+                offense_epoch,
+                record.last_offense_epoch
+            );
+        }
+        Ok(())
     }
 
     /// Return `(validator_set, term_seed)`.
@@ -1022,12 +1191,19 @@ impl PosState {
             addr,
             increased_voting_power
         );
+        let view = self.current_view;
+        let dispute_lock_until = self
+            .dispute_records
+            .get(addr)
+            .map(|record| record.lock_until)
+            .filter(|lock_until| view < *lock_until);
         let mut update_views = Vec::new();
         match self.node_map.get_mut(addr) {
             Some(node_status) => node_status.lock_status.new_lock(
-                self.current_view,
+                view,
                 increased_voting_power,
                 false,
+                dispute_lock_until,
                 &mut update_views,
             ),
             None => bail!("increase voting power of a non-existent node!"),
@@ -1159,14 +1335,55 @@ impl PosState {
         Ok(())
     }
 
-    pub fn forfeit_node(&mut self, addr: &AccountAddress) -> Result<()> {
-        diem_trace!("forfeit_node: {:?}", addr);
+    /// `None` for the pre-CIP-173 event, which carries no offence epoch.
+    pub fn forfeit_node(
+        &mut self, addr: &AccountAddress, offense_epoch: Option<u64>,
+    ) -> Result<()> {
+        diem_trace!("forfeit_node: {:?} {:?}", addr, offense_epoch);
+        let view = self.current_view;
+        let previous = self.dispute_records.get(addr).copied();
+
+        let (rule, record) = match POS_STATE_CONFIG.dispute_locked_views(view) {
+            None => (ForfeitRule::FreezeWithdrawable, None),
+            Some(locked_views) if !POS_STATE_CONFIG.cip173_active(view) => (
+                ForfeitRule::RelockOnActive {
+                    deadline: view.saturating_add(locked_views),
+                },
+                None,
+            ),
+            Some(locked_views) => {
+                let offense_epoch = offense_epoch.ok_or_else(|| {
+                    anyhow!("CIP-173 dispute event without an offence epoch")
+                })?;
+                if previous
+                    .map_or(false, |r| offense_epoch <= r.last_offense_epoch)
+                {
+                    // Both copies of a duplicated dispute are validated
+                    // against the same parent state, so both reach here.
+                    // Rejecting the second would invalidate the whole block an
+                    // honest proposer built.
+                    return Ok(());
+                }
+                let deadline = view
+                    .saturating_add(locked_views)
+                    .max(previous.map_or(0, |r| r.lock_until));
+                (
+                    ForfeitRule::RelockAll { deadline },
+                    Some(DisputeRecord {
+                        last_offense_epoch: offense_epoch,
+                        lock_until: deadline,
+                    }),
+                )
+            }
+        };
+
         let mut update_views = Vec::new();
         match self.node_map.get_mut(&addr) {
-            Some(node) => node
-                .lock_status
-                .forfeit(self.current_view, &mut update_views),
+            Some(node) => node.lock_status.forfeit(rule, &mut update_views),
             None => bail!("Forfeiting node does not exist"),
+        }
+        if let Some(record) = record {
+            self.dispute_records.insert(*addr, record);
         }
         self.record_update_views(addr, update_views);
         Ok(())
@@ -1423,12 +1640,52 @@ impl DisputeEvent {
     }
 }
 
+/// A separate event key rather than a field on `DisputeEvent`, so the
+/// pre-activation encoding stays byte-identical for replay.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct DisputeEventV2 {
+    pub node_id: AccountAddress,
+    pub offense_epoch: u64,
+}
+
+impl DisputeEventV2 {
+    pub fn event_key() -> EventKey {
+        EventKey::new_from_address(&account_config::dispute_address(), 7)
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> anyhow::Result<Self> {
+        bcs::from_bytes(bytes).map_err(Into::into)
+    }
+}
+
+/// Decode either dispute event, `None` for any other key. Both versions are
+/// recognised in one place so a third consumer cannot support one and silently
+/// drop the other.
+pub fn decode_dispute_event(
+    event: &ContractEvent,
+) -> Option<anyhow::Result<(AccountAddress, Option<u64>)>> {
+    if *event.key() == DisputeEvent::event_key() {
+        Some(
+            DisputeEvent::from_bytes(event.event_data())
+                .map(|e| (e.node_id, None)),
+        )
+    } else if *event.key() == DisputeEventV2::event_key() {
+        Some(
+            DisputeEventV2::from_bytes(event.event_data())
+                .map(|e| (e.node_id, Some(e.offense_epoch))),
+        )
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
-        block_info::PivotBlockDecision, transaction::ElectionPayload,
-        validator_config::ConsensusVRFProof,
+        block_info::PivotBlockDecision,
+        term_state::pos_state_config::PosStateConfig,
+        transaction::ElectionPayload, validator_config::ConsensusVRFProof,
     };
     use diem_crypto::{
         bls::BLSPrivateKey,
@@ -1562,6 +1819,318 @@ mod tests {
             state.validate_dispute_simple(&alice.addr, &alice.bls_pk),
             None,
         );
+    }
+
+    /// Two whole terms in, so the transition view starts one.
+    const TRANSITION: View = 2 * ROUND_PER_TERM;
+    /// Epoch `n` is term `n - 1`, so this is the first epoch CIP-173 admits.
+    const FIRST_EPOCH: u64 = 3;
+    const DISPUTE_LOCK: u64 = 1000;
+
+    fn install_config() {
+        const M: u64 = u64::MAX;
+        POS_STATE_CONFIG.get_or_init(|| {
+            PosStateConfig::new(
+                ROUND_PER_TERM,
+                TERM_MAX_SIZE,
+                TERM_ELECTED_SIZE,
+                IN_QUEUE_LOCKED_VIEWS,
+                OUT_QUEUE_LOCKED_VIEWS,
+                M,
+                0,
+                0,
+                M,
+                M,
+                M,
+                0,
+                0,
+                ROUND_PER_TERM,
+                0,
+                DISPUTE_LOCK,
+                TRANSITION,
+            )
+        });
+    }
+
+    fn staked_state(k: &Keys, view: View, epoch: u64, votes: u64) -> PosState {
+        install_config();
+        let mut state = state_with_node(k);
+        state.current_view = view;
+        state.epoch_state.epoch = epoch;
+        state.update_voting_power(&k.addr, votes).expect("staked");
+        state
+    }
+
+    fn dispute_of(k: &Keys) -> DisputePayload {
+        DisputePayload {
+            address: k.addr,
+            bls_pub_key: k.bls_pk.clone(),
+            vrf_pub_key: k.vrf_pk.clone(),
+            conflicting_votes: crate::transaction::ConflictSignature::Vote((
+                vec![],
+                vec![],
+            )),
+        }
+    }
+
+    fn lock_status_of<'a>(
+        state: &'a PosState, k: &Keys,
+    ) -> &'a lock_status::NodeLockStatus {
+        &state.node_map.get(&k.addr).expect("registered").lock_status
+    }
+
+    fn exits_of(state: &PosState, k: &Keys) -> Vec<View> {
+        lock_status_of(state, k)
+            .out_queue
+            .iter()
+            .map(|item| item.view)
+            .collect()
+    }
+
+    #[test]
+    fn dispute_locks_stake_and_records_the_offence() {
+        let alice = keys_from_seed(1);
+        let mut state = staked_state(&alice, TRANSITION, FIRST_EPOCH, 10);
+        assert_eq!(lock_status_of(&state, &alice).available_votes(), 10);
+
+        state
+            .forfeit_node(&alice.addr, Some(FIRST_EPOCH))
+            .expect("forfeit");
+
+        assert_eq!(lock_status_of(&state, &alice).available_votes(), 0);
+        assert_eq!(exits_of(&state, &alice), vec![TRANSITION + DISPUTE_LOCK]);
+        let record = *state.dispute_records.get(&alice.addr).expect("recorded");
+        assert_eq!(record.last_offense_epoch, FIRST_EPOCH);
+        assert_eq!(record.lock_until, TRANSITION + DISPUTE_LOCK);
+    }
+
+    /// Wider than CIP-156 as published, which lets a disputed voter "stake
+    /// more votes to become active votes again"; the penalty is on the
+    /// validator, so it matches force retirement instead.
+    #[test]
+    fn a_deposit_during_the_lock_buys_no_voting_power() {
+        let alice = keys_from_seed(1);
+        let mut state = staked_state(&alice, TRANSITION, FIRST_EPOCH, 10);
+        state
+            .forfeit_node(&alice.addr, Some(FIRST_EPOCH))
+            .expect("forfeit");
+        let lock_until = state.dispute_records[&alice.addr].lock_until;
+
+        state.current_view = TRANSITION + 1;
+        state.update_voting_power(&alice.addr, 50).expect("deposit");
+
+        assert_eq!(lock_status_of(&state, &alice).available_votes(), 0);
+        assert!(exits_of(&state, &alice)
+            .iter()
+            .all(|exit| *exit >= lock_until));
+
+        state.current_view = lock_until;
+        state.update_voting_power(&alice.addr, 7).expect("deposit");
+        assert_eq!(lock_status_of(&state, &alice).available_votes(), 7);
+    }
+
+    /// Locks already running at activation cannot be reconstructed, so those
+    /// validators keep the old rule until they expire.
+    #[test]
+    fn a_lock_that_predates_the_gate_is_not_retrofitted() {
+        let alice = keys_from_seed(1);
+        let mut state = staked_state(&alice, TRANSITION - 1, FIRST_EPOCH, 10);
+        state.forfeit_node(&alice.addr, None).expect("forfeit");
+        assert_eq!(lock_status_of(&state, &alice).available_votes(), 0);
+
+        state.current_view = TRANSITION;
+        state.update_voting_power(&alice.addr, 50).expect("deposit");
+        assert_eq!(lock_status_of(&state, &alice).available_votes(), 50);
+    }
+
+    #[test]
+    fn replayed_evidence_neither_errors_nor_extends_the_lock() {
+        let alice = keys_from_seed(1);
+        let mut state = staked_state(&alice, TRANSITION, FIRST_EPOCH, 10);
+        state
+            .forfeit_node(&alice.addr, Some(FIRST_EPOCH))
+            .expect("forfeit");
+        let exits = exits_of(&state, &alice);
+
+        state.current_view = TRANSITION + 10;
+        assert!(state
+            .validate_dispute(&dispute_of(&alice), FIRST_EPOCH)
+            .is_err());
+
+        // A duplicate inside an already-validated block must pass through as
+        // a no-op, or it would invalidate the whole block.
+        state
+            .forfeit_node(&alice.addr, Some(FIRST_EPOCH))
+            .expect("duplicate is a no-op");
+        assert_eq!(exits_of(&state, &alice), exits);
+    }
+
+    #[test]
+    fn a_later_offence_postpones_the_deadline() {
+        let alice = keys_from_seed(1);
+        let mut state = staked_state(&alice, TRANSITION, FIRST_EPOCH, 10);
+        state
+            .forfeit_node(&alice.addr, Some(FIRST_EPOCH))
+            .expect("forfeit");
+
+        state.current_view = TRANSITION + 10;
+        state.epoch_state.epoch = FIRST_EPOCH + 1;
+        state
+            .validate_dispute(&dispute_of(&alice), FIRST_EPOCH + 1)
+            .expect("a fresh offence is admissible");
+        state
+            .forfeit_node(&alice.addr, Some(FIRST_EPOCH + 1))
+            .expect("forfeit");
+
+        let record = *state.dispute_records.get(&alice.addr).unwrap();
+        assert_eq!(record.last_offense_epoch, FIRST_EPOCH + 1);
+        assert_eq!(record.lock_until, TRANSITION + 10 + DISPUTE_LOCK);
+        assert_eq!(
+            exits_of(&state, &alice),
+            vec![TRANSITION + 10 + DISPUTE_LOCK]
+        );
+    }
+
+    #[test]
+    fn a_dispute_never_shortens_a_withdrawal_already_in_flight() {
+        let alice = keys_from_seed(1);
+        let mut state = staked_state(&alice, TRANSITION, FIRST_EPOCH, 10);
+        // Retire, so the stake leaves at a view well past the dispute lock.
+        state.retire_node(&alice.addr, 10).expect("retire");
+        let exits = exits_of(&state, &alice);
+        assert!(exits.iter().all(|view| *view > TRANSITION + DISPUTE_LOCK));
+
+        state
+            .forfeit_node(&alice.addr, Some(FIRST_EPOCH))
+            .expect("forfeit");
+
+        assert_eq!(exits_of(&state, &alice), exits);
+    }
+
+    #[test]
+    fn evidence_outside_the_admissible_epochs_is_refused() {
+        let alice = keys_from_seed(1);
+        let state = staked_state(&alice, TRANSITION, FIRST_EPOCH, 10);
+
+        assert!(state
+            .validate_dispute(&dispute_of(&alice), FIRST_EPOCH - 1)
+            .is_err());
+        assert!(state
+            .validate_dispute(&dispute_of(&alice), FIRST_EPOCH + 1)
+            .is_err());
+        assert!(state
+            .validate_dispute(&dispute_of(&alice), FIRST_EPOCH)
+            .is_ok());
+    }
+
+    #[test]
+    fn a_pre_activation_dispute_leaves_no_record() {
+        let alice = keys_from_seed(1);
+        let mut state = staked_state(&alice, TRANSITION - 1, FIRST_EPOCH, 10);
+
+        state.forfeit_node(&alice.addr, None).expect("forfeit");
+
+        assert!(state.dispute_records.get(&alice.addr).is_none());
+        assert_eq!(lock_status_of(&state, &alice).available_votes(), 0);
+    }
+
+    #[test]
+    fn persisted_layout_follows_the_transition_view() {
+        let alice = keys_from_seed(1);
+
+        let before = staked_state(&alice, TRANSITION - 1, FIRST_EPOCH, 10);
+        let legacy = before.encode_persisted().expect("encode");
+        assert!(
+            bcs::from_bytes::<PosState>(&legacy).is_err(),
+            "a legacy row must not decode as the current layout, or the \
+             fallback would be reached by states that do not need it"
+        );
+        let decoded = PosState::decode_persisted(&legacy).expect("decode");
+        assert!(decoded.dispute_records.is_empty());
+        assert_eq!(decoded, before);
+
+        let mut after = staked_state(&alice, TRANSITION, FIRST_EPOCH, 10);
+        let empty_but_gated = after.encode_persisted().expect("encode");
+        assert_eq!(
+            PosState::decode_persisted(&empty_but_gated).expect("decode"),
+            after
+        );
+        after
+            .forfeit_node(&alice.addr, Some(FIRST_EPOCH))
+            .expect("forfeit");
+        let with_record = after.encode_persisted().expect("encode");
+        assert_eq!(
+            PosState::decode_persisted(&with_record).expect("decode"),
+            after
+        );
+    }
+
+    #[test]
+    fn the_legacy_layout_is_the_current_one_without_its_last_field() {
+        let alice = keys_from_seed(1);
+        let state = staked_state(&alice, TRANSITION - 1, FIRST_EPOCH, 10);
+        assert!(state.dispute_records.is_empty());
+
+        // Pins the hand-written mirror to the real field order; a round-trip
+        // through the mirror alone would agree with itself however wrong.
+        assert_eq!(
+            bcs::to_bytes(&state).expect("encode"),
+            [state.encode_persisted().expect("encode").as_slice(), &[0u8]]
+                .concat()
+        );
+    }
+
+    /// A migration that dropped the watermark would surface here as evidence
+    /// that can be replayed after the restart.
+    #[test]
+    fn a_dispute_survives_a_restart_on_each_side_of_the_gate() {
+        let alice = keys_from_seed(1);
+        let before = staked_state(&alice, TRANSITION - 1, FIRST_EPOCH, 10);
+
+        let mut state =
+            PosState::decode_persisted(&before.encode_persisted().unwrap())
+                .expect("legacy row still readable");
+        state.current_view = TRANSITION;
+        state
+            .forfeit_node(&alice.addr, Some(FIRST_EPOCH))
+            .expect("forfeit");
+
+        let restarted =
+            PosState::decode_persisted(&state.encode_persisted().unwrap())
+                .expect("current row readable");
+        assert_eq!(restarted, state);
+        assert_eq!(
+            restarted.dispute_records[&alice.addr].last_offense_epoch,
+            FIRST_EPOCH
+        );
+        assert!(restarted
+            .validate_dispute(&dispute_of(&alice), FIRST_EPOCH)
+            .is_err());
+    }
+
+    #[test]
+    fn a_legacy_row_is_readable_up_to_the_transition_view_and_no_further() {
+        let alice = keys_from_seed(1);
+        let state = staked_state(&alice, 0, FIRST_EPOCH, 10);
+
+        let legacy_at = |view: View| {
+            bcs::to_bytes(&PosStateV1Ref {
+                node_map: &state.node_map,
+                current_view: &view,
+                epoch_state: &state.epoch_state,
+                term_list: &state.term_list,
+                retiring_nodes: &state.retiring_nodes,
+                pivot_decision: &state.pivot_decision,
+                node_map_hint: &state.node_map_hint,
+                unlock_event_hint: &state.unlock_event_hint,
+                skipped: &state.skipped,
+            })
+            .unwrap()
+        };
+
+        assert!(PosState::decode_persisted(&legacy_at(TRANSITION - 1)).is_ok());
+        assert!(PosState::decode_persisted(&legacy_at(TRANSITION)).is_ok());
+        assert!(PosState::decode_persisted(&legacy_at(TRANSITION + 1)).is_err());
     }
 
     fn election_payload_for(k: &Keys) -> ElectionPayload {

--- a/crates/pos/types/types/src/term_state/lock_status.rs
+++ b/crates/pos/types/types/src/term_state/lock_status.rs
@@ -187,7 +187,7 @@ impl NodeLockStatus {
 
     pub(super) fn new_lock(
         &mut self, view: View, votes: u64, initialize_mode: bool,
-        update_views: &mut Vec<View>,
+        dispute_lock_until: Option<View>, update_views: &mut Vec<View>,
     ) {
         if votes == 0 {
             return;
@@ -199,12 +199,13 @@ impl NodeLockStatus {
             return;
         }
 
-        // If force retired is not none, new locked tokens will be forced
-        // retire.
-        if self.force_retired.is_some() {
-            let exit_view = view
+        // Removal for inactivity and a dispute penalty both bar topping up
+        // into active voting power, so the deposit queues for withdrawal.
+        if self.force_retired.is_some() || dispute_lock_until.is_some() {
+            let exit_view = (view
                 + POS_STATE_CONFIG.in_queue_locked_views(view)
-                + POS_STATE_CONFIG.out_queue_locked_views(view);
+                + POS_STATE_CONFIG.out_queue_locked_views(view))
+            .max(dispute_lock_until.unwrap_or(0));
             self.out_queue.push(exit_view, votes, update_views);
         } else {
             self.available_votes += votes;
@@ -273,22 +274,20 @@ impl NodeLockStatus {
     }
 
     pub(super) fn forfeit(
-        &mut self, view: View, updated_views: &mut Vec<View>,
+        &mut self, rule: ForfeitRule, updated_views: &mut Vec<View>,
     ) {
         if self.exempt_from_forfeit.is_some() {
             return;
         }
-        match POS_STATE_CONFIG.dispute_locked_views(view) {
-            None => self.exempt_from_forfeit = Some(self.unlocked),
-            Some(dispute_locked_views) => {
-                // available_votes excludes out_queue, so a fully-retired node
-                // (stake only in out_queue) escaped the lock before the fix.
-                let relock = self.available_votes > 0
-                    || (POS_STATE_CONFIG.dispute_lock_includes_out_queue(view)
-                        && !self.out_queue.is_empty());
-                if relock {
-                    // We will lock all votes in `in_queue`, `locked`, and
-                    // `out_queue`.
+        match rule {
+            ForfeitRule::FreezeWithdrawable => {
+                self.exempt_from_forfeit = Some(self.unlocked)
+            }
+            ForfeitRule::RelockOnActive { deadline } => {
+                // `available_votes` excludes `out_queue`, so a fully retired
+                // node escapes the lock. That is what CIP-173 fixes; it must
+                // stay exact to replay history written before the fix.
+                if self.available_votes > 0 {
                     let mut to_lock_votes = self.available_votes;
                     self.in_queue.clear();
                     self.locked = 0;
@@ -298,19 +297,97 @@ impl NodeLockStatus {
                     {
                         to_lock_votes += item.votes;
                     }
-                    // `out_queue` is cleared, so we also clear force_retired in
-                    // case it will not be updated in the
-                    // future.
                     self.force_retired = None;
 
-                    self.out_queue.push(
-                        view.saturating_add(dispute_locked_views),
-                        to_lock_votes,
-                        updated_views,
-                    );
+                    self.out_queue.push(deadline, to_lock_votes, updated_views);
                 }
             }
+            ForfeitRule::RelockAll { deadline } => {
+                self.relock_all(deadline, updated_views)
+            }
         }
+    }
+
+    /// Holds every piece of stake to `max(its own exit view, deadline)`.
+    /// Flooring, not replacing: a dispute filed late would otherwise land
+    /// behind a withdrawal in flight and *shorten* its delay.
+    fn relock_all(&mut self, deadline: View, updated_views: &mut Vec<View>) {
+        // `pop_by_view` sorts first and flooring preserves that order, so the
+        // items can go back without a re-sort. Active stake has no exit view
+        // of its own, so it leads at the deadline.
+        let mut held = Vec::with_capacity(self.out_queue.len() + 1);
+        if self.available_votes > 0 {
+            held.push(StatusItem {
+                view: deadline,
+                votes: self.available_votes,
+            });
+        }
+        while let Some(item) = self.out_queue.pop_by_view(u64::MAX) {
+            held.push(StatusItem {
+                view: item.view.max(deadline),
+                votes: item.votes,
+            });
+        }
+
+        // Unlike the legacy rule this leaves `force_retired` alone: a penalty
+        // must not double as an amnesty for an ongoing retirement.
+        self.in_queue.clear();
+        self.locked = 0;
+        self.available_votes = 0;
+
+        for item in held {
+            self.out_queue.push(item.view, item.votes, updated_views);
+        }
+    }
+}
+
+/// Chosen by `PosState`, which has the transition views and dispute record.
+pub(super) enum ForfeitRule {
+    /// Before CIP-156: forfeit outright rather than lock.
+    FreezeWithdrawable,
+    /// CIP-156: relock, but only for a node that still has active stake.
+    RelockOnActive { deadline: View },
+    /// CIP-173: relock unconditionally, stake already leaving included.
+    RelockAll { deadline: View },
+}
+
+#[cfg(test)]
+mod relock_tests {
+    use super::*;
+
+    /// `relock_all` reads no config, so these cases need no `POS_STATE_CONFIG`.
+    fn status_with(out_queue: &[(View, u64)], active: u64) -> NodeLockStatus {
+        let mut status = NodeLockStatus::default();
+        status.available_votes = active;
+        status.locked = active;
+        for (view, votes) in out_queue {
+            status.out_queue.push(*view, *votes, &mut Vec::new());
+        }
+        status
+    }
+
+    #[test]
+    fn relocking_orders_the_queue_and_never_brings_an_exit_forward() {
+        // Pushed descending, so the order must come from `pop_by_view`.
+        let mut status = status_with(&[(900, 3), (100, 1), (500, 2)], 10);
+        status.force_retired = Some(7);
+        assert!(!status.out_queue.sorted);
+
+        let mut updated = Vec::new();
+        status.forfeit(ForfeitRule::RelockAll { deadline: 500 }, &mut updated);
+
+        let exits: Vec<(View, u64)> = status
+            .out_queue
+            .iter()
+            .map(|item| (item.view, item.votes))
+            .collect();
+        // The later exit survives; the earlier two are held to the deadline.
+        assert_eq!(exits, vec![(500, 10), (500, 1), (500, 2), (900, 3)]);
+        assert!(status.out_queue.sorted);
+        assert_eq!(status.available_votes, 0);
+        assert!(status.in_queue.is_empty());
+        assert_eq!(status.force_retired, Some(7));
+        assert_eq!(updated, vec![500, 500, 500, 900]);
     }
 }
 
@@ -323,7 +400,6 @@ pub mod tests {
         NewLock(u64),
         NewUnlock(u64),
         ForceRetire,
-        Forfeit,
         AssertAvailable(u64),
         AssertLocked(u64),
         AssertUnlocked(u64),
@@ -353,6 +429,7 @@ pub mod tests {
                             view,
                             votes,
                             false,
+                            None,
                             &mut update_views,
                         );
                     }
@@ -361,9 +438,6 @@ pub mod tests {
                     }
                     Operation::ForceRetire => {
                         lock_status.force_retire(view, &mut update_views);
-                    }
-                    Operation::Forfeit => {
-                        lock_status.forfeit(view, &mut update_views)
                     }
                     Operation::AssertAvailable(votes) => {
                         if lock_status.available_votes != votes {

--- a/crates/pos/types/types/src/term_state/pos_state_config.rs
+++ b/crates/pos/types/types/src/term_state/pos_state_config.rs
@@ -28,8 +28,6 @@ pub struct PosStateConfig {
 
     cip156_transition_view: u64,
     cip156_dispute_locked_views: u64,
-    // CIP-173 gates two dispute fixes at one view: evidence must genuinely
-    // conflict, and a dispute also relocks a fully-retired node's out_queue.
     cip173_transition_view: u64,
 
     nonce_limit_transition_view: u64,
@@ -55,9 +53,13 @@ pub trait PosStateConfigTrait {
     // Returning None means the stake should be forfeited instead of being
     // locked.
     fn dispute_locked_views(&self, view: u64) -> Option<u64>;
-    // Both gates below activate at the shared CIP-173 transition view.
-    fn enforce_dispute_conflict(&self, view: u64) -> bool;
-    fn dispute_lock_includes_out_queue(&self, view: u64) -> bool;
+    /// One predicate for the whole CIP-173 dispute rule, because each half
+    /// assumes the others: a chain evaluating them at different views would
+    /// punish differently from one that did not.
+    fn cip173_active(&self, view: u64) -> bool;
+    fn cip173_transition_view(&self) -> u64;
+    /// `None` while the rule is unscheduled.
+    fn dispute_first_admissible_epoch(&self) -> Option<u64>;
 }
 
 impl PosStateConfig {
@@ -71,7 +73,7 @@ impl PosStateConfig {
         cip136_round_per_term: u64, cip156_transition_view: u64,
         cip156_dispute_locked_views: u64, cip173_transition_view: u64,
     ) -> Self {
-        Self {
+        let config = Self {
             round_per_term,
             term_max_size,
             term_elected_size,
@@ -89,7 +91,35 @@ impl PosStateConfig {
             cip173_transition_view,
             nonce_limit_transition_view,
             max_nonce_per_account,
+        };
+        assert!(
+            config.cip173_activation_starts_a_term(),
+            "pos_cip173_transition_view {} must be the first view of a term",
+            cip173_transition_view,
+        );
+        config
+    }
+
+    fn term_view(&self, view: u64) -> (u64, u64) {
+        if view < self.cip136_transition_view {
+            (view / self.round_per_term, view % self.round_per_term)
+        } else {
+            let transition_term =
+                self.cip136_transition_view / self.round_per_term;
+            let view_after = view - self.cip136_transition_view;
+            (
+                transition_term + view_after / self.cip136_round_per_term,
+                view_after % self.cip136_round_per_term,
+            )
         }
+    }
+
+    /// The replay watermark cannot be backfilled, so an epoch straddling the
+    /// activation would hold offences already punished under the old rule and
+    /// let them be filed again as new.
+    fn cip173_activation_starts_a_term(&self) -> bool {
+        self.cip173_transition_view == u64::MAX
+            || self.term_view(self.cip173_transition_view).1 == 0
     }
 }
 
@@ -181,18 +211,7 @@ impl PosStateConfigTrait for OnceCell<PosStateConfig> {
     }
 
     fn get_term_view(&self, view: u64) -> (u64, u64) {
-        let conf = self.get().unwrap();
-        if view < conf.cip136_transition_view {
-            (view / conf.round_per_term, view % conf.round_per_term)
-        } else {
-            let transition_term =
-                conf.cip136_transition_view / conf.round_per_term;
-            let view_after = view - conf.cip136_transition_view;
-            (
-                transition_term + view_after / conf.cip136_round_per_term,
-                view_after % conf.cip136_round_per_term,
-            )
-        }
+        self.get().unwrap().term_view(view)
     }
 
     fn get_starting_view_for_term(&self, term: u64) -> Option<u64> {
@@ -216,12 +235,21 @@ impl PosStateConfigTrait for OnceCell<PosStateConfig> {
         }
     }
 
-    fn enforce_dispute_conflict(&self, view: u64) -> bool {
-        view >= self.get().unwrap().cip173_transition_view
+    fn cip173_active(&self, view: u64) -> bool {
+        view >= self.cip173_transition_view()
     }
 
-    fn dispute_lock_includes_out_queue(&self, view: u64) -> bool {
-        view >= self.get().unwrap().cip173_transition_view
+    fn cip173_transition_view(&self) -> u64 {
+        self.get().unwrap().cip173_transition_view
+    }
+
+    fn dispute_first_admissible_epoch(&self) -> Option<u64> {
+        let conf = self.get().unwrap();
+        if conf.cip173_transition_view == u64::MAX {
+            return None;
+        }
+        // Epoch `n` is term `n - 1`.
+        Some(conf.term_view(conf.cip173_transition_view).0 + 1)
     }
 }
 
@@ -248,5 +276,26 @@ impl Default for PosStateConfig {
             nonce_limit_transition_view: u64::MAX,
             max_nonce_per_account: u64::MAX,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn with_cip173_at(view: u64) -> PosStateConfig {
+        PosStateConfig {
+            cip173_transition_view: view,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn cip173_must_activate_on_a_term_boundary() {
+        assert!(with_cip173_at(u64::MAX).cip173_activation_starts_a_term());
+        assert!(with_cip173_at(2 * ROUND_PER_TERM)
+            .cip173_activation_starts_a_term());
+        assert!(!with_cip173_at(2 * ROUND_PER_TERM + 1)
+            .cip173_activation_starts_a_term());
     }
 }

--- a/crates/pos/types/types/src/transaction/mod.rs
+++ b/crates/pos/types/types/src/transaction/mod.rs
@@ -33,8 +33,8 @@ use crate::{
     ledger_info::LedgerInfo,
     proof::{accumulator::InMemoryAccumulator, TransactionInfoWithProof},
     term_state::{
-        DisputeEvent, ElectionEvent, NodeID, RegisterEvent, RetireEvent,
-        UpdateVotingPowerEvent,
+        DisputeEvent, DisputeEventV2, ElectionEvent, NodeID, RegisterEvent,
+        RetireEvent, UpdateVotingPowerEvent,
     },
     transaction::authenticator::{
         TransactionAuthenticator, TransactionAuthenticatorUnchecked,
@@ -369,6 +369,17 @@ impl DisputePayload {
         };
         ContractEvent::new(
             DisputeEvent::event_key(),
+            bcs::to_bytes(&event).unwrap(),
+        )
+    }
+
+    pub fn to_event_v2(&self, offense_epoch: u64) -> ContractEvent {
+        let event = DisputeEventV2 {
+            node_id: self.address,
+            offense_epoch,
+        };
+        ContractEvent::new(
+            DisputeEventV2::event_key(),
             bcs::to_bytes(&event).unwrap(),
         )
     }


### PR DESCRIPTION
Activating CIP-173 as it stands would make CIP-156's penalty unboundedly extendable by anyone.

Dispute evidence has no replay protection and nothing detects a repeat, so anyone can resubmit it. That is harmless today, because the relock requires stake that has not started leaving and after the first lock there is none. CIP-173 widens the relock to cover unlocking votes — exactly the state the first lock leaves behind — so every resubmission would re-enter and push the deadline out again.

`PosState` now remembers the dispute: a per-validator watermark over the offences already punished, and the view the penalty runs to. Evidence is admitted only for a strictly later epoch, so a replay is refused outright and the deadline stays anchored at submission, matching CIP-156's wording. The watermark cannot be backfilled, so evidence for an offence from before the activation epoch is inadmissible and the penalty does not reach back across the gate.

**One behaviour change needs ratifying.** A disputed validator can no longer re-stake into active voting power, which contradicts CIP-156 as written.

A dispute also stops clearing an ongoing force retirement, which it does today. The dispute lock already outlasts the retirement restriction, so this is only observable when the retirement flag was left stranded — but it is consensus-visible and gated accordingly.

**This is the first `PosState` layout change since PoS went live.** The record is appended as the last field, so older rows still decode; past the transition view a legacy row is refused rather than read as having no dispute state.

**The scheduled activation views have to move before this ships**, and the new one must start a term.

Supersedes #3590, which anchored the deadline to the offence to avoid the new field — at the cost of a one-epoch admissibility window that an equivocator can time around, and with no way to close the re-staking gap.

Based on #3534, not master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-rust/3591)
<!-- Reviewable:end -->
